### PR TITLE
Update TypeScript Native preview to latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260508.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260511.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -207,7 +207,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260508.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260511.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -372,7 +372,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260508.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260511.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -537,7 +537,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260508.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260511.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -702,7 +702,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260508.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260511.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -873,7 +873,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260508.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260511.1"
         },
         {
           "uses": "denoland/setup-deno@v2",

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -39,4 +39,4 @@ export const wasmtime = '44.0.1'
 export const wasmer = '7.1.0'
 
 // https://www.npmjs.com/package/@typescript/native-preview?activeTab=versions
-export const tsgo = '7.0.0-dev.20260508.1'
+export const tsgo = '7.0.0-dev.20260511.1'


### PR DESCRIPTION
## Summary

Updated `@typescript/native-preview` from version `7.0.0-dev.20260508.1` to `7.0.0-dev.20260511.1`, the latest development version as of May 11, 2026.

The update was applied to:
- `fs/ci/config/module.f.ts` - Configuration file with tool versions
- `.github/workflows/ci.yml` - CI workflow file (auto-generated by `npm run update`)

## Testing

- [x] Ran `npm run update` to regenerate CI configuration
- [x] All changes committed and pushed to branch

## Sources

- [@typescript/native-preview on npm](https://www.npmjs.com/package/@typescript/native-preview)
- [TypeScript Native Previews Documentation](https://devblogs.microsoft.com/typescript/announcing-typescript-native-previews/)
- [typescript-go Repository](https://github.com/microsoft/typescript-go)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rzho4b5yYUqERs4xrpznWx)_