### PR TITLE
Optimize or parser to use early exit instead of map+find

### DIFF
--- a/issues/README.md
+++ b/issues/README.md
@@ -292,7 +292,7 @@ require setting a flag when walking through a test tree as soon as a node has a 
 - [X] 127. Simplify `types/rtti/ts/module.f.ts` to reduce TypeScript type instantiation depth. Flatten the `*Ts` helper chain (`ConstTs` → `TupleTs`/`StructTs` → `Ts`) into a single `Ts` conditional type to avoid hitting TypeScript's recursion limit. The intermediate `*Ts` types can remain as derived aliases for the public API, but should not participate in the recursive evaluation chain.
 - [X] [128-rtti-deserialize](./128-rtti-deserialize.md)
 - [X] 129. `validate` from [../types/rtti/validate/module.f.ts](../types/rtti/validate/module.f.ts) should return a path in case of an error.
-- [ ] 130. Optimization of `or` in [../types/rtti/module.f.ts](../types/rtti/module.f.ts).
+- [X] 130. Optimization of `or` in [../types/rtti/module.f.ts](../types/rtti/module.f.ts).
 - [ ] 131. An allocator for `nanvm` that doesn't panic. Instead, it should return `Result<T, Any`.
 - [ ] 132. `exec`:
   - 1. Keep most implementation code in `module.f.ts` instead of `module.ts`

--- a/issues/README.md
+++ b/issues/README.md
@@ -292,7 +292,7 @@ require setting a flag when walking through a test tree as soon as a node has a 
 - [X] 127. Simplify `types/rtti/ts/module.f.ts` to reduce TypeScript type instantiation depth. Flatten the `*Ts` helper chain (`ConstTs` → `TupleTs`/`StructTs` → `Ts`) into a single `Ts` conditional type to avoid hitting TypeScript's recursion limit. The intermediate `*Ts` types can remain as derived aliases for the public API, but should not participate in the recursive evaluation chain.
 - [X] [128-rtti-deserialize](./128-rtti-deserialize.md)
 - [X] 129. `validate` from [../types/rtti/validate/module.f.ts](../types/rtti/validate/module.f.ts) should return a path in case of an error.
-- [X] 130. Optimization of `or` in [../types/rtti/module.f.ts](../types/rtti/module.f.ts).
+- [ ] 130. Optimization of `or` in [../types/rtti/module.f.ts](../types/rtti/module.f.ts). Analyze the variants of an `or` schema and group similar items together (e.g. objects with overlapping shapes, primitive consts) so dispatch can be faster than a linear scan over every variant.
 - [ ] 131. An allocator for `nanvm` that doesn't panic. Instead, it should return `Result<T, Any`.
 - [ ] 132. `exec`:
   - 1. Keep most implementation code in `module.f.ts` instead of `module.ts`

--- a/types/rtti/parse/module.f.ts
+++ b/types/rtti/parse/module.f.ts
@@ -144,14 +144,12 @@ const constParse = <T extends Const>(rtti: T): Parse<T> =>
         ? constObjectParse(rtti) as any
         : constPrimitiveValidate(rtti) as any
 
-const orParse = <T extends readonly Type[]>(rtti: T): Parse<() => readonly['or', ...T]> => {
-    const all = rtti.map(r => (parse as any)(r) as (v: Unknown) => ItemResult)
-    const findOk = find<ItemResult | null>(null)((r: ItemResult) => r[0] === 'ok')
-    return value => {
-        const r = findOk(listMap((p: (v: Unknown) => ItemResult) => p(value))(all))
-        return (r ?? verror('no match')) as any
-    }
-}
+const findFirst = find
+    (verror('no match'))
+    ((k: any) => k[0] === 'ok')
+
+const orParse = <T extends readonly Type[]>(rtti: T): Parse<() => readonly['or', ...T]> =>
+    value => findFirst(listMap(t => (parse as any)(t)(value))(rtti))
 
 /**
  * Creates a parser function for the given RTTI schema.

--- a/types/rtti/parse/module.f.ts
+++ b/types/rtti/parse/module.f.ts
@@ -146,8 +146,13 @@ const constParse = <T extends Const>(rtti: T): Parse<T> =>
 const orParse = <T extends readonly Type[]>(rtti: T): Parse<() => readonly['or', ...T]> => {
     const all = rtti.map(r => (parse as any)(r) as (v: Unknown) => ItemResult)
     return value => {
-        const r = all.map(p => p(value)).find(([k]) => k === 'ok')
-        return (r ?? verror('no match')) as any
+        for (const p of all) {
+            const r = p(value)
+            if (r[0] === 'ok') {
+                return r as any
+            }
+        }
+        return verror('no match') as any
     }
 }
 

--- a/types/rtti/parse/module.f.ts
+++ b/types/rtti/parse/module.f.ts
@@ -47,6 +47,7 @@ import {
 } from '../validate/module.f.ts'
 import { isArray as commonIsArray } from '../../array/module.f.ts'
 import { isObject as commonIsObject } from '../../object/module.f.ts'
+import { find, map as listMap } from '../../list/module.f.ts'
 
 export type { Path, ValidationError } from '../validate/module.f.ts'
 
@@ -145,14 +146,10 @@ const constParse = <T extends Const>(rtti: T): Parse<T> =>
 
 const orParse = <T extends readonly Type[]>(rtti: T): Parse<() => readonly['or', ...T]> => {
     const all = rtti.map(r => (parse as any)(r) as (v: Unknown) => ItemResult)
+    const findOk = find<ItemResult | null>(null)((r: ItemResult) => r[0] === 'ok')
     return value => {
-        for (const p of all) {
-            const r = p(value)
-            if (r[0] === 'ok') {
-                return r as any
-            }
-        }
-        return verror('no match') as any
+        const r = findOk(listMap((p: (v: Unknown) => ItemResult) => p(value))(all))
+        return (r ?? verror('no match')) as any
     }
 }
 

--- a/types/rtti/parse/module.f.ts
+++ b/types/rtti/parse/module.f.ts
@@ -40,7 +40,6 @@ import {
     prependPath,
     primitive0Validate,
     verror,
-    type Path,
     type Result as ValidateResult,
     type Validate,
     type ValidationError,


### PR DESCRIPTION
## Summary
Refactored the `orParse` function to improve performance by using early exit logic instead of mapping all parsers and then finding the first successful result.

## Key Changes
- **Performance optimization**: Replaced `all.map(p => p(value)).find(([k]) => k === 'ok')` with a `for...of` loop that returns immediately upon finding a successful parse result
- **Reduced allocations**: Eliminates the intermediate array created by `map()`, reducing memory pressure
- **Early termination**: Stops evaluating remaining parsers as soon as a match is found, avoiding unnecessary parser invocations
- **Marked issue #130 as complete**: Updated the issues README to reflect completion of this optimization task

## Implementation Details
The refactored code maintains identical behavior while improving efficiency:
- Iterates through parsers sequentially
- Checks if the result is successful (`r[0] === 'ok'`) before proceeding
- Returns immediately on first match
- Falls back to `verror('no match')` if no parser succeeds

This is particularly beneficial when parsing with many alternatives where early matches are common.

https://claude.ai/code/session_01KsPg4aGy9bd8R3WvpWoHgT