### PR TITLE
rtti: collapse `or(true, false)` to `or(boolean)`

### DIFF
--- a/fs/types/rtti/module.f.ts
+++ b/fs/types/rtti/module.f.ts
@@ -214,6 +214,26 @@ const collectStep = ([u, p]: CollectAcc, t: Type): CollectAcc => {
     return tag !== null && isPrim0(tag) ? [u, new Set([...p, tag])] : [u, p]
 }
 
+type CollapseAcc = readonly[boolean, readonly Type[]]
+
+const collapseBoolStep = ([replaced, acc]: CollapseAcc, t: Type): CollapseAcc => {
+    if (typeof t !== 'boolean') { return [replaced, [...acc, t]] }
+    if (replaced) { return [replaced, acc] }
+    return [true, [...acc, boolean]]
+}
+
+/**
+ * Collapses the full `{ true, false }` coverage of `boolean` into the
+ * `boolean` thunk. When both `true` and `false` consts appear in `flat` and
+ * the `boolean` thunk is not already present, replace the first boolean const
+ * with the `boolean` thunk and drop the rest. The subsequent dedup step then
+ * removes any other boolean consts that fall under the new primitive thunk.
+ */
+const collapseBooleanPair = (flat: readonly Type[]): readonly Type[] =>
+    flat.includes(true) && flat.includes(false)
+        ? flat.reduce(collapseBoolStep, [false, []] as CollapseAcc)[1]
+        : flat
+
 type DedupAcc = readonly[ReadonlySet<string>, readonly Type[]]
 
 const dedupStep = ([primThunks, acc]: DedupAcc, t: Type): DedupAcc =>
@@ -229,6 +249,8 @@ const dedupStep = ([primThunks, acc]: DedupAcc, t: Type): DedupAcc =>
  *   `unknown`.
  * - a primitive const ⊆ its primitive type thunk — `42 ⊆ number`,
  *   `'hi' ⊆ string`, `true ⊆ boolean`, `7n ⊆ bigint`.
+ * - the pair `{ true, false }` covers `boolean` — `or(true, false)` collapses
+ *   to `or(boolean)`.
  *
  * `Object.is` is used for deduplication, so `NaN` collapses with itself and
  * `+0` and `-0` stay distinct — matching `constPrimitiveValidate`.
