### PR TITLE
Copy over elements of BigUint, BigInt from nanvm

### DIFF
--- a/nanvm-lib/src/big_int.rs
+++ b/nanvm-lib/src/big_int.rs
@@ -21,12 +21,21 @@ pub trait BigInt<U: Any<BigInt = Self>>: Complex<U> + Container<Header = Sign, I
     }
     fn add(self, other: Self) -> Self {
         if *self.header() == *other.header() {
-            Self::new(self.header().clone(), BigUint::add(self.items(), other.items()).value)
+            Self::new(
+                self.header().clone(),
+                BigUint::add(self.items(), other.items()).value,
+            )
         } else {
             match self.items().cmp(other.items()) {
                 Ordering::Equal => Self::zero(),
-                Ordering::Greater => Self::new(self.header().clone(), BigUint::sub(self.items(), other.items()).value),
-                Ordering::Less => Self::new(other.header().clone(), BigUint::sub(other.items(), self.items()).value),
+                Ordering::Greater => Self::new(
+                    self.header().clone(),
+                    BigUint::sub(self.items(), other.items()).value,
+                ),
+                Ordering::Less => Self::new(
+                    other.header().clone(),
+                    BigUint::sub(other.items(), self.items()).value,
+                ),
             }
         }
     }
@@ -48,9 +57,15 @@ pub trait BigInt<U: Any<BigInt = Self>>: Complex<U> + Container<Header = Sign, I
         self.muldiv_result(&other, uint_result)
     }
     fn shl(self, other: Self) -> Self {
-        Self::new(self.header().clone(), BigUint::shl(self.items(), other.items()).value)
+        Self::new(
+            self.header().clone(),
+            BigUint::shl(self.items(), other.items()).value,
+        )
     }
     fn shr(self, other: Self) -> Self {
-        Self::new(self.header().clone(), BigUint::shr(self.items(), other.items()).value)
+        Self::new(
+            self.header().clone(),
+            BigUint::shr(self.items(), other.items()).value,
+        )
     }
 }

--- a/nanvm-lib/src/big_int.rs
+++ b/nanvm-lib/src/big_int.rs
@@ -1,3 +1,7 @@
+/**
+ * Initial implementation of BigInt based on https://github.com/functionalscript/nanvm/tree/main/nanvm-lib/src/big_numbers/big_int.rs
+ * Credits: https://github.com/Trinidadec
+ */
 use std::cmp::Ordering;
 
 use crate::{

--- a/nanvm-lib/src/big_int.rs
+++ b/nanvm-lib/src/big_int.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use crate::{
     big_uint::BigUint,
     interface::{Any, Complex, Container},
@@ -17,12 +19,38 @@ pub trait BigInt<U: Any<BigInt = Self>>: Complex<U> + Container<Header = Sign, I
             Sign::Negative => Self::new(Sign::Positive, self.items().iter().cloned()),
         }
     }
-    fn mul(self, other: Self) -> Self {
-        let uint_result = BigUint::mul(self.items(), other.items());
+    fn add(self, other: Self) -> Self {
+        if *self.header() == *other.header() {
+            Self::new(self.header().clone(), BigUint::add(self.items(), other.items()).value)
+        } else {
+            match self.items().cmp(other.items()) {
+                Ordering::Equal => Self::zero(),
+                Ordering::Greater => Self::new(self.header().clone(), BigUint::sub(self.items(), other.items()).value),
+                Ordering::Less => Self::new(other.header().clone(), BigUint::sub(other.items(), self.items()).value),
+            }
+        }
+    }
+    fn sub(self, other: Self) -> Self {
+        self.add(other.negate())
+    }
+    fn muldiv_result(&self, other: &Self, uint_result: BigUint) -> Self {
         if *self.header() != *other.header() && !uint_result.is_zero() {
             Self::new(Sign::Negative, uint_result.value)
         } else {
             Self::new(Sign::Positive, uint_result.value)
         }
+    }
+    fn mul(self, other: Self) -> Self {
+        self.muldiv_result(&other, BigUint::mul(self.items(), other.items()))
+    }
+    fn div(self, other: Self) -> Self {
+        let (uint_result, _) = BigUint::div_mod(self.items(), other.items());
+        self.muldiv_result(&other, uint_result)
+    }
+    fn shl(self, other: Self) -> Self {
+        Self::new(self.header().clone(), BigUint::shl(self.items(), other.items()).value)
+    }
+    fn shr(self, other: Self) -> Self {
+        Self::new(self.header().clone(), BigUint::shr(self.items(), other.items()).value)
     }
 }

--- a/nanvm-lib/src/big_int.rs
+++ b/nanvm-lib/src/big_int.rs
@@ -1,0 +1,108 @@
+use crate::{big_uint::BigUint, interface::{Any, Complex, Container}, sign::Sign};
+
+pub trait BigInt<U: Any<BigInt = Self>>: Complex<U> + Container<Header = Sign, Item = u64> {
+    fn is_zero(&self) -> bool {
+        self.items().is_empty()
+    }
+    fn zero() -> Self {
+        Self::new(Sign::Positive, [])
+    }
+    fn negate(self) -> Self {
+        match self.header() {
+            Sign::Positive => Self::new(Sign::Negative, self.items().iter().cloned()),
+            Sign::Negative => Self::new(Sign::Positive, self.items().iter().cloned()),
+        }
+    }
+    fn mul(self, other: Self) -> Self {
+        let uint_result = BigUint::mul(&self.items(), &other.items());
+        if *self.header() != *other.header() && !uint_result.is_zero() {
+            Self::new(Sign::Negative, uint_result.value)
+        } else {
+            Self::new(Sign::Positive, uint_result.value)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    use crate::big_int::BigUint;
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_mul() {
+        let a = BigUint { value: [1u64].to_vec() };
+        let result = &a * &BigUint::ZERO;
+        assert_eq!(&result, &BigUint::ZERO);
+        let result = &BigUint::ZERO * &a;
+        assert_eq!(&result, &BigUint::ZERO);
+
+        let a = BigUint { value: [1].to_vec() };
+        let result = &a * &a;
+        assert_eq!(&result, &a);
+
+        let a = BigUint {
+            value: [1, 2, 3, 4].to_vec(),
+        };
+        let b = BigUint {
+            value: [5, 6, 7].to_vec(),
+        };
+        let result = &a * &b;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [5, 16, 34, 52, 45, 28].to_vec()
+            },
+        );
+        let result = &b * &a;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [5, 16, 34, 52, 45, 28].to_vec()
+            },
+        );
+
+        let a = BigUint {
+            value: [u64::MAX].to_vec(),
+        };
+        let b = BigUint {
+            value: [u64::MAX].to_vec(),
+        };
+        let result = &a * &b;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1, u64::MAX - 1].to_vec()
+            },
+        );
+        let result = &b * &a;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1, u64::MAX - 1].to_vec()
+            },
+        );
+
+        let a = BigUint {
+            value: [u64::MAX, u64::MAX, u64::MAX].to_vec(),
+        };
+        let b = BigUint {
+            value: [u64::MAX].to_vec(),
+        };
+        let result = &a * &b;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1, u64::MAX, u64::MAX, u64::MAX - 1].to_vec()
+            },
+        );
+        let result = &b * &a;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1, u64::MAX, u64::MAX, u64::MAX - 1].to_vec()
+            },
+        );
+    }
+}

