### PR TITLE
Fix join utility function bug

### DIFF
--- a/types/string/module.f.ts
+++ b/types/string/module.f.ts
@@ -18,13 +18,18 @@
 import { type List, reduce as listReduce, repeat as listRepeat } from '../list/module.f.ts'
 import { compose } from '../function/module.f.ts'
 import { unsafeCmp, type Sign } from '../function/compare/module.f.ts'
-import { join as joinOp, concat as concatOp, type Reduce } from '../function/operator/module.f.ts'
+import { concat as concatOp, type Reduce } from '../function/operator/module.f.ts'
 
 const reduce: (o: Reduce<string>) => (input: List<string>) => string
     = o => listReduce(o)('')
 
-export const join: (_: string) => (input: List<string>) => string
-    = compose(joinOp)(reduce)
+export const join
+    : (separator: string) => (input: List<string>) => string
+    = separator => {
+        const op: Reduce<string>
+            = value => prior => prior === '' ? value : `${prior}${separator}${value}`
+        return reduce(op)
+    }
 
 export const concat: (input: List<string>) => string
     = reduce(concatOp)


### PR DESCRIPTION
## Summary
- ensure `join` doesn't prefix a separator for the first element

## Testing
- `npx tsc --noEmit -p tsconfig.json` *(fails: Cannot find module 'node:fs' or its corresponding type declarations)*