### PR TITLE
CI: version config.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1004,7 +1004,7 @@
           "run": "npm ci"
         },
         {
-          "run": "npm test"
+          "run": "npm run test20"
         }
       ]
     },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26"
+            "node-version": "26.1.0"
           }
         },
         {
@@ -197,7 +197,7 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26"
+            "node-version": "26.1.0"
           }
         },
         {
@@ -359,7 +359,7 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26"
+            "node-version": "26.1.0"
           }
         },
         {
@@ -521,7 +521,7 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26"
+            "node-version": "26.1.0"
           }
         },
         {
@@ -683,7 +683,7 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26"
+            "node-version": "26.1.0"
           }
         },
         {
@@ -851,7 +851,7 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26"
+            "node-version": "26.1.0"
           }
         },
         {
@@ -1054,7 +1054,7 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26"
+            "node-version": "26.1.0"
           }
         },
         {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@
         {
           "uses": "wasmerio/setup-wasmer@v3.1",
           "with": {
-            "version": "7.1.0"
+            "version": "v7.1.0"
           }
         },
         {
@@ -197,7 +197,7 @@
         {
           "uses": "wasmerio/setup-wasmer@v3.1",
           "with": {
-            "version": "7.1.0"
+            "version": "v7.1.0"
           }
         },
         {
@@ -362,7 +362,7 @@
         {
           "uses": "wasmerio/setup-wasmer@v3.1",
           "with": {
-            "version": "7.1.0"
+            "version": "v7.1.0"
           }
         },
         {
@@ -527,7 +527,7 @@
         {
           "uses": "wasmerio/setup-wasmer@v3.1",
           "with": {
-            "version": "7.1.0"
+            "version": "v7.1.0"
           }
         },
         {
@@ -692,7 +692,7 @@
         {
           "uses": "wasmerio/setup-wasmer@v3.1",
           "with": {
-            "version": "7.1.0"
+            "version": "v7.1.0"
           }
         },
         {
@@ -863,7 +863,7 @@
         {
           "uses": "wasmerio/setup-wasmer@v3.1",
           "with": {
-            "version": "7.1.0"
+            "version": "v7.1.0"
           }
         },
         {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1072,7 +1072,7 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26.1.0"
+            "node-version": "24"
           }
         },
         {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1079,13 +1079,7 @@
           "run": "npm install -g playwright@1.59.1"
         },
         {
-          "run": "playwright install"
-        },
-        {
-          "run": "playwright install chromium"
-        },
-        {
-          "run": "playwright install firefow"
+          "run": "playwright install firefox"
         },
         {
           "run": "playwright install webkit"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1079,7 +1079,16 @@
           "run": "npm install -g playwright@1.59.1"
         },
         {
-          "run": "playwright install --with-deps"
+          "run": "playwright install"
+        },
+        {
+          "run": "playwright install chromium"
+        },
+        {
+          "run": "playwright install firefow"
+        },
+        {
+          "run": "playwright install webkit"
         },
         {
           "uses": "actions/checkout@v5"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1079,13 +1079,7 @@
           "run": "npm install -g playwright@1.59.1"
         },
         {
-          "run": "sudo apt-get update && sudo apt-get install -y unzip"
-        },
-        {
-          "run": "rm -rf ~/.cache/ms-playwright"
-        },
-        {
-          "run": "DEBUG=pw:install npx playwright install firefox"
+          "run": "playwright install --with-deps"
         },
         {
           "uses": "actions/checkout@v5"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,10 @@
           }
         },
         {
-          "uses": "wasmerio/setup-wasmer@v1"
+          "uses": "wasmerio/setup-wasmer@v3.1",
+          "with": {
+            "version": "7.1.0"
+          }
         },
         {
           "uses": "actions/setup-node@v6",
@@ -192,7 +195,10 @@
           }
         },
         {
-          "uses": "wasmerio/setup-wasmer@v1"
+          "uses": "wasmerio/setup-wasmer@v3.1",
+          "with": {
+            "version": "7.1.0"
+          }
         },
         {
           "uses": "actions/setup-node@v6",
@@ -354,7 +360,10 @@
           }
         },
         {
-          "uses": "wasmerio/setup-wasmer@v1"
+          "uses": "wasmerio/setup-wasmer@v3.1",
+          "with": {
+            "version": "7.1.0"
+          }
         },
         {
           "uses": "actions/setup-node@v6",
@@ -516,7 +525,10 @@
           }
         },
         {
-          "uses": "wasmerio/setup-wasmer@v1"
+          "uses": "wasmerio/setup-wasmer@v3.1",
+          "with": {
+            "version": "7.1.0"
+          }
         },
         {
           "uses": "actions/setup-node@v6",
@@ -678,7 +690,10 @@
           }
         },
         {
-          "uses": "wasmerio/setup-wasmer@v1"
+          "uses": "wasmerio/setup-wasmer@v3.1",
+          "with": {
+            "version": "7.1.0"
+          }
         },
         {
           "uses": "actions/setup-node@v6",
@@ -846,7 +861,10 @@
           }
         },
         {
-          "uses": "wasmerio/setup-wasmer@v1"
+          "uses": "wasmerio/setup-wasmer@v3.1",
+          "with": {
+            "version": "7.1.0"
+          }
         },
         {
           "uses": "actions/setup-node@v6",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1079,6 +1079,9 @@
           "run": "npm install -g playwright@1.59.1"
         },
         {
+          "run": "rm -rf ~/.cache/ms-playwright"
+        },
+        {
           "run": "playwright install firefox"
         },
         {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,10 @@
           }
         },
         {
-          "uses": "oven-sh/setup-bun@v1"
+          "uses": "oven-sh/setup-bun@v2",
+          "with": {
+            "bun-version": "1.3.13"
+          }
         },
         {
           "uses": "actions/checkout@v5"
@@ -207,7 +210,10 @@
           }
         },
         {
-          "uses": "oven-sh/setup-bun@v1"
+          "uses": "oven-sh/setup-bun@v2",
+          "with": {
+            "bun-version": "1.3.13"
+          }
         },
         {
           "uses": "actions/checkout@v5"
@@ -366,7 +372,10 @@
           }
         },
         {
-          "uses": "oven-sh/setup-bun@v1"
+          "uses": "oven-sh/setup-bun@v2",
+          "with": {
+            "bun-version": "1.3.13"
+          }
         },
         {
           "uses": "actions/checkout@v5"
@@ -525,7 +534,10 @@
           }
         },
         {
-          "uses": "oven-sh/setup-bun@v1"
+          "uses": "oven-sh/setup-bun@v2",
+          "with": {
+            "bun-version": "1.3.13"
+          }
         },
         {
           "uses": "actions/checkout@v5"
@@ -684,7 +696,10 @@
           }
         },
         {
-          "uses": "oven-sh/setup-bun@v1"
+          "uses": "oven-sh/setup-bun@v2",
+          "with": {
+            "bun-version": "1.3.13"
+          }
         },
         {
           "uses": "actions/checkout@v5"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1072,7 +1072,7 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "24"
+            "node-version": "24.15.0"
           }
         },
         {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@
         {
           "uses": "denoland/setup-deno@v2",
           "with": {
-            "deno-version": "2"
+            "deno-version": "2.7.14"
           }
         },
         {
@@ -206,7 +206,7 @@
         {
           "uses": "denoland/setup-deno@v2",
           "with": {
-            "deno-version": "2"
+            "deno-version": "2.7.14"
           }
         },
         {
@@ -368,7 +368,7 @@
         {
           "uses": "denoland/setup-deno@v2",
           "with": {
-            "deno-version": "2"
+            "deno-version": "2.7.14"
           }
         },
         {
@@ -530,7 +530,7 @@
         {
           "uses": "denoland/setup-deno@v2",
           "with": {
-            "deno-version": "2"
+            "deno-version": "2.7.14"
           }
         },
         {
@@ -692,7 +692,7 @@
         {
           "uses": "denoland/setup-deno@v2",
           "with": {
-            "deno-version": "2"
+            "deno-version": "2.7.14"
           }
         },
         {
@@ -860,7 +860,7 @@
         {
           "uses": "denoland/setup-deno@v2",
           "with": {
-            "deno-version": "2"
+            "deno-version": "2.7.14"
           }
         },
         {
@@ -1058,7 +1058,7 @@
           }
         },
         {
-          "run": "npm install -g playwright@1.58.2"
+          "run": "npm install -g playwright@1.59.1"
         },
         {
           "run": "playwright install --with-deps"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1079,6 +1079,9 @@
           "run": "npm install -g playwright@1.59.1"
         },
         {
+          "run": "sudo apt-get update && sudo apt-get install -y unzip"
+        },
+        {
           "run": "rm -rf ~/.cache/ms-playwright"
         },
         {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -994,7 +994,7 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "20"
+            "node-version": "20.20.2"
           }
         },
         {
@@ -1004,7 +1004,7 @@
           "run": "npm ci"
         },
         {
-          "run": "npm run test20"
+          "run": "npm test"
         }
       ]
     },
@@ -1014,7 +1014,7 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "22"
+            "node-version": "22.22.2"
           }
         },
         {
@@ -1034,7 +1034,7 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "24"
+            "node-version": "24.15.0"
           }
         },
         {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1082,10 +1082,7 @@
           "run": "rm -rf ~/.cache/ms-playwright"
         },
         {
-          "run": "playwright install firefox"
-        },
-        {
-          "run": "playwright install webkit"
+          "run": "DEBUG=pw:install npx playwright install firefox"
         },
         {
           "uses": "actions/checkout@v5"

--- a/ci/config/module.f.ts
+++ b/ci/config/module.f.ts
@@ -14,4 +14,11 @@ export const images = {
     }
 } as const
 
