### PR TITLE
Add path tracking to validation errors in rtti validate

### DIFF
--- a/issues/README.md
+++ b/issues/README.md
@@ -291,7 +291,7 @@ require setting a flag when walking through a test tree as soon as a node has a 
 - [X] 126. `types/rtti` should support `undefined`, `null` instead of `"undefined"` and `"null"`.
 - [X] 127. Simplify `types/rtti/ts/module.f.ts` to reduce TypeScript type instantiation depth. Flatten the `*Ts` helper chain (`ConstTs` → `TupleTs`/`StructTs` → `Ts`) into a single `Ts` conditional type to avoid hitting TypeScript's recursion limit. The intermediate `*Ts` types can remain as derived aliases for the public API but should not participate in the recursive evaluation chain.
 - [ ] [128-rtti-deserialize](./128-rtti-deserialize.md)
-- [ ] 129. `validate` from [../types/rtti/validate/module.f.ts](../types/rtti/validate/module.f.ts) should return a path in case of an error.
+- [X] 129. `validate` from [../types/rtti/validate/module.f.ts](../types/rtti/validate/module.f.ts) should return a path in case of an error.
 - [ ] 130. Optimization of `or` in [../types/rtti/module.f.ts](../types/rtti/module.f.ts).
 - [ ] 131. An allocator for `nanvm` that doesn't panic. Instead, it should return `Result<T, Any`.
 - [ ] 132. `exec`:

--- a/types/rtti/README.md
+++ b/types/rtti/README.md
@@ -49,7 +49,7 @@ type Person = Ts<typeof person>
 
 const v = validate(person)
 v({ name: 'Alice', age: 30 })  // ['ok', { name: 'Alice', age: 30 }]
-v({ name: 'Alice' })           // ['error', 'unexpected value']
+v({ name: 'Alice' })           // ['error', { path: ['age'], message: 'unexpected value' }]
 
 // Recursive schema
 const listOfStrings = array(string)

--- a/types/rtti/validate/module.f.ts
+++ b/types/rtti/validate/module.f.ts
@@ -3,7 +3,13 @@
  *
  * The main entry point is `validate(rtti)`, which takes a schema `Type` and returns
  * a `Validate<T>` function. When called with an unknown value, it returns a `Result`
- * that is either `['ok', typedValue]` or `['error', message]`.
+ * that is either `['ok', typedValue]` or `['error', { path, message }]`.
+ *
+ * ## Error path
+ *
+ * On failure, the error carries a `path` pointing at the offending sub-value:
+ * each step is the string property name (for structs/records) or the stringified
+ * index (for tuples/arrays). The path is empty when the failure is at the root.
  *
  * ## Dispatch strategy
  *
@@ -13,6 +19,7 @@
  *   - `'unknown'` — always succeeds (any DJS value is valid)
  *   - `Tag1` (`'array'`, `'record'`) — delegates to `containerValidate`
  *   - `Tag0` (`'boolean'`, `'number'`, `'string'`, `'bigint'`) — uses `typeof` check
+ *   - `'or'` — tries each variant; reports `'no match'` at the current location if all fail
  * - **`Const`** schemas (primitives, tuples, structs) validate by exact equality or
  *   recursive field/element checking.
  *
