### PR TITLE
Mark test filter as P5

### DIFF
--- a/issues/README.md
+++ b/issues/README.md
@@ -9,7 +9,7 @@
 - [ ] 16. License in JSR file?
 - [X] [17-djs-extension](./17-djs-extension.md).
 - [ ] 18. Find a formatter for `.f.js` and `.f.ts` files.
-- [ ] 20. Test framework should be able to run a subset of tests.
+- [ ] P5 20. Test framework should be able to run a subset of tests.
 - [ ] [21-test-framework-silent-mode](./21-test-framework-silent-mode.md). Silent mode with light progress by default; use `--verbose` for full output.
 - [ ] 23. a console program similar to one that we have in the NaNVM repo.
 - [ ] 24. create `./fsc.ts` that supports the same behavior as current NaNVM Rust implementation:


### PR DESCRIPTION
## Summary
- revert filterMap helper and command-line filtering from `fst`
- mark test filter issue as low priority (P5)

## Testing
- `npx tsc`
- `npm run test22`
- `cargo test`
- `cargo clippy`
- `cargo fmt -- --check`