--- a/nanvm-lib/src/big_int.rs
+++ b/nanvm-lib/src/big_int.rs
@@ -1,4 +1,8 @@
-use crate::{big_uint::BigUint, interface::{Any, Complex, Container}, sign::Sign};
+use crate::{
+    big_uint::BigUint,
+    interface::{Any, Complex, Container},
+    sign::Sign,
+};
 
 pub trait BigInt<U: Any<BigInt = Self>>: Complex<U> + Container<Header = Sign, Item = u64> {
     fn is_zero(&self) -> bool {
@@ -14,95 +18,11 @@ pub trait BigInt<U: Any<BigInt = Self>>: Complex<U> + Container<Header = Sign, I
         }
     }
     fn mul(self, other: Self) -> Self {
-        let uint_result = BigUint::mul(&self.items(), &other.items());
+        let uint_result = BigUint::mul(self.items(), other.items());
         if *self.header() != *other.header() && !uint_result.is_zero() {
             Self::new(Sign::Negative, uint_result.value)
         } else {
             Self::new(Sign::Positive, uint_result.value)
         }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use wasm_bindgen_test::wasm_bindgen_test;
-
-    use crate::big_int::BigUint;
-
-    #[test]
-    #[wasm_bindgen_test]
-    fn test_mul() {
-        let a = BigUint { value: [1u64].to_vec() };
-        let result = &a * &BigUint::ZERO;
-        assert_eq!(&result, &BigUint::ZERO);
-        let result = &BigUint::ZERO * &a;
-        assert_eq!(&result, &BigUint::ZERO);
-
-        let a = BigUint { value: [1].to_vec() };
-        let result = &a * &a;
-        assert_eq!(&result, &a);
-
-        let a = BigUint {
-            value: [1, 2, 3, 4].to_vec(),
-        };
-        let b = BigUint {
-            value: [5, 6, 7].to_vec(),
-        };
-        let result = &a * &b;
-        assert_eq!(
-            &result,
-            &BigUint {
-                value: [5, 16, 34, 52, 45, 28].to_vec()
-            },
-        );
-        let result = &b * &a;
-        assert_eq!(
-            &result,
-            &BigUint {
-                value: [5, 16, 34, 52, 45, 28].to_vec()
-            },
-        );
-
-        let a = BigUint {
-            value: [u64::MAX].to_vec(),
-        };
-        let b = BigUint {
-            value: [u64::MAX].to_vec(),
-        };
-        let result = &a * &b;
-        assert_eq!(
-            &result,
-            &BigUint {
-                value: [1, u64::MAX - 1].to_vec()
-            },
-        );
-        let result = &b * &a;
-        assert_eq!(
-            &result,
-            &BigUint {
-                value: [1, u64::MAX - 1].to_vec()
-            },
-        );
-
-        let a = BigUint {
-            value: [u64::MAX, u64::MAX, u64::MAX].to_vec(),
-        };
-        let b = BigUint {
-            value: [u64::MAX].to_vec(),
-        };
-        let result = &a * &b;
-        assert_eq!(
-            &result,
-            &BigUint {
-                value: [1, u64::MAX, u64::MAX, u64::MAX - 1].to_vec()
-            },
-        );
-        let result = &b * &a;
-        assert_eq!(
-            &result,
-            &BigUint {
-                value: [1, u64::MAX, u64::MAX, u64::MAX - 1].to_vec()
-            },
-        );
     }
 }

--- a/nanvm-lib/src/big_uint.rs
+++ b/nanvm-lib/src/big_uint.rs
@@ -1,5 +1,7 @@
 use std::{
-    cmp::Ordering, iter, ops::{Add, Div, Mul, Shl, Shr, Sub}
+    cmp::Ordering,
+    iter,
+    ops::{Add, Div, Mul, Shl, Shr, Sub},
 };
 
 use crate::default::default;