@@ -26,7 +33,6 @@
  */
 import type { Unknown } from '../../../djs/module.f.ts'
 import {
-    isTag1,
     type Const,
     type ConstObject,
     type Info0,
@@ -37,24 +43,38 @@ import {
     type Tuple,
     type Type
 } from '../module.f.ts'
-import { error, ok, type Result as CommonResult } from '../../result/module.f.ts'
+import { error, ok, type Error, type Result as CommonResult } from '../../result/module.f.ts'
 import type { Ts } from '../ts/module.f.ts'
 import { isArray as commonIsArray } from '../../array/module.f.ts'
 import { isObject as commonIsObject, type ReadonlyRecord } from '../../object/module.f.ts'
-import { identity } from '../../function/module.f.ts'
 import type { Primitive } from '../../../djs/module.f.ts'
 
-/** Validation result: either the typed value or an error message. */
-export type Result<T extends Type> = CommonResult<Ts<T>, string>
+/** A path to a sub-value within the validated structure. Each step is an object key or stringified array index. */
+export type Path = readonly string[]
+
+/** Detailed validation failure: the offending `path` plus a short `message`. */
+export type ValidationError = {
+    readonly path: Path
+    readonly message: string
+}
+
+/** Validation result: either the typed value or a `ValidationError`. */
+export type Result<T extends Type> = CommonResult<Ts<T>, ValidationError>
 
 /** A function that validates an unknown value against schema `T`. */
 export type Validate<T extends Type> = (value: Unknown) => Result<T>
 
+const verror = (message: string): Error<ValidationError> =>
+    error({ path: [], message })
+
+const prependPath = (key: string, r: Error<ValidationError>): Error<ValidationError> =>
+    error({ path: [key, ...r[1].path], message: r[1].message })
+
 /** Type guard narrowing `Unknown` to a specific container type `C`. */
 type IsContainer<C extends Unknown> = (value: Unknown) => value is C
 
-/** Extracts the items to validate from a container. */
-type GetItems<C extends Unknown> = (value: C) => ReadonlyArray<Unknown>
+/** Extracts `[key, value]` entries from a container, with stringified keys for path reporting. */
+type GetEntries<C extends Unknown> = (value: C) => ReadonlyArray<readonly[string, Unknown]>
 
 /** Maps a `Tag1` to its runtime container type. */
 type Container<K extends Tag1> = K extends 'array'
@@ -67,23 +87,23 @@ type Container<K extends Tag1> = K extends 'array'
  * non-empty) to avoid infinite recursion with recursive schemas.
  */
 const containerValidate =
