### PR TITLE
docs: prefer CLI parameters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,4 +26,5 @@ If either installation fails, skip all test commands.
   - Reuse code,
   - Don't repeat yourself,
   - Avoid side effects and mutability.
+- Prefer CLI parameters over environment variables when adding new features.
 - Ensure all of the above tests pass before submitting changes.


### PR DESCRIPTION
## Summary
- advise against using environment variables in AGENTS instructions
- revert subset test execution feature

## Testing
- `npm ci`
- `cargo fetch`
- `npx tsc`
- `npm run test22`
- `cargo test`
- `cargo clippy`
- `cargo fmt -- --check`