@@ -13,7 +15,9 @@ impl BigUint {
     pub const ZERO: BigUint = BigUint { value: Vec::new() };
 
     pub fn one() -> BigUint {
-        BigUint { value: [1].to_vec() }
+        BigUint {
+            value: [1].to_vec(),
+        }
     }
 
     pub fn normalize(&mut self) {
@@ -41,7 +45,9 @@ impl BigUint {
     }
 
     pub fn from_u64(n: u64) -> Self {
-        BigUint { value: [n].to_vec() }
+        BigUint {
+            value: [n].to_vec(),
+        }
     }
 
     pub fn pow(&self, exp: &BigUint) -> BigUint {
@@ -92,15 +98,20 @@ impl BigUint {
     }
 
     pub fn div_mod(a: &[u64], b: &[u64]) -> (BigUint, BigUint) {
-        if b.len() == 0 {
+        if b.is_empty() {
             panic!("attempt to divide by zero");
         }
 
-        let left = BigUint{ value: a.to_vec() };
-        let right = BigUint{ value: b.to_vec() };
+        let left = BigUint { value: a.to_vec() };
+        let right = BigUint { value: b.to_vec() };
         match left.cmp(&right) {
             Ordering::Less => (default(), left),
-            Ordering::Equal => (BigUint { value: [1].to_vec() }, default()),
+            Ordering::Equal => (
+                BigUint {
+                    value: [1].to_vec(),
+                },
+                default(),
+            ),
             Ordering::Greater => {
                 let mut a = left;
                 let mut result = BigUint::ZERO;
@@ -142,7 +153,7 @@ impl BigUint {
     }
 
     pub fn mul(a: &[u64], b: &[u64]) -> Self {
-        if a.len() == 0 || b.len() == 0 {
+        if a.is_empty() || b.is_empty() {
             return BigUint::ZERO;
         }
 
@@ -376,16 +387,28 @@ mod test {
     #[test]
     #[wasm_bindgen_test]
     fn test_ord() {
-        let a = BigUint { value: [1].to_vec() };
-        let b = BigUint { value: [1].to_vec() };
+        let a = BigUint {
+            value: [1].to_vec(),
+        };
+        let b = BigUint {
+            value: [1].to_vec(),
+        };
         assert_eq!(a.cmp(&b), Ordering::Equal);
 
-        let a = BigUint { value: [1].to_vec() };
-        let b = BigUint { value: [2].to_vec() };
+        let a = BigUint {
+            value: [1].to_vec(),
+        };
+        let b = BigUint {
+            value: [2].to_vec(),
+        };
         assert_eq!(a.cmp(&b), Ordering::Less);
 
-        let a = BigUint { value: [2].to_vec() };
-        let b = BigUint { value: [1].to_vec() };
+        let a = BigUint {
+            value: [2].to_vec(),
+        };
+        let b = BigUint {
+            value: [1].to_vec(),
+        };
         assert_eq!(a.cmp(&b), Ordering::Greater);
 
         let a = BigUint {
@@ -400,12 +423,23 @@ mod test {
     #[test]
     #[wasm_bindgen_test]
     fn test_add() {
-        let a = BigUint { value: [1].to_vec() };
-        let b = BigUint { value: [2].to_vec() };
+        let a = BigUint {
+            value: [1].to_vec(),
+        };
+        let b = BigUint {
+            value: [2].to_vec(),
+        };
         let result = &a + &b;
-        assert_eq!(&result, &BigUint { value: [3].to_vec() });
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [3].to_vec()
+            }
+        );
 
-        let a = BigUint { value: [1].to_vec() };
+        let a = BigUint {
+            value: [1].to_vec(),
+        };
         let b = BigUint {
             value: [2, 4].to_vec(),
         };
@@ -469,17 +503,28 @@ mod test {
         let result = &a - &b;
         assert_eq!(&result, &BigUint::ZERO);
 
-        let a = BigUint { value: [3].to_vec() };
-        let b = BigUint { value: [2].to_vec() };
+        let a = BigUint {
+            value: [3].to_vec(),
+        };
+        let b = BigUint {
+            value: [2].to_vec(),
+        };
         let result = &a - &b;
-        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1].to_vec()
+            }
+        );
         let result = &b - &a;
         assert_eq!(&result, &BigUint::ZERO);
 
         let a = BigUint {
             value: [0, 1].to_vec(),
         };
-        let b = BigUint { value: [1].to_vec() };
+        let b = BigUint {
+            value: [1].to_vec(),
+        };
         let result = &a - &b;
         assert_eq!(
             &result,
@@ -492,13 +537,17 @@ mod test {
     #[test]
     #[wasm_bindgen_test]
     fn test_mul() {
-        let a = BigUint { value: [1].to_vec() };
+        let a = BigUint {
+            value: [1].to_vec(),
+        };
         let result = &a * &BigUint::ZERO;
         assert_eq!(&result, &BigUint::ZERO);
         let result = &BigUint::ZERO * &a;
         assert_eq!(&result, &BigUint::ZERO);
 
-        let a = BigUint { value: [1].to_vec() };
+        let a = BigUint {
+            value: [1].to_vec(),
+        };
         let result = &a * &a;
         assert_eq!(&result, &a);
 
@@ -570,7 +619,9 @@ mod test {
     #[should_panic(expected = "attempt to divide by zero")]
     #[wasm_bindgen_test]
     fn test_div_by_zero() {
-        let a = BigUint { value: [1].to_vec() };
+        let a = BigUint {
+            value: [1].to_vec(),
+        };
         let _result = &a / &BigUint::ZERO;
     }
 
@@ -584,24 +635,46 @@ mod test {
     #[test]
     #[wasm_bindgen_test]
     fn test_div_simple() {
-        let a = BigUint { value: [2].to_vec() };
-        let b = BigUint { value: [7].to_vec() };
+        let a = BigUint {
+            value: [2].to_vec(),
+        };
+        let b = BigUint {
+            value: [7].to_vec(),
+        };
         let result = &a / &b;
         assert_eq!(&result, &BigUint::ZERO);
 
-        let a = BigUint { value: [7].to_vec() };
+        let a = BigUint {
+            value: [7].to_vec(),
+        };
         let result = &a / &a;
-        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1].to_vec()
+            }
+        );
 
-        let a = BigUint { value: [7].to_vec() };
-        let b = BigUint { value: [2].to_vec() };
+        let a = BigUint {
+            value: [7].to_vec(),
+        };
+        let b = BigUint {
+            value: [2].to_vec(),
+        };
         let result = &a / &b;
-        assert_eq!(&result, &BigUint { value: [3].to_vec() });
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [3].to_vec()
+            }
+        );
 
         let a = BigUint {
             value: [6, 8].to_vec(),
         };
-        let b = BigUint { value: [2].to_vec() };
+        let b = BigUint {
+            value: [2].to_vec(),
+        };
         let result = &a / &b;
         assert_eq!(
             &result,
@@ -613,7 +686,9 @@ mod test {
         let a = BigUint {
             value: [4, 7].to_vec(),
         };
-        let b = BigUint { value: [2].to_vec() };
+        let b = BigUint {
+            value: [2].to_vec(),
+        };
         let result = &a / &b;
         assert_eq!(
             &result,
@@ -629,12 +704,19 @@ mod test {
             value: [1, 2].to_vec(),
         };
         let result = &a / &b;
-        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1].to_vec()
+            }
+        );
 
         let a = BigUint {
             value: [1, 1].to_vec(),
         };
-        let b = BigUint { value: [1].to_vec() };
+        let b = BigUint {
+            value: [1].to_vec(),
+        };
         let result = &a / &b;
         assert_eq!(
             &result,
@@ -650,14 +732,23 @@ mod test {
         let result = BigUint::div_mod(&[7], &[2]);
         assert_eq!(
             result,
-            (BigUint { value: [3].to_vec() }, BigUint { value: [1].to_vec() })
+            (
+                BigUint {
+                    value: [3].to_vec()
+                },
+                BigUint {
+                    value: [1].to_vec()
+                }
+            )
         );
 
         let result = BigUint::div_mod(&[7, 5], &[0, 3]);
         assert_eq!(
             result,
             (
-                BigUint { value: [1].to_vec() },
+                BigUint {
+                    value: [1].to_vec()
+                },
                 BigUint {
                     value: [7, 2].to_vec()
                 }
@@ -672,9 +763,16 @@ mod test {
             value: [100].to_vec(),
         };
         let result = a.pow_u64(0);
-        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1].to_vec()
+            }
+        );
 
-        let a = BigUint { value: [2].to_vec() };
+        let a = BigUint {
+            value: [2].to_vec(),
+        };
         let result = a.pow_u64(7);
         assert_eq!(
             &result,
@@ -683,7 +781,9 @@ mod test {
             }
         );
 
-        let a = BigUint { value: [5].to_vec() };
+        let a = BigUint {
+            value: [5].to_vec(),
+        };
         let result = a.pow_u64(3);
         assert_eq!(
             &result,
@@ -698,15 +798,30 @@ mod test {
 
         let a = BigUint::ZERO;
         let result = a.pow_u64(0);
-        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1].to_vec()
+            }
+        );
 
         let a = BigUint::one();
         let result = a.pow_u64(0);
-        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1].to_vec()
+            }
+        );
 
         let a = BigUint::one();
         let result = a.pow_u64(100);
-        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1].to_vec()
+            }
+        );
     }
 
     #[test]
@@ -716,10 +831,19 @@ mod test {
             value: [100].to_vec(),
         };
         let result = a.pow(&BigUint::ZERO);
-        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1].to_vec()
+            }
+        );
 
-        let a = BigUint { value: [2].to_vec() };
-        let result = a.pow(&BigUint { value: [7].to_vec() });
+        let a = BigUint {
+            value: [2].to_vec(),
+        };
+        let result = a.pow(&BigUint {
+            value: [7].to_vec(),
+        });
         assert_eq!(
             &result,
             &BigUint {
@@ -727,8 +851,12 @@ mod test {
             }
         );
 
-        let a = BigUint { value: [5].to_vec() };
-        let result = a.pow(&BigUint { value: [3].to_vec() });
+        let a = BigUint {
+            value: [5].to_vec(),
+        };
+        let result = a.pow(&BigUint {
+            value: [3].to_vec(),
+        });
         assert_eq!(
             &result,
             &BigUint {
@@ -744,24 +872,41 @@ mod test {
 
         let a = BigUint::ZERO;
         let result = a.pow(&BigUint::ZERO);
-        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1].to_vec()
+            }
+        );
 
         let a = BigUint::one();
         let result = a.pow(&BigUint::ZERO);
-        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1].to_vec()
+            }
+        );
 
         let a = BigUint::one();
         let result = a.pow(&BigUint {
             value: [100, 100].to_vec(),
         });
