### PR TITLE
HTML void tags are handled in runtime

### DIFF
--- a/html/test.f.cjs
+++ b/html/test.f.cjs
@@ -5,10 +5,30 @@ module.exports = {
         const r = _.htmlToString(['html', []])
         if (r !== '<!DOCTYPE html><html></html>') { throw r }
     },
+    empty2: () => {
+        const r = _.htmlToString(['html'])
+        if (r !== '<!DOCTYPE html><html></html>') { throw r }
+    },
+    void: () => {
+        const r = _.htmlToString(['area'])
+        if (r !== '<!DOCTYPE html><area>') { throw r }
+    },
     some: () => {
         /** @type {_.Element} */
         const x = ['div', {}, ['<div>&amp;</div>', ['a', { href: 'hello"' }, []]]]
         const s = _.htmlToString(x)
         if (s !== '<!DOCTYPE html><div>&lt;div&gt;&amp;amp;&lt;/div&gt;<a href="hello&quot;"></a></div>') { throw s }
+    },
+    some2: () => {
+        /** @type {_.Element} */
+        const x = ['div', ['<div>&amp;</div>', ['a', { href: 'hello"' }, []]]]
+        const s = _.htmlToString(x)
+        if (s !== '<!DOCTYPE html><div>&lt;div&gt;&amp;amp;&lt;/div&gt;<a href="hello&quot;"></a></div>') { throw s }
+    },
+    someVoid: () => {
+        /** @type {_.Element} */
+        const x = ['div', [['br', {id: '5'}], '<div>&amp;</div>', ['a', { href: 'hello"' }, []]]]
+        const s = _.htmlToString(x)
+        if (s !== '<!DOCTYPE html><div><br id="5">&lt;div&gt;&amp;amp;&lt;/div&gt;<a href="hello&quot;"></a></div>') { throw s }
     }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/functionalscript/functionalscript#readme",
   "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.5.4"
+    "@types/node": "^22.9.0",
+    "typescript": "^5.6.3"
   }
 }


### PR DESCRIPTION
During HTML serialization, [Void elements](https://developer.mozilla.org/en-US/docs/Glossary/Void_element) are recognized in run-time.

**Note:** It only applies to elements without nodes.