### PR TITLE
RTTI: parse (deserializer)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,11 @@ where `<...Module documentation...>` should be documentation for the module.
   - Reuse code,
   - Don't repeat yourself,
   - Avoid side effects and mutability.
+- When a sibling module already has the type or helper you need, import it — add `export` to the existing declaration if it's not yet exported, rather than duplicating it (e.g. `parse` reuses `Path`, `ValidationError`, `verror`, `prependPath`, `primitive0Validate`, `constPrimitiveValidate` from `validate`).
+- Don't mutate arrays or objects in place. Avoid `.push`, `.pop`, `.shift`, `.unshift`, `.splice`, `.sort`, `.reverse`, and index/property assignment on accumulators. Build new values with `.map`, `.filter`, `.flatMap`, spread, and `Object.fromEntries(entries.map(...))`.
+- When adding a new `module.f.ts` under an existing namespace, register it in the `exports` map of `deno.json`.
+- After fixing an issue from [./issues/README.md](./issues/README.md), mark the corresponding bullet `[X]`.
+- Add an entry for the change under `## Unreleased` in [./CHANGELOG.md](./CHANGELOG.md), in the same `Topic: short description [PR#](url)` style as existing entries.
 - Only import other `.f.ts` files from FunctionalScript modules. Avoid references to built-in or external Node modules such as `node:path` in `.f.ts` files.
 - Use `let` variables only within the function body where they are declared.
 - CLI parameters are preferred over environment variables when adding new features.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- RTTI: parse (deserializer) [760](https://github.com/functionalscript/functionalscript/pull/760)
+
 ## 0.13.0
 
 - RTTI: `print(mut?: true)` [754](https://github.com/functionalscript/functionalscript/pull/754)

--- a/deno.json
+++ b/deno.json
@@ -78,6 +78,7 @@
     "./types/result/module.f.ts": "./types/result/module.f.ts",
     "./types/result/module.ts": "./types/result/module.ts",
     "./types/rtti/module.f.ts": "./types/rtti/module.f.ts",
+    "./types/rtti/parse/module.f.ts": "./types/rtti/parse/module.f.ts",
     "./types/rtti/ts/module.f.ts": "./types/rtti/ts/module.f.ts",
     "./types/rtti/validate/module.f.ts": "./types/rtti/validate/module.f.ts",
     "./types/sorted_list/module.f.ts": "./types/sorted_list/module.f.ts",

--- a/issues/README.md
+++ b/issues/README.md
@@ -297,6 +297,7 @@ require setting a flag when walking through a test tree as soon as a node has a 
 - [ ] 132. `exec`:
   - 1. Keep most implementation code in `module.f.ts` instead of `module.ts`
   - 2. use async functions and await instead of `.then`
+- [ ] 133. Investigate common parts in `rtti/validate` and `rtti/parse`.
 
 ## Language Specification
 

--- a/issues/README.md
+++ b/issues/README.md
@@ -290,7 +290,7 @@ require setting a flag when walking through a test tree as soon as a node has a 
   3. at least one function should be `throw`.
 - [X] 126. `types/rtti` should support `undefined`, `null` instead of `"undefined"` and `"null"`.
 - [X] 127. Simplify `types/rtti/ts/module.f.ts` to reduce TypeScript type instantiation depth. Flatten the `*Ts` helper chain (`ConstTs` → `TupleTs`/`StructTs` → `Ts`) into a single `Ts` conditional type to avoid hitting TypeScript's recursion limit. The intermediate `*Ts` types can remain as derived aliases for the public API but should not participate in the recursive evaluation chain.
-- [ ] [128-rtti-deserialize](./128-rtti-deserialize.md)
+- [X] [128-rtti-deserialize](./128-rtti-deserialize.md)
 - [X] 129. `validate` from [../types/rtti/validate/module.f.ts](../types/rtti/validate/module.f.ts) should return a path in case of an error.
 - [ ] 130. Optimization of `or` in [../types/rtti/module.f.ts](../types/rtti/module.f.ts).
 - [ ] 131. An allocator for `nanvm` that doesn't panic. Instead, it should return `Result<T, Any`.

--- a/types/rtti/parse/module.f.ts
+++ b/types/rtti/parse/module.f.ts
@@ -59,6 +59,8 @@ export type Parse<T extends Type> = Validate<T>
 type ItemResult = CommonResult<Unknown, ValidationError>
 
 const indexedFirstError = (results: readonly ItemResult[]): readonly[number, Error<ValidationError>] | null => {
+    // TODO: findIndex breaks type inference,
+    //       we should replace it with something else.
     const i = results.findIndex(r => r[0] === 'error')
     return i < 0 ? null : [i, results[i] as Error<ValidationError>]
 }
@@ -74,10 +76,10 @@ const arrayParse =
     <I extends Type>(item: I): Parse<Info1<'array', I>> => value =>
 {
     if (!commonIsArray(value)) {
-        return verror('unexpected value') as any
+        return verror('unexpected value')
     }
     if (value.length === 0) {
-        return ok([]) as any
+        return ok([] as any)
     }
     // Note: we shouldn't instantiate `itemParse` until we know the array is non-empty.
     //       Otherwise, we can get infinite recursion on empty arrays for recursive schemas.
@@ -93,11 +95,11 @@ const recordParse =
     <I extends Type>(item: I): Parse<Info1<'record', I>> => value =>
 {
     if (!commonIsObject(value)) {
-        return verror('unexpected value') as any
+        return verror('unexpected value')
     }
     const entries = Object.entries(value)
     if (entries.length === 0) {
-        return ok({}) as any
+        return ok({} as any)
     }
     const itemParse = parse(item) as (v: Unknown) => ItemResult
     const results = entries.map(([k, v]) => [k, itemParse(v)] as const)
@@ -109,7 +111,7 @@ const recordParse =
 
 const tupleParse = <T extends Tuple>(rtti: T): Parse<T> => value => {
     if (!commonIsArray(value)) {
-        return verror('unexpected value') as any
+        return verror('unexpected value')
     }
     const results = rtti.map((t, i) => (parse(t) as any)(value[i]) as ItemResult)
     const err = indexedFirstError(results)
@@ -120,7 +122,7 @@ const tupleParse = <T extends Tuple>(rtti: T): Parse<T> => value => {
 
 const structParse = <T extends Struct>(rtti: T): Parse<T> => value => {
     if (!commonIsObject(value)) {
-        return verror('unexpected value') as any
+        return verror('unexpected value')
     }
     const results = Object.entries(rtti).map(
         ([k, t]) => [k, (parse(t) as any)(value[k]) as ItemResult] as const,

--- a/types/rtti/parse/module.f.ts
+++ b/types/rtti/parse/module.f.ts
@@ -1,0 +1,212 @@
+/**
+ * Runtime deserialization of unknown values against RTTI schemas.
+ *
+ * The main entry point is `parse(rtti)`, which takes a schema `Type` and returns
+ * a `Parse<T>` function. When called with an unknown value, it returns a `Result`
+ * that is either `['ok', newValue]` or `['error', { path, message }]`.
+ *
+ * Unlike `validate`, which checks an existing value in-place and returns it
+ * unchanged on success, `parse` always returns a freshly constructed value that
+ * contains only the fields/elements declared by the schema. This makes both
+ * structs and tuples effectively closed at runtime, matching the TypeScript
+ * type produced by `Ts<T>`:
+ *
+ * - Tuples: the result has exactly the schema's length; extra elements are dropped.
+ * - Structs: the result contains only the schema's keys; extra properties are dropped.
+ * - Arrays/records: every element/value is itself parsed, so a fresh container is
+ *   always returned even if the inner type is a primitive.
+ *
+ * This also provides forward compatibility with extended serialization formats:
+ * a schema-based parser keeps working when newer versions of the format add
+ * extra fields or tuple elements.
+ *
+ * The error path semantics match `validate`: each step is the string property
+ * name (struct/record) or the stringified index (tuple/array); the path is empty
+ * when the failure is at the root.
+ *
+ * @module
+ */
+import type { Unknown } from '../../../djs/module.f.ts'
+import {
+    type Const,
+    type ConstObject,
+    type Info0,
+    type Info1,
+    type Primitive0,
+    type Struct,
+    type Tuple,
+    type Type,
+} from '../module.f.ts'
+import { error, ok, type Error, type Result as CommonResult } from '../../result/module.f.ts'
+import type { Ts } from '../ts/module.f.ts'
+import { isArray as commonIsArray } from '../../array/module.f.ts'
+import { isObject as commonIsObject } from '../../object/module.f.ts'
+import type { Primitive } from '../../../djs/module.f.ts'
+
+/** A path to a sub-value within the parsed structure. Each step is an object key or stringified array index. */
+export type Path = readonly string[]
+
+/** Detailed parse failure: the offending `path` plus a short `message`. */
+export type ParseError = {
+    readonly path: Path
+    readonly message: string
+}
+
+/** Parse result: either the freshly constructed typed value or a `ParseError`. */
+export type Result<T extends Type> = CommonResult<Ts<T>, ParseError>
+
+/** A function that parses an unknown value into the schema `T`. */
+export type Parse<T extends Type> = (value: Unknown) => Result<T>
+
+const perror = (message: string): Error<ParseError> =>
+    error({ path: [], message })
+
+const prependPath = (key: string, r: Error<ParseError>): Error<ParseError> =>
+    error({ path: [key, ...r[1].path], message: r[1].message })
+
+const arrayParse =
+    <I extends Type>(item: I): Parse<Info1<'array', I>> => value =>
+{
+    if (!commonIsArray(value)) {
+        return perror('unexpected value') as any
+    }
+    if (value.length === 0) {
+        return ok([]) as any
+    }
+    // Note: we shouldn't instantiate `itemParse` until we know the array is non-empty.
+    //       Otherwise, we can get infinite recursion on empty arrays for recursive schemas.
+    const itemParse = parse(item) as (v: Unknown) => CommonResult<Unknown, ParseError>
+    const out: Unknown[] = []
+    for (let i = 0; i < value.length; i++) {
+        const r = itemParse(value[i])
+        if (r[0] === 'error') {
+            return prependPath(String(i), r) as any
+        }
+        out.push(r[1])
+    }
+    return ok(out) as any
+}
+
+const recordParse =
+    <I extends Type>(item: I): Parse<Info1<'record', I>> => value =>
+{
+    if (!commonIsObject(value)) {
+        return perror('unexpected value') as any
+    }
+    const entries = Object.entries(value)
+    if (entries.length === 0) {
+        return ok({}) as any
+    }
+    const itemParse = parse(item) as (v: Unknown) => CommonResult<Unknown, ParseError>
+    const out: { [k: string]: Unknown } = {}
+    for (const [k, v] of entries) {
+        const r = itemParse(v)
+        if (r[0] === 'error') {
+            return prependPath(k, r) as any
+        }
+        out[k] = r[1]
+    }
+    return ok(out) as any
+}
+
+/** Parses a `Tag0` primitive schema using `typeof`. */
+const primitive0Parse = <K extends Primitive0, T extends Info0<K>>(tag: K): Parse<T> =>
+    value => typeof value === tag ? ok(value) as any : perror('unexpected value') as any
+
+const tupleParse = <T extends Tuple>(rtti: T): Parse<T> => value => {
+    if (!commonIsArray(value)) {
+        return perror('unexpected value') as any
+    }
+    const out: Unknown[] = []
+    for (let i = 0; i < rtti.length; i++) {
+        const r = (parse(rtti[i]) as any)(value[i]) as CommonResult<Unknown, ParseError>
+        if (r[0] === 'error') {
+            return prependPath(String(i), r) as any
+        }
+        out.push(r[1])
+    }
+    return ok(out) as any
+}
+
+const structParse = <T extends Struct>(rtti: T): Parse<T> => value => {
+    if (!commonIsObject(value)) {
+        return perror('unexpected value') as any
+    }
+    const out: { [k: string]: Unknown } = {}
+    for (const [k, v] of Object.entries(rtti)) {
+        const r = (parse(v) as any)(value[k]) as CommonResult<Unknown, ParseError>
+        if (r[0] === 'error') {
+            return prependPath(k, r) as any
+        }
+        out[k] = r[1]
+    }
+    return ok(out) as any
+}
+
+const constObjectParse = <T extends ConstObject>(rtti: T): Parse<T> =>
+    commonIsArray(rtti)
+        ? tupleParse(rtti) as any
+        : structParse(rtti) as any
+
+/** Parses a primitive `Const` schema using strict equality (`===`). */
+const constPrimitiveParse = <T extends Primitive>(rtti: T): Parse<T> =>
+    value => rtti === value
+        ? ok(value) as any
+        : perror('unexpected value') as any
+
+const constParse = <T extends Const>(rtti: T): Parse<T> =>
+    typeof rtti === 'object' && rtti !== null
+        ? constObjectParse(rtti) as any
+        : constPrimitiveParse(rtti) as any
+
+const orParse = <T extends readonly Type[]>(rtti: T): Parse<() => readonly['or', ...T]> => {
+    const all = rtti.map(r => parse(r))
+    return value => {
+        for (const i of all) {
+            const r = (i as any)(value)
+            if (r[0] === 'ok') {
+                return r
+            }
+        }
+        return perror('no match') as any
+    }
+}
+
+/**
+ * Creates a parser function for the given RTTI schema.
+ *
+ * The returned function takes an unknown value and returns either
+ * `['ok', newValue]` containing a freshly constructed value matching the schema,
+ * or `['error', { path, message }]` describing the failure location.
+ *
+ * @param rtti - A schema `Type`: a `Thunk` for tag-based schemas, or a `Const`
+ *   (primitive literal, tuple, or struct) for exact-value schemas.
+ * @returns A `Parse<T>` function.
+ *
+ * @example
+ * ```ts
+ * const p = parse(array(number))
+ * p([1, 2, 3])         // ['ok', [1, 2, 3]]   (a new array)
+ * p([1, 'two'])        // ['error', { path: ['1'], message: 'unexpected value' }]
+ *
+ * // tuples are closed: extra elements are dropped
+ * parse([number, number] as const)([1, 2, 3]) // ['ok', [1, 2]]
+ *
+ * // structs drop undeclared keys
+ * parse({ a: number } as const)({ a: 1, b: 2 }) // ['ok', { a: 1 }]
+ * ```
+ */
+export const parse = <T extends Type>(rtti: T): Parse<T> => {
+    if (typeof rtti === 'function') {
+        const [tag, ...value] = rtti()
+        switch (tag) {
+            case 'const': return constParse(value[0] as Const) as any
+            case 'array': return arrayParse(value[0]) as any
+            case 'record': return recordParse(value[0]) as any
+            case 'unknown': return ok as any
+            case 'or': return orParse(value) as any
+        }
+        return primitive0Parse(tag) as any
+    }
+    return constParse(rtti) as any
+}

--- a/types/rtti/parse/module.f.ts
+++ b/types/rtti/parse/module.f.ts
@@ -20,9 +20,8 @@
  * a schema-based parser keeps working when newer versions of the format add
  * extra fields or tuple elements.
  *
- * The error path semantics match `validate`: each step is the string property
- * name (struct/record) or the stringified index (tuple/array); the path is empty
- * when the failure is at the root.
+ * Error path semantics, error type, and primitive/const-primitive checks are
+ * shared with `validate`; only container construction differs.
  *
  * @module
  */
@@ -30,52 +29,45 @@ import type { Unknown } from '../../../djs/module.f.ts'
 import {
     type Const,
     type ConstObject,
-    type Info0,
     type Info1,
-    type Primitive0,
     type Struct,
     type Tuple,
     type Type,
 } from '../module.f.ts'
-import { error, ok, type Error, type Result as CommonResult } from '../../result/module.f.ts'
-import type { Ts } from '../ts/module.f.ts'
+import { ok, type Result as CommonResult } from '../../result/module.f.ts'
+import {
+    constPrimitiveValidate,
+    prependPath,
+    primitive0Validate,
+    verror,
+    type Path,
+    type Result as ValidateResult,
+    type Validate,
+    type ValidationError,
+} from '../validate/module.f.ts'
 import { isArray as commonIsArray } from '../../array/module.f.ts'
 import { isObject as commonIsObject } from '../../object/module.f.ts'
-import type { Primitive } from '../../../djs/module.f.ts'
 
-/** A path to a sub-value within the parsed structure. Each step is an object key or stringified array index. */
-export type Path = readonly string[]
+export type { Path, ValidationError } from '../validate/module.f.ts'
 
-/** Detailed parse failure: the offending `path` plus a short `message`. */
-export type ParseError = {
-    readonly path: Path
-    readonly message: string
-}
-
-/** Parse result: either the freshly constructed typed value or a `ParseError`. */
-export type Result<T extends Type> = CommonResult<Ts<T>, ParseError>
+/** Parse result: either the freshly constructed typed value or a `ValidationError`. */
+export type Result<T extends Type> = ValidateResult<T>
 
 /** A function that parses an unknown value into the schema `T`. */
-export type Parse<T extends Type> = (value: Unknown) => Result<T>
-
-const perror = (message: string): Error<ParseError> =>
-    error({ path: [], message })
-
-const prependPath = (key: string, r: Error<ParseError>): Error<ParseError> =>
-    error({ path: [key, ...r[1].path], message: r[1].message })
+export type Parse<T extends Type> = Validate<T>
 
 const arrayParse =
     <I extends Type>(item: I): Parse<Info1<'array', I>> => value =>
 {
     if (!commonIsArray(value)) {
-        return perror('unexpected value') as any
+        return verror('unexpected value') as any
     }
     if (value.length === 0) {
         return ok([]) as any
     }
     // Note: we shouldn't instantiate `itemParse` until we know the array is non-empty.
     //       Otherwise, we can get infinite recursion on empty arrays for recursive schemas.
-    const itemParse = parse(item) as (v: Unknown) => CommonResult<Unknown, ParseError>
+    const itemParse = parse(item) as (v: Unknown) => CommonResult<Unknown, ValidationError>
     const out: Unknown[] = []
     for (let i = 0; i < value.length; i++) {
         const r = itemParse(value[i])
@@ -91,13 +83,13 @@ const recordParse =
     <I extends Type>(item: I): Parse<Info1<'record', I>> => value =>
 {
     if (!commonIsObject(value)) {
-        return perror('unexpected value') as any
+        return verror('unexpected value') as any
     }
     const entries = Object.entries(value)
     if (entries.length === 0) {
         return ok({}) as any
     }
-    const itemParse = parse(item) as (v: Unknown) => CommonResult<Unknown, ParseError>
+    const itemParse = parse(item) as (v: Unknown) => CommonResult<Unknown, ValidationError>
     const out: { [k: string]: Unknown } = {}
     for (const [k, v] of entries) {
         const r = itemParse(v)
@@ -109,17 +101,13 @@ const recordParse =
     return ok(out) as any
 }
 
-/** Parses a `Tag0` primitive schema using `typeof`. */
-const primitive0Parse = <K extends Primitive0, T extends Info0<K>>(tag: K): Parse<T> =>
-    value => typeof value === tag ? ok(value) as any : perror('unexpected value') as any
-
 const tupleParse = <T extends Tuple>(rtti: T): Parse<T> => value => {
     if (!commonIsArray(value)) {
-        return perror('unexpected value') as any
+        return verror('unexpected value') as any
     }
     const out: Unknown[] = []
     for (let i = 0; i < rtti.length; i++) {
-        const r = (parse(rtti[i]) as any)(value[i]) as CommonResult<Unknown, ParseError>
+        const r = (parse(rtti[i]) as any)(value[i]) as CommonResult<Unknown, ValidationError>
         if (r[0] === 'error') {
             return prependPath(String(i), r) as any
         }
@@ -130,11 +118,11 @@ const tupleParse = <T extends Tuple>(rtti: T): Parse<T> => value => {
 
 const structParse = <T extends Struct>(rtti: T): Parse<T> => value => {
     if (!commonIsObject(value)) {
-        return perror('unexpected value') as any
+        return verror('unexpected value') as any
     }
     const out: { [k: string]: Unknown } = {}
     for (const [k, v] of Object.entries(rtti)) {
-        const r = (parse(v) as any)(value[k]) as CommonResult<Unknown, ParseError>
+        const r = (parse(v) as any)(value[k]) as CommonResult<Unknown, ValidationError>
         if (r[0] === 'error') {
             return prependPath(k, r) as any
         }
@@ -148,16 +136,10 @@ const constObjectParse = <T extends ConstObject>(rtti: T): Parse<T> =>
         ? tupleParse(rtti) as any
         : structParse(rtti) as any
 
-/** Parses a primitive `Const` schema using strict equality (`===`). */
-const constPrimitiveParse = <T extends Primitive>(rtti: T): Parse<T> =>
-    value => rtti === value
-        ? ok(value) as any
-        : perror('unexpected value') as any
-
 const constParse = <T extends Const>(rtti: T): Parse<T> =>
     typeof rtti === 'object' && rtti !== null
         ? constObjectParse(rtti) as any
-        : constPrimitiveParse(rtti) as any
+        : constPrimitiveValidate(rtti) as any
 
 const orParse = <T extends readonly Type[]>(rtti: T): Parse<() => readonly['or', ...T]> => {
     const all = rtti.map(r => parse(r))
@@ -168,7 +150,7 @@ const orParse = <T extends readonly Type[]>(rtti: T): Parse<() => readonly['or',
                 return r
             }
         }
-        return perror('no match') as any
+        return verror('no match') as any
     }
 }
 
@@ -206,7 +188,7 @@ export const parse = <T extends Type>(rtti: T): Parse<T> => {
             case 'unknown': return ok as any
             case 'or': return orParse(value) as any
         }
-        return primitive0Parse(tag) as any
+        return primitive0Validate(tag) as any
     }
     return constParse(rtti) as any
 }

--- a/types/rtti/parse/module.f.ts
+++ b/types/rtti/parse/module.f.ts
@@ -34,7 +34,7 @@ import {
     type Tuple,
     type Type,
 } from '../module.f.ts'
-import { ok, type Result as CommonResult } from '../../result/module.f.ts'
+import { ok, type Error, type Result as CommonResult } from '../../result/module.f.ts'
 import {
     constPrimitiveValidate,
     prependPath,
@@ -56,6 +56,20 @@ export type Result<T extends Type> = ValidateResult<T>
 /** A function that parses an unknown value into the schema `T`. */
 export type Parse<T extends Type> = Validate<T>
 
+type ItemResult = CommonResult<Unknown, ValidationError>
+
+const indexedFirstError = (results: readonly ItemResult[]): readonly[number, Error<ValidationError>] | null => {
+    const i = results.findIndex(r => r[0] === 'error')
+    return i < 0 ? null : [i, results[i] as Error<ValidationError>]
+}
+
+const keyedFirstError = (
+    results: readonly (readonly[string, ItemResult])[],
+): readonly[string, Error<ValidationError>] | null => {
+    const e = results.find(([, r]) => r[0] === 'error')
+    return e === undefined ? null : [e[0], e[1] as Error<ValidationError>]
+}
+
 const arrayParse =
     <I extends Type>(item: I): Parse<Info1<'array', I>> => value =>
 {
@@ -67,16 +81,12 @@ const arrayParse =
     }
     // Note: we shouldn't instantiate `itemParse` until we know the array is non-empty.
     //       Otherwise, we can get infinite recursion on empty arrays for recursive schemas.
-    const itemParse = parse(item) as (v: Unknown) => CommonResult<Unknown, ValidationError>
-    const out: Unknown[] = []
-    for (let i = 0; i < value.length; i++) {
-        const r = itemParse(value[i])
-        if (r[0] === 'error') {
-            return prependPath(String(i), r) as any
-        }
-        out.push(r[1])
-    }
-    return ok(out) as any
+    const itemParse = parse(item) as (v: Unknown) => ItemResult
+    const results = value.map(itemParse)
+    const err = indexedFirstError(results)
+    return (err === null
+        ? ok(results.map(r => r[1]))
+        : prependPath(String(err[0]), err[1])) as any
 }
 
 const recordParse =
@@ -89,46 +99,36 @@ const recordParse =
     if (entries.length === 0) {
         return ok({}) as any
     }
-    const itemParse = parse(item) as (v: Unknown) => CommonResult<Unknown, ValidationError>
-    const out: { [k: string]: Unknown } = {}
-    for (const [k, v] of entries) {
-        const r = itemParse(v)
-        if (r[0] === 'error') {
-            return prependPath(k, r) as any
-        }
-        out[k] = r[1]
-    }
-    return ok(out) as any
+    const itemParse = parse(item) as (v: Unknown) => ItemResult
+    const results = entries.map(([k, v]) => [k, itemParse(v)] as const)
+    const err = keyedFirstError(results)
+    return (err === null
+        ? ok(Object.fromEntries(results.map(([k, r]) => [k, r[1]])))
+        : prependPath(err[0], err[1])) as any
 }
 
 const tupleParse = <T extends Tuple>(rtti: T): Parse<T> => value => {
     if (!commonIsArray(value)) {
         return verror('unexpected value') as any
     }
-    const out: Unknown[] = []
-    for (let i = 0; i < rtti.length; i++) {
-        const r = (parse(rtti[i]) as any)(value[i]) as CommonResult<Unknown, ValidationError>
-        if (r[0] === 'error') {
-            return prependPath(String(i), r) as any
-        }
-        out.push(r[1])
-    }
-    return ok(out) as any
+    const results = rtti.map((t, i) => (parse(t) as any)(value[i]) as ItemResult)
+    const err = indexedFirstError(results)
+    return (err === null
+        ? ok(results.map(r => r[1]))
+        : prependPath(String(err[0]), err[1])) as any
 }
 
 const structParse = <T extends Struct>(rtti: T): Parse<T> => value => {
     if (!commonIsObject(value)) {
         return verror('unexpected value') as any
     }
-    const out: { [k: string]: Unknown } = {}
-    for (const [k, v] of Object.entries(rtti)) {
-        const r = (parse(v) as any)(value[k]) as CommonResult<Unknown, ValidationError>
-        if (r[0] === 'error') {
-            return prependPath(k, r) as any
-        }
-        out[k] = r[1]
-    }
-    return ok(out) as any
+    const results = Object.entries(rtti).map(
+        ([k, t]) => [k, (parse(t) as any)(value[k]) as ItemResult] as const,
+    )
+    const err = keyedFirstError(results)
+    return (err === null
+        ? ok(Object.fromEntries(results.map(([k, r]) => [k, r[1]])))
+        : prependPath(err[0], err[1])) as any
 }
 
 const constObjectParse = <T extends ConstObject>(rtti: T): Parse<T> =>
@@ -142,15 +142,10 @@ const constParse = <T extends Const>(rtti: T): Parse<T> =>
         : constPrimitiveValidate(rtti) as any
 
 const orParse = <T extends readonly Type[]>(rtti: T): Parse<() => readonly['or', ...T]> => {
-    const all = rtti.map(r => parse(r))
+    const all = rtti.map(r => (parse as any)(r) as (v: Unknown) => ItemResult)
     return value => {
-        for (const i of all) {
-            const r = (i as any)(value)
-            if (r[0] === 'ok') {
-                return r
-            }
-        }
-        return verror('no match') as any
+        const r = all.map(p => p(value)).find(([k]) => k === 'ok')
+        return (r ?? verror('no match')) as any
     }
 }
 

--- a/types/rtti/parse/test.f.ts
+++ b/types/rtti/parse/test.f.ts
@@ -1,0 +1,315 @@
+import { parse, type ParseError } from './module.f.ts'
+import { boolean, number, string, bigint, unknown, array, record, or, option } from '../module.f.ts'
+import type { Assert, Equal } from '../../ts/module.f.ts'
+import type { Ts } from '../ts/module.f.ts'
+import type { Unknown as DjsUnknown } from '../../../djs/module.f.ts'
+
+const assertOk = ([k]: readonly [string, unknown]) => { if (k !== 'ok') { throw 'expected ok' } }
+const assertError = ([k]: readonly [string, unknown]) => { if (k !== 'error') { throw 'expected error' } }
+
+const unwrap = <T>(r: readonly [string, unknown]): T => {
+    if (r[0] !== 'ok') { throw 'expected ok' }
+    return r[1] as T
+}
+
+const assertErrorPath = (expected: readonly string[]) =>
+    (r: readonly [string, unknown]) => {
+        if (r[0] !== 'error') { throw 'expected error' }
+        const e = r[1] as ParseError
+        if (e.path.length !== expected.length) { throw `path length ${e.path.length} != ${expected.length}` }
+        for (let i = 0; i < expected.length; i++) {
+            if (e.path[i] !== expected[i]) { throw `path[${i}] ${e.path[i]} != ${expected[i]}` }
+        }
+    }
+
+const assertDeepEqual = (a: unknown, b: unknown): void => {
+    if (a === b) { return }
+    if (a instanceof Array && b instanceof Array) {
+        if (a.length !== b.length) { throw `array length ${a.length} != ${b.length}` }
+        for (let i = 0; i < a.length; i++) { assertDeepEqual(a[i], b[i]) }
+        return
+    }
+    if (typeof a === 'object' && a !== null && typeof b === 'object' && b !== null) {
+        const ka = Object.keys(a).sort()
+        const kb = Object.keys(b).sort()
+        if (ka.length !== kb.length) { throw `key count ${ka.length} != ${kb.length}` }
+        for (let i = 0; i < ka.length; i++) {
+            if (ka[i] !== kb[i]) { throw `key ${ka[i]} != ${kb[i]}` }
+            assertDeepEqual((a as any)[ka[i]], (b as any)[kb[i]])
+        }
+        return
+    }
+    throw `not deep-equal: ${String(a)} vs ${String(b)}`
+}
+
+export default {
+    boolean: {
+        ok: () => {
+            type _ = Assert<Equal<Ts<typeof boolean>, boolean>>
+            assertOk(parse(boolean)(true))
+            assertOk(parse(boolean)(false))
+        },
+        error: () => {
+            assertError(parse(boolean)(0))
+            assertError(parse(boolean)('true'))
+            assertError(parse(boolean)(null))
+        },
+    },
+    number: {
+        ok: () => {
+            type _ = Assert<Equal<Ts<typeof number>, number>>
+            assertOk(parse(number)(42))
+        },
+        error: () => {
+            assertError(parse(number)('42'))
+            assertError(parse(number)(42n))
+        },
+    },
+    string: {
+        ok: () => {
+            type _ = Assert<Equal<Ts<typeof string>, string>>
+            assertOk(parse(string)('hello'))
+        },
+        error: () => {
+            assertError(parse(string)(42))
+            assertError(parse(string)(null))
+        },
+    },
+    bigint: {
+        ok: () => {
+            type _ = Assert<Equal<Ts<typeof bigint>, bigint>>
+            assertOk(parse(bigint)(4n))
+        },
+        error: () => {
+            assertError(parse(bigint)(4))
+            assertError(parse(bigint)('4'))
+        },
+    },
+    unknown: {
+        ok: () => {
+            type _ = Assert<Equal<Ts<typeof unknown>, DjsUnknown>>
+            assertOk(parse(unknown)(null))
+            assertOk(parse(unknown)(42))
+            assertOk(parse(unknown)('hello'))
+            assertOk(parse(unknown)(true))
+            assertOk(parse(unknown)({}))
+            assertOk(parse(unknown)([]))
+        },
+    },
+    const: {
+        null: {
+            ok: () => assertOk(parse(null)(null)),
+            error: () => {
+                assertError(parse(null)(undefined))
+                assertError(parse(null)(0))
+            },
+        },
+        undefined: {
+            ok: () => assertOk(parse(undefined)(undefined)),
+            error: () => assertError(parse(undefined)(null)),
+        },
+        number: {
+            ok: () => assertOk(parse(42 as const)(42)),
+            error: () => assertError(parse(42 as const)(43)),
+        },
+        string: {
+            ok: () => assertOk(parse('hello' as const)('hello')),
+            error: () => assertError(parse('hello' as const)('world')),
+        },
+        bigint: {
+            ok: () => assertOk(parse(7n as const)(7n)),
+            error: () => assertError(parse(7n as const)(8n)),
+        },
+        boolean: {
+            ok: () => assertOk(parse(true as const)(true)),
+            error: () => assertError(parse(true as const)(false)),
+        },
+        tuple: {
+            ok: () => {
+                const t = [42, 'hello'] as const
+                const r = parse(t)([42, 'hello'])
+                assertDeepEqual(unwrap(r), [42, 'hello'])
+            },
+            // The key behavior change vs `validate`: extra tuple elements are dropped.
+            extraItemsDropped: () => {
+                const r = parse([42] as const)([42, 'extra'])
+                assertDeepEqual(unwrap(r), [42])
+            },
+            error: () => {
+                assertError(parse([42] as const)([99]))
+                assertError(parse([42] as const)({}))
+            },
+        },
+        struct: {
+            ok: () => {
+                const t = { a: 42, b: 'hello' } as const
+                const r = parse(t)({ a: 42, b: 'hello' })
+                assertDeepEqual(unwrap(r), { a: 42, b: 'hello' })
+            },
+            // Undeclared properties are dropped from the constructed value.
+            extraKeysDropped: () => {
+                const r = parse({ a: 42 as const } as const)({ a: 42, b: 'extra' })
+                assertDeepEqual(unwrap(r), { a: 42 })
+            },
+            error: () => {
+                assertError(parse({ a: 42 } as const)({ a: 99 }))
+                assertError(parse({ a: 42 } as const)([]))
+            },
+        },
+    },
+    array: {
+        empty: () => {
+            const r = parse(array(number))([])
+            assertDeepEqual(unwrap(r), [])
+        },
+        ok: () => {
+            const r = parse(array(number))([1, 2, 3])
+            assertDeepEqual(unwrap(r), [1, 2, 3])
+        },
+        // `parse` always constructs a new array, even when the inner type is a primitive.
+        freshArray: () => {
+            const input = [1, 2, 3]
+            const out = unwrap<readonly number[]>(parse(array(number))(input))
+            if (out === input as unknown) { throw 'expected a fresh array' }
+            assertDeepEqual(out, [1, 2, 3])
+        },
+        error: () => {
+            assertError(parse(array(number))([1, 'two', 3]))
+            assertError(parse(array(number))({}))
+            assertError(parse(array(number))(null))
+        },
+        nested: () => {
+            const r = parse(array(array(boolean)))([[true, false], [false]])
+            assertDeepEqual(unwrap(r), [[true, false], [false]])
+            assertError(parse(array(array(boolean)))([[true, 42]]))
+        },
+    },
+    record: {
+        empty: () => {
+            const r = parse(record(number))({})
+            assertDeepEqual(unwrap(r), {})
+        },
+        ok: () => {
+            const r = parse(record(string))({ a: 'hello', b: 'world' })
+            assertDeepEqual(unwrap(r), { a: 'hello', b: 'world' })
+        },
+        // `parse` always constructs a new record.
+        freshRecord: () => {
+            const input = { a: 1, b: 2 }
+            const out = unwrap<Record<string, number>>(parse(record(number))(input))
+            if (out === input as unknown) { throw 'expected a fresh record' }
+            assertDeepEqual(out, { a: 1, b: 2 })
+        },
+        error: () => {
+            assertError(parse(record(number))({ a: 1, b: 'two' }))
+            assertError(parse(record(number))(null))
+            assertError(parse(record(number))([]))
+        },
+    },
+    constThunk: {
+        primitive: () => {
+            const t = () => ['const', 7n] as const
+            assertOk(parse(t)(7n))
+            assertError(parse(t)(8n))
+        },
+    },
+    or: {
+        consts: {
+            ok: () => {
+                const t = or(...[false, 42, 'hello'] as const)
+                assertOk(parse(t)(false))
+                assertOk(parse(t)(42))
+                assertOk(parse(t)('hello'))
+            },
+            error: () => {
+                const t = or(...[false, 42, 'hello'] as const)
+                assertError(parse(t)(true))
+                assertError(parse(t)(43))
+                assertError(parse(t)('world'))
+                assertError(parse(t)(null))
+            },
+        },
+        thunks: {
+            ok: () => {
+                const t = or(number, string)
+                assertOk(parse(t)(42))
+                assertOk(parse(t)('hello'))
+            },
+            error: () => {
+                const t = or(number, string)
+                assertError(parse(t)(true))
+                assertError(parse(t)(null))
+            },
+        },
+        // First matching variant wins; the freshly-constructed value comes from that variant.
+        firstMatchWins: () => {
+            const t = or([number] as const, array(number))
+            const out = unwrap<readonly number[]>(parse(t)([1, 2, 3]))
+            // The const tuple `[number]` matches first and returns a length-1 result.
+            assertDeepEqual(out, [1])
+        },
+    },
+    option: {
+        ok: () => {
+            const t = option(number)
+            assertOk(parse(t)(42))
+            assertOk(parse(t)(undefined))
+        },
+        error: () => {
+            const t = option(number)
+            assertError(parse(t)(null))
+            assertError(parse(t)('42'))
+        },
+    },
+    path: {
+        rootMismatch: () => assertErrorPath([])(parse(number)('not a number')),
+        arrayIndex: () => assertErrorPath(['1'])(parse(array(number))([1, 'two', 3])),
+        recordKey: () => {
+            const r = parse(record(number))({ a: 1, b: 'two', c: 3 })
+            assertErrorPath(['b'])(r)
+        },
+        nestedArray: () => assertErrorPath(['0', '1'])(
+            parse(array(array(number)))([[1, 'x'], [2, 3]])
+        ),
+        tupleIndex: () => assertErrorPath(['1'])(
+            parse([number, number] as const)([1, 'two'])
+        ),
+        structKey: () => assertErrorPath(['b'])(
+            parse({ a: number, b: number } as const)({ a: 1, b: 'two' })
+        ),
+        deepStruct: () => {
+            const schema = { user: { name: string, age: number } } as const
+            const r = parse(schema)({ user: { name: 'A', age: 'old' } })
+            assertErrorPath(['user', 'age'])(r)
+        },
+        recursiveSchema: () => {
+            type A = readonly A[]
+            const list = () => ['array', list] as const
+            const r = parse(list)([[[42]] as unknown as A])
+            assertErrorPath(['0', '0', '0'])(r)
+        },
+        orRoot: () => assertErrorPath([])(parse(or(number, string))(true)),
+    },
+    recursive: {
+        arrayOfArrays: () => {
+            type A = readonly A[]
+            const list = () => ['array', list] as const
+            type _A = Assert<Equal<A, Ts<typeof list>>>
+            const v = parse(list)
+            assertOk(v([]))
+            assertOk(v([[], []]))
+            assertOk(v([[[], []], []]))
+            assertError(v([42]))
+            assertError(v(null))
+        },
+        recordOfRecords: () => {
+            const tree = () => ['record', tree] as const
+            type A = { readonly[K in string]: A }
+            type _ = Assert<Equal<A, Ts<typeof tree>>>
+            const v = parse(tree)
+            assertOk(v({}))
+            assertOk(v({ a: {}, b: { c: {} } }))
+            assertError(v({ a: 42 }))
+        },
+    },
+}

--- a/types/rtti/parse/test.f.ts
+++ b/types/rtti/parse/test.f.ts
@@ -1,4 +1,4 @@
-import { parse, type ParseError } from './module.f.ts'
+import { parse, type ValidationError } from './module.f.ts'
 import { boolean, number, string, bigint, unknown, array, record, or, option } from '../module.f.ts'
 import type { Assert, Equal } from '../../ts/module.f.ts'
 import type { Ts } from '../ts/module.f.ts'
@@ -15,7 +15,7 @@ const unwrap = <T>(r: readonly [string, unknown]): T => {
 const assertErrorPath = (expected: readonly string[]) =>
     (r: readonly [string, unknown]) => {
         if (r[0] !== 'error') { throw 'expected error' }
-        const e = r[1] as ParseError
+        const e = r[1] as ValidationError
         if (e.path.length !== expected.length) { throw `path length ${e.path.length} != ${expected.length}` }
         for (let i = 0; i < expected.length; i++) {
             if (e.path[i] !== expected[i]) { throw `path[${i}] ${e.path[i]} != ${expected[i]}` }

--- a/types/rtti/validate/module.f.ts
+++ b/types/rtti/validate/module.f.ts
@@ -64,10 +64,12 @@ export type Result<T extends Type> = CommonResult<Ts<T>, ValidationError>
 /** A function that validates an unknown value against schema `T`. */
 export type Validate<T extends Type> = (value: Unknown) => Result<T>
 
-const verror = (message: string): Error<ValidationError> =>
+/** Builds an error result with empty path and the given message. */
+export const verror = (message: string): Error<ValidationError> =>
     error({ path: [], message })
 
-const prependPath = (key: string, r: Error<ValidationError>): Error<ValidationError> =>
+/** Prepends `key` to the error's path, used to build the path bottom-up. */
+export const prependPath = (key: string, r: Error<ValidationError>): Error<ValidationError> =>
     error({ path: [key, ...r[1].path], message: r[1].message })
 
 /** Type guard narrowing `Unknown` to a specific container type `C`. */
@@ -123,7 +125,7 @@ const isObject: IsContainer<ReadonlyRecord<string, Unknown>> =
 const recordValidate = containerValidate<'record'>(isObject, Object.entries)
 
 /** Validates a `Tag0` primitive schema using `typeof`. */
-const primitive0Validate = <K extends Primitive0, T extends Info0<K>>(tag: K): Validate<T> =>
+export const primitive0Validate = <K extends Primitive0, T extends Info0<K>>(tag: K): Validate<T> =>
     value => typeof value === tag ? ok(value) as any : verror('unexpected value') as any
 
 /**
@@ -164,7 +166,7 @@ const constObjectValidate = <T extends ConstObject>(rtti: T): Validate<T> =>
         : structValidate(rtti) as any
 
 /** Validates a primitive `Const` schema using strict equality (`===`). */
-const constPrimitiveValidate = <T extends Primitive>(rtti: T): Validate<T> =>
+export const constPrimitiveValidate = <T extends Primitive>(rtti: T): Validate<T> =>
     value => rtti === value
         ? ok(value) as any
         : verror('unexpected value') as any


### PR DESCRIPTION
## Summary
Introduces a new `parse` module under `types/rtti/` that provides runtime deserialization of unknown values against RTTI schemas. Unlike the existing `validate` function which checks values in-place, `parse` always returns freshly constructed values containing only schema-declared fields/elements.

## Key Changes
- **New `types/rtti/parse/module.f.ts`**: Core parsing implementation with the following features:
  - `parse(rtti)` function that creates a parser for any RTTI schema type
  - Returns `Result<T>` tuples: either `['ok', value]` or `['error', ParseError]`
  - Detailed error tracking with path information (property names and array indices)
  - Support for all schema types: primitives, arrays, records, tuples, structs, const values, and unions (`or`)
  - Recursive schema support via thunks

- **New `types/rtti/parse/test.f.ts`**: Comprehensive test suite covering:
  - All primitive types (boolean, number, string, bigint, unknown)
  - Const values (literals, tuples, structs)
  - Collections (arrays, records) with nesting
  - Union types (`or`) with first-match-wins semantics
  - Optional values
  - Error path tracking at various nesting levels
  - Recursive schema definitions

- **Updated `deno.json`**: Added export mapping for the new parse module

## Notable Implementation Details
- **Closed semantics**: Tuples and structs are effectively closed at runtime—extra tuple elements and object properties are dropped, matching TypeScript's type semantics
- **Fresh construction**: Arrays and records always return new instances, even for primitive element types
- **Lazy instantiation**: Parsers for array/record items are only instantiated when needed to avoid infinite recursion on empty collections with recursive schemas
- **Error path semantics**: Consistent with `validate`—empty path for root failures, string keys for objects, stringified indices for arrays
- **Forward compatibility**: Schema-based parsing naturally handles extended serialization formats by ignoring undeclared fields

https://claude.ai/code/session_01Y3gNsC9dwe3maJPAGTZFDn