### PR TITLE
Fix parser: allow identifier object keys

### DIFF
--- a/djs/parser/module.f.ts
+++ b/djs/parser/module.f.ts
@@ -384,12 +384,15 @@ const parseArrayValueOp
     }
 }
 
+// allow identifier property names (#2410)
 const parseObjectStartOp
     : (token: DjsToken) => (state: ParseValueState) => ParserState
     = token => state => {
     switch (token.kind)
     {
-        case 'string': return pushKey(state)(token.value)
+        case 'string':
+        case 'id':
+            return pushKey(state)(String(token.value))
         case '}': return endObject(state)
         case 'ws':
         case 'nl':
@@ -450,7 +453,9 @@ const parseObjectCommaOp
     = token => state => {
     switch (token.kind)
     {
-        case 'string': return pushKey(state)(token.value)
+        case 'string':
+        case 'id':
+            return pushKey(state)(String(token.value))
         case 'ws':
         case 'nl':
         case '//':

--- a/djs/parser/test.f.ts
+++ b/djs/parser/test.f.ts
@@ -119,6 +119,13 @@ export default {
             if (result !== '[[],[{"a":{"b":{"c":["array",["d"]]}}}]]') { throw result }
         },
         () => {
+            const tokenList = tokenizeString('export default {a: 1}')
+            const obj = parser.parseFromTokens(tokenList)
+            if (obj[0] !== 'ok') { throw obj }
+            const result = stringifyDjsModule(obj[1])
+            if (result !== '[[],[{"a":1}]]') { throw result }
+        },
+        () => {
             const tokenList = tokenizeString('export default 1234567890n')
             const obj = parser.parseFromTokens(tokenList)
             if (obj[0] !== 'ok') { throw obj }


### PR DESCRIPTION
## Summary
- enable unquoted identifier names as object keys
- add test for object literal with identifier key
- remove shorthand property logic so it's handled separately

## Testing
- `npx tsc`
- `npm run test22`
- `cargo test`
- `cargo clippy`
- `cargo fmt -- --check`
