### PR TITLE
Upgrade Node.js 22 to version 22.22.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1030,7 +1030,7 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "22.22.2"
+            "node-version": "22.22.3"
           }
         },
         {

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -29,7 +29,7 @@ export const rust = '1.95.0'
 // https://nodejs.org/en/download
 export const node = {
     default: '26.1.0',
-    others: ['22.22.2', '24.15.0'],
+    others: ['22.22.3', '24.15.0'],
 } as const
 
 // https://github.com/bytecodealliance/wasmtime/releases

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,13 +37,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
-      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.21.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/fsevents": {
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
-      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     }


### PR DESCRIPTION
## Summary
This pull request updates the Node.js 22.x version used in CI and development configurations from 22.22.2 to 22.22.3.

## Changes
- Updated Node.js version in GitHub Actions CI workflow from 22.22.2 to 22.22.3
- Updated Node.js 22.x version in the module configuration from 22.22.2 to 22.22.3

## Details
This is a patch version bump for Node.js 22.x, ensuring the CI pipeline and development environment use the latest available patch release in the 22.22.x series.

https://claude.ai/code/session_01WPgzCHjgYBfUPGCMFBMtjH