### PR TITLE
Fix typo in language doc

### DIFF
--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -1,4 +1,4 @@
-# FunctionaScript Programming Language
+# FunctionalScript Programming Language
 
 ## 1. Module Ecosystem
 


### PR DESCRIPTION
Missing an `l` in the language name.