+// https://bun.sh/
 export const bun = '1.3.13'
+
+// https://deno.com/
+export const deno = '2.7.14'
+
+// https://www.npmjs.com/package/playwright
+export const playwright = '1.59.1'

--- a/ci/config/module.f.ts
+++ b/ci/config/module.f.ts
@@ -29,5 +29,5 @@ export const rust = '1.95.0'
 // https://nodejs.org/en/download
 export const node = {
     default: '26.1.0',
-    others: ['20', '22', '24'],
+    others: ['20.20.2', '22.22.2', '24.15.0'],
 } as const

--- a/ci/config/module.f.ts
+++ b/ci/config/module.f.ts
@@ -36,4 +36,4 @@ export const node = {
 export const wasmtime = '44.0.1'
 
 // https://github.com/wasmerio/wasmer/releases
-export const wasmer = '7.1.0'
+export const wasmer = 'v7.1.0'

--- a/ci/config/module.f.ts
+++ b/ci/config/module.f.ts
@@ -31,3 +31,6 @@ export const node = {
     default: '26.1.0',
     others: ['20.20.2', '22.22.2', '24.15.0'],
 } as const
+
+// https://github.com/bytecodealliance/wasmtime/releases
+export const wasmtime = '44.0.1'

--- a/ci/config/module.f.ts
+++ b/ci/config/module.f.ts
@@ -34,3 +34,6 @@ export const node = {
 
 // https://github.com/bytecodealliance/wasmtime/releases
 export const wasmtime = '44.0.1'
+
+// https://github.com/wasmerio/wasmer/releases
+export const wasmer = '7.1.0'

--- a/ci/config/module.f.ts
+++ b/ci/config/module.f.ts
@@ -36,4 +36,4 @@ export const node = {
 export const wasmtime = '44.0.1'
 
 // https://github.com/wasmerio/wasmer/releases
-export const wasmer = 'v7.1.0'
+export const wasmer = '7.1.0'

--- a/ci/config/module.f.ts
+++ b/ci/config/module.f.ts
@@ -26,5 +26,8 @@ export const playwright = '1.59.1'
 // https://rust-lang.org/
 export const rust = '1.95.0'
 
-// 
-export const node = '26.1.0'
+// https://nodejs.org/en/download
+export const node = {
+    default: '26.1.0',
+    others: ['20', '22', '24'],
+} as const

--- a/ci/config/module.f.ts
+++ b/ci/config/module.f.ts
@@ -1,0 +1,17 @@
+// https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+export const images = {
+    ubuntu: {
+        intel: 'ubuntu-24.04',
+        arm: 'ubuntu-24.04-arm'
+    },
+    macos: {
+        intel: 'macos-26-intel',
+        arm: 'macos-26'
+    },
+    windows: {
+        intel: 'windows-2025',
+        arm: 'windows-11-arm',
+    }
+} as const
+
+export const bun = '1.3.13'

--- a/ci/config/module.f.ts
+++ b/ci/config/module.f.ts
@@ -25,3 +25,6 @@ export const playwright = '1.59.1'
 
 // https://rust-lang.org/
 export const rust = '1.95.0'
+
+// 
+export const node = '26.1.0'

--- a/ci/config/module.f.ts
+++ b/ci/config/module.f.ts
@@ -22,3 +22,6 @@ export const deno = '2.7.14'
 
 // https://www.npmjs.com/package/playwright
 export const playwright = '1.59.1'
+
+// https://rust-lang.org/
+export const rust = '1.95.0'

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -172,7 +172,7 @@ const nodeVersions: Jobs = Object.fromEntries(node.others.map(v => [
     ubuntu(nodeSteps(v))
 ]))
 
-const playwrightJob: Job = ubuntu(basicNode(node.default)([
+const playwrightJob: Job = ubuntu(basicNode('24')([
     // install({ uses: 'actions/cache@v4', with: { path: '~/.cache/ms-playwright', key: `${images.ubuntu.intel}-${playwrightAndVersion}` } }),
     install({ run: `npm install -g ${playwrightAndVersion}` }),
     //install({ run: 'playwright install --with-deps' }),

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -176,9 +176,9 @@ const playwrightJob: Job = ubuntu(basicNode(node.default)([
     // install({ uses: 'actions/cache@v4', with: { path: '~/.cache/ms-playwright', key: `${images.ubuntu.intel}-${playwrightAndVersion}` } }),
     install({ run: `npm install -g ${playwrightAndVersion}` }),
     //install({ run: 'playwright install --with-deps' }),
-    install({ run: 'playwright install' }),
-    install({ run: 'playwright install chromium' }),
-    install({ run: 'playwright install firefow' }),
+    //install({ run: 'playwright install' }),
+    //install({ run: 'playwright install chromium' }),
+    install({ run: 'playwright install firefox' }),
     install({ run: 'playwright install webkit' }),
     // we have to use `npx` to make sure that we respect `@playwright/test` version from
     // the `package.json`.

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -172,6 +172,7 @@ const nodeVersions: Jobs = Object.fromEntries(node.others.map(v => [
     ubuntu(nodeSteps(v))
 ]))
 
+// Playwright installation is stuck on Node 26 (May 7 2026) so we use Node 24.
 const playwrightJob: Job = ubuntu(basicNode(node.others.at(-1)!)([
     install({ run: `npm install -g ${playwrightAndVersion}` }),
     install({ run: 'playwright install --with-deps' }),

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -163,13 +163,13 @@ const nodeSteps = (v: string) => [
 ]
 
 const ubuntu = (ms: readonly MetaStep[]): Job => ({
-    'runs-on': 'ubuntu-24.04',
+    'runs-on': images.ubuntu.intel,
     steps: toSteps(ms)
 })
 
 const nodeVersions: Jobs = Object.fromEntries(nodes.map(v => [`node${v}`, ubuntu(nodeSteps(v))]))
 
-const defaultNodeVersion = '26'
+const defaultNodeVersion = '26.1.0'
 
 const wasmtimeVersion = '44.0.1'
 

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -6,6 +6,7 @@
 import { utf8 } from '../text/module.f.ts'
 import { begin, pure, type Effect } from '../types/effects/module.f.ts'
 import { writeFile, type NodeEffect, type NodeOp } from '../types/effects/node/module.f.ts'
+import { bun, images } from './config/module.f.ts'
 
 const os = ['ubuntu', 'macos', 'windows'] as const
 
@@ -14,22 +15,6 @@ type Os = typeof os[number]
 const architecture = ['intel', 'arm'] as const
 
 type Architecture = typeof architecture[number]
-
-// https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
-const images = {
-    ubuntu: {
-        intel: 'ubuntu-24.04',
-        arm: 'ubuntu-24.04-arm'
-    },
-    macos: {
-        intel: 'macos-26-intel',
-        arm: 'macos-26'
-    },
-    windows: {
-        intel: 'windows-2025',
-        arm: 'windows-11-arm',
-    }
-} as const
 
 type Image = typeof images[Os][Architecture]
 
@@ -87,7 +72,12 @@ const installOnWindowsArm = ({ def, name, path }: Tool) => (v: Os) => (a: Archit
         : def)
 
 const installBun = installOnWindowsArm({
-    def: { uses: 'oven-sh/setup-bun@v1' },
+    def: {
+        uses: 'oven-sh/setup-bun@v2',
+        with: {
+            'bun-version': bun
+        },
+    },
     name: 'bun',
     path: 'bun.sh'
 })

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -179,8 +179,8 @@ const playwrightJob: Job = ubuntu(basicNode(node.default)([
     //install({ run: 'playwright install' }),
     //install({ run: 'playwright install chromium' }),
     install({ run: 'rm -rf ~/.cache/ms-playwright' }),
-    install({ run: 'playwright install firefox' }),
-    install({ run: 'playwright install webkit' }),
+    install({ run: 'DEBUG=pw:install npx playwright install firefox' }),
+    // install({ run: 'playwright install webkit' }),
     // we have to use `npx` to make sure that we respect `@playwright/test` version from
     // the `package.json`.
     ...['chromium', 'firefox', 'webkit'].map(browser =>

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -172,17 +172,9 @@ const nodeVersions: Jobs = Object.fromEntries(node.others.map(v => [
     ubuntu(nodeSteps(v))
 ]))
 
-const playwrightJob: Job = ubuntu(basicNode('24')([
-    // install({ uses: 'actions/cache@v4', with: { path: '~/.cache/ms-playwright', key: `${images.ubuntu.intel}-${playwrightAndVersion}` } }),
+const playwrightJob: Job = ubuntu(basicNode(node.others.at(-1)!)([
     install({ run: `npm install -g ${playwrightAndVersion}` }),
     install({ run: 'playwright install --with-deps' }),
-    //install({ run: 'playwright install' }),
-    //install({ run: 'playwright install chromium' }),
-    //install({ run: 'sudo apt-get update && sudo apt-get install -y unzip' }),
-    //install({ run: 'rm -rf ~/.cache/ms-playwright' }),
-    //install({ run: 'DEBUG=pw:install npx playwright install firefox' }),
-    // install({ run: 'playwright install webkit' }),
-    
     // we have to use `npx` to make sure that we respect `@playwright/test` version from
     // the `package.json`.
     ...['chromium', 'firefox', 'webkit'].map(browser =>

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -178,6 +178,7 @@ const playwrightJob: Job = ubuntu(basicNode(node.default)([
     //install({ run: 'playwright install --with-deps' }),
     //install({ run: 'playwright install' }),
     //install({ run: 'playwright install chromium' }),
+    install({ run: 'rm -rf ~/.cache/ms-playwright' }),
     install({ run: 'playwright install firefox' }),
     install({ run: 'playwright install webkit' }),
     // we have to use `npx` to make sure that we respect `@playwright/test` version from

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -175,7 +175,11 @@ const nodeVersions: Jobs = Object.fromEntries(node.others.map(v => [
 const playwrightJob: Job = ubuntu(basicNode(node.default)([
     // install({ uses: 'actions/cache@v4', with: { path: '~/.cache/ms-playwright', key: `${images.ubuntu.intel}-${playwrightAndVersion}` } }),
     install({ run: `npm install -g ${playwrightAndVersion}` }),
-    install({ run: 'playwright install --with-deps' }),
+    //install({ run: 'playwright install --with-deps' }),
+    install({ run: 'playwright install' }),
+    install({ run: 'playwright install chromium' }),
+    install({ run: 'playwright install firefow' }),
+    install({ run: 'playwright install webkit' }),
     // we have to use `npx` to make sure that we respect `@playwright/test` version from
     // the `package.json`.
     ...['chromium', 'firefox', 'webkit'].map(browser =>
@@ -209,7 +213,7 @@ const job = (v: Os) => (a: Architecture): readonly [string, Job] => {
         }),
         install({
             uses: 'wasmerio/setup-wasmer@v3.1',
-            with: { version: wasmer },
+            with: { version: `v${wasmer}` },
         }),
         ...wasmTarget('wasm32-wasip1'),
         ...wasmTarget('wasm32-wasip2'),

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -165,7 +165,10 @@ const ubuntu = (ms: readonly MetaStep[]): Job => ({
     steps: toSteps(ms)
 })
 
-const nodeVersions: Jobs = Object.fromEntries(node.others.map(v => [`node${v}`, ubuntu(nodeSteps(v))]))
+const nodeVersions: Jobs = Object.fromEntries(node.others.map(v => [
+    `node${v.split('.')[0]}`,
+    ubuntu(nodeSteps(v))
+]))
 
 const wasmtimeVersion = '44.0.1'
 

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -6,7 +6,7 @@
 import { utf8 } from '../text/module.f.ts'
 import { begin, pure, type Effect } from '../types/effects/module.f.ts'
 import { writeFile, type NodeOp } from '../types/effects/node/module.f.ts'
-import { bun, deno, images, node, playwright, rust } from './config/module.f.ts'
+import { bun, deno, images, node, playwright, rust, wasmtime } from './config/module.f.ts'
 
 const os = ['ubuntu', 'macos', 'windows'] as const
 
@@ -170,8 +170,6 @@ const nodeVersions: Jobs = Object.fromEntries(node.others.map(v => [
     ubuntu(nodeSteps(v))
 ]))
 
-const wasmtimeVersion = '44.0.1'
-
 const playwrightJob: Job = ubuntu(basicNode(node.default)([
     // install({ uses: 'actions/cache@v4', with: { path: '~/.cache/ms-playwright', key: `${images.ubuntu.intel}-${playwrightAndVersion}` } }),
     install({ run: `npm install -g ${playwrightAndVersion}` }),
@@ -205,7 +203,7 @@ const job = (v: Os) => (a: Architecture): readonly [string, Job] => {
         ...cargoTest(),
         install({
             uses: 'bytecodealliance/actions/wasmtime/setup@v1',
-            with: { version: wasmtimeVersion }
+            with: { version: wasmtime }
         }),
         install({ uses: 'wasmerio/setup-wasmer@v1' }),
         ...wasmTarget('wasm32-wasip1'),

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -6,7 +6,7 @@
 import { utf8 } from '../text/module.f.ts'
 import { begin, pure, type Effect } from '../types/effects/module.f.ts'
 import { writeFile, type NodeEffect, type NodeOp } from '../types/effects/node/module.f.ts'
-import { bun, images } from './config/module.f.ts'
+import { bun, deno, images, playwright } from './config/module.f.ts'
 
 const os = ['ubuntu', 'macos', 'windows'] as const
 
@@ -79,10 +79,13 @@ const installBun = installOnWindowsArm({
         },
     },
     name: 'bun',
-    path: 'bun.sh'
+    path: 'bun.sh',
 })
 
-const installDeno = install({ uses: 'denoland/setup-deno@v2', with: { 'deno-version': '2' } })
+const installDeno = install({
+    uses: 'denoland/setup-deno@v2',
+    with: { 'deno-version': deno },
+})
 
 const cargoTest = (target?: string, config?: string): readonly MetaStep[] => {
     const to = target ? ` --target ${target}` : ''
@@ -126,9 +129,7 @@ const node = (version: string) => (extra: readonly MetaStep[]): readonly MetaSte
 
 const findTgz = (v: Os) => v === 'windows' ? '(Get-ChildItem *.tgz).FullName' : './*.tgz'
 
-const playwrightVersion = '1.58.2'
-
-const playwrightAndVersion = `playwright@${playwrightVersion}`
+const playwrightAndVersion = `playwright@${playwright}`
 
 const rustToolchain = '1.95.0'
 
@@ -174,7 +175,7 @@ const defaultNodeVersion = '26'
 
 const wasmtimeVersion = '44.0.1'
 
-const playwright: Job = ubuntu(basicNode(defaultNodeVersion)([
+const playwrightJob: Job = ubuntu(basicNode(defaultNodeVersion)([
     //install({ uses: 'actions/cache@v4', with: { path: '~/.cache/ms-playwright', key: `${images.ubuntu.intel}-${playwrightAndVersion}` } }),
     install({ run: `npm install -g ${playwrightAndVersion}` }),
     install({ run: 'playwright install --with-deps' }),
@@ -249,7 +250,7 @@ const job = (v: Os) => (a: Architecture): readonly [string, Job] => {
 const jobs = {
     ...Object.fromEntries(os.flatMap(v => architecture.map(job(v)))),
     ...nodeVersions,
-    playwright,
+    playwright: playwrightJob,
 }
 
 const gha: GitHubAction = {

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -6,7 +6,7 @@
 import { utf8 } from '../text/module.f.ts'
 import { begin, pure, type Effect } from '../types/effects/module.f.ts'
 import { writeFile, type NodeOp } from '../types/effects/node/module.f.ts'
-import { bun, deno, images, playwright, rust } from './config/module.f.ts'
+import { bun, deno, images, node, playwright, rust } from './config/module.f.ts'
 
 const os = ['ubuntu', 'macos', 'windows'] as const
 
@@ -152,8 +152,6 @@ const toSteps = (m: readonly MetaStep[]): readonly Step[] => {
     ]
 }
 
-const nodes = ['20', '22', '24']
-
 const nodeTest = (v: string) => v === '20' ? 'run test20' : 'test'
 
 const nodeSteps = (v: string) => [
@@ -167,14 +165,12 @@ const ubuntu = (ms: readonly MetaStep[]): Job => ({
     steps: toSteps(ms)
 })
 
-const nodeVersions: Jobs = Object.fromEntries(nodes.map(v => [`node${v}`, ubuntu(nodeSteps(v))]))
-
-const node = '26.1.0'
+const nodeVersions: Jobs = Object.fromEntries(node.others.map(v => [`node${v}`, ubuntu(nodeSteps(v))]))
 
 const wasmtimeVersion = '44.0.1'
 
-const playwrightJob: Job = ubuntu(basicNode(node)([
-    //install({ uses: 'actions/cache@v4', with: { path: '~/.cache/ms-playwright', key: `${images.ubuntu.intel}-${playwrightAndVersion}` } }),
+const playwrightJob: Job = ubuntu(basicNode(node.default)([
+    // install({ uses: 'actions/cache@v4', with: { path: '~/.cache/ms-playwright', key: `${images.ubuntu.intel}-${playwrightAndVersion}` } }),
     install({ run: `npm install -g ${playwrightAndVersion}` }),
     install({ run: 'playwright install --with-deps' }),
     // we have to use `npx` to make sure that we respect `@playwright/test` version from
@@ -215,7 +211,7 @@ const job = (v: Os) => (a: Architecture): readonly [string, Job] => {
         ...wasmTarget('wasm32-wasip1-threads'),
         ...i686(a, v),
         // Node.js
-        ...nodeTests(node)([
+        ...nodeTests(node.default)([
             // TypeScript Preview
             install({ run: 'npm install -g @typescript/native-preview'}),
             test({ run: 'tsgo' }),

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -175,13 +175,14 @@ const nodeVersions: Jobs = Object.fromEntries(node.others.map(v => [
 const playwrightJob: Job = ubuntu(basicNode('24')([
     // install({ uses: 'actions/cache@v4', with: { path: '~/.cache/ms-playwright', key: `${images.ubuntu.intel}-${playwrightAndVersion}` } }),
     install({ run: `npm install -g ${playwrightAndVersion}` }),
-    //install({ run: 'playwright install --with-deps' }),
+    install({ run: 'playwright install --with-deps' }),
     //install({ run: 'playwright install' }),
     //install({ run: 'playwright install chromium' }),
-    install({ run: 'sudo apt-get update && sudo apt-get install -y unzip' }),
-    install({ run: 'rm -rf ~/.cache/ms-playwright' }),
-    install({ run: 'DEBUG=pw:install npx playwright install firefox' }),
+    //install({ run: 'sudo apt-get update && sudo apt-get install -y unzip' }),
+    //install({ run: 'rm -rf ~/.cache/ms-playwright' }),
+    //install({ run: 'DEBUG=pw:install npx playwright install firefox' }),
     // install({ run: 'playwright install webkit' }),
+    
     // we have to use `npx` to make sure that we respect `@playwright/test` version from
     // the `package.json`.
     ...['chromium', 'firefox', 'webkit'].map(browser =>

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -5,8 +5,8 @@
  */
 import { utf8 } from '../text/module.f.ts'
 import { begin, pure, type Effect } from '../types/effects/module.f.ts'
-import { writeFile, type NodeEffect, type NodeOp } from '../types/effects/node/module.f.ts'
-import { bun, deno, images, playwright } from './config/module.f.ts'
+import { writeFile, type NodeOp } from '../types/effects/node/module.f.ts'
+import { bun, deno, images, playwright, rust } from './config/module.f.ts'
 
 const os = ['ubuntu', 'macos', 'windows'] as const
 
@@ -131,18 +131,16 @@ const findTgz = (v: Os) => v === 'windows' ? '(Get-ChildItem *.tgz).FullName' : 
 
 const playwrightAndVersion = `playwright@${playwright}`
 
-const rustToolchain = '1.95.0'
-
 const toSteps = (m: readonly MetaStep[]): readonly Step[] => {
     const filter = (st: StepType) => m.flatMap((mt: MetaStep): Step[] => mt.type === st ? [mt.step] : [])
     const aptGet = m.flatMap(v => v.type === 'apt-get' ? [v.package] : []).join(' ')
 
-    const rust = m.find(v => v.type === 'rust') !== undefined
+    const needRust = m.find(v => v.type === 'rust') !== undefined
     const targets = m.flatMap(v => v.type === 'rust' && v.target !== undefined ? [v.target] : []).join(',')
     return [
         ...(aptGet !== '' ? [{ run: `sudo apt-get update && sudo apt-get install -y ${aptGet}` }] : []),
-        ...(rust ? [{
-            uses: `dtolnay/rust-toolchain@${rustToolchain}`,
+        ...(needRust ? [{
+            uses: `dtolnay/rust-toolchain@${rust}`,
             with: {
                 components: 'rustfmt,clippy',
                 targets

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -121,7 +121,7 @@ const basicNode = (version: string) => (extra: readonly MetaStep[]): readonly Me
     ...extra,
 ])
 
-const node = (version: string) => (extra: readonly MetaStep[]): readonly MetaStep[] => basicNode(version)([
+const nodeTests = (version: string) => (extra: readonly MetaStep[]): readonly MetaStep[] => basicNode(version)([
     test({ run: 'npm test' }),
     test({ run: 'npm run fst' }),
     ...extra,
@@ -169,11 +169,11 @@ const ubuntu = (ms: readonly MetaStep[]): Job => ({
 
 const nodeVersions: Jobs = Object.fromEntries(nodes.map(v => [`node${v}`, ubuntu(nodeSteps(v))]))
 
-const defaultNodeVersion = '26.1.0'
+const node = '26.1.0'
 
 const wasmtimeVersion = '44.0.1'
 
-const playwrightJob: Job = ubuntu(basicNode(defaultNodeVersion)([
+const playwrightJob: Job = ubuntu(basicNode(node)([
     //install({ uses: 'actions/cache@v4', with: { path: '~/.cache/ms-playwright', key: `${images.ubuntu.intel}-${playwrightAndVersion}` } }),
     install({ run: `npm install -g ${playwrightAndVersion}` }),
     install({ run: 'playwright install --with-deps' }),
@@ -215,7 +215,7 @@ const job = (v: Os) => (a: Architecture): readonly [string, Job] => {
         ...wasmTarget('wasm32-wasip1-threads'),
         ...i686(a, v),
         // Node.js
-        ...node(defaultNodeVersion)([
+        ...nodeTests(node)([
             // TypeScript Preview
             install({ run: 'npm install -g @typescript/native-preview'}),
             test({ run: 'tsgo' }),

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -178,6 +178,7 @@ const playwrightJob: Job = ubuntu(basicNode(node.default)([
     //install({ run: 'playwright install --with-deps' }),
     //install({ run: 'playwright install' }),
     //install({ run: 'playwright install chromium' }),
+    install({ run: 'sudo apt-get update && sudo apt-get install -y unzip' }),
     install({ run: 'rm -rf ~/.cache/ms-playwright' }),
     install({ run: 'DEBUG=pw:install npx playwright install firefox' }),
     // install({ run: 'playwright install webkit' }),

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -6,7 +6,7 @@
 import { utf8 } from '../text/module.f.ts'
 import { begin, pure, type Effect } from '../types/effects/module.f.ts'
 import { writeFile, type NodeOp } from '../types/effects/node/module.f.ts'
-import { bun, deno, images, node, playwright, rust, wasmtime } from './config/module.f.ts'
+import { bun, deno, images, node, playwright, rust, wasmer, wasmtime } from './config/module.f.ts'
 
 const os = ['ubuntu', 'macos', 'windows'] as const
 
@@ -207,7 +207,10 @@ const job = (v: Os) => (a: Architecture): readonly [string, Job] => {
             uses: 'bytecodealliance/actions/wasmtime/setup@v1',
             with: { version: wasmtime }
         }),
-        install({ uses: 'wasmerio/setup-wasmer@v1' }),
+        install({
+            uses: 'wasmerio/setup-wasmer@v3.1',
+            with: { version: wasmer },
+        }),
         ...wasmTarget('wasm32-wasip1'),
         ...wasmTarget('wasm32-wasip2'),
         ...wasmTarget('wasm32-unknown-unknown'),

--- a/ci/module.f.ts
+++ b/ci/module.f.ts
@@ -152,7 +152,9 @@ const toSteps = (m: readonly MetaStep[]): readonly Step[] => {
     ]
 }
 
-const nodeTest = (v: string) => v === '20' ? 'run test20' : 'test'
+const major = (v: string) => v.split('.')[0]
+
+const nodeTest = (v: string) => major(v) === '20' ? 'run test20' : 'test'
 
 const nodeSteps = (v: string) => [
     install(installNode(v)),
@@ -166,7 +168,7 @@ const ubuntu = (ms: readonly MetaStep[]): Job => ({
 })
 
 const nodeVersions: Jobs = Object.fromEntries(node.others.map(v => [
-    `node${v.split('.')[0]}`,
+    `node${major(v)}`,
     ubuntu(nodeSteps(v))
 ]))
 


### PR DESCRIPTION
## CI: Centralize tool versions and update dependencies

Extract all tool versions and runner images into a dedicated `ci/config/module.f.ts` module so they can be updated and reviewed in one place rather than scattered across `ci/module.f.ts`.

### Changes

**New `ci/config/module.f.ts`**
- Centralizes runner images (Ubuntu, macOS, Windows × Intel/ARM) with a link to the GitHub Actions docs
- Pins explicit versions for all tools: Bun, Deno, Playwright, Rust, Node.js, Wasmtime, Wasmer — each with a link to the upstream release page

**Updated `ci/module.f.ts`**
- Imports all constants from `ci/config/module.f.ts`
- Upgrades Bun action from `setup-bun@v1` to `setup-bun@v2` with explicit `bun-version` pin
- Pins Deno to `2.7.14` (was `'2'`, unversioned)
- Upgrades Playwright to `1.59.1` (was `1.58.2`)
- Pins Wasmer to `7.1.0` and bumps action from `setup-wasmer@v1` to `setup-wasmer@v3.1`
- Renames local `node` function → `nodeTests`, `playwright` var → `playwrightJob`, `rust` bool → `needRust` to avoid shadowing the imported config constants
- Node version matrix now driven by `node.others` (full semver strings) with a `major()` helper replacing the old hard-coded `['20', '22', '24']` list
- Playwright job explicitly uses Node 24 (`node.others.at(-1)`) with a comment explaining that Playwright installation is broken on Node 26 as of May 2026
