### PR TITLE
Add clippy and fmt to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         .\rustup-init.exe -y --default-toolchain stable --profile minimal
         echo "$env:USERPROFILE\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH
     - uses: actions/checkout@v3
-    - run: cargo test ${{ matrix.type }} ${{ matrix.target }} 
+    - run: cargo test ${{ matrix.type }} ${{ matrix.target }}
 
   rust-wasm:
     strategy:
@@ -129,3 +129,11 @@ jobs:
           node-version: 20
       - uses: taiki-e/install-action@wasm-pack
       - run: wasm-pack test --node ${{ matrix.type }} ./nanvm-lib
+
+  rust-lints:
+    runs-on: ubuntu-latest
+    steps:
+      - run: rustup update
+      - uses: actions/checkout@v3
+      - run: cargo clippy -- -D warnings
+      - run: cargo fmt -- --check

--- a/nanvm-lib/src/bast.rs
+++ b/nanvm-lib/src/bast.rs
@@ -11,8 +11,7 @@ pub trait Serailizable: Sized {
     fn deserialize(data: &mut impl Iterator<Item = u8>) -> io::Result<Self>;
 }
 
-impl<T: Container<Header: Serailizable, Item: Serailizable>> Serailizable for T
-{
+impl<T: Container<Header: Serailizable, Item: Serailizable>> Serailizable for T {
     fn serialize(&self, c: &mut impl Collect) {
         self.header().serialize(c);
         let items = self.items();
@@ -34,10 +33,7 @@ impl<T: Container<Header: Serailizable, Item: Serailizable>> Serailizable for T
 }
 
 fn unexpected_eof() -> io::Error {
-    io::Error::new(
-        io::ErrorKind::UnexpectedEof,
-        "Unexpected end of data",
-    )
+    io::Error::new(io::ErrorKind::UnexpectedEof, "Unexpected end of data")
 }
 
 impl Serailizable for u8 {


### PR DESCRIPTION
## Summary
- run `cargo clippy` and `cargo fmt -- --check` in a new `rust-lints` job
- keep the `rust` job focused on running tests

## Testing
- `npm ci`
- `npx tsc`
- `npm run test22`
- `cargo fetch`
- `cargo test`
- `cargo clippy`
- `cargo fmt -- --check`