-    <K extends Tag1>(isContainer: IsContainer<Container<K>>, getItems: GetItems<Container<K>>) =>
+    <K extends Tag1>(isContainer: IsContainer<Container<K>>, getEntries: GetEntries<Container<K>>) =>
     <I extends Type>(item: I): Validate<Info1<K, I>> => value =>
 {
     if (!isContainer(value)) {
-        return error('unexpected value') as any
+        return verror('unexpected value') as any
     }
-    const items = getItems(value)
-    if (items.length === 0) {
+    const entries = getEntries(value)
+    if (entries.length === 0) {
         return ok(value)
     }
-    // Note: we shouldn't instantiate `itemValidate` until we make sure `items` is not empty.
+    // Note: we shouldn't instantiate `itemValidate` until we make sure `entries` is not empty.
     //       Otherwise, we can get infinite recursion on empty arrays and objects
     const itemValidate = validate(item)
-    for (const i of items) {
-        const r = itemValidate(i)
+    for (const [k, v] of entries) {
+        const r = itemValidate(v)
         if (r[0] === 'error') {
-            return r
+            return prependPath(k, r) as any
         }
     }
     return ok(value)
@@ -92,21 +112,19 @@ const containerValidate =
 const isArray: IsContainer<ReadonlyArray<Unknown>> =
     value => commonIsArray(value)
 
-const arrayValidate = containerValidate<'array'>(isArray, identity)
+const arrayEntries = (value: ReadonlyArray<Unknown>): ReadonlyArray<readonly[string, Unknown]> =>
+    value.map((v, i) => [String(i), v] as const)
+
+const arrayValidate = containerValidate<'array'>(isArray, arrayEntries)
 
 const isObject: IsContainer<ReadonlyRecord<string, Unknown>> =
     value => commonIsObject(value)
 
-const recordValidate = containerValidate<'record'>(isObject, Object.values)
-
-const tag1Validate = <K extends Tag1, I extends Type, T extends Info1<K, I>>([tag, item]: T): Validate<T> =>
-    tag === 'array'
-        ? arrayValidate(item) as any
-        : recordValidate(item) as any
+const recordValidate = containerValidate<'record'>(isObject, Object.entries)
 
 /** Validates a `Tag0` primitive schema using `typeof`. */
 const primitive0Validate = <K extends Primitive0, T extends Info0<K>>(tag: K): Validate<T> =>
-    value => typeof value === tag ? ok(value) as any : error('unexpected value') as any
+    value => typeof value === tag ? ok(value) as any : verror('unexpected value') as any
 
 /**
  * Builds a validator for `Tuple` or `Struct` const schemas.
@@ -118,13 +136,13 @@ const constContainerValidate =
     <T extends Tuple|Struct>(rtti: T): Validate<T> => value =>
 {
     if (!isContainer(value)) {
-        return error('unexpected value') as any
+        return verror('unexpected value') as any
     }
     for (const [k, v] of Object.entries(rtti)) {
         const item = getItem(value, k)
         const r = (validate(v) as any)(item) as Result<T>
         if (r[0] === 'error') {
-            return r
+            return prependPath(k, r) as any
         }
     }
     return ok(value)
@@ -149,7 +167,7 @@ const constObjectValidate = <T extends ConstObject>(rtti: T): Validate<T> =>
 const constPrimitiveValidate = <T extends Primitive>(rtti: T): Validate<T> =>
     value => rtti === value
         ? ok(value) as any
-        : error('unexpected value') as any
+        : verror('unexpected value') as any
 
 const constValidate = <T extends Const>(rtti: T): Validate<T> =>
     typeof rtti === 'object' && rtti !== null
@@ -165,7 +183,7 @@ const orValidate = <T extends readonly Type[]>(rtti: T): Validate<() => readonly
                 return r
             }
         }
-        return error('no match') as any
+        return verror('no match') as any
     }
 }
 
@@ -175,13 +193,14 @@ const orValidate = <T extends readonly Type[]>(rtti: T): Validate<() => readonly
  * @param rtti - A schema `Type`: a `Thunk` for tag-based schemas, or a `Const`
  *   (primitive literal, tuple, or struct) for exact-value schemas.
  * @returns A `Validate<T>` function that checks an unknown value and returns
- *   `['ok', value]` or `['error', message]`.
+ *   `['ok', value]` or `['error', { path, message }]`.
  *
  * @example
  * ```ts
  * const v = validate(array(number))
- * v([1, 2, 3])   // ['ok', [1, 2, 3]]
- * v(['a', 'b'])  // ['error', 'unexpected value']
+ * v([1, 2, 3])         // ['ok', [1, 2, 3]]
+ * v([1, 'two'])        // ['error', { path: ['1'], message: 'unexpected value' }]
+ * v(['a'])             // ['error', { path: ['0'], message: 'unexpected value' }]
  * ```
  */
 export const validate = <T extends Type>(rtti: T): Validate<T> => {

--- a/types/rtti/validate/test.f.ts
+++ b/types/rtti/validate/test.f.ts
@@ -1,4 +1,4 @@
-import { validate } from './module.f.ts'
+import { validate, type ValidationError } from './module.f.ts'
 import { boolean, number, string, bigint, unknown, array, record, or, option } from '../module.f.ts'
 import type { Assert, Equal } from '../../ts/module.f.ts'
 import type { Ts } from '../ts/module.f.ts'
@@ -6,6 +6,16 @@ import type { Unknown as DjsUnknown } from '../../../djs/module.f.ts'
 
 const assertOk = ([k]: readonly [string, unknown]) => { if (k !== 'ok') { throw 'expected ok' } }
 const assertError = ([k]: readonly [string, unknown]) => { if (k !== 'error') { throw 'expected error' } }
+
+const assertErrorPath = (expected: readonly string[]) =>
+    (r: readonly [string, unknown]) => {
+        if (r[0] !== 'error') { throw 'expected error' }
+        const e = r[1] as ValidationError
+        if (e.path.length !== expected.length) { throw `path length ${e.path.length} != ${expected.length}` }
+        for (let i = 0; i < expected.length; i++) {
+            if (e.path[i] !== expected[i]) { throw `path[${i}] ${e.path[i]} != ${expected[i]}` }
+        }
+    }
 
 export default {
     boolean: {
@@ -228,6 +238,37 @@ export default {
             assertError(validate(t)(null))
             assertError(validate(t)('42'))
         },
+    },
+    path: {
+        rootMismatch: () => assertErrorPath([])(validate(number)('not a number')),
+        arrayIndex: () => assertErrorPath(['1'])(validate(array(number))([1, 'two', 3])),
+        recordKey: () => {
+            const r = validate(record(number))({ a: 1, b: 'two', c: 3 })
+            // record iteration order matches Object.entries; 'b' is the failing key
+            assertErrorPath(['b'])(r)
+        },
+        nestedArray: () => assertErrorPath(['0', '1'])(
+            validate(array(array(number)))([[1, 'x'], [2, 3]])
+        ),
+        tupleIndex: () => assertErrorPath(['1'])(
+            validate([number, number] as const)([1, 'two'])
+        ),
+        structKey: () => assertErrorPath(['b'])(
+            validate({ a: number, b: number } as const)({ a: 1, b: 'two' })
+        ),
+        deepStruct: () => {
+            const schema = { user: { name: string, age: number } } as const
+            const r = validate(schema)({ user: { name: 'A', age: 'old' } })
+            assertErrorPath(['user', 'age'])(r)
+        },
+        recursiveSchema: () => {
+            type A = readonly A[]
+            const list = () => ['array', list] as const
+            // [[[42]]] — innermost element 42 is a number, not an array
+            const r = validate(list)([[[42]] as unknown as A])
+            assertErrorPath(['0', '0', '0'])(r)
+        },
+        orRoot: () => assertErrorPath([])(validate(or(number, string))(true)),
     },
     recursive: {
         arrayOfArrays: () => {


### PR DESCRIPTION
## Summary

Enhanced the validation error reporting in `types/rtti/validate` to include a `path` field that pinpoints the exact location of validation failures within nested structures. This makes it significantly easier to debug validation errors in complex schemas.

## Key Changes

- **Error structure redesign**: Changed `Result<T>` error type from a simple `string` message to a `ValidationError` object containing:
  - `path`: A `Path` (array of string keys/indices) pointing to the offending sub-value
  - `message`: The original error message
  
- **Path tracking implementation**:
  - Added `prependPath()` helper to build up the path as validation recurses through nested structures
  - Modified `containerValidate()` to track both keys and values using a new `GetEntries<C>` type
  - Updated array validation to stringify indices for path reporting
  - Updated record validation to use `Object.entries()` for key tracking
  - Updated tuple and struct validation to prepend field/index names to error paths

- **Simplified dispatch logic**: Removed the `tag1Validate` function and `isTag1` import, inlining the array/record dispatch directly in the main `validate()` function

- **Documentation updates**:
  - Added comprehensive "Error path" section explaining the new path field
  - Updated JSDoc examples to show the new error format
  - Added note about `'or'` variant behavior in dispatch strategy docs

- **Test coverage**: Added comprehensive path tracking tests covering:
  - Root-level mismatches (empty path)
  - Array indices and record keys
  - Nested structures (arrays of arrays, structs with nested objects)
  - Tuple and struct field paths
  - Recursive schemas
  - `or` variant failures at root level

## Implementation Details

The path is built incrementally as validation descends through the structure. When a validation fails at any depth, the error is caught and the current key/index is prepended to the path before returning. This creates a complete breadcrumb trail from the root to the exact failing value.

https://claude.ai/code/session_01CAgY7vbEVP4FPSTQiCAgzk