### PR TITLE
Add ci(rust) function to fs/ci/module.f.ts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ where `<...Module documentation...>` should be documentation for the module.
 - After fixing an issue from [./issues/README.md](./issues/README.md), mark the corresponding bullet `[X]`.
 - Reference issues from [./issues/README.md](./issues/README.md) with the `i` prefix as an explicit link, not GitHub's `#` prefix. `#NNN` is reserved for GitHub PR/issue numbers; `iNNN` refers to entries in `issues/README.md`. Always render the reference as a markdown link, e.g. [i135](./issues/README.md), so the reader can navigate to the issue list.
 - Add an entry for the change under `## Unreleased` in [./CHANGELOG.md](./CHANGELOG.md), in the same `Topic: short description [NNN](url)` style as existing entries. The link must point to the pull request (`/pull/NNN`), not to an issue — update it to the real PR number once the PR is opened.
+- When the version is bumped in `deno.json`/`package.json`, create a new `## X.Y.Z` section in `CHANGELOG.md` immediately after `## Unreleased` and move all entries from `## Unreleased` into it, leaving `## Unreleased` empty.
 - Only import other `.f.ts` files from FunctionalScript modules. Avoid references to built-in or external Node modules such as `node:path` in `.f.ts` files.
 - Use `let` variables only within the function body where they are declared.
 - CLI parameters are preferred over environment variables when adding new features.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.14.1
