### PR TITLE
Implement BigInt Ord::cmp and add unit tests

### DIFF
--- a/nanvm-lib/src/vm/bigint/cmp.rs
+++ b/nanvm-lib/src/vm/bigint/cmp.rs
@@ -1,4 +1,4 @@
-use crate::vm::{IVm, bigint::BigInt};
+use crate::vm::{IContainer, IVm, bigint::BigInt};
 use std::cmp::Ordering;
 
 impl<A: IVm> PartialOrd for BigInt<A> {
@@ -8,7 +8,56 @@ impl<A: IVm> PartialOrd for BigInt<A> {
 }
 
 impl<A: IVm> Ord for BigInt<A> {
-    fn cmp(&self, _rhs: &Self) -> Ordering {
-        todo!()
+    fn cmp(&self, rhs: &Self) -> Ordering {
+        use crate::sign::Sign;
+
+        let lhs_sign = *self.0.header();
+        let rhs_sign = *rhs.0.header();
+
+        match (lhs_sign, rhs_sign) {
+            (Sign::Positive, Sign::Negative) => Ordering::Greater,
+            (Sign::Negative, Sign::Positive) => Ordering::Less,
+            (Sign::Positive, Sign::Positive) => self.clone().abs_cmp_vec(rhs.clone()),
+            (Sign::Negative, Sign::Negative) => rhs.clone().abs_cmp_vec(self.clone()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{naive::Naive, vm::bigint::BigInt};
+    use std::cmp::Ordering;
+
+    type TestBigInt = BigInt<Naive>;
+
+    #[test]
+    fn cmp_positive_vs_negative() {
+        let lhs: TestBigInt = 1u64.into();
+        let rhs: TestBigInt = (-1i64).into();
+        assert_eq!(lhs.cmp(&rhs), Ordering::Greater);
+        assert_eq!(rhs.cmp(&lhs), Ordering::Less);
+    }
+
+    #[test]
+    fn cmp_positive_by_absolute_value() {
+        let lhs: TestBigInt = 5u64.into();
+        let rhs: TestBigInt = 6u64.into();
+        assert_eq!(lhs.cmp(&rhs), Ordering::Less);
+        assert_eq!(rhs.cmp(&lhs), Ordering::Greater);
+    }
+
+    #[test]
+    fn cmp_negative_reverses_absolute_order() {
+        let lhs: TestBigInt = (-5i64).into();
+        let rhs: TestBigInt = (-6i64).into();
+        assert_eq!(lhs.cmp(&rhs), Ordering::Greater);
+        assert_eq!(rhs.cmp(&lhs), Ordering::Less);
+    }
+
+    #[test]
+    fn cmp_equal_values() {
+        let lhs: TestBigInt = 0u64.into();
+        let rhs: TestBigInt = 0u64.into();
+        assert_eq!(lhs.cmp(&rhs), Ordering::Equal);
     }
 }


### PR DESCRIPTION
### Motivation

- `BigInt` previously implemented `Ord` but `cmp` was `todo!()` which could panic when ordering BigInts was used, so a correct, sign-aware comparison is required.

### Description

- Implemented `Ord::cmp` for `BigInt` in `nanvm-lib/src/vm/bigint/cmp.rs` to compare signs first and then compare absolute values, reversing the absolute comparison for negative operands.
- Imported `IContainer` so `header()` is available on the internal container and used `crate::sign::Sign` to inspect signs.
- Added focused unit tests under `#[cfg(test)]` in `nanvm-lib/src/vm/bigint/cmp.rs` covering positive-vs-negative, positive absolute ordering, negative reversed ordering, and equality.

### Testing

- Ran `npm ci`, `npm run update`, and `npx tsc` which completed successfully.
- Ran the JavaScript test suite via `npm test` and the full test TAP output completed with no failures.
- Ran Rust checks `cargo test`, `cargo clippy`, and `cargo fmt -- --check` and all succeeded, including the new `BigInt` comparison tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e63dca1830832b8552cbc04712321b)