### PR TITLE
Minor refactoring and improve `log2` algorithm.

### DIFF
--- a/issues/README.md
+++ b/issues/README.md
@@ -55,6 +55,7 @@
       ```
     - Examples use only public API and located in `*example.f.ts` files.
     - API tests use only public API and located in `*test.f.ts` files.
+29. [ ] Test in a browser. It's important for such browsers as FireFox because we don't have SpiderMonkey as a CLI.
 
 ## Language Specification
 

--- a/main.ts
+++ b/main.ts
@@ -1,23 +1,19 @@
-import * as tokenizer from './djs/tokenizer/module.f.ts'
-const { tokenize } = tokenizer
-import * as parser from './djs/parser/module.f.ts'
-const { parse } = parser
-import * as serializer from './djs/serializer/module.f.ts'
-const { djsModuleStringify } = serializer
-import * as list from './types/list/module.f.ts'
-const { toArray } = list
-import * as o from './types/object/module.f.ts'
-const { sort } = o
-import * as encoding from './text/utf16/module.f.ts'
-import fs from 'node:fs'
+import { type DjsToken, tokenize } from './djs/tokenizer/module.f.ts'
+import { parse } from './djs/parser/module.f.ts'
+import { djsModuleStringify } from './djs/serializer/module.f.ts'
+import { toArray } from './types/list/module.f.ts'
+import { sort } from './types/object/module.f.ts'
+import { stringToList } from './text/utf16/module.f.ts'
+import * as fs from 'node:fs'
+import * as process from 'node:process'
 
 const tokenizeString
-    : (s: string) => readonly tokenizer.DjsToken[]
-    = s => toArray(tokenize(encoding.stringToList(s)))
+    : (s: string) => readonly DjsToken[]
+    = s => toArray(tokenize(stringToList(s)))
 
 const stringifyDjsModule = djsModuleStringify(sort)
 
-var args = process.argv.slice(2)
+const args = process.argv.slice(2)
 
 if (args.length < 2) {
   console.log('Error: Requires 2 or more arguments');

--- a/nodejs/version/main.ts
+++ b/nodejs/version/main.ts
@@ -1,4 +1,4 @@
-import * as _ from './module.f.ts'
+import { updateVersion } from './module.f.ts'
 import fs from 'node:fs'
 
-_.updateVersion({ fs })
+updateVersion({ fs })

--- a/types/bigint/README.md
+++ b/types/bigint/README.md
@@ -25,10 +25,13 @@ https://github.com/functionalscript/functionalscript/actions/runs/12521052013/jo
 
 [benchmark.html](./benchmark.html)
 
-|Browser     |str bin|str hex|old log2|log2|
-|------------|-------|-------|--------|----|
-|Chrome,  AMD|   1298|    328|     623| 452|
-|FireFox, AMD|   1797|    323|    1704|1267|
+|Browser|CPU|str bin|str hex|old log2|log2|
+|-------|---|-------|-------|--------|----|
+|Chrome |AMD|   1298|    328|     623| 452|
+|Chrome | M1|    673|    176|     162| 106|
+|Safari | M1|    712|    180|     160| 106|
+|Firefox|AMD|   1797|    323|    1704|1267|
+|Firefox| M1|    788|    201|     910| 683|
 
 ### Minus versus Not
 

--- a/types/bigint/README.md
+++ b/types/bigint/README.md
@@ -21,7 +21,7 @@ Bun has a `bigint` size limitation. It's `1_048_575` bits (`1024 ** 2`) or `131_
 
 ### newLog2 (32 based) versus others (2024/12/27)
 
-|Framework| str     |stringHex|log2     |newLog2 |
+|Framework|str bin  |str hex  |old log2 |log2    |
 |---------|---------|---------|---------|--------|
 |Bun      | 994.3296|458.6633 |1038.7439|669.9755|
 |Deno 2   |1884.6942|485.5894 | 240.4493|143.2709|
@@ -32,7 +32,7 @@ Bun has a `bigint` size limitation. It's `1_048_575` bits (`1024 ** 2`) or `131_
 |Node 18  |1888.5652|590.6440 | 243.8712|134.0867|
 |Node 16  |1901.8710|560.1892 | 339.8360|213.6341|
 
-`newLog2` wins on Deno and Node (V8) but slight lose on Bun (WebKit).
+The new `log2` wins on Deno and Node (V8) but slightly loses on Bun (WebKit).
 
 https://github.com/functionalscript/functionalscript/actions/runs/12521052013/job/34927599441?pr=346
 

--- a/types/bigint/README.md
+++ b/types/bigint/README.md
@@ -4,21 +4,6 @@ Bun has a `bigint` size limitation. It's `1_048_575` bits (`1024 ** 2`) or `131_
 
 ## Benchmarks
 
-### log2 versus toString (2024/11/25)
-
-|Framework|log2(x)           |x.toString(2).length|
-|---------|------------------|--------------------|
-|Bun      |1.781681          |2.079615            |
-|Deno 1   |0.710344          |1.917003            |
-|Deno 2   |0.986602          |2.286932            |
-|Node 16  |1.521150          |2.330505            |
-|Node 18  |1.393006          |2.312573            |
-|Node 20  |1.055315          |2.320039            |
-|Node 22  |0.983075          |2.336697            |
-|Node 23  |0.699960          |1.872965            |
-
-`log2` wins.
-
 ### newLog2 (32 based) versus others (2024/12/27)
 
 |Framework|str bin  |str hex  |old log2 |log2    |
@@ -50,3 +35,20 @@ https://github.com/functionalscript/functionalscript/actions/runs/12521052013/jo
 |Node 23  |18.246697         | 58.825815        |
 
 `-` wins.
+
+## Old Benchmarks
+
+### log2 versus toString (2024/11/25)
+
+|Framework|log2(x)           |x.toString(2).length|
+|---------|------------------|--------------------|
+|Bun      |1.781681          |2.079615            |
+|Deno 1   |0.710344          |1.917003            |
+|Deno 2   |0.986602          |2.286932            |
+|Node 16  |1.521150          |2.330505            |
+|Node 18  |1.393006          |2.312573            |
+|Node 20  |1.055315          |2.320039            |
+|Node 22  |0.983075          |2.336697            |
+|Node 23  |0.699960          |1.872965            |
+
+`log2` wins.

--- a/types/bigint/README.md
+++ b/types/bigint/README.md
@@ -27,11 +27,11 @@ https://github.com/functionalscript/functionalscript/actions/runs/12521052013/jo
 
 |Browser|CPU|str bin|str hex|old log2|log2|
 |-------|---|-------|-------|--------|----|
-|Chrome |AMD|   1298|    328|     623| 452|
+|Chrome |AMD|   1214|    334|     532| 369|
 |Chrome | M1|    673|    176|     162| 106|
-|Safari | M1|    712|    180|     160| 106|
 |Firefox|AMD|   1797|    323|    1704|1267|
 |Firefox| M1|    788|    201|     910| 683|
+|Safari | M1|    712|    180|     160| 106|
 
 ### Minus versus Not
 

--- a/types/bigint/README.md
+++ b/types/bigint/README.md
@@ -21,6 +21,15 @@ The new `log2` wins on Deno and Node (V8) but slightly loses on Bun (WebKit).
 
 https://github.com/functionalscript/functionalscript/actions/runs/12521052013/job/34927599441?pr=346
 
+**Browser Test**
+
+[benchmark.html](./benchmark.html)
+
+|Browser     |str bin|str hex|old log2|log2|
+|------------|-------|-------|--------|----|
+|Chrome,  AMD|   1298|    328|     623| 452|
+|FireFox, AMD|   1797|    323|    1704|1267|
+
 ### Minus versus Not
 
 |Framework|minus `-`         |not `~`           |

--- a/types/bigint/README.md
+++ b/types/bigint/README.md
@@ -19,6 +19,23 @@ Bun has a `bigint` size limitation. It's `1_048_575` bits (`1024 ** 2`) or `131_
 
 `log2` wins.
 
+### newLog2 (32 based) versus others (2024/12/27)
+
+|Framework| str     |stringHex|log2     |newLog2 |
+|---------|---------|---------|---------|--------|
+|Bun      | 994.3296|458.6633 |1038.7439|669.9755|
+|Deno 2   |1884.6942|485.5894 | 240.4493|143.2709|
+|Deno 1   |1878.0000|494.0000 | 268.0000|168.0000|
+|Node 23  |1855.9599|558.6656 | 241.5325|138.5897|
+|Node 22  |1863.8143|533.0014 | 225.9727|121.1032|
+|Node 20  |1938.3770|561.1601 | 253.4389|129.6232|
+|Node 18  |1888.5652|590.6440 | 243.8712|134.0867|
+|Node 16  |1901.8710|560.1892 | 339.8360|213.6341|
+
+`newLog2` wins on Deno and Node (V8) but slight lose on Bun (WebKit).
+
+https://github.com/functionalscript/functionalscript/actions/runs/12521052013/job/34927599441?pr=346
+
 ### Minus versus Not
 
 |Framework|minus `-`         |not `~`           |

--- a/types/bigint/benchmark.html
+++ b/types/bigint/benchmark.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script></script>
+    </head>
+    <body>
+
+    </body>
+</html>

--- a/types/bigint/benchmark.html
+++ b/types/bigint/benchmark.html
@@ -4,6 +4,6 @@
     </head>
     <body>
         <pre id="log"></pre>
-        <script src="./benchmark.js"></script>
+        <script src="./benchmark.mjs"></script>
     </body>
 </html>

--- a/types/bigint/benchmark.html
+++ b/types/bigint/benchmark.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <script></script>
     </head>
     <body>
-
+        <pre id="log"></pre>
+        <script src="./benchmark.js"></script>
     </body>
 </html>