+
+- CI: add `ci(rust: boolean)` function to conditionally include Rust steps [780](https://github.com/functionalscript/functionalscript/pull/780)
 - RTTI: fix `NaN` handling in const validation by using `Object.is` instead of `===` [777](https://github.com/functionalscript/functionalscript/pull/777)
 
 ## 0.14.0

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@functionalscript/functionalscript",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "MIT",
   "exports": {
     "./fs/asn.1/module.f.ts": "./fs/asn.1/module.f.ts",

--- a/fs/ci/module.f.ts
+++ b/fs/ci/module.f.ts
@@ -14,11 +14,11 @@ import { playwrightJob } from './playwright/module.f.ts'
 import { bunSteps } from './bun/module.f.ts'
 import { denoSteps } from './deno/module.f.ts'
 
-const job = (o: Os) => (a: Architecture): readonly [string, Job] => {
+const job = (rust: boolean) => (o: Os) => (a: Architecture): readonly [string, Job] => {
     const id = `${o}-${a}`
     const image = images[o][a]
     const result = [
-        ...rustSteps(o, a),
+        ...(rust ? rustSteps(o, a) : []),
         ...nodeMainSteps(o),
         ...denoSteps,
         ...bunSteps(o, a),
@@ -26,20 +26,22 @@ const job = (o: Os) => (a: Architecture): readonly [string, Job] => {
     return [id, { 'runs-on': image, steps: toSteps(result) }]
 }
 
-const jobs: Jobs = {
-    ...Object.fromEntries(os.flatMap(o => architecture.map(job(o)))),
-    ...nodeVersions,
-    playwright: playwrightJob,
+export const ci = (rust: boolean): Effect<NodeOp, number> => {
+    const jobs: Jobs = {
+        ...Object.fromEntries(os.flatMap(o => architecture.map(job(rust)(o)))),
+        ...nodeVersions,
+        playwright: playwrightJob,
+    }
+    const gha: GitHubAction = {
+        name: 'CI',
+        on: { pull_request: {} },
+        jobs,
+    }
+    return begin
+        .step(() => writeFile('.github/workflows/ci.yml', utf8(JSON.stringify(gha, null, '  '))))
+        .step(() => pure(0))
 }
 
-const gha: GitHubAction = {
-    name: 'CI',
-    on: { pull_request: {} },
-    jobs,
-}
+const defaultEffect: Effect<NodeOp, number> = ci(true)
 
-export const effect: Effect<NodeOp, number> = begin
-    .step(() => writeFile('.github/workflows/ci.yml', utf8(JSON.stringify(gha, null, '  '))))
-    .step(() => pure(0))
-
-export default () => effect
+export default () => defaultEffect

--- a/fs/ci/module.f.ts
+++ b/fs/ci/module.f.ts
@@ -14,20 +14,20 @@ import { playwrightJob } from './playwright/module.f.ts'
 import { bunSteps } from './bun/module.f.ts'
 import { denoSteps } from './deno/module.f.ts'
 
-const job = (v: Os) => (a: Architecture): readonly [string, Job] => {
-    const id = `${v}-${a}`
-    const image = images[v][a]
+const job = (o: Os) => (a: Architecture): readonly [string, Job] => {
+    const id = `${o}-${a}`
+    const image = images[o][a]
     const result = [
-        ...rustSteps(a, v),
-        ...nodeMainSteps(v),
+        ...rustSteps(o, a),
+        ...nodeMainSteps(o),
         ...denoSteps,
-        ...bunSteps(v, a),
+        ...bunSteps(o, a),
     ]
     return [id, { 'runs-on': image, steps: toSteps(result) }]
 }
 
 const jobs: Jobs = {
-    ...Object.fromEntries(os.flatMap(v => architecture.map(job(v)))),
+    ...Object.fromEntries(os.flatMap(o => architecture.map(job(o)))),
     ...nodeVersions,
     playwright: playwrightJob,
 }

--- a/fs/ci/rust/module.f.ts
+++ b/fs/ci/rust/module.f.ts
@@ -34,7 +34,7 @@ const i686 = (a: Architecture, v: Os): readonly MetaStep[] => {
     return []
 }
 
-export const rustSteps = (a: Architecture, v: Os): readonly MetaStep[] => [
+export const rustSteps = (v: Os, a: Architecture): readonly MetaStep[] => [
     test({ run: 'cargo fmt -- --check' }),
     test({ run: 'cargo clippy -- -D warnings' }),
     ...cargoTest(),

--- a/fs/ci/test.f.ts
+++ b/fs/ci/test.f.ts
@@ -1,0 +1,42 @@
+import { ci } from './module.f.ts'
+import { utf8ToString } from '../text/module.f.ts'
+import { isVec } from '../types/bit_vec/module.f.ts'
+import { emptyState, virtual } from '../types/effects/node/virtual/module.f.ts'
+
+type Step = {
+    readonly run?: string
+    readonly uses?: string
+}
+
+type Gha = {
+    readonly jobs: { readonly [k: string]: { readonly steps: readonly Step[] } }
+}
+
+const hasCargo = (gha: Gha): boolean =>
+    Object.values(gha.jobs).some(job => job.steps.some(step => step.run?.includes('cargo')))
+
+const githubState = {
+    ...emptyState,
+    root: { '.github': { workflows: {} } },
+}
+
+const run = (rust: boolean): Gha => {
+    const [state, result] = virtual(githubState)(ci(rust))
+    if (result !== 0) { throw result }
+    const dotGithub = state.root['.github']
+    if (dotGithub === undefined || isVec(dotGithub)) { throw dotGithub }
+    const workflows = dotGithub['workflows']
+    if (workflows === undefined || isVec(workflows)) { throw workflows }
+    const file = workflows['ci.yml']
+    if (!isVec(file)) { throw file }
+    return JSON.parse(utf8ToString(file))
+}
+
+export default {
+    rust: () => {
+        if (!hasCargo(run(true))) { throw 'expected Rust steps' }
+    },
+    noRust: () => {
+        if (hasCargo(run(false))) { throw 'unexpected Rust steps' }
+    },
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "functionalscript",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "functionalscript",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "bin": {
         "fjs": "fs/fjs/module.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "functionalscript",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "type": "module",
   "files": [
     "**/*.js",


### PR DESCRIPTION
# Summary

- Exports a `ci(rust: boolean)` function that conditionally includes Rust steps
- Parameterizes internal `job` helper with `rust: boolean`
- Fixes argument order in `rustSteps` call (was `(a, v)`, now `(o, a)`)
- Default export continues to generate CI with Rust enabled via `ci(true)`

## Test plan

- [x] Verify `ci(true)` produces the same output as before (Rust steps included)
- [x] Verify `ci(false)` produces CI config without any Rust steps