### PR TITLE
Clarify serialization guidance for BNF helpers

### DIFF
--- a/bnf/README.md
+++ b/bnf/README.md
@@ -2,8 +2,14 @@
 
 See [Backus-Naur form](https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form).
 
-- the new functional parser [./module.f.ts](./module.f.ts),
-- the new serializable parser [./data/](./data/).
+- the functional grammar helpers in [./module.f.ts](./module.f.ts) for composing
+  new grammars from existing pieces,
+- the serializable parser data in [./data/](./data/) (use the transformer in
+  [./data/module.f.ts](./data/module.f.ts) to emit it).
+
+In this module a **Sequence** is an ordered array of rules, while a **Variant**
+is a mapping of production names to rule choices. The capitalized names in the
+docs match the exported types to keep the vocabulary consistent.
 
 ## Functional Representation
 
@@ -48,7 +54,7 @@ export default [{
 
 ```ts
 type DispatchRule = {
-    readonly emptyTag: string|true|undefined  
+    readonly emptyTag: string|true|undefined
     readonly rangeMap: RangeMap<{
         readonly tag: string|undefined
         readonly rules: DispatchRule[]
@@ -92,13 +98,13 @@ const sequence: DispatchRule = {
     }
 }
 
-const twoSequences: DispitchRule = {
+const twoSequences: DispatchRule = {
     rangeMap: {
         0x20: [digit, sequence]
     }
 }
 
-const emtpy: DispatchRule = {
+const empty: DispatchRule = {
     emptyTag: true,
     rangeMap: {}
 }
@@ -109,17 +115,17 @@ const minus: DispatchRule = {
     }
 }
 
-const optionalMap: DispatchRule = {
+const optionalMinus: DispatchRule = {
     emptyTag: 'none',
     rangeMap: {
         0x2D..0x2D: { tag: 'minus', rules: [] }
     }
 }
 
-const iDigit: Dispatch = {
+const iDigit: DispatchRule = {
     rangeMap: {
-        0x2D..0x2D: { output: [{"minus:" ["-"]}], rules: [digit] }
-        0x30..0x39: { output: [{"none": []}], rules: [] }
+        0x2D..0x2D: { output: [{ "minus": ['-'] }], rules: [digit] },
+        0x30..0x39: { output: [{ "none": [] }], rules: [] },
     }
 }
 ```

--- a/bnf/module.f.ts
+++ b/bnf/module.f.ts
@@ -1,3 +1,14 @@
+/**
+ * Functional building blocks for representing grammars in Backus–Naur Form (BNF).
+ * The module provides helpers to model terminals, Sequences, Variants, and
+ * repetition patterns as combinators for building new grammars from other
+ * grammars. Symbols are stored as UTF-16 code points and terminal ranges are
+ * packed into 48-bit numbers for compactness. To emit a serializable
+ * representation, use the transformer in `bnf/data/module.f.ts`.
+ *
+ * @module
+ */
+
 import { codePointListToString, stringToCodePointList } from '../text/utf16/module.f.ts'
 import { type Array2, isArray2 } from '../types/array/module.f.ts'
 import { map, toArray, repeat as listRepeat } from '../types/list/module.f.ts'
@@ -13,18 +24,21 @@ import { map, toArray, repeat as listRepeat } from '../types/list/module.f.ts'
  */
 export type TerminalRange = number
 
-/** A sequence of rules. */
+/** Sequence: ordered collection of rules evaluated left-to-right. */
 export type Sequence = readonly Rule[]
 
-/** A variant */
+/** Variant: map of named choices keyed by their production names. */
 export type Variant = {
     readonly[k in string]: Rule
 }
 
+/** Resolved rule representation (no laziness). */
 export type DataRule = Variant | Sequence | TerminalRange | string
 
+/** Function that returns a rule, used for recursive definitions. */
 export type LazyRule = () => DataRule
 
+/** Either a concrete rule or a thunk returning one. */
 export type Rule = DataRule | LazyRule
 
 // Internals:
@@ -42,8 +56,12 @@ const mask = (1 << offset) - 1
 
 const isValid = (r: number): boolean => r >= 0 && r <= mask
 
+/** Highest valid Unicode scalar value as a string. */
 export const max: string = codePointListToString([0x10FFFF])
 
+/**
+ * Combine two 24-bit code points into a single {@link TerminalRange}.
+ */
 export const rangeEncode = (a: number, b: number): TerminalRange => {
     if (!isValid(a) || !isValid(b) || a > b) {
         throw `Invalid range ${a} ${b}.`
@@ -51,16 +69,23 @@ export const rangeEncode = (a: number, b: number): TerminalRange => {
     return (a << offset) | b
 }
 
+/** Encode a single code point into a {@link TerminalRange}. */
 export const oneEncode = (a: number): TerminalRange => rangeEncode(a, a)
 
+/** Split a packed {@link TerminalRange} into its start and end code points. */
 export const rangeDecode = (r: number): Array2<number> =>
     [r >> offset, r & mask]
 
 const mapOneEncode = map(oneEncode)
 
+/** Convert a string into a sequence of single-character terminal ranges. */
 export const toSequence = (s: string): readonly TerminalRange[] =>
     toArray(mapOneEncode(stringToCodePointList(s)))
 
+/**
+ * Normalize a string into a sequence, collapsing to a single range when
+ * possible. Useful for concise inline definitions.
+ */
 export const str = (s: string): readonly TerminalRange[] | TerminalRange => {
     const x = toSequence(s)
     return x.length === 1 ? x[0] : x
@@ -68,9 +93,17 @@ export const str = (s: string): readonly TerminalRange[] | TerminalRange => {
 
 const mapEntry = map((v: number) => [fromCodePoint(v), oneEncode(v)])
 
+/**
+ * Create a {@link RangeVariant} where each character in the string is a key
+ * mapping to its own terminal range.
+ */
 export const set = (s: string): RangeVariant =>
     fromEntries(toArray(mapEntry(stringToCodePointList(s))))
 
+/**
+ * Encode a two-character string as a range from the first to the second code
+ * point.
+ */
 export const range = (ab: string): TerminalRange => {
     const a = toArray(stringToCodePointList(ab))
     if (!isArray2(a)) {
@@ -81,11 +114,14 @@ export const range = (ab: string): TerminalRange => {
 
 type RangeList = readonly TerminalRange[]
 
-/**
- * A set of terminal ranges compatible with the `Variant` rule.
- */
+/** Variant map specialized for terminal ranges. */
 export type RangeVariant = { readonly [k in string]: TerminalRange }
 
+/**
+ * Convert a {@link TerminalRange} back into its string identifier.
+ * Single-character ranges produce a one-character string; wider ranges return
+ * both bounds.
+ */
 export const rangeToId = (r: TerminalRange): string => {
     const ab = rangeDecode(r)
     const [a, b] = ab
@@ -118,6 +154,10 @@ const removeOne = (list: RangeList, ab: number): RangeList => {
     return result
 }
 
+/**
+ * Remove each range in `removeSet` from `range`, returning the remaining
+ * segments as a {@link RangeVariant}.
+ */
 export const remove = (range: TerminalRange, removeSet: RangeVariant): RangeVariant => {
     let result: RangeList = [range]
     for (const r of values(removeSet)) {
@@ -137,6 +177,7 @@ export type Option<S> = {
     none: None
 }
 
+/** Construct an {@link Option} from a rule. */
 export const option = <S extends Rule>(some: S): Option<S> => ({
     some,
     none,
@@ -145,7 +186,7 @@ export const option = <S extends Rule>(some: S): Option<S> => ({
 export type Repeat0Plus<T> = () => Option<readonly[T, Repeat0Plus<T>]>
 
 /**
- * Repeat zero or more times.
+ * Repeat a rule zero or more times, represented as a lazy option.
  *
  * https://english.stackexchange.com/questions/506480/single-word-quantifiers-for-zero-or-more-like-cardinalities
  * - zero or more - any, 0Plus
@@ -161,26 +202,38 @@ export const repeat0Plus = <T extends Rule>(some: T): Repeat0Plus<T> => {
 export type Repeat1Plus<T> = readonly[T, Repeat0Plus<T>]
 
 /**
- * Repeat one or more times.
+ * Repeat a rule one or more times.
  */
 export const repeat1Plus = <T extends Rule>(some: T): Repeat1Plus<T> =>
     [some, repeat0Plus(some)]
 
 export type Join1Plus<T, S> = readonly[T, Repeat0Plus<readonly[S, T]>]
 
+/**
+ * Repeat a rule one or more times with a separator between items.
+ */
 export const join1Plus = <T extends Rule, S extends Rule>(some: T, separator: S): Join1Plus<T, S> =>
     [some, repeat0Plus([separator, some])]
 
 export type Join0Plus<T, S> = Option<readonly[T, Repeat0Plus<readonly[S, T]>]>
 
+/**
+ * Repeat a rule zero or more times with a separator between items.
+ */
 export const join0Plus = <T extends Rule, S extends Rule>(some: T, separator: S): Rule =>
     option(join1Plus(some, separator))
 
 export type Repeat<T> = readonly T[]
 
+/**
+ * Repeat a rule a fixed number of times, returning a concrete sequence.
+ */
 export const repeat = (n: number) => <T extends Rule>(some: T): Repeat<T> =>
     toArray(listRepeat(some)(n))
 
+/**
+ * Check whether a rule is empty or resolves to an empty rule.
+ */
 export const isEmpty = (rule: Rule): boolean => {
     const d = typeof rule === 'function' ? rule() : rule
     return d === '' || (d instanceof Array && d.length === 0)


### PR DESCRIPTION
## Summary
- clarify that BNF helper combinators build grammars but are not themselves serializable and reference the transformer module
- update the BNF README to note the transformer path when exporting serializable data

## Testing
- npx tsc *(fails: command not found: npx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693386064194832ba69b6b5e86082de2)