### PR TITLE
Support trailing comma in parser

### DIFF
--- a/djs/parser/module.f.ts
+++ b/djs/parser/module.f.ts
@@ -337,9 +337,12 @@ const isValueToken
 const parseValueOp
     : (token: DjsToken) => (state: ParseValueState) => ParserState
     = token => state => {
-    if (isValueToken(token)) { return pushValue(state)(tokenToValue(token)) }
     switch (token.kind)
     {
+        case ']':
+            return state.valueState === '[,'
+                ? endArray(state)
+                : { state: 'error', message: 'unexpected token' }
         case 'id': return pushRef(state)(token.value)
         case '[': return startArray(state)
         case '{': return startObject(state)
@@ -347,7 +350,9 @@ const parseValueOp
         case 'nl':
         case '//':
         case '/*': return state
-        default: return { state: 'error', message: 'unexpected token' }
+        default:
+            if (isValueToken(token)) { return pushValue(state)(tokenToValue(token)) }
+            return { state: 'error', message: 'unexpected token' }
     }
 }
 
@@ -453,6 +458,7 @@ const parseObjectCommaOp
     = token => state => {
     switch (token.kind)
     {
+        case '}': return endObject(state)
         case 'string':
         case 'id':
             return pushKey(state)(String(token.value))

--- a/djs/parser/test.f.ts
+++ b/djs/parser/test.f.ts
@@ -138,6 +138,20 @@ export default {
             if (obj[0] !== 'ok') { throw obj }
             const result = stringifyDjsModule(obj[1])
             if (result !== '[[],[["array",[1234567890n]]]]') { throw result }
+        },
+        () => {
+            const tokenList = tokenizeString('export default [1,]')
+            const obj = parser.parseFromTokens(tokenList)
+            if (obj[0] !== 'ok') { throw obj }
+            const result = stringifyDjsModule(obj[1])
+            if (result !== '[[],[["array",[1]]]]') { throw result }
+        },
+        () => {
+            const tokenList = tokenizeString('export default {"a":1,}')
+            const obj = parser.parseFromTokens(tokenList)
+            if (obj[0] !== 'ok') { throw obj }
+            const result = stringifyDjsModule(obj[1])
+            if (result !== '[[],[{"a":1}]]') { throw result }
         }
     ],
     invalid: [
@@ -182,12 +196,6 @@ export default {
             const obj = parser.parseFromTokens(tokenList)
             if (obj[0] !== 'error') { throw obj }
             if (obj[1] !== 'unexpected end') { throw obj }
-        },
-        () => {
-            const tokenList = tokenizeString('export default [1,]')
-            const obj = parser.parseFromTokens(tokenList)
-            if (obj[0] !== 'error') { throw obj }
-            if (obj[1] !== 'unexpected token') { throw obj }
         },
         () => {
             const tokenList = tokenizeString('export default [,1]')
@@ -248,12 +256,6 @@ export default {
             const obj = parser.parseFromTokens(tokenList)
             if (obj[0] !== 'error') { throw obj }
             if (obj[1] !== 'unexpected end') { throw obj }
-        },
-        () => {
-            const tokenList = tokenizeString('export default {"1":2,}')
-            const obj = parser.parseFromTokens(tokenList)
-            if (obj[0] !== 'error') { throw obj }
-            if (obj[1] !== 'unexpected token') { throw obj }
         },
         () => {
             const tokenList = tokenizeString('export default {,"1":2}')

--- a/json/parser/test.f.ts
+++ b/json/parser/test.f.ts
@@ -98,6 +98,18 @@ export default {
             const obj = parser.parse(tokenList)
             const result = stringify(obj)
             if (result !== '["ok",{"a":{"b":{"c":["d"]}}}]') { throw result }
+        },
+        () => {
+            const tokenList = tokenizeString('[1,]')
+            const obj = parser.parse(tokenList)
+            const result = stringify(obj)
+            if (result !== '["ok",[1]]') { throw result }
+        },
+        () => {
+            const tokenList = tokenizeString('{"a":1,}')
+            const obj = parser.parse(tokenList)
+            const result = stringify(obj)
+            if (result !== '["ok",{"a":1}]') { throw result }
         }
     ],
     invalid: [
@@ -142,12 +154,6 @@ export default {
             const obj = parser.parse(tokenList)
             const result = stringify(obj)
             if (result !== '["error","unexpected end"]') { throw result }
-        },
-        () => {
-            const tokenList = tokenizeString('[1,]')
-            const obj = parser.parse(tokenList)
-            const result = stringify(obj)
-            if (result !== '["error","unexpected token"]') { throw result }
         },
         () => {
             const tokenList = tokenizeString('[,1]')
@@ -208,12 +214,6 @@ export default {
             const obj = parser.parse(tokenList)
             const result = stringify(obj)
             if (result !== '["error","unexpected end"]') { throw result }
-        },
-        () => {
-            const tokenList = tokenizeString('{"1":2,}')
-            const obj = parser.parse(tokenList)
-            const result = stringify(obj)
-            if (result !== '["error","unexpected token"]') { throw result }
         },
         () => {
             const tokenList = tokenizeString('{,"1":2}')


### PR DESCRIPTION
## Summary
- allow trailing commas in DJS and JSON parsers
- add regression tests for arrays and objects with trailing commas
- refactor parser value dispatch to analyze `token.kind` first

## Testing
- `npx tsc`
- `npm run test22`
- `cargo test`
- `cargo clippy`
- `cargo fmt -- --check`
