### PR TITLE
Update docs: adopt .f.js extension for data

### DIFF
--- a/djs/README.md
+++ b/djs/README.md
@@ -25,7 +25,7 @@
   ```
 - [x] import
   ```js
-  import a from 'c.d.js'
+  import a from 'c.f.js'
   export default { a: a, b: a}
   ```
 - [ ] short form

--- a/issues/03-djs.md
+++ b/issues/03-djs.md
@@ -3,7 +3,7 @@
 Parse this code
 
 ```js
-import a from 'c.d.js'
+import a from 'c.f.js'
 const c = [12, 'x']
 export default { a: a, b: a, c: c}
 ```

--- a/issues/17-djs-extension.md
+++ b/issues/17-djs-extension.md
@@ -1,6 +1,6 @@
-# `.d.js` extension conflict
+# `.d.js` extension conflict (resolved)
 
- We use an extension `.d.js` for data JS files, but if we can't use it for TypeScript files, like `.d.ts` because it means declaration TypeScript files. There are several solutions to the problem:
-
-1. Use only `.f.js` extension but make sure that `export default` has no functions at the end. In this case we can reference `.f.js` files as well to use functions to transform data (preferred).
-2. Don't use it for TypeScript until we have type annotations in JavaScript.
+We previously considered the `.d.js` extension for data modules. This conflicted
+with TypeScript declaration files (`.d.ts`). We decided to rely solely on the
+`.f.js` extension for data and code modules. Data files must end with
+`export default` and contain no trailing functions.

--- a/issues/README.md
+++ b/issues/README.md
@@ -7,7 +7,7 @@
 - [ ] [11-fs-load](./11-fs-load.md)
 - [ ] 13. Docs for JSR. See https://jsr.io/@functionalscript/functionalscript/score
 - [ ] 16. License in JSR file?
-- [ ] [17-djs-extension](./17-djs-extension.md).
+- [X] [17-djs-extension](./17-djs-extension.md).
 - [ ] 18. Find a formatter for `.f.js` and `.f.ts` files.
 - [ ] 20. Test framework should be able to run a subset of tests.
 - [ ] 21. Test Framework silent mode. Show progress and failed tests only.

--- a/issues/lang/2130-default-import.md
+++ b/issues/lang/2130-default-import.md
@@ -1,7 +1,7 @@
 # Default Import
 
 ```js
-import a from './a.d.js'
+import a from './a.f.js'
 export default [a]
 ```
 

--- a/issues/lang/3240-export.md
+++ b/issues/lang/3240-export.md
@@ -34,7 +34,7 @@ type DefaultExport = {
 We don't need to change `import` for now if we implement `import * as X from ...`. For example
 
 ```js
-// types/list/module.d.js
+// types/list/module.f.js
 export const map = ...
 ```
 


### PR DESCRIPTION
## Summary
- document use of `.f.js` for data modules
- mark the extension issue resolved

## Testing
- `npm ci`
- `cargo fetch`
- `npx tsc`
- `npm run test22`
- `cargo test`
- `cargo clippy`
- `cargo fmt -- --check`