### PR TITLE
Add JSDoc comments for path module exports

### DIFF
--- a/path/module.f.ts
+++ b/path/module.f.ts
@@ -23,17 +23,30 @@ const foldNormalizeOp: Fold<string, List<string>>
     }
 }
 
+/**
+ * Splits a path into normalized segments.
+ *
+ * Empty (`""`) and current-directory (`"."`) segments are removed, parent-directory
+ * (`".."`) segments collapse the previous segment when possible, and Windows
+ * separators are converted to POSIX separators.
+ */
 export const parse = (path: string): readonly string[] => {
     const split = path.replaceAll('\\', '/').split('/')
     return toArray(fold(foldNormalizeOp)([])(split))
 }
 
+/**
+ * Normalizes a path string by parsing and rejoining it with POSIX separators.
+ */
 export const normalize: Unary<string, string>
 = path => {
     const foldResult = parse(path)
     return join('/')(foldResult)
 }
 
+/**
+ * Concatenates two path fragments and returns a normalized path.
+ */
 export const concat: Reduce<string>
 = a => b => {
     const s = stringConcat([a, '/', b])


### PR DESCRIPTION
### Motivation
- Provide clear JSDoc documentation for the public APIs in `path/module.f.ts` to match repository documentation standards and clarify normalization behavior.

### Description
- Add JSDoc comments for `parse`, `normalize`, and `concat` describing removal of `""`/`.` segments, handling of `".."`, and conversion of Windows separators to POSIX separators.

### Testing
- Ran `npm ci`, `cargo fetch`, `npm run update`, `npx tsc`, `npm test`, `cargo test`, `cargo clippy`, and `cargo fmt -- --check`, and all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aae24b8ca4832ba8b72e619ad5c5c4)