### PR TITLE
TF: detect pass-on-throw tests by enclosing `throw` key (#30)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ where `<...Module documentation...>` should be documentation for the module.
 - When adding a new `module.f.ts` under an existing namespace, register it in the `exports` map of `deno.json`.
 - After fixing an issue from [./issues/README.md](./issues/README.md), mark the corresponding bullet `[X]`.
 - Reference issues from [./issues/README.md](./issues/README.md) with the `i` prefix as an explicit link, not GitHub's `#` prefix. `#NNN` is reserved for GitHub PR/issue numbers; `iNNN` refers to entries in `issues/README.md`. Always render the reference as a markdown link, e.g. [i135](./issues/README.md), so the reader can navigate to the issue list.
-- Add an entry for the change under `## Unreleased` in [./CHANGELOG.md](./CHANGELOG.md), in the same `Topic: short description [PR#](url)` style as existing entries.
+- Add an entry for the change under `## Unreleased` in [./CHANGELOG.md](./CHANGELOG.md), in the same `Topic: short description [NNN](url)` style as existing entries. The link must point to the pull request (`/pull/NNN`), not to an issue — update it to the real PR number once the PR is opened.
 - Only import other `.f.ts` files from FunctionalScript modules. Avoid references to built-in or external Node modules such as `node:path` in `.f.ts` files.
 - Use `let` variables only within the function body where they are declared.
 - CLI parameters are preferred over environment variables when adding new features.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Test framework: detect pass-on-throw tests by enclosing `throw` key, supporting function references and grouped tests [#30](https://github.com/functionalscript/functionalscript/issues/30)
+- Test framework: detect pass-on-throw tests by enclosing `throw` key, supporting function references and grouped tests [769](https://github.com/functionalscript/functionalscript/pull/769)
 - CI: centralize tool versions, split into per-tool modules, add Playwright browser cache [764](https://github.com/functionalscript/functionalscript/pull/764)
 - Refactor StateScan to swap input and state parameter order [763](https://github.com/functionalscript/functionalscript/pull/763).
 - SUL: first three levels. BitVec: chunking functions. [755](https://github.com/functionalscript/functionalscript/pull/757)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Test framework: detect pass-on-throw tests by enclosing `throw` key, supporting function references and grouped tests [#30](https://github.com/functionalscript/functionalscript/issues/30)
 - CI: centralize tool versions, split into per-tool modules, add Playwright browser cache [764](https://github.com/functionalscript/functionalscript/pull/764)
 - Refactor StateScan to swap input and state parameter order [763](https://github.com/functionalscript/functionalscript/pull/763).
 - SUL: first three levels. BitVec: chunking functions. [755](https://github.com/functionalscript/functionalscript/pull/757)

--- a/dev/tf/all.test.ts
+++ b/dev/tf/all.test.ts
@@ -17,7 +17,7 @@ type Awaitable<T> = Promise<T> | T
 
 type SubTestRunnerFunc = (name: string, f: () => Awaitable<void>) => Awaitable<void>
 
-type Test = readonly[string, unknown]
+type Test = readonly[string, unknown, boolean]
 
 type TestFunc = (f: SubTestRunnerFunc) => Awaitable<void>
 
@@ -51,17 +51,19 @@ const scanModule = (x: Test): TestFunc => async(subTestRunner: SubTestRunnerFunc
         }
         subTests = rest
         //
-        const [name, value] = first
-        const set = parse(value)
+        const [name, value, throws] = first
+        const set = parse(throws)(value)
         if (typeof set === 'function') {
             await subTestRunner(name, () => {
                 const r = set()
-                subTests = [...subTests, [`${name}()`, r]]
+                // The result of a function is walked as a fresh sub-tree;
+                // the parent's `throws` flag does not propagate into it.
+                subTests = [...subTests, [`${name}()`, r, false]]
             })
         } else {
             for (const [j, y] of set) {
                 const pr = `${name}/${j}`
-                subTests = [...subTests, [pr, y]]
+                subTests = [...subTests, [pr, y, throws || j === 'throw']]
             }
         }
     }
@@ -71,7 +73,7 @@ const run = async(): Promise<void> => {
     const x = await loadModuleMap(io)
     for (const [i, v] of Object.entries(x)) {
         if (isTest(i)) {
-            framework(i, scanModule(['', v.default]))
+            framework(i, scanModule(['', v.default, false]))
         }
     }
 }

--- a/dev/tf/module.f.ts
+++ b/dev/tf/module.f.ts
@@ -57,16 +57,17 @@ export type Test = () => unknown
 
 export type TestSet = Test | readonly(readonly[string, unknown])[]
 
-export const parseTestSet = (t: TryCatch) => (x: unknown): TestSet => {
+export const parseTestSet = (t: TryCatch) => (throws: boolean) => (x: unknown): TestSet => {
     switch (typeof x) {
         case 'function': {
             if (x.length === 0) {
                 const xt = x as Test
-                if (xt.name !== 'throw') {
+                if (!throws && xt.name !== 'throw') {
                     return xt
                 }
-                // Usual tests throw on error, but if the function name is 'throw',
-                // then the test passes if it throws.
+                // Pass-on-throw: the test passes if it throws. Triggered when the
+                // enclosing tree node is named 'throw' (so any function reference
+                // works, not only inline ones whose inferred name is 'throw').
                 return () => {
                     const [tag, value] = t(xt)
                     if (tag === 'ok') {
@@ -95,11 +96,11 @@ export const test = <T>(input: Input<T>): readonly[number, T] => {
         : (k: readonly[string, Module]) => (fs: FullState<T>) => FullState<T>
         = ([k, v]) => {
         const test
-            : (i: string) => (v: unknown) => (fs: FullState<T>) => FullState<T>
-            = i => v => ([ts, state]) => {
+            : (i: string) => (throws: boolean) => (v: unknown) => (fs: FullState<T>) => FullState<T>
+            = i => throws => v => ([ts, state]) => {
             const next = test(`${i}| `)
 
-            const set = parse(v)
+            const set = parse(throws)(v)
             if (typeof set === 'function') {
                 const [[s, r], delta, state0] = measure(() => tryCatch(set))(state)
                 state = state0
@@ -116,14 +117,16 @@ export const test = <T>(input: Input<T>): readonly[number, T] => {
                 } else {
                     ts = addPass(delta)(ts)
                     log(`${i}() ${fgGreen}ok${reset}, ${timeFormat(delta)}`);
-                    [ts, state] = next(r)([ts, state])
+                    // The result of a function is walked as a fresh sub-tree;
+                    // the parent's `throws` flag does not propagate into it.
+                    [ts, state] = next(false)(r)([ts, state])
                 }
             } else {
                 const f
                     : (k: readonly[string|number, unknown]) => (fs: FullState<T>) => FullState<T>
                     = ([k, v]) => ([time, state]) => {
                     log(`${i}${k}:`);
-                    [time, state] = next(v)([time, state])
+                    [time, state] = next(throws || k === 'throw')(v)([time, state])
                     return [time, state]
                 }
                 [ts, state] = fold(f)([ts, state])(set)
@@ -133,7 +136,7 @@ export const test = <T>(input: Input<T>): readonly[number, T] => {
         return ([ts, state]) => {
             if (isTest(k)) {
                 log(`testing ${k}`);
-                [ts, state] = test('| ')(v.default)([ts, state])
+                [ts, state] = test('| ')(false)(v.default)([ts, state])
             }
             return [ts, state]
         }

--- a/dev/tf/test.f.ts
+++ b/dev/tf/test.f.ts
@@ -1,5 +1,23 @@
+// A helper whose own `name` is not `'throw'`. The test framework should still
+// treat it as a pass-on-throw test when the enclosing key is `throw`.
+const helperThrows: () => unknown = () => { throw 'helper failure' }
+
 export default {
     throw: () => {
         throw [() => {}, () => {}]
-    }
+    },
+    // `throw` key with a function reference (function name is `helperThrows`).
+    throwReference: {
+        throw: helperThrows,
+    },
+    // `throw` key with a group: every leaf function under it must throw to pass.
+    throwGroup: {
+        throw: {
+            inline: () => { throw 'inline failure' },
+            reference: helperThrows,
+            nested: {
+                deep: () => { throw 'deep failure' },
+            },
+        },
+    },
 }

--- a/issues/README.md
+++ b/issues/README.md
@@ -26,7 +26,7 @@
     - Examples use only public API and are located in `*example.f.ts` files.
     - API tests use only public API and are located in `*test.f.ts` files.
 - [ ] 29. Test in a browser. It's important for such browsers as Firefox because we don't have SpiderMonkey as a CLI.
-- [ ] 30. Infra for exception-throwing tests that pass on the throw should be improved.
+- [X] 30. Infra for exception-throwing tests that pass on the throw should be improved.
 For example, 'throw' field could not be an immediate function but a reference to a helper function that throws
 (e.g., 'test_throw') - in this case, the current infra will not recognize the 'throw' as the function name.
 Also, 'throw' could be a group of test functions (all of them passing tests when throwing). These improvements


### PR DESCRIPTION
Closes #30.

## Summary

Previously, pass-on-throw semantics were triggered only when the function's
own `name` property was `'throw'`. That worked for inline arrow functions
auto-named by their enclosing property key (`throw: () => …`) but missed two
patterns called out in the issue:

- function references whose name is not `'throw'`:
  ```ts
  const helperThrows = () => { throw 'x' }
  export default { throw: helperThrows }
  ```
- groups under `throw` where every leaf must throw to pass:
  ```ts
  export default {
    throw: {
      inline:    () => { throw 'a' },
      reference: helperThrows,
      nested:    { deep: () => { throw 'b' } },
    },
  }
  ```

## Changes

- `parseTestSet` and the recursive walker in `dev/tf/module.f.ts` now thread a
  `throws` flag.
- The flag is set when descending into a tree node whose key is `'throw'` and
  is inherited through all nested children, so any function reached under
  that subtree gets pass-on-throw semantics regardless of its own name.
- The flag does not propagate into the value returned by a function — that
  return value is a fresh sub-tree.
- `dev/tf/all.test.ts` is updated to thread the same flag.
- The legacy `xt.name === 'throw'` check is retained as a fallback for
  backward compatibility.
- New tests in `dev/tf/test.f.ts` exercise both new patterns
  (`throwReference` and `throwGroup`).

## Test plan

- [x] `npx tsc --noEmit` passes.
- [x] `node --test --experimental-strip-types dev/tf/all.test.ts` — 1455 / 1455 pass.
- [x] `node --experimental-strip-types fjs/module.ts t` (in-house runner) — 1379 / 1379 pass.
- [x] New tests visible in output: `/throwReference/throw`,
  `/throwGroup/throw/inline`, `/throwGroup/throw/reference`,
  `/throwGroup/throw/nested/deep`.

https://claude.ai/code/session_018H1DnG9rsYRtXLj6XefAV5

---
_Generated by [Claude Code](https://claude.ai/code/session_018H1DnG9rsYRtXLj6XefAV5)_