--- a/types/bigint/benchmark.mjs
+++ b/types/bigint/benchmark.mjs
@@ -1,0 +1,86 @@
+const log2 = v => {
+    if (v <= 0n) { return -1n }
+    let result = 31n
+    let i = 32n
+    while (true) {
+        const n = v >> i
+        if (n === 0n) {
+            // overshot
+            break
+        }
+        v = n
+        result += i
+        i <<= 1n
+    }
+    // We know that `v` is not 0 so it doesn't make sense to check `n` when `i` is 0.
+    // Because of this, We check if `i` is greater than 32 before we divide it by 2.
+    while (i !== 32n) {
+        i >>= 1n
+        const n = v >> i
+        if (n !== 0n) {
+            result += i
+            v = n
+        }
+    }
+    return result - BigInt(Math.clz32(Number(v)))
+}
+
+const oldLog2 = v => {
+    if (v <= 0n) { return -1n }
+    let result = 0n
+    let i = 1n
+    while (true) {
+        const n = v >> i
+        if (n === 0n) {
+            // overshot
+            break
+        }
+        v = n
+        result += i
+        i <<= 1n // multiple by two
+    }
+    // We know that `v` is not 0 so it doesn't make sense to check `n` when `i` is 0.
+    // Because of this, We check if `i` is greater than 1 before we divide it by 2.
+    while (i !== 1n) {
+        i >>= 1n
+        const n = v >> i
+        if (n !== 0n) {
+            result += i
+            v = n
+        }
+    }
+    return result
+}
+
+const stringLog2 = v => BigInt(v.toString(2).length) - 1n
+
+const stringHexLog2 = v => {
+    const len = (BigInt(v.toString(16).length) - 1n) << 2n
+    const x = v >> len
+    return len + 31n - BigInt(Math.clz32(Number(x)))
+}
+
+const log = document.getElementById('log')
+
+const benchmark = (s, f) => {
+    const start = performance.now()
+    //
+    let e = 1_048_575n
+    let c = 1n << e
+    for (let i = 0n; i < 1_000; ++i) {
+        const x = f(c)
+        if (x !== e) { throw x }
+        c >>= 1n
+        --e
+    }
+    //
+    const end = performance.now()
+    const dif = end - start
+    //
+    log.innerText += `${s}: ${dif}\n`
+}
+
+benchmark('stringLog2', stringLog2)
+benchmark('stringHexLog2', stringHexLog2)
+benchmark('oldLog2', oldLog2)
+benchmark('log2', log2)

--- a/types/bigint/module.f.ts
+++ b/types/bigint/module.f.ts
@@ -54,7 +54,7 @@ export const log2 = (v: bigint): bigint => {
         i <<= 1n
     }
     // We know that `v` is not 0 so it doesn't make sense to check `n` when `i` is 0.