@@ -237,7 +259,7 @@ const dedupStep = ([primThunks, acc]: DedupAcc, t: Type): DedupAcc =>
  * a future change — see goals 1 and 3 of issue 130.
  */
 const reduceOr = <T extends Type[]>(types: readonly Type[]): readonly Type[] => {
-    const flat = flattenOr(types)
+    const flat = collapseBooleanPair(flattenOr(types))
     const [hasUnknown, primThunks] = flat.reduce(
         collectStep,
         [false, new Set<string>()],
@@ -253,6 +275,8 @@ const reduceOr = <T extends Type[]>(types: readonly Type[]): readonly Type[] => 
  * The resulting `or` is normalized at construction time:
  * - nested `or` thunks are flattened into the outer union,
  * - any `unknown` variant collapses the whole union to `unknown`,
+ * - the pair `{ true, false }` collapses to the `boolean` thunk
+ *   (e.g. `or(true, false)` → `or(boolean)`),
  * - primitive consts subsumed by a matching primitive thunk are dropped
  *   (e.g. `or(42, number)` → `or(number)`),
  * - duplicate variants are deduplicated via `Object.is`.

--- a/fs/types/rtti/test.f.ts
+++ b/fs/types/rtti/test.f.ts
@@ -116,6 +116,53 @@ export default {
                 assertEq(variantsOf(or(0 as number, -0 as number)).length, 2)
             },
         },
+        booleanPairCollapse: {
+            basic: () => {
+                // `{ true, false }` covers all of `boolean` — collapses to `boolean`.
+                const v = variantsOf(or(true as const, false as const))
+                assertEq(v.length, 1)
+                assertEq(v[0], boolean)
+            },
+            reversed: () => {
+                // Order doesn't matter.
+                const v = variantsOf(or(false as const, true as const))
+                assertEq(v.length, 1)
+                assertEq(v[0], boolean)
+            },
+            repeated: () => {
+                // Duplicate `true`/`false` consts still collapse to a single `boolean`.
+                const v = variantsOf(or(true as const, true as const, false as const, false as const))
+                assertEq(v.length, 1)
+                assertEq(v[0], boolean)
+            },
+            withOtherVariants: () => {
+                // Other variants are preserved; const number `42` is dropped by the
+                // existing `number` thunk subset rule.
+                const v = variantsOf(or(true as const, 42 as const, false as const, number))
+                assertEq(v.length, 2)
+                assertEq(v[0], boolean)
+                assertEq(v[1], number)
+            },
+            onlyTrueKept: () => {
+                // Without a matching `false`, no collapse — the const is kept as-is.
+                const v = variantsOf(or(true as const))
+                assertEq(v.length, 1)
+                assertEq(v[0], true)
+            },
+            onlyFalseKept: () => {
+                // Without a matching `true`, no collapse — the const is kept as-is.
+                const v = variantsOf(or(false as const))
+                assertEq(v.length, 1)
+                assertEq(v[0], false)
+            },
+            nested: () => {
+                // Collapse applies after flattening nested `or`s.
+                const v = variantsOf(or(or(true as const, 42 as const), false as const))
+                assertEq(v.length, 2)
+                assertEq(v[0], boolean)
+                assertEq(v[1], 42)
+            },
+        },
         emptyStillNever: () => {
             assertEq(variantsOf(or()).length, 0)
             assertEq(variantsOf(never).length, 0)

--- a/issues/130-or-optimization.md
+++ b/issues/130-or-optimization.md
@@ -14,8 +14,8 @@ Examples:
 - [x] Any type is a subset of `unknown` — `or(unknown, ...rest)` simplifies to `unknown`.
 - [x] Duplicate variants (`A ⊆ A` and `A ⊇ A`) collapse to a single variant.
 - [ ] A complete set of variants that together cover a wider type collapses to that wider type:
-  - `['or', true, false]` ≡ `['boolean']`.
-  - `['or', ...all primitive type thunks, ...all object/array thunks]` ≡ `['unknown']` (a union of every variant that makes up `unknown` is `unknown`).
+  - [x] `['or', true, false]` ≡ `['boolean']`.
+  - [ ] `['or', ...all primitive type thunks, ...all object/array thunks]` ≡ `['unknown']` (a union of every variant that makes up `unknown` is `unknown`).
 
 This requires generic subset utilities on `Type`:
 


### PR DESCRIPTION
## Summary

Tackles one of the unchecked items in [issue 130](./issues/130-or-optimization.md) — "a complete set of variants that together cover a wider type collapses to that wider type" — for the boolean case:

- `or(true, false)` now normalizes to `or(boolean)`.
- Works alongside the existing rules: nested-`or` flattening, `unknown` collapse, primitive-thunk subset, and `Object.is` dedup.
- When both `true` and `false` consts appear without a `boolean` thunk, the first boolean const is replaced with the `boolean` thunk and the remaining boolean consts are dropped by the existing dedup pass. Position of other variants is preserved.

## Test plan

- [x] `tsc` passes.
- [x] Existing `or` tests still pass (`flatten`, `unknownCollapse`, `dropPrimitiveSubset`, `dedup`, `emptyStillNever`).
- [x] New `booleanPairCollapse` sub-suite covers: basic, reversed, repeated, mixed with other variants, single-side (no collapse), and nested via `or(or(...), ...)`.
- [x] Full test suite (1504 tests) passes via `fs/dev/tf/all.test.ts`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKASzzw1iCszja7JVVCzck)_