### PR TITLE
Update docs for rust linting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ This repository contains both Node.js (TypeScript) and Rust code.
 - Run `npm test` to test FunctionalScript (`.f.ts`) files with Node 24+.
   If your environment uses Node 22, run `npm run test22` instead so that Node's `--experimental-strip-types` flag is applied.
 - Run `cargo test` to test the Rust crate in `nanvm-lib`.
+- Run `cargo clippy` to lint the Rust crate.
+- Run `cargo fmt -- --check` to verify formatting.
 
 ## Pull Requests
 - Ensure all of the above tests pass before submitting changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,8 @@ cargo fetch
 ```bash
 npm test
 cargo test
+cargo clippy
+cargo fmt -- --check
 ```
 
 Feel free to open [issues](https://github.com/functionalscript/functionalscript/issues).


### PR DESCRIPTION
## Summary
- document `cargo clippy` and `cargo fmt -- --check` in CONTRIBUTING
- list clippy and fmt checks in AGENTS instructions

## Testing
- `npx tsc`
- `npm run test22`
- `cargo test`
- `cargo clippy` *(fails: 'cargo-clippy' is not installed)*
- `cargo fmt -- --check` *(fails: 'cargo-fmt' is not installed)*