-    // Because of this, We check if `i` is greater than 1 before we divide it by 2.
+    // Because of this, We check if `i` is greater than 32 before we divide it by 2.
     while (i !== 32n) {
         i >>= 1n
         const n = v >> i

--- a/types/bigint/module.f.ts
+++ b/types/bigint/module.f.ts
@@ -5,20 +5,14 @@
  *
  * ```js
  * // Example usage:
- * import { sum, abs, log2, bitLength, mask } from './bigintUtilities';
+ * import { sum, abs, log2, bitLength, mask } from './module.f.ts'
  *
- * const a = [1n, 2n, 3n];
- * const total = sum(a); // 6n
- * const absoluteValue = abs(-42n); // 42n
- * const logValue = log2(8n); // 3n
- * const bitCount = bitLength(255n); // 8n
- * const bitmask = mask(5n); // 31n
+ * const total = sum([1n, 2n, 3n]) // 6n
+ * const absoluteValue = abs(-42n) // 42n
+ * const logValue = log2(8n) // 3n
+ * const bitCount = bitLength(255n) // 8n
+ * const bitmask = mask(5n) // 31n
  * ```
- *
- * @remarks
- * The module emphasizes type safety and performance, leveraging `bigint`'s ability to handle arbitrarily large integers.
- * Functions like `log2` and `bitLength` provide low-level binary manipulation utilities, while `sum` and `addition` demonstrate
- * basic arithmetic operations.
  */
 
 import { unsafeCmp, type Sign } from '../function/compare/module.f.ts'
@@ -34,13 +28,12 @@ export const addition: Reduce = a => b => a + b
 export const sum: (input: List<bigint>) => bigint
     = reduce(addition)(0n)
 
-export const abs: Unary = a => a >= 0 ? a : -a
+export const abs: Unary
+    = a => a >= 0 ? a : -a
 
-export const sign = (a: bigint): Sign =>
-    unsafeCmp(a)(0n)
+export const sign = (a: bigint): Sign => unsafeCmp(a)(0n)
 
-export const serialize = (a: bigint): string =>
-    `${a}n`
+export const serialize = (a: bigint): string => `${a}n`
 
 /**
  * Calculates the base-2 logarithm (floor).

--- a/types/bigint/module.f.ts
+++ b/types/bigint/module.f.ts
@@ -1,6 +1,28 @@
-import * as compare from '../function/compare/module.f.ts'
+/**
+ * This module provides a collection of utility functions and type definitions for working with `bigint` values in JavaScript.
+ *
+ * @example
+ *
+ * ```js
+ * // Example usage:
+ * import { sum, abs, log2, bitLength, mask } from './bigintUtilities';
+ *
+ * const a = [1n, 2n, 3n];
+ * const total = sum(a); // 6n
+ * const absoluteValue = abs(-42n); // 42n
+ * const logValue = log2(8n); // 3n
+ * const bitCount = bitLength(255n); // 8n
+ * const bitmask = mask(5n); // 31n
+ * ```
+ *
+ * @remarks
+ * The module emphasizes type safety and performance, leveraging `bigint`'s ability to handle arbitrarily large integers.
+ * Functions like `log2` and `bitLength` provide low-level binary manipulation utilities, while `sum` and `addition` demonstrate
+ * basic arithmetic operations.
+ */
+
+import { unsafeCmp, type Sign } from '../function/compare/module.f.ts'
 import type * as Operator from '../function/operator/module.f.ts'
-const { unsafeCmp } = compare
 import { reduce, type List } from '../list/module.f.ts'
 
 export type Unary = Operator.Unary<bigint, bigint>
@@ -9,13 +31,12 @@ export type Reduce = Operator.Reduce<bigint>
 
 export const addition: Reduce = a => b => a + b
 
-export const sum
-    : (input: List<bigint>) => bigint
+export const sum: (input: List<bigint>) => bigint
     = reduce(addition)(0n)
 
 export const abs: Unary = a => a >= 0 ? a : -a
 
-export const sign = (a: bigint): compare.Sign =>
+export const sign = (a: bigint): Sign =>
     unsafeCmp(a)(0n)
 
 export const serialize = (a: bigint): string =>

--- a/types/bigint/module.f.ts
+++ b/types/bigint/module.f.ts
@@ -40,11 +40,9 @@ export const serialize = (a: bigint): string =>
  *    determining the exact value of the logarithm.
  */
 export const log2 = (v: bigint): bigint => {
-    // TODO: use step 32 and `Math.clz32()` at the end.
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32
     if (v <= 0n) { return -1n }
-    let result = 0n
-    let i = 1n
+    let result = 31n
+    let i = 32n
     while (true) {
         const n = v >> i
         if (n === 0n) {
@@ -57,7 +55,7 @@ export const log2 = (v: bigint): bigint => {
     }
     // We know that `v` is not 0 so it doesn't make sense to check `n` when `i` is 0.
     // Because of this, We check if `i` is greater than 1 before we divide it by 2.
-    while (i !== 1n) {
+    while (i !== 32n) {
         i >>= 1n
         const n = v >> i
         if (n !== 0n) {
@@ -65,7 +63,7 @@ export const log2 = (v: bigint): bigint => {
             v = n
         }
     }
-    return result
+    return result - BigInt(Math.clz32(Number(v)))
 }
 
 /**

--- a/types/bigint/test.f.ts
+++ b/types/bigint/test.f.ts
@@ -1,11 +1,9 @@
 import { sum, abs, serialize, log2, bitLength, mask } from './module.f.ts'
 
-const newLog2 = (v: bigint): bigint => {
-    // TODO: use step 32 and `Math.clz32()` at the end.
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32
+const oldLog2 = (v: bigint): bigint => {
     if (v <= 0n) { return -1n }
     let result = 0n
-    let i = 32n
+    let i = 1n
     while (true) {
         const n = v >> i
         if (n === 0n) {
@@ -18,7 +16,7 @@ const newLog2 = (v: bigint): bigint => {
     }
     // We know that `v` is not 0 so it doesn't make sense to check `n` when `i` is 0.
     // Because of this, We check if `i` is greater than 1 before we divide it by 2.
-    while (i !== 32n) {
+    while (i !== 1n) {
         i >>= 1n
         const n = v >> i
         if (n !== 0n) {
@@ -26,7 +24,7 @@ const newLog2 = (v: bigint): bigint => {
             v = n
         }
     }
-    return result + 31n - BigInt(Math.clz32(Number(v)))
+    return result
 }
 
 const stringLog2 = (v: bigint): bigint => BigInt(v.toString(2).length) - 1n
@@ -52,8 +50,8 @@ export default {
     benchmark: {
         str: benchmark(stringLog2),
         stringHexLog2: benchmark(stringHexLog2),
+        oldLog2: benchmark(oldLog2),
         log2: benchmark(log2),
-        newLog2: benchmark(newLog2),
     },
     mask: () => {
         const result = mask(3n) // 7n

--- a/types/bigint/test.f.ts
+++ b/types/bigint/test.f.ts
@@ -47,6 +47,22 @@ const benchmark = (f: (_: bigint) => bigint) => () => {
 }
 
 export default {
+    example: () => {
+        const total = sum([1n, 2n, 3n]) // 6n
+        if (total !== 6n) { throw total }
+
+        const absoluteValue = abs(-42n) // 42n
+        if (absoluteValue !== 42n) { throw total }
+
+        const logValue = log2(8n) // 3n
+        if (logValue !== 3n) { throw total }
+
+        const bitCount = bitLength(255n) // 8n
+        if (bitCount !== 8n) { throw total }
+
+        const bitmask = mask(5n) // 31n
+        if (bitmask !== 31n) { throw total }
+    },
     benchmark: {
         str: benchmark(stringLog2),
         stringHexLog2: benchmark(stringHexLog2),

--- a/types/btree/find/module.f.ts
+++ b/types/btree/find/module.f.ts
@@ -1,27 +1,27 @@
-import * as _ from '../types/module.f.ts'
-import * as List from '../../list/module.f.ts'
-import * as cmp from '../../function/compare/module.f.ts'
-const { index3, index5 } = cmp
-import * as Array from '../../array/module.f.ts'
+import type { Leaf1, Leaf2, Branch3, Branch5, TNode } from '../types/module.f.ts'
+import type * as List from '../../list/module.f.ts'
+import { index3, index5, type Compare } from '../../function/compare/module.f.ts'
+import type * as Array from '../../array/module.f.ts'
+import type { Index3, Index5 } from "../../array/module.f.ts";
 
-type FirstLeaf1<T> = readonly[cmp.Index3, _.Leaf1<T>]
+type FirstLeaf1<T> = readonly[Index3, Leaf1<T>]
 
-type FirstBranch3<T> = readonly[1, _.Branch3<T>]
+type FirstBranch3<T> = readonly[1, Branch3<T>]
 
-type FirstLeaf2<T> = readonly[cmp.Index5, _.Leaf2<T>]
+type FirstLeaf2<T> = readonly[Index5, Leaf2<T>]
 
-type FirstBranch5<T> = readonly[1|3, _.Branch5<T>]
+type FirstBranch5<T> = readonly[1|3, Branch5<T>]
 
 type First<T> = FirstLeaf1<T> | FirstBranch3<T> | FirstLeaf2<T> | FirstBranch5<T>
 
-type PathItem3<T> = readonly[0|2, _.Branch3<T>]
+type PathItem3<T> = readonly[0|2, Branch3<T>]
 
-type PathItem5<T> = readonly[0|2|4, _.Branch5<T>]
+type PathItem5<T> = readonly[0|2|4, Branch5<T>]
 
 export type PathItem<T> = PathItem3<T> | PathItem5<T>
 
 const child
-= <T>(item: PathItem<T>): _.TNode<T> => (item[1][item[0]] as _.TNode<T>)
+= <T>(item: PathItem<T>): TNode<T> => (item[1][item[0]] as TNode<T>)
 
 export type Path<T> = List.List<PathItem<T>>
 
@@ -31,11 +31,11 @@ export type Result<T> = {
 }
 
 export const find
-= <T>(c: cmp.Compare<T>): (node: _.TNode<T>) => Result<T> => {
+= <T>(c: Compare<T>): (node: TNode<T>) => Result<T> => {
     const i3 = index3(c)
     const i5 = index5(c)
     const f
-        = (tail: Path<T>) => (node: _.TNode<T>): Result<T> => {
+        = (tail: Path<T>) => (node: TNode<T>): Result<T> => {
         const append
             : (index: Array.KeyOf<typeof node>) => Result<T>
             = index => {

--- a/types/btree/find/test.f.ts
+++ b/types/btree/find/test.f.ts
@@ -3,8 +3,7 @@ import * as list from '../../list/module.f.ts'
 import * as json from '../../../json/module.f.ts'
 import { sort } from '../../object/module.f.ts'
 import type * as btree from '../types/module.f.ts'
-import * as string from '../../string/module.f.ts'
-const { cmp } = string
+import { cmp } from '../../string/module.f.ts'
 import * as s from '../set/module.f.ts'
 
 const jsonStr = json.stringify(sort)

--- a/types/btree/module.f.ts
+++ b/types/btree/module.f.ts
@@ -1,33 +1,31 @@
 import { flat, type List, type Thunk } from '../list/module.f.ts'
 import { map } from '../nullable/module.f.ts'
-import type * as _ from './types/module.f.ts'
+import type { TNode, Tree } from './types/module.f.ts'
 
-const nodeValues
-    : <T>(node: _.TNode<T>) => Thunk<T>
+const nodeValues: <T>(node: TNode<T>) => Thunk<T>
     = node => () => {
-    switch (node.length) {
-        case 1: case 2: { return node }
-        case 3: {
-            return flat([
-                nodeValues(node[0]),
-                [node[1]],
-                nodeValues(node[2])
-            ])
-        }
-        default: {
-            return flat([
-                nodeValues(node[0]),
-                [node[1]],
-                nodeValues(node[2]),
-                [node[3]],
-                nodeValues(node[4])
-            ])
+        switch (node.length) {
+            case 1: case 2: { return node }
+            case 3: {
+                return flat([
+                    nodeValues(node[0]),
+                    [node[1]],
+                    nodeValues(node[2])
+                ])
+            }
+            default: {
+                return flat([
+                    nodeValues(node[0]),
+                    [node[1]],
+                    nodeValues(node[2]),
+                    [node[3]],
+                    nodeValues(node[4])
+                ])
+            }
         }
     }
-}
 
 export const empty = null
 
-export const values
-    : <T>(tree: _.Tree<T>) => List<T>
+export const values: <T>(tree: Tree<T>) => List<T>
     = map(nodeValues)

--- a/types/btree/remove/module.f.ts
+++ b/types/btree/remove/module.f.ts
@@ -1,9 +1,9 @@
-import * as _ from '../types/module.f.ts'
-import * as Cmp from '../../function/compare/module.f.ts'
+import type * as _ from '../types/module.f.ts'
+import type * as Cmp from '../../function/compare/module.f.ts'
 import * as find from '../find/module.f.ts'
 import * as list from '../../list/module.f.ts'
 const { fold, concat, next } = list
-import * as Array from '../../array/module.f.ts'
+import type * as Array from '../../array/module.f.ts'
 import * as n from '../../nullable/module.f.ts'
 const { map } = n
 

--- a/types/btree/remove/test.f.ts
+++ b/types/btree/remove/test.f.ts
@@ -1,25 +1,21 @@
 import * as _ from './module.f.ts'
-import type * as BTree from '../types/module.f.ts'
+import type { TNode } from '../types/module.f.ts'
 import * as s from '../set/module.f.ts'
-import * as str from '../../string/module.f.ts'
-const { cmp } = str
+import { cmp } from '../../string/module.f.ts'
 import * as json from '../../../json/module.f.ts'
-import * as o from '../../object/module.f.ts'
-const { sort } = o
+import { sort } from '../../object/module.f.ts'
 
-const set = (node: BTree.TNode<string>) => (value: string) =>
+const set = (node: TNode<string>) => (value: string) =>
     s.set(cmp(value))(() => value)(node)
 
 const remove
-    = (node: BTree.TNode<string>) => (value: string): BTree.TNode<string> | null =>
+    = (node: TNode<string>) => (value: string): TNode<string> | null =>
         _.nodeRemove(cmp(value))(node)
 
 const jsonStr = json.stringify(sort)
 
 const test = () => {
-    let _map
-        : BTree.TNode<string> | null
-        = ['1']
+    let _map: TNode<string> | null = ['1']
     for (let i = 2; i <= 38; i++)
         _map = set(_map)((i * i).toString())
     {
@@ -413,9 +409,7 @@ const test = () => {
 }
 
 const test2 = () => {
-    let _map
-        : BTree.TNode<string>|null
-        = ['1']
+    let _map: TNode<string>|null = ['1']
     for (let i = 2; i <= 10; i++)
         _map = set(_map)((i * i).toString())
     if (_map.length !== 3) { throw _map }

--- a/types/btree/set/module.f.ts
+++ b/types/btree/set/module.f.ts
@@ -1,9 +1,7 @@
-import * as _ from '../types/module.f.ts'
-import * as btreeFind from '../find/module.f.ts'
-const { find } = btreeFind
-import * as Cmp from '../../function/compare/module.f.ts'
-import * as list from '../../list/module.f.ts'
-const { fold } = list
+import type * as _ from '../types/module.f.ts'
+import { find, type PathItem } from '../find/module.f.ts'
+import type * as Cmp from '../../function/compare/module.f.ts'
+import { fold } from '../../list/module.f.ts'
 
 type Branch1To3<T> = _.Branch1<T> | _.Branch3<T>
 
@@ -12,7 +10,7 @@ const b57
     = b => b.length === 5 ? [b] : [[b[0], b[1], b[2]], b[3], [b[4], b[5], b[6]]]
 
 const reduceOp
-    : <T>(i: btreeFind.PathItem<T>) => (a: Branch1To3<T>) => Branch1To3<T>
+    : <T>(i: PathItem<T>) => (a: Branch1To3<T>) => Branch1To3<T>
     = ([i, x]) => a => {
     switch (i) {
         case 0: {

--- a/types/btree/set/test.f.ts
+++ b/types/btree/set/test.f.ts
@@ -1,19 +1,17 @@
 import * as _ from './module.f.ts'
-import type * as BTree from '../types/module.f.ts'
+import type { TNode } from '../types/module.f.ts'
 import { cmp } from '../../string/module.f.ts'
 import * as json from '../../../json/module.f.ts'
 import { sort } from '../../object/module.f.ts'
 
-const set = (node: BTree.TNode<string>) => (value: string): BTree.TNode<string> =>
+const set = (node: TNode<string>) => (value: string): TNode<string> =>
     _.set(cmp(value))(() => value)(node)
 
 const jsonStr = json.stringify(sort)
 
 const test = [
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 10; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -21,9 +19,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 11; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -31,9 +27,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 12; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -41,9 +35,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 13; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -51,9 +43,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 14; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -61,9 +51,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 15; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -71,9 +59,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 16; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -81,9 +67,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 17; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -91,9 +75,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 18; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -103,9 +85,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 19; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -115,9 +95,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 20; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -129,9 +107,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 21; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -143,9 +119,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 22; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -157,9 +131,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 23; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -171,9 +143,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 24; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -185,9 +155,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 25; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -199,9 +167,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 26; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -215,9 +181,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 27; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -231,9 +195,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 28; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -247,9 +209,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 29; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -263,9 +223,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 30; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -279,9 +237,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 31; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -295,9 +251,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 32; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -311,9 +265,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 33; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -327,9 +279,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 34; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -343,9 +293,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 35; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -359,9 +307,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 36; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -375,9 +321,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 37; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)
@@ -391,9 +335,7 @@ const test = [
     },
 
     () => {
-        let _map
-            : BTree.TNode<string>
-            = ['1']
+        let _map: TNode<string> = ['1']
         for (let i = 2; i <= 38; i++)
             _map = set(_map)((i * i).toString())
         const r = jsonStr(_map)

--- a/types/btree/test.f.ts
+++ b/types/btree/test.f.ts
@@ -1,52 +1,43 @@
-import type * as BTree from './types/module.f.ts'
-import * as _ from './module.f.ts'
-const { values } = _
+import type { TNode } from './types/module.f.ts'
+import { values } from './module.f.ts'
 import * as json from '../../json/module.f.ts'
-import * as o from '../object/module.f.ts'
-const { sort } = o
-import * as str from '../string/module.f.ts'
-const { cmp } = str
-import * as list from '../list/module.f.ts'
+import { sort } from '../object/module.f.ts'
+import { cmp } from '../string/module.f.ts'
+import { next, toArray, type List, type Result } from '../list/module.f.ts'
 import * as s from './set/module.f.ts'
 import * as f from './find/module.f.ts'
 
 const jsonStr = json.stringify(sort)
 
 const stringify
-    : (sequence: list.List<json.Unknown>) => string
-    = sequence => jsonStr(list.toArray(sequence))
+    : (sequence: List<json.Unknown>) => string
+    = sequence => jsonStr(toArray(sequence))
 
 const set
-    : (node: BTree.TNode<string>) => (value: string) => BTree.TNode<string>
+    : (node: TNode<string>) => (value: string) => TNode<string>
     = node => value => s.set(cmp(value))(() => value)(node)
 
 const valueTest1 =() => {
-    let _map
-        : BTree.TNode<string>
-        = ['a']
+    let _map: TNode<string> = ['a']
     _map = set(_map)('b')
     _map = set(_map)('c')
     _map = set(_map)('d')
     _map = set(_map)('e')
     _map = set(_map)('f')
-    let result = stringify(values(_map))
+    const result = stringify(values(_map))
     if (result !== '["a","b","c","d","e","f"]') { throw result }
 }
 
 const valuesTest2 = () => {
-    let _map
-        : BTree.TNode<string>
-        = ['1']
+    let _map: TNode<string> = ['1']
     for(let i = 2; i <= 10; i++)
         _map = set(_map)((i*i).toString())
-    let result = stringify(values(_map))
+    const result = stringify(values(_map))
     if (result !== '["1","100","16","25","36","4","49","64","81","9"]') { throw result }
 }
 
 const findTrue = () => {
-    let _map
-        : BTree.TNode<string>
-        = ['a']
+    let _map: TNode<string> = ['a']
     _map = set(_map)('b')
     _map = set(_map)('c')
     const result = f.value(f.find(cmp('b'))(_map).first)
@@ -54,9 +45,7 @@ const findTrue = () => {
 }
 
 const find = () => {
-    let _map
-        : BTree.TNode<string>
-        = ['a']
+    let _map: TNode<string> = ['a']
     _map = set(_map)('b')
     _map = set(_map)('c')
     const result = f.value(f.find(cmp('e'))(_map).first)
@@ -64,9 +53,7 @@ const find = () => {
 }
 
 const test = () => {
-    let _map
-        : BTree.TNode<string>
-        = ['a']
+    let _map: TNode<string> = ['a']
     _map = set(_map)('b')
     _map = set(_map)('c')
     _map = set(_map)('d')
@@ -74,11 +61,9 @@ const test = () => {
     _map = set(_map)('f')
     //
     {
-        let _item
-            : list.Result<string>
-            = list.next(values(_map))
+        let _item: Result<string> = next(values(_map))
         while (_item !== null) {
-            _item = list.next(_item.tail)
+            _item = next(_item.tail)
         }
     }
 }

--- a/types/btree/types/module.f.ts
+++ b/types/btree/types/module.f.ts
@@ -1,14 +1,4 @@
-export type Array1<T> = readonly[T]
-
-export type Array2<T> = readonly[T,T]
-
-export type Array3<T> = readonly[T,T,T]
-
-type Index2 = 0|1
-
-type Index3 = 0|1|2
-
-type Index5 = 0|1|2|3|4
+import type { Array1, Array2 } from '../../array/module.f.ts'
 
 export type Leaf1<T> = Array1<T>
 

--- a/types/byte_set/module.f.ts
+++ b/types/byte_set/module.f.ts
@@ -1,8 +1,7 @@
 import { compose } from '../function/module.f.ts'
-import type * as RangeMap from '../range_map/module.f.ts'
-import type * as SortedSet from '../sorted_set/module.f.ts'
-import * as list from '../list/module.f.ts'
-const { reverse, countdown, flat, map } = list
+import type { RangeMap } from '../range_map/module.f.ts'
+import type { SortedSet } from '../sorted_set/module.f.ts'
+import { reverse, countdown, flat, map } from '../list/module.f.ts'
 
 export type ByteSet = bigint
 type Byte = number
@@ -61,7 +60,7 @@ export const unset
 const counter = reverse(countdown(256))
 
 const toRangeMapOp
-    : (n: ByteSet) => (s: string) => (i: number) => RangeMap.RangeMap<SortedSet.SortedSet<string>>
+    : (n: ByteSet) => (s: string) => (i: number) => RangeMap<SortedSet<string>>
     = n => s => i => {
     const current = has(i + 1)(n)
     const prev = has(i)(n)
@@ -69,5 +68,5 @@ const toRangeMapOp
 }
 
 export const toRangeMap
-    : (n: ByteSet) => (s: string) => RangeMap.RangeMap<SortedSet.SortedSet<string>>
+    : (n: ByteSet) => (s: string) => RangeMap<SortedSet<string>>
     = n => s => flat(map(toRangeMapOp(n)(s))(counter))

--- a/types/byte_set/module.f.ts
+++ b/types/byte_set/module.f.ts
@@ -17,56 +17,45 @@ export const empty = 0n
 //                        0    1    2    3    4    5    6    7    8    9    A    B    C    D    E    F
 export const universe = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFFn
 
-export const one
-    : (n: Byte) => ByteSet
+export const one: (n: Byte) => ByteSet
     = n => 1n << BigInt(n)
 
-export const range
-    : (r: readonly[Byte, Byte]) => ByteSet
+export const range: (r: readonly[Byte, Byte]) => ByteSet
     = ([b, e]) => one(e - b + 1) - 1n << BigInt(b)
 
 // set operations
 
-export const union
-    : (a: ByteSet) => (b: ByteSet) => ByteSet
+export const union: (a: ByteSet) => (b: ByteSet) => ByteSet
     = a => b => a | b
 
-const intersect
-    : (a: ByteSet) => (b: ByteSet) => ByteSet
+const intersect: (a: ByteSet) => (b: ByteSet) => ByteSet
     = a => b => a & b
 
-export const complement
-    : (n: ByteSet) => ByteSet
+export const complement: (n: ByteSet) => ByteSet
     = n => universe ^ n
 
-const difference
-    : (a: ByteSet) => (b: ByteSet) => ByteSet
+const difference: (a: ByteSet) => (b: ByteSet) => ByteSet
     = compose(intersect)(compose(complement))
 
 // additional operations
 
-export const set
-    : (_: number) => (b: ByteSet) => ByteSet
+export const set: (_: number) => (b: ByteSet) => ByteSet
     = compose(one)(union)
 
-export const setRange
-    : (_: readonly [number, number]) => (b: ByteSet) => ByteSet
+export const setRange: (_: readonly [number, number]) => (b: ByteSet) => ByteSet
     = compose(range)(union)
 
-export const unset
-    : (n: Byte) => (s: ByteSet) => ByteSet
+export const unset: (n: Byte) => (s: ByteSet) => ByteSet
     = n => s => difference(s)(one(n))
 
 const counter = reverse(countdown(256))
 
-const toRangeMapOp
-    : (n: ByteSet) => (s: string) => (i: number) => RangeMap<SortedSet<string>>
+const toRangeMapOp: (n: ByteSet) => (s: string) => (i: number) => RangeMap<SortedSet<string>>
     = n => s => i => {
-    const current = has(i + 1)(n)
-    const prev = has(i)(n)
-    return current === prev ? null : [[prev ? [s] : [], i]]
-}
+        const current = has(i + 1)(n)
+        const prev = has(i)(n)
+        return current === prev ? null : [[prev ? [s] : [], i]]
+    }
 
-export const toRangeMap
-    : (n: ByteSet) => (s: string) => RangeMap<SortedSet<string>>
+export const toRangeMap: (n: ByteSet) => (s: string) => RangeMap<SortedSet<string>>
     = n => s => flat(map(toRangeMapOp(n)(s))(counter))

--- a/types/byte_set/test.f.ts
+++ b/types/byte_set/test.f.ts
@@ -1,9 +1,7 @@
 import * as _ from './module.f.ts'
-import * as list from '../list/module.f.ts'
-const { every, countdown, map, toArray } = list
+import { every, countdown, map, toArray } from '../list/module.f.ts'
 import * as json from '../../json/module.f.ts'
-import * as o from '../object/module.f.ts'
-const { sort } = o
+import { sort } from '../object/module.f.ts'
 
 const stringify
     : (a: readonly json.Unknown[]) => string

--- a/types/function/compare/module.f.ts
+++ b/types/function/compare/module.f.ts
@@ -1,10 +1,4 @@
-import type * as Array from '../../array/module.f.ts'
-
-export type Index3 = Array.Index3
-
-export type Index5 = Array.Index5
-
-type Array2<T> = Array.Array2<T>
+import type { Index3, Index5, Array2 } from '../../array/module.f.ts'
 
 export type Sign = -1|0|1
 

--- a/types/function/operator/module.f.ts
+++ b/types/function/operator/module.f.ts
@@ -5,15 +5,12 @@ export type Fold<I, O> = Binary<I, O, O>
 export const join = (separator: string): Reduce<string> => value => prior =>
     `${prior}${separator}${value}`
 
-export const concat
-    : Reduce<string>
-    = i => acc =>
-        `${acc}${i}`
+export const concat: Reduce<string> = i => acc =>
+    `${acc}${i}`
 
 export type Unary<T, R> = (value: T) => R
 
-export const logicalNot
-    : Unary<boolean, boolean>
+export const logicalNot: Unary<boolean, boolean>
     = v => !v
 
 export type Equal<T> = Binary<T, T, boolean>
@@ -40,20 +37,16 @@ export type Reduce<T> = Fold<T, T>
 export const reduceToScan = <T>(op: Reduce<T>): Scan<T, T> => init =>
     [init, foldToScan(op)(init)]
 
-export const addition
-    : Reduce<number>
+export const addition: Reduce<number>
     = a => b => a + b
 
-export const min
-    : Reduce<number>
+export const min: Reduce<number>
     = a => b => a < b ? a : b
 
-export const max
-    : Reduce<number>
+export const max: Reduce<number>
     = a => b => a > b ? a : b
 
-export const increment
-    : (b: number) => number
+export const increment: (b: number) => number
     = addition(1)
 
 export const counter = () => increment

--- a/types/function/test.f.ts
+++ b/types/function/test.f.ts
@@ -1,14 +1,11 @@
 import { fn } from './module.f.ts'
 
 export default () => {
-    const f
-        : (x: string) => readonly[string]
+    const f: (x: string) => readonly[string]
         = x => [x]
-    const g
-        : (x: readonly[string]) => readonly[number]
+    const g: (x: readonly[string]) => readonly[number]
         = ([x]) => [x.length]
-    const w
-        : (x: readonly[number]) => number
+    const w: (x: readonly[number]) => number
         = ([x]) => x
 
     const r = fn(f).then(g).then(w).result

--- a/types/map/module.f.ts
+++ b/types/map/module.f.ts
@@ -1,20 +1,16 @@
-import type * as BtreeTypes from '../btree/types/module.f.ts'
+import type { Tree } from '../btree/types/module.f.ts'
 import { value, find } from '../btree/find/module.f.ts'
 import { set } from '../btree/set/module.f.ts'
 import { remove as btreeRemove } from '../btree/remove/module.f.ts'
 import { values } from '../btree/module.f.ts'
-import type * as Compare from '../function/compare/module.f.ts'
+import type { Sign } from '../function/compare/module.f.ts'
 import { cmp } from '../string/module.f.ts'
 import { fold, type List } from '../list/module.f.ts'
-import type * as Operator from '../function/operator/module.f.ts'
-
-export type Sign = Compare.Sign
-
-type Cmp<T> = Compare.Compare<T>
+import type { Reduce } from '../function/operator/module.f.ts'
 
 export type Entry<T> = readonly [string, T]
 
-export type Map<T> = BtreeTypes.Tree<Entry<T>>
+export type Map<T> = Tree<Entry<T>>
 
 const keyCmp
     : (a: string) => <T>(b: Entry<T>) => Sign
@@ -28,12 +24,12 @@ export const at
     }
 
 const setReduceEntry
-    : <T>(reduce: Operator.Reduce<T>) => (entry: Entry<T>) => (map: Map<T>) => Map<T>
+    : <T>(reduce: Reduce<T>) => (entry: Entry<T>) => (map: Map<T>) => Map<T>
     = reduce => entry =>
         set(keyCmp(entry[0]))(old => old === null ? entry : [old[0], reduce(old[1])(entry[1])])
 
 export const setReduce
-    : <T>(reduce: Operator.Reduce<T>) => (name: string) => (value: T) => (map: Map<T>) => Map<T>
+    : <T>(reduce: Reduce<T>) => (name: string) => (value: T) => (map: Map<T>) => Map<T>
     = reduce => name => value => setReduceEntry(reduce)([name, value])
 
 const replace

--- a/types/map/test.f.ts
+++ b/types/map/test.f.ts
@@ -1,5 +1,5 @@
 import { at, setReplace, setReduce, empty, entries, remove, type Map } from './module.f.ts'
-import * as seq from '../list/module.f.ts'
+import { toArray } from '../list/module.f.ts'
 
 export default {
     main: [
@@ -52,7 +52,7 @@ export default {
             if (at('x')(m) !== 12) { throw 'error' }
             if (at('y')(m) !== 44) { throw 'error' }
             if (at('a')(m) !== null) { throw 'error' }
-            const e = seq.toArray(entries(m))
+            const e = toArray(entries(m))
             if (e.length !== 2) { throw 'error' }
         },
     ],

--- a/types/monoid/module.f.ts
+++ b/types/monoid/module.f.ts
@@ -72,19 +72,18 @@ export type Monoid<T> = {
  * const resultConcat = repeat(concat)('ha')(3n) // 'hahaha'
  * ```
  */
-export const repeat
-    = <T>({ identity, operation }: Monoid<T>) => (a: T) => (n: bigint): T => {
-        let ai = a
-        let ni = n
-        let result = identity
-        while (true) {
-            if ((ni & 1n) !== 0n) {
-                result = operation(result)(ai)
-            }
-            ni >>= 1n
-            if (ni === 0n) {
-                return result
-            }
-            ai = operation(ai)(ai)
+export const repeat = <T>({ identity, operation }: Monoid<T>) => (a: T) => (n: bigint): T => {
+    let ai = a
+    let ni = n
+    let result = identity
+    while (true) {
+        if ((ni & 1n) !== 0n) {
+            result = operation(result)(ai)
         }
+        ni >>= 1n
+        if (ni === 0n) {
+            return result
+        }
+        ai = operation(ai)(ai)
     }
+}

--- a/types/nibble_set/module.f.ts
+++ b/types/nibble_set/module.f.ts
@@ -5,30 +5,23 @@ export const empty = 0
 
 export const universe = 0xFFFF
 
-const one
-    : (n: Nibble) => NibbleSet
+const one: (n: Nibble) => NibbleSet
     = n => 1 << n
 
-export const has
-    : (n: Nibble) => (s: NibbleSet) => boolean
+export const has: (n: Nibble) => (s: NibbleSet) => boolean
     = n => s => ((s >> n) & 1) === 1
 
-export const set
-    : (n: Nibble) => (s: NibbleSet) => NibbleSet
+export const set: (n: Nibble) => (s: NibbleSet) => NibbleSet
     = n => s => s | one(n)
 
-export const complement
-    : (n: NibbleSet) => NibbleSet
+export const complement: (n: NibbleSet) => NibbleSet
     = s => universe ^ s
 
-export const unset
-    : (n: Nibble) => (s: NibbleSet) => NibbleSet
+export const unset: (n: Nibble) => (s: NibbleSet) => NibbleSet
     = n => s => s & complement(one(n))
 
-const range
-    : (r: readonly [number, number]) => NibbleSet
+const range: (r: readonly [number, number]) => NibbleSet
     = ([a, b]) => one(b - a + 1) - 1 << a
 
-export const setRange
-    : (r: readonly [number, number]) => (s: NibbleSet) => NibbleSet
+export const setRange: (r: readonly [number, number]) => (s: NibbleSet) => NibbleSet
     = r => s => s | range(r)

--- a/types/nibble_set/test.f.ts
+++ b/types/nibble_set/test.f.ts
@@ -1,56 +1,56 @@
 import { every, map, countdown } from '../list/module.f.ts'
-import * as _ from './module.f.ts'
+import { empty, has, set, setRange, unset, universe, complement } from './module.f.ts'
 
 export default {
     has: () => {
-        if (_.has(0)(_.empty)) { throw _.empty }
-        if (_.has(1)(_.empty)) { throw _.empty }
-        if (_.has(15)(_.empty)) { throw _.empty }
+        if (has(0)(empty)) { throw empty }
+        if (has(1)(empty)) { throw empty }
+        if (has(15)(empty)) { throw empty }
     },
     set: [
         () => {
-            const s = _.set(0)(_.empty)
+            const s = set(0)(empty)
             if(s !== 1) { throw s }
-            if(!_.has(0)(s)) { throw s }
-            if (_.has(1)(s)) { throw s }
-            if (_.has(15)(s)) { throw s }
+            if(!has(0)(s)) { throw s }
+            if (has(1)(s)) { throw s }
+            if (has(15)(s)) { throw s }
         },
         () => {
-            const s = _.set(15)(_.empty)
+            const s = set(15)(empty)
             if (s !== 0x8000) { throw s }
-            if (_.has(0)(s)) { throw s }
-            if (_.has(1)(s)) { throw s }
-            if (!_.has(15)(s)) { throw s }
+            if (has(0)(s)) { throw s }
+            if (has(1)(s)) { throw s }
+            if (!has(15)(s)) { throw s }
         }
     ],
     unset: () => [
         () => {
-            const a = _.set(0)(_.empty)
-            const result = _.unset(0)(a)
+            const a = set(0)(empty)
+            const result = unset(0)(a)
             if (result !== 0) { throw result }
         },
         () => {
-            const a = _.set(15)(_.empty)
-            const result = _.unset(15)(a)
+            const a = set(15)(empty)
+            const result = unset(15)(a)
             if (result !== 0) { throw result }
         }
     ],
     setRange: () => {
-        const result = _.setRange([2, 5])(_.empty)
+        const result = setRange([2, 5])(empty)
         if (result !== 60) { throw result }
     },
     universe: () => {
-        const x = every(map((v: number) => _.has(v)(_.universe))(countdown(16)))
+        const x = every(map((v: number) => has(v)(universe))(countdown(16)))
         if (!x) { throw x }
     },
     compliment: {
         empty: () => {
-            const r = _.complement(_.empty)
-            if (r !== _.universe) { throw r }
+            const r = complement(empty)
+            if (r !== universe) { throw r }
         },
         universe: () => {
-            const r = _.complement(_.universe)
-            if (r !== _.empty) { throw r }
+            const r = complement(universe)
+            if (r !== empty) { throw r }
         },
     }
 }

--- a/types/nullable/module.f.ts
+++ b/types/nullable/module.f.ts
@@ -1,9 +1,7 @@
 export type Nullable<T> = T | null
 
-export const map
-    : <T, R>(f: (value: T) => R) => (value: Nullable<T>) => Nullable<R>
+export const map: <T, R>(f: (value: T) => R) => (value: Nullable<T>) => Nullable<R>
     = f => value => value === null ? null : f(value)
 
-export const match
-    : <T, R>(f: (_: T) => R) => (none: () => R) => (_: Nullable<T>) => Nullable<R>
+export const match: <T, R>(f: (_: T) => R) => (none: () => R) => (_: Nullable<T>) => Nullable<R>
     = f => none => value => value === null ? none() : f(value)

--- a/types/nullable/test.f.ts
+++ b/types/nullable/test.f.ts
@@ -1,7 +1,7 @@
-import * as _ from './module.f.ts'
+import { map } from './module.f.ts'
 
 export default () => {
-    const optionSq = _.map((v: number) => v * v)
+    const optionSq = map((v: number) => v * v)
     const sq3 = optionSq(3)
     if (sq3 !== 9) { throw sq3 }
     const sqNull = optionSq(null)

--- a/types/number/module.f.ts
+++ b/types/number/module.f.ts
@@ -1,20 +1,15 @@
 import { reduce, type List } from '../list/module.f.ts'
 import { addition, min as minOp, max as maxOp } from '../function/operator/module.f.ts'
-import * as compare from '../function/compare/module.f.ts'
-const { unsafeCmp } = compare
+import { unsafeCmp, type Sign } from '../function/compare/module.f.ts'
 
-export const sum
-    : (input: List<number>) => number
+export const sum: (input: List<number>) => number
     = reduce(addition)(0)
 
-export const min
-    : (input: List<number>) => number | null
+export const min: (input: List<number>) => number | null
     = reduce(minOp)(null)
 
-export const max
-    : (input: List<number>) => number | null
+export const max: (input: List<number>) => number | null
     = reduce(maxOp)(null)
 
-export const cmp
-    : (a: number) => (b: number) => compare.Sign
+export const cmp: (a: number) => (b: number) => Sign
     = unsafeCmp

--- a/types/object/module.f.ts
+++ b/types/object/module.f.ts
@@ -9,21 +9,17 @@ export type Map<T> = {
 
 export type Entry<T> = readonly[string, T]
 
-export const at
-    : (name: string) => <T>(object: Map<T>) => T|null
+export const at: (name: string) => <T>(object: Map<T>) => T|null
     = name => object => {
-    const r = getOwnPropertyDescriptor(object, name)
-    return r === void 0 ? null : r.value
-}
+        const r = getOwnPropertyDescriptor(object, name)
+        return r === void 0 ? null : r.value
+    }
 
-export const sort
-    : <T>(e: List<Entry<T>>) => List<Entry<T>>
+export const sort: <T>(e: List<Entry<T>>) => List<Entry<T>>
     = e => mapEntries(mapFromEntries(e))
 
-export const fromEntries
-    : <T>(e: List<Entry<T>>) => Map<T>
+export const fromEntries: <T>(e: List<Entry<T>>) => Map<T>
     = e => objectFromEntries(iterable(e))
 
-export const fromMap
-    : <T>(m: BtMap<T>) => Map<T>
+export const fromMap: <T>(m: BtMap<T>) => Map<T>
     = m => fromEntries(mapEntries(m))

--- a/types/object/test.f.ts
+++ b/types/object/test.f.ts
@@ -1,14 +1,14 @@
-import * as _ from './module.f.ts'
+import { at } from './module.f.ts'
 
 export default {
     ctor: () => {
         const a = {}
-        const value = _.at('constructor')(a)
+        const value = at('constructor')(a)
         if (value !== null) { throw value }
     },
     property: () => {
         const a = { constructor: 42 }
-        const value = _.at('constructor')(a)
+        const value = at('constructor')(a)
         if (value !== 42) { throw value }
     }
 }

--- a/types/range/module.f.ts
+++ b/types/range/module.f.ts
@@ -1,4 +1,3 @@
-
 export type Range = readonly [number, number]
 
 export const contains: (range: Range) => (i: number) => boolean

--- a/types/range/module.f.ts
+++ b/types/range/module.f.ts
@@ -1,10 +1,8 @@
 
 export type Range = readonly [number, number]
 
-export const contains
-    : (range: Range) => (i: number) => boolean
+export const contains: (range: Range) => (i: number) => boolean
     = ([b, e]) => i => b <= i && i <= e
 
-export const one
-    : (i: number) => Range
+export const one: (i: number) => Range
     = a => [a, a]

--- a/types/range/test.f.ts
+++ b/types/range/test.f.ts
@@ -1,9 +1,9 @@
-import * as _ from './module.f.ts'
+import { contains } from './module.f.ts'
 
 export default () => {
-    if (!_.contains([0, 5])(1)) { throw 1 }
-    if (!_.contains([0, 5])(0)) { throw 0 }
-    if (!_.contains([0, 5])(5)) { throw 5 }
-    if (_.contains([0, 5])(-1)) { throw -1 }
-    if (_.contains([0, 5])(6)) { throw 6 }
+    if (!contains([0, 5])(1)) { throw 1 }
+    if (!contains([0, 5])(0)) { throw 0 }
+    if (!contains([0, 5])(5)) { throw 5 }
+    if (contains([0, 5])(-1)) { throw -1 }
+    if (contains([0, 5])(6)) { throw 6 }
 }

--- a/types/range_map/module.f.ts
+++ b/types/range_map/module.f.ts
@@ -2,7 +2,7 @@ import { genericMerge, type TailReduce, type ReduceOp, type SortedList } from '.
 import { next } from '../list/module.f.ts'
 import type * as Option from '../nullable/module.f.ts'
 import { cmp } from '../number/module.f.ts'
-import type * as O from '../function/operator/module.f.ts'
+import type { Reduce, Equal } from '../function/operator/module.f.ts'
 import type * as Range from '../range/module.f.ts'
 
 export type Entry<T> = [T, number]
@@ -12,16 +12,15 @@ export type RangeMap<T> = SortedList<Entry<T>>
 export type RangeMapArray<T> = readonly Entry<T>[]
 
 export type Operators<T> = {
-    readonly union: O.Reduce<T>
-    readonly equal: O.Equal<T>
+    readonly union: Reduce<T>
+    readonly equal: Equal<T>
 }
 
 type RangeState<T> = Option.Nullable<Entry<T>>
 
-export type RangeMerge<T> = O.Reduce<RangeMap<T>>
+export type RangeMerge<T> = Reduce<RangeMap<T>>
 
-const reduceOp
-    : <T>(union: O.Reduce<T>) => (equal: O.Equal<T>) => ReduceOp<Entry<T>, RangeState<T>>
+const reduceOp: <T>(union: Reduce<T>) => (equal: Equal<T>) => ReduceOp<Entry<T>, RangeState<T>>
     = union => equal => state => ([aItem, aMax]) => ([bItem, bMax]) => {
         const sign = cmp(aMax)(bMax)
         const min = sign === 1 ? bMax : aMax
@@ -30,8 +29,7 @@ const reduceOp
         return [newState, sign, [u, min]]
     }
 
-const tailReduce
-    : <T>(equal: O.Equal<T>) => TailReduce<Entry<T>, RangeState<T>>
+const tailReduce: <T>(equal: Equal<T>) => TailReduce<Entry<T>, RangeState<T>>
     = equal => state => tail => {
         if (state === null) { return tail }
         const tailResult = next(tail)
@@ -40,12 +38,10 @@ const tailReduce
         return { first: state, tail: tailResult }
     }
 
-export const merge
-    : <T>(op: Operators<T>) => RangeMerge<T>
+export const merge: <T>(op: Operators<T>) => RangeMerge<T>
     = ({ union, equal }) => genericMerge({ reduceOp: reduceOp(union)(equal), tailReduce: tailReduce(equal) })(null)
 
-export const get
-    : <T>(def: T) => (value: number) => (rm: RangeMapArray<T>) => T
+export const get: <T>(def: T) => (value: number) => (rm: RangeMapArray<T>) => T
     = def => value => rm => {
         const len = rm.length
         let b = 0
@@ -62,6 +58,5 @@ export const get
         }
     }
 
-export const fromRange
-    : <T>(def: T) => (r: Range.Range) => (value: T) => RangeMapArray<T>
+export const fromRange: <T>(def: T) => (r: Range.Range) => (value: T) => RangeMapArray<T>
     = def => ([a, b]) => v => [[def, a - 1], [v, b]]

--- a/types/range_map/module.f.ts
+++ b/types/range_map/module.f.ts
@@ -1,9 +1,9 @@
 import { genericMerge, type TailReduce, type ReduceOp, type SortedList } from '../sorted_list/module.f.ts'
 import { next } from '../list/module.f.ts'
-import type * as Option from '../nullable/module.f.ts'
+import type { Nullable } from '../nullable/module.f.ts'
 import { cmp } from '../number/module.f.ts'
 import type { Reduce, Equal } from '../function/operator/module.f.ts'
-import type * as Range from '../range/module.f.ts'
+import type { Range } from '../range/module.f.ts'
 
 export type Entry<T> = [T, number]
 
@@ -16,7 +16,7 @@ export type Operators<T> = {
     readonly equal: Equal<T>
 }
 
-type RangeState<T> = Option.Nullable<Entry<T>>
+type RangeState<T> = Nullable<Entry<T>>
 
 export type RangeMerge<T> = Reduce<RangeMap<T>>
 
@@ -58,5 +58,5 @@ export const get: <T>(def: T) => (value: number) => (rm: RangeMapArray<T>) => T
         }
     }
 
-export const fromRange: <T>(def: T) => (r: Range.Range) => (value: T) => RangeMapArray<T>
+export const fromRange: <T>(def: T) => (r: Range) => (value: T) => RangeMapArray<T>
     = def => ([a, b]) => v => [[def, a - 1], [v, b]]

--- a/types/range_map/test.f.ts
+++ b/types/range_map/test.f.ts
@@ -1,9 +1,7 @@
 import * as _ from './module.f.ts'
-import * as compare from '../function/compare/module.f.ts'
-const { unsafeCmp } = compare
+import { unsafeCmp } from '../function/compare/module.f.ts'
 import * as json from '../../json/module.f.ts'
-import * as object from '../object/module.f.ts'
-const { sort } = object
+import { sort } from '../object/module.f.ts'
 import * as sortedSet from '../sorted_set/module.f.ts'
 import * as list from '../list/module.f.ts'
 import * as operator from '../function/operator/module.f.ts'

--- a/types/result/module.f.ts
+++ b/types/result/module.f.ts
@@ -4,16 +4,13 @@ export type Error<E> = readonly ['error', E]
 
 export type Result<T, E> = Ok<T> | Error<E>
 
-export const ok
-    : <T>(value: T) => Ok<T>
+export const ok: <T>(value: T) => Ok<T>
     = value => ['ok', value]
 
-export const error
-    : <E>(e: E) => Error<E>
+export const error: <E>(e: E) => Error<E>
     = e => ['error', e]
 
-export const unwrap
-    : <T, E>(r: Result<T, E>) => T
+export const unwrap: <T, E>(r: Result<T, E>) => T
     = ([kind, v]) => {
         if (kind === 'error') { throw v }
         return v

--- a/types/result/module.ts
+++ b/types/result/module.ts
@@ -1,8 +1,7 @@
-import * as result from './module.f.ts'
-const { ok, error } = result
+import { ok, error, type Result } from './module.f.ts'
 
 const tryCatch
-    : <T>(f: () => T) => result.Result<T, unknown>
+    : <T>(f: () => T) => Result<T, unknown>
     = f => {
         // Side effect: `try catch` is not allowed in FunctionalScript.
         try {

--- a/types/sorted_list/module.f.ts
+++ b/types/sorted_list/module.f.ts
@@ -7,7 +7,7 @@ export type SortedList<T> = List<T>
 
 type SortedArray<T> = readonly T[]
 
-type Cmp<T> =(a: T) => (b: T) => compare.Sign
+type Cmp<T> = (a: T) => (b: T) => compare.Sign
 
 export type ReduceOp<T, S> = (state: S) => (a: T) => (b: T) => readonly[option.Nullable<T>, compare.Sign, S]
 

--- a/types/sorted_list/module.f.ts
+++ b/types/sorted_list/module.f.ts
@@ -1,15 +1,15 @@
-import type * as compare from '../function/compare/module.f.ts'
+import type { Sign } from '../function/compare/module.f.ts'
 import { type List, next } from '../list/module.f.ts'
-import type * as option from '../nullable/module.f.ts'
+import type { Nullable } from '../nullable/module.f.ts'
 import { identity } from '../function/module.f.ts'
 
 export type SortedList<T> = List<T>
 
 type SortedArray<T> = readonly T[]
 
-type Cmp<T> = (a: T) => (b: T) => compare.Sign
+type Cmp<T> = (a: T) => (b: T) => Sign
 
-export type ReduceOp<T, S> = (state: S) => (a: T) => (b: T) => readonly[option.Nullable<T>, compare.Sign, S]
+export type ReduceOp<T, S> = (state: S) => (a: T) => (b: T) => readonly[Nullable<T>, Sign, S]
 
 export type TailReduce<T, S> = (state: S) => (tail: List<T>) => List<T>
 
@@ -21,21 +21,20 @@ type MergeReduce<T, S> = {
 export const genericMerge
     = <T,S>({ reduceOp, tailReduce }: MergeReduce<T,S>)
         : (state: S) => (a: List<T>) => (b: List<T>) => List<T> => {
-    const f
-        : (state: S) => (a: List<T>) => (b: List<T>) => List<T>
-        = state => a => b => () => {
-        const aResult = next(a)
-        if (aResult === null) { return tailReduce(state)(b) }
-        const bResult = next(b)
-        if (bResult === null) { return tailReduce(state)(aResult) }
-        const [first, sign, stateNext] = reduceOp(state)(aResult.first)(bResult.first)
-        const aNext = sign === 1 ? a : aResult.tail
-        const bNext = sign === -1 ? b : bResult.tail
-        const tail = f(stateNext)(aNext)(bNext)
-        return first === null ? tail : { first, tail }
+        const f: (state: S) => (a: List<T>) => (b: List<T>) => List<T>
+            = state => a => b => () => {
+                const aResult = next(a)
+                if (aResult === null) { return tailReduce(state)(b) }
+                const bResult = next(b)
+                if (bResult === null) { return tailReduce(state)(aResult) }
+                const [first, sign, stateNext] = reduceOp(state)(aResult.first)(bResult.first)
+                const aNext = sign === 1 ? a : aResult.tail
+                const bNext = sign === -1 ? b : bResult.tail
+                const tail = f(stateNext)(aNext)(bNext)
+                return first === null ? tail : { first, tail }
+            }
+        return f
     }
-    return f
-}
 
 type CmpReduceOp<T> = ReduceOp<T, null>
 

--- a/types/sorted_list/test.f.ts
+++ b/types/sorted_list/test.f.ts
@@ -3,7 +3,6 @@ import { type Sign, unsafeCmp } from '../function/compare/module.f.ts'
 import * as json from '../../json/module.f.ts'
 import { sort } from '../object/module.f.ts'
 import { toArray, countdown, length } from '../list/module.f.ts'
-import type * as Map from '../map/module.f.ts'
 import { flip } from '../function/module.f.ts'
 
 const stringify

--- a/types/sorted_list/test.f.ts
+++ b/types/sorted_list/test.f.ts
@@ -1,4 +1,4 @@
-import * as _ from './module.f.ts'
+import { find, merge } from './module.f.ts'
 import { type Sign, unsafeCmp } from '../function/compare/module.f.ts'
 import * as json from '../../json/module.f.ts'
 import { sort } from '../object/module.f.ts'
@@ -14,36 +14,36 @@ const reverseCmp: <T>(a: T) => (b: T) => Sign
 export default {
     sortedMergre: [
         () => {
-            const result = stringify(toArray(_.merge(unsafeCmp)([2, 3, 4])([1, 3, 5])))
+            const result = stringify(toArray(merge(unsafeCmp)([2, 3, 4])([1, 3, 5])))
             if (result !== '[1,2,3,4,5]') { throw result }
         },
         () => {
-            const result = stringify(toArray(_.merge(unsafeCmp)([1, 2, 3])([])))
+            const result = stringify(toArray(merge(unsafeCmp)([1, 2, 3])([])))
             if (result !== '[1,2,3]') { throw result }
         },
         () => {
             const n = 10_000
             const list = countdown(n)
-            const result = _.merge(reverseCmp)(list)(list)
+            const result = merge(reverseCmp)(list)(list)
             const len = length(result)
             if (len != n) { throw result }
         }
     ],
     find: [
         () => {
-            const result = _.find(unsafeCmp)(0)([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+            const result = find(unsafeCmp)(0)([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
             if (result !== 0) { throw result }
         },
         () => {
-            const result = _.find(unsafeCmp)(3)([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+            const result = find(unsafeCmp)(3)([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
             if (result !== null) { throw result }
         },
         () => {
-            const result = _.find(unsafeCmp)(77)([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+            const result = find(unsafeCmp)(77)([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
             if (result !== null) { throw result }
         },
         () => {
-            const result = _.find(unsafeCmp)(80)([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+            const result = find(unsafeCmp)(80)([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
             if (result !== 80) { throw result }
         }
     ]

--- a/types/sorted_list/test.f.ts
+++ b/types/sorted_list/test.f.ts
@@ -5,12 +5,10 @@ import { sort } from '../object/module.f.ts'
 import { toArray, countdown, length } from '../list/module.f.ts'
 import { flip } from '../function/module.f.ts'
 
-const stringify
-    : (a: readonly json.Unknown[]) => string
+const stringify: (a: readonly json.Unknown[]) => string
     = json.stringify(sort)
 
-const reverseCmp
-    : <T>(a: T) => (b: T) => Sign
+const reverseCmp: <T>(a: T) => (b: T) => Sign
     = flip(unsafeCmp)
 
 export default {

--- a/types/sorted_list/test.f.ts
+++ b/types/sorted_list/test.f.ts
@@ -1,5 +1,5 @@
 import * as _ from './module.f.ts'
-import { unsafeCmp } from '../function/compare/module.f.ts'
+import { type Sign, unsafeCmp } from '../function/compare/module.f.ts'
 import * as json from '../../json/module.f.ts'
 import { sort } from '../object/module.f.ts'
 import { toArray, countdown, length } from '../list/module.f.ts'
@@ -11,7 +11,7 @@ const stringify
     = json.stringify(sort)
 
 const reverseCmp
-    : <T>(a: T) => (b: T) => Map.Sign
+    : <T>(a: T) => (b: T) => Sign
     = flip(unsafeCmp)
 
 export default {

--- a/types/sorted_set/module.f.ts
+++ b/types/sorted_set/module.f.ts
@@ -1,34 +1,29 @@
-import type * as Compare from '../function/compare/module.f.ts'
+import type { Sign } from '../function/compare/module.f.ts'
 import { toArray } from "../list/module.f.ts"
 import { merge, genericMerge, find, type SortedList, type ReduceOp } from '../sorted_list/module.f.ts'
 
 export type SortedSet<T> = readonly T[]
 
-type Cmp<T> = (a: T) => (b: T) => Compare.Sign
+type Cmp<T> = (a: T) => (b: T) => Sign
 
 type Byte = number
 
-export const union
-    : <T>(cmp: Cmp<T>) => (a: SortedSet<T>) => (b: SortedSet<T>) => SortedSet<T>
+export const union: <T>(cmp: Cmp<T>) => (a: SortedSet<T>) => (b: SortedSet<T>) => SortedSet<T>
     = cmp => a => b => toArray(merge(cmp)(a)(b))
 
-export const intersect
-    : <T>(cmp: Cmp<T>) => (a: SortedSet<T>) => (b: SortedSet<T>) => SortedSet<T>
+export const intersect: <T>(cmp: Cmp<T>) => (a: SortedSet<T>) => (b: SortedSet<T>) => SortedSet<T>
     = cmp => a => b => toArray(intersectMerge(cmp)(a)(b))
 
 const tailReduce = () => () => null
 
-const intersectMerge
-    : <T>(cmp: Cmp<T>) => (a: SortedList<T>) => (b: SortedList<T>) => SortedList<T>
+const intersectMerge: <T>(cmp: Cmp<T>) => (a: SortedList<T>) => (b: SortedList<T>) => SortedList<T>
     = cmp => genericMerge({ reduceOp: intersectReduce(cmp), tailReduce })(null)
 
-const intersectReduce
-    : <T, S>(cmp: Cmp<T>) => ReduceOp<T, S>
+const intersectReduce: <T, S>(cmp: Cmp<T>) => ReduceOp<T, S>
     = cmp => state => a => b => {
         const sign = cmp(a)(b)
         return [sign === 0 ? a : null, sign, state]
     }
 
-export const has
-    : <T>(cmp: Cmp<T>) => (value: T) => (set: SortedSet<T>) => boolean
+export const has: <T>(cmp: Cmp<T>) => (value: T) => (set: SortedSet<T>) => boolean
     = cmp => value => set => find(cmp)(value)(set) === value

--- a/types/sorted_set/test.f.ts
+++ b/types/sorted_set/test.f.ts
@@ -1,4 +1,4 @@
-import * as _ from './module.f.ts'
+import { has, intersect, union } from './module.f.ts'
 import { type Sign, unsafeCmp } from '../function/compare/module.f.ts'
 import * as json from '../../json/module.f.ts'
 import { sort } from '../object/module.f.ts'
@@ -16,46 +16,46 @@ const reverseCmp
 export default {
     union: [
         () => {
-            const result = stringify(toArray(_.union(unsafeCmp)([2, 3, 4])([1, 3, 5])))
+            const result = stringify(toArray(union(unsafeCmp)([2, 3, 4])([1, 3, 5])))
             if (result !== '[1,2,3,4,5]') { throw result }
         },
         () => {
-            const result = stringify(toArray(_.union(unsafeCmp)([1, 2, 3])([])))
+            const result = stringify(toArray(union(unsafeCmp)([1, 2, 3])([])))
             if (result !== '[1,2,3]') { throw result }
         },
         () => {
             const n = 10_000
             const sortedSet = toArray(countdown(n))
-            const result = _.union(reverseCmp)(sortedSet)(sortedSet)
+            const result = union(reverseCmp)(sortedSet)(sortedSet)
             const len = length(result)
             if (len != n) { throw result }
         }
     ],
     intersect: [
         () => {
-            const result = stringify(toArray(_.intersect(unsafeCmp)([2, 3, 4])([1, 3, 5])))
+            const result = stringify(toArray(intersect(unsafeCmp)([2, 3, 4])([1, 3, 5])))
             if (result !== '[3]') { throw result }
         },
         () => {
-            const result = stringify(toArray(_.intersect(unsafeCmp)([1, 2, 3])([])))
+            const result = stringify(toArray(intersect(unsafeCmp)([1, 2, 3])([])))
             if (result !== '[]') { throw result }
         }
     ],
     has: [
         () => {
-            const result = _.has(unsafeCmp)(0)([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+            const result = has(unsafeCmp)(0)([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
             if (!result) { throw result }
         },
         () => {
-            const result = _.has(unsafeCmp)(3)([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+            const result = has(unsafeCmp)(3)([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
             if (result) { throw result }
         },
         () => {
-            const result = _.has(unsafeCmp)(77)([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+            const result = has(unsafeCmp)(77)([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
             if (result) { throw result }
         },
         () => {
-            const result = _.has(unsafeCmp)(80)([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
+            const result = has(unsafeCmp)(80)([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
             if (!result) { throw result }
         }
     ]

--- a/types/sorted_set/test.f.ts
+++ b/types/sorted_set/test.f.ts
@@ -5,12 +5,10 @@ import { sort } from '../object/module.f.ts'
 import { toArray, countdown, length } from '../list/module.f.ts'
 import { flip } from '../function/module.f.ts'
 
-const stringify
-    : (a: readonly json.Unknown[]) => string
+const stringify: (a: readonly json.Unknown[]) => string
     = a => json.stringify(sort)(a)
 
-const reverseCmp
-    : <T>(a: T) => (b: T) => Sign
+const reverseCmp: <T>(a: T) => (b: T) => Sign
     = flip(unsafeCmp)
 
 export default {

--- a/types/sorted_set/test.f.ts
+++ b/types/sorted_set/test.f.ts
@@ -1,9 +1,8 @@
 import * as _ from './module.f.ts'
-import { unsafeCmp } from '../function/compare/module.f.ts'
+import { type Sign, unsafeCmp } from '../function/compare/module.f.ts'
 import * as json from '../../json/module.f.ts'
 import { sort } from '../object/module.f.ts'
 import { toArray, countdown, length } from '../list/module.f.ts'
-import type * as Map from '../map/module.f.ts'
 import { flip } from '../function/module.f.ts'
 
 const stringify
@@ -11,7 +10,7 @@ const stringify
     = a => json.stringify(sort)(a)
 
 const reverseCmp
-    : <T>(a: T) => (b: T) => Map.Sign
+    : <T>(a: T) => (b: T) => Sign
     = flip(unsafeCmp)
 
 export default {

--- a/types/string/module.f.ts
+++ b/types/string/module.f.ts
@@ -1,25 +1,19 @@
 import { type List, reduce as listReduce, repeat as listRepeat } from '../list/module.f.ts'
 import { compose } from '../function/module.f.ts'
-import * as compare from '../function/compare/module.f.ts'
-const { unsafeCmp } = compare
+import { unsafeCmp, type Sign } from '../function/compare/module.f.ts'
 import { join as joinOp, concat as concatOp, type Reduce } from '../function/operator/module.f.ts'
 
-const reduce
-    : (o: Reduce<string>) => (input: List<string>) => string
+const reduce: (o: Reduce<string>) => (input: List<string>) => string
     = o => listReduce(o)('')
 
-export const join
-    : (_: string) => (input: List<string>) => string
+export const join: (_: string) => (input: List<string>) => string
     = compose(joinOp)(reduce)
 
-export const concat
-    : (input: List<string>) => string
+export const concat: (input: List<string>) => string
     = reduce(concatOp)
 
-export const repeat
-    : (n: string) => (v: number) => string
+export const repeat: (n: string) => (v: number) => string
     = v => compose(listRepeat(v))(concat)
 
-export const cmp
-    : (a: string) => (b: string) => compare.Sign
+export const cmp: (a: string) => (b: string) => Sign
     = unsafeCmp

--- a/types/string_set/module.f.ts
+++ b/types/string_set/module.f.ts
@@ -1,4 +1,4 @@
-import type * as BtreeTypes from '../btree/types/module.f.ts'
+import type { Tree } from '../btree/types/module.f.ts'
 import * as btree from '../btree/module.f.ts'
 import { find, isFound } from '../btree/find/module.f.ts'
 import { remove as btreeRemove } from '../btree/remove/module.f.ts'
@@ -10,7 +10,7 @@ import { compose } from '../function/module.f.ts'
 export const values: (s: StringSet) => List<string> = btree.values
 export const empty: null = btree.empty
 
-export type StringSet = BtreeTypes.Tree<string>
+export type StringSet = Tree<string>
 
 export const contains
     : (value: string) => (set: StringSet) => boolean

--- a/types/string_set/test.f.ts
+++ b/types/string_set/test.f.ts
@@ -1,34 +1,34 @@
-import * as _ from './module.f.ts'
+import { contains, remove, set } from './module.f.ts'
 
 export default {
     contains: () => {
-        const r = _.set('hello')(null)
-        if (!_.contains('hello')(r)) { throw r }
-        if (_.contains('hello1')(r)) { throw r }
+        const r = set('hello')(null)
+        if (!contains('hello')(r)) { throw r }
+        if (contains('hello1')(r)) { throw r }
     },
     remove: () => {
-        let r = _.set('hello')(null)
-        r = _.set('world')(r)
-        r = _.set('HELLO')(r)
-        r = _.set('WORLD!')(r)
-        if (!_.contains('hello')(r)) { throw r }
-        if (_.contains('hello1')(r)) { throw r }
-        if (!_.contains('HELLO')(r)) { throw r }
-        if (_.contains('WORLD')(r)) { throw r }
-        if (!_.contains('world')(r)) { throw r }
-        if (_.contains('world!')(r)) { throw r }
-        if (!_.contains('WORLD!')(r)) { throw r }
+        let r = set('hello')(null)
+        r = set('world')(r)
+        r = set('HELLO')(r)
+        r = set('WORLD!')(r)
+        if (!contains('hello')(r)) { throw r }
+        if (contains('hello1')(r)) { throw r }
+        if (!contains('HELLO')(r)) { throw r }
+        if (contains('WORLD')(r)) { throw r }
+        if (!contains('world')(r)) { throw r }
+        if (contains('world!')(r)) { throw r }
+        if (!contains('WORLD!')(r)) { throw r }
         //
-        r = _.remove('hello')(r)
-        if (_.contains('hello')(r)) { throw r }
-        if (!_.contains('world')(r)) { throw r }
-        r = _.remove('world')(r)
-        if (_.contains('world')(r)) { throw r }
-        if (!_.contains('HELLO')(r)) { throw r }
-        r = _.remove('HELLO')(r)
-        if (_.contains('HELLO')(r)) { throw r }
-        if (!_.contains('WORLD!')(r)) { throw r }
-        r = _.remove('WORLD!')(r)
+        r = remove('hello')(r)
+        if (contains('hello')(r)) { throw r }
+        if (!contains('world')(r)) { throw r }
+        r = remove('world')(r)
+        if (contains('world')(r)) { throw r }
+        if (!contains('HELLO')(r)) { throw r }
+        r = remove('HELLO')(r)
+        if (contains('HELLO')(r)) { throw r }
+        if (!contains('WORLD!')(r)) { throw r }
+        r = remove('WORLD!')(r)
         if (r !== null) { throw r }
     }
 }


### PR DESCRIPTION
|Framework|str bin|str hex|old log2|log2|
|---------|-------|-------|--------|----|
|Bun      |    994|    458|    1038| 669|
|Deno 2   |   1884|    485|     240| 143|
|Deno 1   |   1878|    494|     268| 168|
|Node 23  |   1855|    558|     241| 138|
|Node 22  |   1863|    533|     225| 121|
|Node 20  |   1938|    561|     253| 129|
|Node 18  |   1888|    590|     243| 134|
|Node 16  |   1901|    560|     339| 213|

New `log2` wins on Deno and Node (V8) but slightly loses on Bun (WebKit).

**Browser Test**

|Browser|CPU|str bin|str hex|old log2|log2|
|-------|---|-------|-------|--------|----|
|Chrome |AMD|   1214|    334|     532| 369|
|Chrome | M1|    673|    176|     162| 106|
|Firefox|AMD|   1797|    323|    1704|1267|
|Firefox| M1|    788|    201|     910| 683|
|Safari | M1|    712|    180|     160| 106|