### PR TITLE
node.js 23 w/o `--experimental-strip-types`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ on:
   pull_request:
 
 jobs:
-  node22:
+  node20:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [16, 18, 20, 22]
+        node-version: [16, 18, 20]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -23,6 +23,17 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run test20
+
+  node22:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 22
     - run: npm ci
     - run: npm run test22
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ on:
   pull_request:
 
 jobs:
-  node20:
+  node22:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [16, 18, 20]
+        node-version: [16, 18, 20, 22]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -24,14 +24,14 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
-    - run: npm run test20
+    - run: npm run test22
 
   node:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: ['22.13', 23]
+        node-version: [23]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22, 23]
+        node-version: ['22.13', 23]
 
     steps:
     - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.12",
       "license": "AGPL-3.0-only",
       "devDependencies": {
-        "@types/node": "^22.10.2",
+        "@types/node": "^22.10.5",
         "typescript": "^5.7.2"
       }
     },
@@ -18,6 +18,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
       "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -27,6 +28,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -39,7 +41,8 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "functionalscript",
-  "version": "0.3.10",
+  "version": "0.3.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "functionalscript",
-      "version": "0.3.10",
+      "version": "0.3.12",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "@types/node": "^22.10.2",
@@ -14,9 +14,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.20.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/functionalscript/functionalscript#readme",
   "devDependencies": {
-    "@types/node": "^22.10.2",
+    "@types/node": "^22.10.5",
     "typescript": "^5.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "tsc-emit": "tsc --NoEmit false",
     "prepack": "npm run tsc-emit",
     "test20": "npm run prepack && node --trace-uncaught ./dev/test.js",
-    "test": "tsc && node --experimental-strip-types --trace-uncaught ./dev/test.ts",
-    "comtest": "node --experimental-strip-types ./com/test/build.ts",
-    "index": "node --experimental-strip-types ./dev/index.ts",
-    "version": "node --experimental-strip-types ./nodejs/version/main.ts",
-    "fsc": "node --experimental-strip-types ./main.ts"
+    "test": "tsc && node --trace-uncaught ./dev/test.ts",
+    "comtest": "node ./com/test/build.ts",
+    "index": "node ./dev/index.ts",
+    "version": "node ./nodejs/version/main.ts",
+    "fsc": "node ./main.ts"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "tsc-emit": "tsc --NoEmit false",
     "prepack": "npm run tsc-emit",
-    "test22": "npm run prepack && node --trace-uncaught ./dev/test.js",
+    "test20": "npm run prepack && node --trace-uncaught ./dev/test.js",
+    "test22": "tsc && node --experimental-strip-types --trace-uncaught ./dev/test.ts",
     "test": "tsc && node --trace-uncaught ./dev/test.ts",
     "comtest": "node ./com/test/build.ts",
     "index": "node ./dev/index.ts",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "tsc-emit": "tsc --NoEmit false",
     "prepack": "npm run tsc-emit",
-    "test20": "npm run prepack && node --trace-uncaught ./dev/test.js",
+    "test22": "npm run prepack && node --trace-uncaught ./dev/test.js",
     "test": "tsc && node --trace-uncaught ./dev/test.ts",
     "comtest": "node ./com/test/build.ts",
     "index": "node ./dev/index.ts",


### PR DESCRIPTION
For developers: if you use Node, update it to version `23.6` or higher! 

https://nodejs.org/en/download

Make sure:

```
> node -v
v23.6.0
```