-        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1].to_vec()
+            }
+        );
     }
 
     #[test]
     #[should_panic(expected = "Maximum BigUint size exceeded")]
     #[wasm_bindgen_test]
     fn test_pow_overflow() {
-        let a = BigUint { value: [5].to_vec() };
+        let a = BigUint {
+            value: [5].to_vec(),
+        };
         let _result = a.pow(&BigUint {
             value: [100, 100].to_vec(),
         });
@@ -773,7 +918,9 @@ mod test {
         let result = &BigUint::ZERO << &BigUint::ZERO;
         assert_eq!(&result, &BigUint::ZERO);
 
-        let a = BigUint { value: [5].to_vec() };
+        let a = BigUint {
+            value: [5].to_vec(),
+        };
         let result = &a << &BigUint::ZERO;
         assert_eq!(result, a);
 
@@ -784,12 +931,23 @@ mod test {
     #[test]
     #[wasm_bindgen_test]
     fn test_shl() {
-        let a = BigUint { value: [1].to_vec() };
+        let a = BigUint {
+            value: [1].to_vec(),
+        };
         let result = &a << &a;
-        assert_eq!(result, BigUint { value: [2].to_vec() });
+        assert_eq!(
+            result,
+            BigUint {
+                value: [2].to_vec()
+            }
+        );
 
-        let a = BigUint { value: [5].to_vec() };
-        let b = BigUint { value: [63].to_vec() };
+        let a = BigUint {
+            value: [5].to_vec(),
+        };
+        let b = BigUint {
+            value: [63].to_vec(),
+        };
         let result = &a << &b;
         assert_eq!(
             result,
@@ -801,7 +959,9 @@ mod test {
         let a = BigUint {
             value: [5, 9].to_vec(),
         };
-        let b = BigUint { value: [63].to_vec() };
+        let b = BigUint {
+            value: [63].to_vec(),
+        };
         let result = &a << &b;
         assert_eq!(
             result,
@@ -813,7 +973,9 @@ mod test {
         let a = BigUint {
             value: [5, 9].to_vec(),
         };
-        let b = BigUint { value: [64].to_vec() };
+        let b = BigUint {
+            value: [64].to_vec(),
+        };
         let result = &a << &b;
         assert_eq!(
             result,
@@ -825,7 +987,9 @@ mod test {
         let a = BigUint {
             value: [5, 9].to_vec(),
         };
-        let b = BigUint { value: [65].to_vec() };
+        let b = BigUint {
+            value: [65].to_vec(),
+        };
         let result = &a << &b;
         assert_eq!(
             result,
@@ -852,7 +1016,9 @@ mod test {
         let result = &BigUint::ZERO >> &BigUint::ZERO;
         assert_eq!(&result, &BigUint::ZERO);
 
-        let a = BigUint { value: [5].to_vec() };
+        let a = BigUint {
+            value: [5].to_vec(),
+        };
         let result = &a >> &BigUint::ZERO;
         assert_eq!(result, a);
 
@@ -872,19 +1038,32 @@ mod test {
         let result = &a >> &b;
         assert_eq!(result, BigUint::ZERO);
 
-        let a = BigUint { value: [1].to_vec() };
+        let a = BigUint {
+            value: [1].to_vec(),
+        };
         let result = &a >> &a;
         assert_eq!(result, BigUint::ZERO);
 
-        let a = BigUint { value: [2].to_vec() };
-        let b = BigUint { value: [1].to_vec() };
+        let a = BigUint {
+            value: [2].to_vec(),
+        };
+        let b = BigUint {
+            value: [1].to_vec(),
+        };
         let result = &a >> &b;
-        assert_eq!(result, BigUint { value: [1].to_vec() });
+        assert_eq!(
+            result,
+            BigUint {
+                value: [1].to_vec()
+            }
+        );
 
         let a = BigUint {
             value: [1, 5, 9].to_vec(),
         };
-        let b = BigUint { value: [65].to_vec() };
+        let b = BigUint {
+            value: [65].to_vec(),
+        };
         let result = &a >> &b;
         assert_eq!(
             result,

--- a/nanvm-lib/src/big_uint.rs
+++ b/nanvm-lib/src/big_uint.rs
@@ -104,12 +104,7 @@ impl BigUint {
             return a_len.cmp(&b_len);
         }
 
-        for (a_digit, b_digit) in a
-            .iter()
-            .copied()
-            .rev()
-            .zip(b.iter().copied().rev())
-        {
+        for (a_digit, b_digit) in a.iter().copied().rev().zip(b.iter().copied().rev()) {
             if a_digit != b_digit {
                 return a_digit.cmp(&b_digit);
             }
@@ -245,35 +240,45 @@ impl BigUint {
     }
 
     pub fn shl(_a: &[u64], _b: &[u64]) -> Self {
-        return BigUint::ZERO;
+        BigUint::ZERO
     }
 
     pub fn shr(_a: &[u64], _b: &[u64]) -> Self {
-        return BigUint::ZERO;
+        BigUint::ZERO
     }
 }
 
 impl Add for &BigUint {
     type Output = BigUint;
-    fn add(self, other: Self) -> Self::Output { BigUint::add(&self.value, &other.value) }
+    fn add(self, other: Self) -> Self::Output {
+        BigUint::add(&self.value, &other.value)
+    }
 }
 
 impl Sub for &BigUint {
     type Output = BigUint;
-    fn sub(self, other: Self) -> Self::Output { BigUint::sub(&self.value, &other.value) }
+    fn sub(self, other: Self) -> Self::Output {
+        BigUint::sub(&self.value, &other.value)
+    }
 }
 
 impl PartialOrd for BigUint {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp(other)) }
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl Ord for BigUint {
-    fn cmp(&self, other: &Self) -> Ordering { BigUint::cmp(&self.value, &other.value) }
+    fn cmp(&self, other: &Self) -> Ordering {
+        BigUint::cmp(&self.value, &other.value)
+    }
 }
 
 impl Mul for &BigUint {
     type Output = BigUint;
-    fn mul(self, other: Self) -> Self::Output { BigUint::mul(&self.value, &other.value) }
+    fn mul(self, other: Self) -> Self::Output {
+        BigUint::mul(&self.value, &other.value)
+    }
 }
 
 impl Div for &BigUint {

--- a/nanvm-lib/src/big_uint.rs
+++ b/nanvm-lib/src/big_uint.rs
@@ -138,7 +138,7 @@ impl BigUint {
     }
 
     pub fn sub(a: &[u64], b: &[u64]) -> Self {
-        match a.cmp(b) {
+        match BigUint::cmp(a, b) {
             Ordering::Less | Ordering::Equal => BigUint::ZERO,
             Ordering::Greater => {
                 let mut value: Vec<_> = default();
@@ -527,20 +527,19 @@ mod test {
         let result = &b - &a;
         assert_eq!(&result, &BigUint::ZERO);
 
-        // TODO: discuss this test!!!
-        // let a = BigUint {
-        //     value: [0, 1].to_vec(),
-        // };
-        // let b = BigUint {
-        //     value: [1].to_vec(),
-        // };
-        // let result = &a - &b;
-        // assert_eq!(
-        //     &result,
-        //     &BigUint {
-        //         value: [u64::MAX].to_vec()
-        //     }
-        // );
+        let a = BigUint {
+            value: [0, 1].to_vec(),
+        };
+        let b = BigUint {
+            value: [1].to_vec(),
+        };
+        let result = &a - &b;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [u64::MAX].to_vec()
+            }
+        );
     }
 
     #[test]

--- a/nanvm-lib/src/big_uint.rs
+++ b/nanvm-lib/src/big_uint.rs
@@ -1,0 +1,896 @@
+use std::{
+    cmp::Ordering, iter, ops::{Add, Div, Mul, Shl, Shr, Sub}
+};
+
+use crate::default::default;
+
+#[derive(Debug, PartialEq, Clone, Eq, Default)]
+pub struct BigUint {
+    pub value: Vec<u64>,
+}
+
+impl BigUint {
+    pub const ZERO: BigUint = BigUint { value: Vec::new() };
+
+    pub fn one() -> BigUint {
+        BigUint { value: [1].to_vec() }
+    }
+
+    pub fn normalize(&mut self) {
+        while let Some(&0) = self.value.last() {
+            self.value.pop();
+        }
+    }
+
+    pub fn is_one(&self) -> bool {
+        self.len() == 1 && self.value[0] == 1
+    }
+
+    pub fn len(&self) -> usize {
+        self.value.len()
+    }
+
+    // Clippy wants is_empty as soon as it sees len.
+    // We want to use is_zero instead, but let's be respectful to Clippy anyway.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn is_zero(&self) -> bool {
+        self.is_empty()
+    }
+
+    pub fn from_u64(n: u64) -> Self {
+        BigUint { value: [n].to_vec() }
+    }
+
+    pub fn pow(&self, exp: &BigUint) -> BigUint {
+        if self.is_one() {
+            return BigUint::one();
+        }
+
+        if self.is_zero() {
+            return if exp.is_zero() {
+                BigUint::one()
+            } else {
+                BigUint::ZERO
+            };
+        }
+
+        if exp.is_zero() {
+            return BigUint::one();
+        }
+
+        if exp.len() != 1 {
+            panic!("Maximum BigUint size exceeded")
+        }
+
+        self.pow_u64(exp.value[0])
+    }
+
+    pub fn pow_u64(&self, mut exp: u64) -> BigUint {
+        let mut res = BigUint::one();
+        let mut b = self.clone();
+        loop {
+            if exp == 0 {
+                return res;
+            }
+            if exp & 1 > 0 {
+                res = &res * &b;
+            }
+            exp >>= 1;
+            b = &b * &b;
+        }
+    }
+
+    pub fn get_last_bit(&self) -> u64 {
+        if self.is_zero() {
+            return 0;
+        }
+
+        self.value[0] & 1
+    }
+
+    pub fn div_mod(a: &[u64], b: &[u64]) -> (BigUint, BigUint) {
+        if b.len() == 0 {
+            panic!("attempt to divide by zero");
+        }
+
+        let left = BigUint{ value: a.to_vec() };
+        let right = BigUint{ value: b.to_vec() };
+        match left.cmp(&right) {
+            Ordering::Less => (default(), left),
+            Ordering::Equal => (BigUint { value: [1].to_vec() }, default()),
+            Ordering::Greater => {
+                let mut a = left;
+                let mut result = BigUint::ZERO;
+                loop {
+                    if a.cmp(&right) == Ordering::Less {
+                        return (result, a);
+                    }
+                    let a_high_digit = a.len() - 1;
+                    let b_high_digit = b.len() - 1;
+                    let a_high = a.value[a_high_digit];
+                    let b_high = b[b_high_digit];
+                    let (q_index, q_digit) = match b_high.cmp(&a_high) {
+                        Ordering::Less | Ordering::Equal => {
+                            (a_high_digit - b_high_digit, a_high / b_high)
+                        }
+                        Ordering::Greater => {
+                            let a_high_2 =
+                                ((a_high as u128) << 64) + a.value[a_high_digit - 1] as u128;
+                            (
+                                a_high_digit - b_high_digit - 1,
+                                (a_high_2 / b_high as u128) as u64,
+                            )
+                        }
+                    };
+                    let mut q = BigUint {
+                        value: new_resize(q_index + 1),
+                    };
+                    q.value[q_index] = q_digit;
+                    let mut m = &right * &q;
+                    if a.cmp(&m) == Ordering::Less {
+                        q.value[q_index] = q_digit - 1;
+                        m = BigUint::mul(b, &q.value);
+                    }
+                    a = &a - &m;
+                    result = &result + &q;
+                }
+            }
+        }
+    }
+
+    pub fn mul(a: &[u64], b: &[u64]) -> Self {
+        if a.len() == 0 || b.len() == 0 {
+            return BigUint::ZERO;
+        }
+
+        let lhs_max = a.len() - 1;
+        let rhs_max = b.len() - 1;
+        let total_max = a.len() + b.len() - 1;
+        let mut value = new_resize(total_max + 1);
+        let mut i: usize = 0;
+        while i < total_max {
+            let mut j = i.saturating_sub(rhs_max);
+            let max = if i < lhs_max { i } else { lhs_max };
+            while j <= max {
+                value = add_to_vec(value, i, a[j] as u128 * b[i - j] as u128);
+                j += 1;
+            }
+            i += 1;
+        }
+
+        let mut result = BigUint { value };
+        result.normalize();
+        result
+    }
+}
+
+impl Add for &BigUint {
+    type Output = BigUint;
+
+    fn add(self, other: Self) -> Self::Output {
+        let mut value: Vec<_> = default();
+        let mut carry = 0;
+        let iter = match other.len() > self.len() {
+            true => other
+                .value
+                .iter()
+                .copied()
+                .zip(self.value.iter().copied().chain(iter::repeat(0))),
+            false => self
+                .value
+                .iter()
+                .copied()
+                .zip(other.value.iter().copied().chain(iter::repeat(0))),
+        };
+        for (a, b) in iter {
+            let next = a as u128 + b as u128 + carry;
+            value.push(next as u64);
+            carry = next >> 64;
+        }
+        if carry != 0 {
+            value.push(carry as u64);
+        }
+        BigUint { value }
+    }
+}
+
+impl Sub for &BigUint {
+    type Output = BigUint;
+
+    fn sub(self, other: Self) -> Self::Output {
+        match self.cmp(other) {
+            Ordering::Less | Ordering::Equal => BigUint::ZERO,
+            Ordering::Greater => {
+                let mut value: Vec<_> = default();
+                let mut borrow = 0;
+                let iter = self
+                    .value
+                    .iter()
+                    .copied()
+                    .zip(other.value.iter().copied().chain(iter::repeat(0)));
+                for (a, b) in iter {
+                    let next = a as i128 - b as i128 - borrow;
+                    value.push(next as u64);
+                    borrow = next >> 64 & 1;
+                }
+                let mut res = BigUint { value };
+                res.normalize();
+                res
+            }
+        }
+    }
+}
+
+impl PartialOrd for BigUint {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for BigUint {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let self_len = self.len();
+        let other_len = other.len();
+        if self_len != other_len {
+            return self_len.cmp(&other_len);
+        }
+
+        for (self_digit, other_digit) in self
+            .value
+            .iter()
+            .copied()
+            .rev()
+            .zip(other.value.iter().copied().rev())
+        {
+            if self_digit != other_digit {
+                return self_digit.cmp(&other_digit);
+            }
+        }
+
+        Ordering::Equal
+    }
+}
+
+impl Mul for &BigUint {
+    type Output = BigUint;
+
+    fn mul(self, other: Self) -> Self::Output {
+        BigUint::mul(&self.value, &other.value)
+    }
+}
+
+impl Div for &BigUint {
+    type Output = BigUint;
+
+    fn div(self, b: Self) -> Self::Output {
+        if b.is_zero() {
+            panic!("attempt to divide by zero");
+        }
+
+        let (res, _) = BigUint::div_mod(self.value.as_slice(), b.value.as_slice());
+        res
+    }
+}
+
+impl Shl for &BigUint {
+    type Output = BigUint;
+
+    fn shl(self, rhs: Self) -> Self::Output {
+        if self.is_zero() | rhs.is_zero() {
+            return self.clone();
+        }
+
+        if rhs.len() != 1 {
+            panic!("Maximum BigUint size exceeded")
+        }
+
+        let mut value = self.value.clone();
+        let shift_mod = rhs.value[0] & ((1 << 6) - 1);
+        if shift_mod > 0 {
+            let len = value.len();
+            value.push(0); //todo: check if it is neccessary?
+            for i in (0..=len - 1).rev() {
+                let mut digit = value[i] as u128;
+                digit <<= shift_mod;
+                value[i + 1] |= (digit >> 64) as u64;
+                value[i] = digit as u64;
+            }
+        }
+
+        let number_of_zeros = (rhs.value[0] / 64) as usize;
+        if number_of_zeros > 0 {
+            let mut zeros_vector: Vec<_> = new_resize(number_of_zeros);
+            zeros_vector.extend(value);
+            value = zeros_vector;
+        }
+
+        let mut res = BigUint { value };
+        res.normalize();
+        res
+    }
+}
+
+impl Shr for &BigUint {
+    type Output = BigUint;
+
+    fn shr(self, rhs: Self) -> Self::Output {
+        if self.is_zero() | rhs.is_zero() {
+            return self.clone();
+        }
+
+        let number_to_remove = (rhs.value[0] / 64) as usize;
+        if number_to_remove >= self.len() {
+            return BigUint::ZERO;
+        }
+
+        let mut value = self.value.clone();
+        value = value.split_off(number_to_remove);
+        let shift_mod = rhs.value[0] & ((1 << 6) - 1);
+        if shift_mod > 0 {
+            let len = value.len();
+            let mask = 1 << (shift_mod - 1);
+            let mut i = 0;
+            loop {
+                value[i] >>= shift_mod;
+                i += 1;
+                if i == len {
+                    break;
+                }
+                value[i - 1] |= (value[i] & mask) << (64 - shift_mod);
+            }
+        }
+
+        let mut res = BigUint { value };
+        res.normalize();
+        res
+    }
+}
+
+pub fn new_resize<T: Default + Clone>(size: usize) -> Vec<T> {
+    let mut vec = Vec::with_capacity(size);
+    vec.resize(size, default());
+    vec
+}
+
+fn add_to_vec(mut vec: Vec<u64>, index: usize, add: u128) -> Vec<u64> {
+    let sum = vec[index] as u128 + add;
+    vec[index] = sum as u64;
+    let carry = sum >> 64;
+    if carry > 0 {
+        vec = add_to_vec(vec, index + 1, carry);
+    }
+    vec
+}
+
+#[cfg(test)]
+mod test {
+    use std::cmp::Ordering;
+
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    use super::BigUint;
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_ord() {
+        let a = BigUint { value: [1].to_vec() };
+        let b = BigUint { value: [1].to_vec() };
+        assert_eq!(a.cmp(&b), Ordering::Equal);
+
+        let a = BigUint { value: [1].to_vec() };
+        let b = BigUint { value: [2].to_vec() };
+        assert_eq!(a.cmp(&b), Ordering::Less);
+
+        let a = BigUint { value: [2].to_vec() };
+        let b = BigUint { value: [1].to_vec() };
+        assert_eq!(a.cmp(&b), Ordering::Greater);
+
+        let a = BigUint {
+            value: [1, 2].to_vec(),
+        };
+        let b = BigUint {
+            value: [2, 1].to_vec(),
+        };
+        assert_eq!(a.cmp(&b), Ordering::Greater);
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_add() {
+        let a = BigUint { value: [1].to_vec() };
+        let b = BigUint { value: [2].to_vec() };
+        let result = &a + &b;
+        assert_eq!(&result, &BigUint { value: [3].to_vec() });
+
+        let a = BigUint { value: [1].to_vec() };
+        let b = BigUint {
+            value: [2, 4].to_vec(),
+        };
+        let result = &a + &b;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [3, 4].to_vec()
+            }
+        );
+
+        let a = BigUint {
+            value: [1 << 63].to_vec(),
+        };
+        let b = BigUint {
+            value: [1 << 63].to_vec(),
+        };
+        let result = &a + &b;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [0, 1].to_vec()
+            }
+        );
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_add_overflow() {
+        let a = BigUint {
+            value: [u64::MAX, 0, 1].to_vec(),
+        };
+        let b = BigUint {
+            value: [u64::MAX, u64::MAX].to_vec(),
+        };
+        let result = &a + &b;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [u64::MAX - 1, 0, 2].to_vec()
+            }
+        );
+        let result = &b + &a;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [u64::MAX - 1, 0, 2].to_vec()
+            }
+        );
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_sub() {
+        let a = BigUint {
+            value: [1 << 63].to_vec(),
+        };
+        let b = BigUint {
+            value: [1 << 63].to_vec(),
+        };
+        let result = &a - &b;
+        assert_eq!(&result, &BigUint::ZERO);
+
+        let a = BigUint { value: [3].to_vec() };
+        let b = BigUint { value: [2].to_vec() };
+        let result = &a - &b;
+        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+        let result = &b - &a;
+        assert_eq!(&result, &BigUint::ZERO);
+
+        let a = BigUint {
+            value: [0, 1].to_vec(),
+        };
+        let b = BigUint { value: [1].to_vec() };
+        let result = &a - &b;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [u64::MAX].to_vec()
+            }
+        );
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_mul() {
+        let a = BigUint { value: [1].to_vec() };
+        let result = &a * &BigUint::ZERO;
+        assert_eq!(&result, &BigUint::ZERO);
+        let result = &BigUint::ZERO * &a;
+        assert_eq!(&result, &BigUint::ZERO);
+
+        let a = BigUint { value: [1].to_vec() };
+        let result = &a * &a;
+        assert_eq!(&result, &a);
+
+        let a = BigUint {
+            value: [1, 2, 3, 4].to_vec(),
+        };
+        let b = BigUint {
+            value: [5, 6, 7].to_vec(),
+        };
+        let result = &a * &b;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [5, 16, 34, 52, 45, 28].to_vec()
+            },
+        );
+        let result = &b * &a;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [5, 16, 34, 52, 45, 28].to_vec()
+            },
+        );
+
+        let a = BigUint {
+            value: [u64::MAX].to_vec(),
+        };
+        let b = BigUint {
+            value: [u64::MAX].to_vec(),
+        };
+        let result = &a * &b;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1, u64::MAX - 1].to_vec()
+            },
+        );
+        let result = &b * &a;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1, u64::MAX - 1].to_vec()
+            },
+        );
+
+        let a = BigUint {
+            value: [u64::MAX, u64::MAX, u64::MAX].to_vec(),
+        };
+        let b = BigUint {
+            value: [u64::MAX].to_vec(),
+        };
+        let result = &a * &b;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1, u64::MAX, u64::MAX, u64::MAX - 1].to_vec()
+            },
+        );
+        let result = &b * &a;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1, u64::MAX, u64::MAX, u64::MAX - 1].to_vec()
+            },
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "attempt to divide by zero")]
+    #[wasm_bindgen_test]
+    fn test_div_by_zero() {
+        let a = BigUint { value: [1].to_vec() };
+        let _result = &a / &BigUint::ZERO;
+    }
+
+    #[test]
+    #[should_panic(expected = "attempt to divide by zero")]
+    #[wasm_bindgen_test]
+    fn test_div_zero_by_zero() {
+        let _result = &BigUint::ZERO / &BigUint::ZERO;
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_div_simple() {
+        let a = BigUint { value: [2].to_vec() };
+        let b = BigUint { value: [7].to_vec() };
+        let result = &a / &b;
+        assert_eq!(&result, &BigUint::ZERO);
+
+        let a = BigUint { value: [7].to_vec() };
+        let result = &a / &a;
+        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+
+        let a = BigUint { value: [7].to_vec() };
+        let b = BigUint { value: [2].to_vec() };
+        let result = &a / &b;
+        assert_eq!(&result, &BigUint { value: [3].to_vec() });
+
+        let a = BigUint {
+            value: [6, 8].to_vec(),
+        };
+        let b = BigUint { value: [2].to_vec() };
+        let result = &a / &b;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [3, 4].to_vec()
+            }
+        );
+
+        let a = BigUint {
+            value: [4, 7].to_vec(),
+        };
+        let b = BigUint { value: [2].to_vec() };
+        let result = &a / &b;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [(1 << 63) + 2, 3].to_vec()
+            }
+        );
+
+        let a = BigUint {
+            value: [0, 4].to_vec(),
+        };
+        let b = BigUint {
+            value: [1, 2].to_vec(),
+        };
+        let result = &a / &b;
+        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+
+        let a = BigUint {
+            value: [1, 1].to_vec(),
+        };
+        let b = BigUint { value: [1].to_vec() };
+        let result = &a / &b;
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [1, 1].to_vec()
+            }
+        );
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_div_mod() {
+        let result = BigUint::div_mod(&[7], &[2]);
+        assert_eq!(
+            result,
+            (BigUint { value: [3].to_vec() }, BigUint { value: [1].to_vec() })
+        );
+
+        let result = BigUint::div_mod(&[7, 5], &[0, 3]);
+        assert_eq!(
+            result,
+            (
+                BigUint { value: [1].to_vec() },
+                BigUint {
+                    value: [7, 2].to_vec()
+                }
+            )
+        );
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_pow_u64() {
+        let a = BigUint {
+            value: [100].to_vec(),
+        };
+        let result = a.pow_u64(0);
+        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+
+        let a = BigUint { value: [2].to_vec() };
+        let result = a.pow_u64(7);
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [128].to_vec()
+            }
+        );
+
+        let a = BigUint { value: [5].to_vec() };
+        let result = a.pow_u64(3);
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [125].to_vec()
+            }
+        );
+
+        let a = BigUint::ZERO;
+        let result = a.pow_u64(3);
+        assert_eq!(&result, &BigUint::ZERO);
+
+        let a = BigUint::ZERO;
+        let result = a.pow_u64(0);
+        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+
+        let a = BigUint::one();
+        let result = a.pow_u64(0);
+        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+
+        let a = BigUint::one();
+        let result = a.pow_u64(100);
+        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_pow() {
+        let a = BigUint {
+            value: [100].to_vec(),
+        };
+        let result = a.pow(&BigUint::ZERO);
+        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+
+        let a = BigUint { value: [2].to_vec() };
+        let result = a.pow(&BigUint { value: [7].to_vec() });
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [128].to_vec()
+            }
+        );
+
+        let a = BigUint { value: [5].to_vec() };
+        let result = a.pow(&BigUint { value: [3].to_vec() });
+        assert_eq!(
+            &result,
+            &BigUint {
+                value: [125].to_vec()
+            }
+        );
+
+        let a = BigUint::ZERO;
+        let result = a.pow(&BigUint {
+            value: [100, 100].to_vec(),
+        });
+        assert_eq!(&result, &BigUint::ZERO);
+
+        let a = BigUint::ZERO;
+        let result = a.pow(&BigUint::ZERO);
+        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+
+        let a = BigUint::one();
+        let result = a.pow(&BigUint::ZERO);
+        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+
+        let a = BigUint::one();
+        let result = a.pow(&BigUint {
+            value: [100, 100].to_vec(),
+        });
+        assert_eq!(&result, &BigUint { value: [1].to_vec() });
+    }
+
+    #[test]
+    #[should_panic(expected = "Maximum BigUint size exceeded")]
+    #[wasm_bindgen_test]
+    fn test_pow_overflow() {
+        let a = BigUint { value: [5].to_vec() };
+        let _result = a.pow(&BigUint {
+            value: [100, 100].to_vec(),
+        });
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_shl_zero() {
+        let result = &BigUint::ZERO << &BigUint::ZERO;
+        assert_eq!(&result, &BigUint::ZERO);
+
+        let a = BigUint { value: [5].to_vec() };
+        let result = &a << &BigUint::ZERO;
+        assert_eq!(result, a);
+
+        let result = &BigUint::ZERO << &a;
+        assert_eq!(result, BigUint::ZERO);
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_shl() {
+        let a = BigUint { value: [1].to_vec() };
+        let result = &a << &a;
+        assert_eq!(result, BigUint { value: [2].to_vec() });
+
+        let a = BigUint { value: [5].to_vec() };
+        let b = BigUint { value: [63].to_vec() };
+        let result = &a << &b;
+        assert_eq!(
+            result,
+            BigUint {
+                value: [1 << 63, 2].to_vec()
+            }
+        );
+
+        let a = BigUint {
+            value: [5, 9].to_vec(),
+        };
+        let b = BigUint { value: [63].to_vec() };
+        let result = &a << &b;
+        assert_eq!(
+            result,
+            BigUint {
+                value: [1 << 63, (1 << 63) + 2, 4].to_vec()
+            }
+        );
+
+        let a = BigUint {
+            value: [5, 9].to_vec(),
+        };
+        let b = BigUint { value: [64].to_vec() };
+        let result = &a << &b;
+        assert_eq!(
+            result,
+            BigUint {
+                value: [0, 5, 9].to_vec()
+            }
+        );
+
+        let a = BigUint {
+            value: [5, 9].to_vec(),
+        };
+        let b = BigUint { value: [65].to_vec() };
+        let result = &a << &b;
+        assert_eq!(
+            result,
+            BigUint {
+                value: [0, 10, 18].to_vec()
+            }
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Maximum BigUint size exceeded")]
+    #[wasm_bindgen_test]
+    fn test_shl_overflow() {
+        let a = BigUint::one();
+        let b = BigUint {
+            value: [1, 1].to_vec(),
+        };
+        let _result = &a << &b;
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_shr_zero() {
+        let result = &BigUint::ZERO >> &BigUint::ZERO;
+        assert_eq!(&result, &BigUint::ZERO);
+
+        let a = BigUint { value: [5].to_vec() };
+        let result = &a >> &BigUint::ZERO;
+        assert_eq!(result, a);
+
+        let result = &BigUint::ZERO >> &a;
+        assert_eq!(result, BigUint::ZERO);
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_shr() {
+        let a = BigUint {
+            value: [1, 1, 1, 1].to_vec(),
+        };
+        let b = BigUint {
+            value: [256].to_vec(),
+        };
+        let result = &a >> &b;
+        assert_eq!(result, BigUint::ZERO);
+
+        let a = BigUint { value: [1].to_vec() };
+        let result = &a >> &a;
+        assert_eq!(result, BigUint::ZERO);
+
+        let a = BigUint { value: [2].to_vec() };
+        let b = BigUint { value: [1].to_vec() };
+        let result = &a >> &b;
+        assert_eq!(result, BigUint { value: [1].to_vec() });
+
+        let a = BigUint {
+            value: [1, 5, 9].to_vec(),
+        };
+        let b = BigUint { value: [65].to_vec() };
+        let result = &a >> &b;
+        assert_eq!(
+            result,
+            BigUint {
+                value: [(1 << 63) + 2, 4].to_vec()
+            }
+        );
+    }
+}

--- a/nanvm-lib/src/big_uint.rs
+++ b/nanvm-lib/src/big_uint.rs
@@ -1,3 +1,7 @@
+/**
+ * Initial implementation of BigUint based on https://github.com/functionalscript/nanvm/tree/main/nanvm-lib/src/big_numbers/big_uint.rs
+ * Credits: https://github.com/Trinidadec
+ */
 use std::{
     cmp::Ordering,
     iter,

--- a/nanvm-lib/src/default.rs
+++ b/nanvm-lib/src/default.rs
@@ -1,0 +1,3 @@
+pub fn default<T: Default>() -> T {
+    T::default()
+}

--- a/nanvm-lib/src/interface.rs
+++ b/nanvm-lib/src/interface.rs
@@ -18,7 +18,9 @@ pub trait Complex<U: Any>: PartialEq + Sized + Container {
     fn try_from_unknown(u: U) -> Result<Self, U>;
 }
 
-pub trait String16<U: Any<String16 = Self>>: Complex<U> + Container<Header = (), Item = u16> {
+pub trait String16<U: Any<String16 = Self>>:
+    Complex<U> + Container<Header = (), Item = u16>
+{
     fn concat(self, other: Self) -> Self;
 }
 
@@ -227,7 +229,9 @@ pub trait Any: PartialEq + Sized + Clone + fmt::Debug {
                 Numeric::BigInt(_) => Self::exception(
                     "TypeError: Cannot mix BigInt and other types, use explicit conversions",
                 ),
-                Numeric::Number(f2) => Ok(Self::new_simple(Simple::Number(((f1 as i128) << ((f2 as i128) & 0x1F)) as f64))),
+                Numeric::Number(f2) => Ok(Self::new_simple(Simple::Number(
+                    ((f1 as i128) << ((f2 as i128) & 0x1F)) as f64,
+                ))),
             },
         }
     }
@@ -244,7 +248,9 @@ pub trait Any: PartialEq + Sized + Clone + fmt::Debug {
                 Numeric::BigInt(_) => Self::exception(
                     "TypeError: Cannot mix BigInt and other types, use explicit conversions",
                 ),
-                Numeric::Number(f2) => Ok(Self::new_simple(Simple::Number(((f1 as i128) >> ((f2 as i128) & 0x1F)) as f64))),
+                Numeric::Number(f2) => Ok(Self::new_simple(Simple::Number(
+                    ((f1 as i128) >> ((f2 as i128) & 0x1F)) as f64,
+                ))),
             },
         }
     }

--- a/nanvm-lib/src/lib.rs
+++ b/nanvm-lib/src/lib.rs
@@ -1,3 +1,6 @@
+pub mod big_int;
+pub mod big_uint;
+pub mod default;
 pub mod extension;
 pub mod interface;
 pub mod naive;

--- a/nanvm-lib/src/naive.rs
+++ b/nanvm-lib/src/naive.rs
@@ -1,4 +1,9 @@
-use crate::{big_int, interface::{self, Container}, sign::Sign, simple::Simple};
+use crate::{
+    big_int,
+    interface::{self, Container},
+    sign::Sign,
+    simple::Simple,
+};
 use core::{fmt, marker::PhantomData};
 use std::rc;
 

--- a/nanvm-lib/src/naive.rs
+++ b/nanvm-lib/src/naive.rs
@@ -1,4 +1,4 @@
-use crate::{big_int, interface, sign::Sign, simple::Simple};
+use crate::{big_int, interface::{self, Container}, sign::Sign, simple::Simple};
 use core::{fmt, marker::PhantomData};
 use std::rc;
 
@@ -93,7 +93,11 @@ impl interface::Complex<Any> for String16 {
     }
 }
 
-impl interface::String16<Any> for String16 {}
+impl interface::String16<Any> for String16 {
+    fn concat(self, other: Self) -> Self {
+        Self::new((), self.items().iter().chain(other.items().iter()).cloned())
+    }
+}
 
 // BigInt
 
@@ -201,6 +205,10 @@ impl interface::Any for Any {
         } else {
             None
         }
+    }
+
+    fn is_string16(&self) -> bool {
+        matches!(self, Self::String16(_))
     }
 
     fn pack(u: interface::Unpacked<Self>) -> Self {

--- a/nanvm-lib/src/naive.rs
+++ b/nanvm-lib/src/naive.rs
@@ -1,4 +1,4 @@
-use crate::{interface, sign::Sign, simple::Simple};
+use crate::{big_int, interface, sign::Sign, simple::Simple};
 use core::{fmt, marker::PhantomData};
 use std::rc;
 
@@ -112,7 +112,7 @@ impl interface::Complex<Any> for BigInt {
     }
 }
 
-impl interface::BigInt<Any> for BigInt {}
+impl big_int::BigInt<Any> for BigInt {}
 
 // Array
 

--- a/nanvm-lib/tests/test.rs
+++ b/nanvm-lib/tests/test.rs
@@ -1,6 +1,7 @@
 use core::panic;
 
 use nanvm_lib::{
+    big_int,
     interface::{Any, Complex, Container, Extension, Unpacked, Utf8},
     naive,
     nullish::Nullish,
@@ -433,11 +434,34 @@ fn multiply<A: Any>() {
     }
 }
 
+fn big_int_mul<A: Any>() {
+    let n0 = A::BigInt::new(Sign::Positive, []).to_unknown();
+    let n1 = A::BigInt::new(Sign::Positive, [1]).to_unknown();
+    assert_eq!(A::multiply(n1.clone(), n0.clone()).unwrap(), n0);
+    assert_eq!(A::multiply(n0.clone(), n1.clone()).unwrap(), n0);
+
+    let n_minus1 = A::BigInt::new(Sign::Negative, [1]).to_unknown();
+    assert_eq!(A::multiply(n_minus1.clone(), n0.clone()).unwrap(), n0);
+    assert_eq!(A::multiply(n0.clone(), n_minus1.clone()).unwrap(), n0);
+    assert_eq!(A::multiply(n_minus1.clone(), n_minus1.clone()).unwrap(), n1);
+
+    let a = A::BigInt::new(Sign::Positive, [1, 2, 3, 4]).to_unknown();
+    let b = A::BigInt::new(Sign::Positive, [5, 6, 7]).to_unknown();
+    let expected = A::BigInt::new(Sign::Positive, [5, 16, 34, 52, 45, 28]).to_unknown();
+    assert_eq!(A::multiply(a.clone(), b.clone()).unwrap(), expected);
+    assert_eq!(A::multiply(b.clone(), a.clone()).unwrap(), expected);
+
+    let a = A::BigInt::new(Sign::Negative, [u64::MAX]).to_unknown();
+    let expected = A::BigInt::new(Sign::Positive, [1, u64::MAX - 1]).to_unknown();
+    assert_eq!(A::multiply(a.clone(), a.clone()).unwrap(), expected);
+}
+
 fn test_vm<A: Any>() {
     eq::<A>();
     unary_plus::<A>();
     unary_minus::<A>();
     multiply::<A>();
+    big_int_mul::<A>();
 }
 
 #[test]

--- a/nanvm-lib/tests/test.rs
+++ b/nanvm-lib/tests/test.rs
@@ -454,6 +454,12 @@ fn big_int_mul<A: Any>() {
     let a = A::BigInt::new(Sign::Negative, [u64::MAX]).to_unknown();
     let expected = A::BigInt::new(Sign::Positive, [1, u64::MAX - 1]).to_unknown();
     assert_eq!(A::multiply(a.clone(), a.clone()).unwrap(), expected);
+
+    let b = A::BigInt::new(Sign::Negative, [u64::MAX, u64::MAX, u64::MAX]).to_unknown();
+    let expected =
+        A::BigInt::new(Sign::Positive, [1, u64::MAX, u64::MAX, u64::MAX - 1]).to_unknown();
+    assert_eq!(A::multiply(a.clone(), b.clone()).unwrap(), expected);
+    assert_eq!(A::multiply(b.clone(), a.clone()).unwrap(), expected);
 }
 
 fn test_vm<A: Any>() {

--- a/nanvm-lib/tests/test.rs
+++ b/nanvm-lib/tests/test.rs
@@ -317,7 +317,7 @@ fn multiply<A: Any>() {
     let null: A = Simple::Nullish(Nullish::Null).to_unknown();
     let true_: A = Simple::Boolean(true).to_unknown();
     let false_: A = Simple::Boolean(false).to_unknown();
-    let bi0: A = A::BigInt::new(Sign::Positive, [0]).to_unknown();
+    let bi0: A = A::BigInt::new(Sign::Positive, []).to_unknown();
     let bi1: A = A::BigInt::new(Sign::Positive, [1]).to_unknown();
     let bi_minus1: A = A::BigInt::new(Sign::Negative, [1]).to_unknown();
     let bi10: A = A::BigInt::new(Sign::Positive, [10]).to_unknown();


### PR DESCRIPTION
Nanvm's BigUint is copied over as a helper for nanvm-lib's BigInt (that does not implement std::ops) - together with its tests.

Some trivial adjustments are done to avoid copying in trivial cases (more to come).