### PR TITLE
Add Uint8Array bit vector conversions

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -73,7 +73,8 @@
     "./types/sorted_list/module.f.ts": "./types/sorted_list/module.f.ts",
     "./types/sorted_set/module.f.ts": "./types/sorted_set/module.f.ts",
     "./types/string/module.f.ts": "./types/string/module.f.ts",
-    "./types/string_set/module.f.ts": "./types/string_set/module.f.ts"
+    "./types/string_set/module.f.ts": "./types/string_set/module.f.ts",
+    "./types/uint8array/module.f.ts": "./types/uint8array/module.f.ts"
   },
   "tasks": {
     "doc": "deno doc --html **/module.f.ts",

--- a/types/list/module.f.ts
+++ b/types/list/module.f.ts
@@ -36,10 +36,16 @@ type Concat<T> = {
     readonly tail: List<T>
 }
 
-const fromArray = <T>(array: readonly T[]): Result<T> => {
+export const fromArray = <T>(array: readonly T[]): Result<T> => {
     const at = (i: number): Result<T> =>
         i < array.length ? { first: array[i], tail: () => at(i + 1) } : null
     return at(0)
+}
+
+export const fromArrayLike = <T>(length: number) => (at: (i: number) => T): Result<T> => {
+    const step = (i: number): Result<T> =>
+        i < length ? { first: at(i), tail: () => step(i + 1) } : null
+    return step(0)
 }
 
 export const concat = <T>(head: List<T>) => (tail: List<T>): List<T> =>

--- a/types/uint8array/module.f.ts
+++ b/types/uint8array/module.f.ts
@@ -1,0 +1,22 @@
+/**
+ * Conversions between Uint8Array values and bit vectors.
+ *
+ * @module
+ */
+import { msb, u8List, u8ListToVec, type Vec } from "../bit_vec/module.f.ts"
+import { toArray } from "../list/module.f.ts"
+
+const u8ListToVecMsb = u8ListToVec(msb)
+const u8ListMsb = u8List(msb)
+
+/**
+ * Converts a Uint8Array into an MSB-first bit vector.
+ */
+export const toVec = (input: Uint8Array): Vec =>
+    u8ListToVecMsb(Array.from(input))
+
+/**
+ * Converts an MSB-first bit vector into a Uint8Array.
+ */
+export const fromVec = (input: Vec): Uint8Array =>
+    Uint8Array.from(toArray(u8ListMsb(input)))

--- a/types/uint8array/module.f.ts
+++ b/types/uint8array/module.f.ts
@@ -4,24 +4,16 @@
  * @module
  */
 import { msb, u8List, u8ListToVec, type Vec } from "../bit_vec/module.f.ts"
-import { iterable, type List } from "../list/module.f.ts"
+import { fromArrayLike, iterable } from "../list/module.f.ts"
 
 const u8ListToVecMsb = u8ListToVec(msb)
 const u8ListMsb = u8List(msb)
-
-const toList = (input: Uint8Array): List<number> => {
-    const step = (index: number): List<number> =>
-        index < input.length
-            ? { first: input[index], tail: () => step(index + 1) }
-            : null
-    return step(0)
-}
 
 /**
  * Converts a Uint8Array into an MSB-first bit vector.
  */
 export const toVec = (input: Uint8Array): Vec =>
-    u8ListToVecMsb(toList(input))
+    u8ListToVecMsb(fromArrayLike<number>(input.length)(index => input[index]))
 
 /**
  * Converts an MSB-first bit vector into a Uint8Array.

--- a/types/uint8array/module.f.ts
+++ b/types/uint8array/module.f.ts
@@ -4,19 +4,27 @@
  * @module
  */
 import { msb, u8List, u8ListToVec, type Vec } from "../bit_vec/module.f.ts"
-import { toArray } from "../list/module.f.ts"
+import { iterable, type List } from "../list/module.f.ts"
 
 const u8ListToVecMsb = u8ListToVec(msb)
 const u8ListMsb = u8List(msb)
+
+const toList = (input: Uint8Array): List<number> => {
+    const step = (index: number): List<number> =>
+        index < input.length
+            ? { first: input[index], tail: () => step(index + 1) }
+            : null
+    return step(0)
+}
 
 /**
  * Converts a Uint8Array into an MSB-first bit vector.
  */
 export const toVec = (input: Uint8Array): Vec =>
-    u8ListToVecMsb(Array.from(input))
+    u8ListToVecMsb(toList(input))
 
 /**
  * Converts an MSB-first bit vector into a Uint8Array.
  */
 export const fromVec = (input: Vec): Uint8Array =>
-    Uint8Array.from(toArray(u8ListMsb(input)))
+    Uint8Array.from(iterable(u8ListMsb(input)))


### PR DESCRIPTION
### Motivation
- Implement issue 105 by providing conversions between `Uint8Array` and the existing bit vector `Vec` type.
- Consumers need a simple way to convert binary `Uint8Array` data to/from the MSB-first bit-vector representation used across the codebase.

### Description
- Add new module `types/uint8array/module.f.ts` exporting `toVec` and `fromVec` to convert `Uint8Array` ↔ `Vec`.
- Implementation reuses existing APIs: `msb`, `u8List`, `u8ListToVec` from `types/bit_vec` and `toArray` from `types/list` to avoid duplication.
- The conversions operate with MSB-first ordering to match the project's UTF-8 and CBase32 handling.

### Testing
- Ran `npx tsc` to type-check the repository and it succeeded.
- Ran `npm test` and the test suite completed successfully with coverage output.
- Ran `cargo test`, `cargo clippy`, and `cargo fmt -- --check` for `nanvm-lib`, and all commands passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962267a0f74832b95880d7a472ba506)