### PR TITLE
Use Object.is for const primitive validation to handle NaN and signed zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- RTTI: fix `NaN` handling in const validation by using `Object.is` instead of `===` [777](https://github.com/functionalscript/functionalscript/pull/777)
+
 ## 0.14.0
 
 - Restructure [773](https://github.com/functionalscript/functionalscript/pull/773)

--- a/fs/types/rtti/parse/test.f.ts
+++ b/fs/types/rtti/parse/test.f.ts
@@ -112,6 +112,35 @@ export default {
             ok: () => assertOk(parse(42 as const)(42)),
             error: () => assertError(parse(42 as const)(43)),
         },
+        nan: {
+            ok: () => assertOk(parse(NaN as number)(NaN)),
+            error: () => {
+                assertError(parse(NaN as number)(0))
+                assertError(parse(0 as const)(NaN))
+                assertError(parse(42 as const)(NaN))
+            },
+        },
+        infinity: {
+            ok: () => {
+                assertOk(parse(Infinity as number)(Infinity))
+                assertOk(parse(-Infinity as number)(-Infinity))
+            },
+            error: () => {
+                assertError(parse(Infinity as number)(-Infinity))
+                assertError(parse(Infinity as number)(0))
+            },
+        },
+        signedZero: {
+            // `Object.is` distinguishes +0 and -0; `===` treats them equal.
+            distinct: () => {
+                assertError(parse(0 as const)(-0))
+                assertError(parse(-0 as number)(0))
+            },
+            self: () => {
+                assertOk(parse(0 as const)(0))
+                assertOk(parse(-0 as number)(-0))
+            },
+        },
         string: {
             ok: () => assertOk(parse('hello' as const)('hello')),
             error: () => assertError(parse('hello' as const)('world')),

--- a/fs/types/rtti/validate/module.f.ts
+++ b/fs/types/rtti/validate/module.f.ts
@@ -165,9 +165,15 @@ const constObjectValidate = <T extends ConstObject>(rtti: T): Validate<T> =>
         ? tupleValidate(rtti) as any
         : structValidate(rtti) as any
 
-/** Validates a primitive `Const` schema using strict equality (`===`). */
+/**
+ * Validates a primitive `Const` schema using `Object.is` (SameValue).
+ *
+ * `Object.is` is used instead of `===` so that:
+ * - `NaN` const schemas match `NaN` values (`===` would always fail because `NaN !== NaN`).
+ * - `+0` and `-0` are treated as distinct const values.
+ */
 export const constPrimitiveValidate = <T extends Primitive>(rtti: T): Validate<T> =>
-    value => rtti === value
+    value => Object.is(rtti, value)
         ? ok(value) as any
         : verror('unexpected value') as any
 

--- a/fs/types/rtti/validate/test.f.ts
+++ b/fs/types/rtti/validate/test.f.ts
@@ -96,6 +96,35 @@ export default {
             },
             error: () => assertError(validate(42 as const)(43)),
         },
+        nan: {
+            ok: () => assertOk(validate(NaN as number)(NaN)),
+            error: () => {
+                assertError(validate(NaN as number)(0))
+                assertError(validate(0 as const)(NaN))
+                assertError(validate(42 as const)(NaN))
+            },
+        },
+        infinity: {
+            ok: () => {
+                assertOk(validate(Infinity as number)(Infinity))
+                assertOk(validate(-Infinity as number)(-Infinity))
+            },
+            error: () => {
+                assertError(validate(Infinity as number)(-Infinity))
+                assertError(validate(Infinity as number)(0))
+            },
+        },
+        signedZero: {
+            // `Object.is` distinguishes +0 and -0; `===` treats them equal.
+            distinct: () => {
+                assertError(validate(0 as const)(-0))
+                assertError(validate(-0 as number)(0))
+            },
+            self: () => {
+                assertOk(validate(0 as const)(0))
+                assertOk(validate(-0 as number)(-0))
+            },
+        },
         string: {
             ok: () => {
                 type _ = Assert<Equal<Ts<'hello'>, 'hello'>>

--- a/issues/README.md
+++ b/issues/README.md
@@ -332,7 +332,7 @@ require setting a flag when walking through a test tree as soon as a node has a 
      const t = null as const
      const a: Ts<typeof t> = ...
      ```
-- [ ] 142. `NaN` handling in `constPrimitiveValidate` (and `parse`'s primitive path) in [../types/rtti/validate/module.f.ts](../types/rtti/validate/module.f.ts). The current check uses `rtti === value`, but `NaN === NaN` is `false`, so a `NaN` const schema never matches any value — including `NaN` itself.
+- [X] 142. `NaN` handling in `constPrimitiveValidate` (and `parse`'s primitive path) in [../types/rtti/validate/module.f.ts](../types/rtti/validate/module.f.ts). The current check uses `rtti === value`, but `NaN === NaN` is `false`, so a `NaN` const schema never matches any value — including `NaN` itself.
 
   ```ts
   validate(NaN as number)(NaN) // currently error, expected ok


### PR DESCRIPTION
## Summary
Replace strict equality (`===`) with `Object.is` (SameValue) in const primitive validation to properly handle special numeric values like `NaN` and distinguish between `+0` and `-0`.

## Changes
- **Core fix**: Updated `constPrimitiveValidate` in `fs/types/rtti/validate/module.f.ts` to use `Object.is(rtti, value)` instead of `rtti === value`
  - Enables `NaN` const schemas to match `NaN` values (previously impossible since `NaN !== NaN`)
  - Treats `+0` and `-0` as distinct const values, matching their semantic difference
  - Updated documentation to explain the rationale

- **Test coverage**: Added comprehensive test cases in both `fs/types/rtti/parse/test.f.ts` and `fs/types/rtti/validate/test.f.ts`
  - `nan` tests: Verify `NaN` matches itself but not other values
  - `infinity` tests: Verify `Infinity` and `-Infinity` are distinct
  - `signedZero` tests: Verify `+0` and `-0` are treated as distinct values

- **Issue tracking**: Marked issue #142 as resolved in `issues/README.md`

## Implementation Details
`Object.is` implements the SameValue algorithm from the ECMAScript specification, which differs from `===` in two key ways:
- `Object.is(NaN, NaN)` returns `true` (unlike `NaN === NaN`)
- `Object.is(+0, -0)` returns `false` (unlike `+0 === -0`)

This change ensures const schemas behave correctly for all primitive values, including edge cases that strict equality cannot handle.

https://claude.ai/code/session_01E9UQ9jyCrTpLSVCGkfhBUM