### PR TITLE
Add issue for test framework silent mode

### DIFF
--- a/issues/21-test-framework-silent-mode.md
+++ b/issues/21-test-framework-silent-mode.md
@@ -1,0 +1,3 @@
+# Test Framework Silent Mode
+
+Simplify default output of the test framework. By default, show only brief progress (for example, a dot per test or a summary) and list failing tests. Provide a `--verbose` flag to enable the current detailed output.

--- a/issues/README.md
+++ b/issues/README.md
@@ -10,7 +10,7 @@
 - [X] [17-djs-extension](./17-djs-extension.md).
 - [ ] 18. Find a formatter for `.f.js` and `.f.ts` files.
 - [ ] 20. Test framework should be able to run a subset of tests.
-- [ ] 21. Test Framework silent mode. Show progress and failed tests only.
+- [ ] [21-test-framework-silent-mode](./21-test-framework-silent-mode.md). Silent mode with light progress by default; use `--verbose` for full output.
 - [ ] 23. a console program similar to one that we have in the NaNVM repo.
 - [ ] 24. create `./fsc.ts` that supports the same behavior as current NaNVM Rust implementation:
     - [ ] run `node ./fsc.ts input.f.js output.f.js`


### PR DESCRIPTION
## Summary
- describe silent mode for test framework in a new issue file
- link issue 21 in the issues list and clarify desired behaviour

## Testing
- `npm ci`
- `cargo fetch`
- `npx tsc`
- `npm run test22`
- `cargo test`
- `cargo clippy`
- `cargo fmt -- --check`
