### PR TITLE
Fix parser: allow identifier object keys

### DIFF
--- a/djs/parser/module.f.ts
+++ b/djs/parser/module.f.ts
@@ -389,7 +389,9 @@ const parseObjectStartOp
     = token => state => {
     switch (token.kind)
     {
-        case 'string': return pushKey(state)(token.value)
+        case 'string':
+        case 'id':
+            return pushKey(state)(String(token.value))
         case '}': return endObject(state)
         case 'ws':
         case 'nl':
@@ -405,6 +407,17 @@ const parseObjectKeyOp
     switch (token.kind)
     {
         case ':': return { ... state, valueState: '{:', top: state.top, stack: state.stack }
+        case '}': {
+            const next = pushRef(state)(state.top?.[2] ?? '')
+            if (next.state === 'error') return next
+            return endObject(next as ParseValueState)
+        }
+        case ',': {
+            const next = pushRef(state)(state.top?.[2] ?? '')
+            if (next.state === 'error') return next
+            const ps = next as ParseValueState
+            return { ... ps, valueState: '{,', top: ps.top, stack: ps.stack }
+        }
         case 'ws':
         case 'nl':
         case '//':
@@ -450,7 +463,9 @@ const parseObjectCommaOp
     = token => state => {
     switch (token.kind)
     {
-        case 'string': return pushKey(state)(token.value)
+        case 'string':
+        case 'id':
+            return pushKey(state)(String(token.value))
         case 'ws':
         case 'nl':
         case '//':

--- a/djs/parser/test.f.ts
+++ b/djs/parser/test.f.ts
@@ -119,6 +119,13 @@ export default {
             if (result !== '[[],[{"a":{"b":{"c":["array",["d"]]}}}]]') { throw result }
         },
         () => {
+            const tokenList = tokenizeString('export default {a: 1}')
+            const obj = parser.parseFromTokens(tokenList)
+            if (obj[0] !== 'ok') { throw obj }
+            const result = stringifyDjsModule(obj[1])
+            if (result !== '[[],[{"a":1}]]') { throw result }
+        },
+        () => {
             const tokenList = tokenizeString('export default 1234567890n')
             const obj = parser.parseFromTokens(tokenList)
             if (obj[0] !== 'ok') { throw obj }
@@ -387,6 +394,13 @@ export default {
             if (obj[0] !== 'ok') { throw obj }
             const result = stringifyDjsModule(obj[1])
             if (result !== '[[],[1,2,{"1st":["cref",1],"2nd":["cref",0],"3rd":["cref",1]}]]') { throw result }
+        },
+        () => {
+            const tokenList = tokenizeString('const a = 5 \n export default { a }')
+            const obj = parser.parseFromTokens(tokenList)
+            if (obj[0] !== 'ok') { throw obj }
+            const result = stringifyDjsModule(obj[1])
+            if (result !== '[[],[5,{"a":["cref",0]}]]') { throw result }
         },
     ],
     invalidWithConst:[


### PR DESCRIPTION
## Summary
- support identifiers as object literal keys and shorthand properties
- test parsing identifier object keys and shorthand export

## Testing
- `npx tsc`
- `npm run test22`
- `cargo test`
- `cargo clippy`
- `cargo fmt -- --check`
