### PR TITLE
NodeProgram: add env parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- NodeProgram: add `env` parameter [795](https://github.com/functionalscript/functionalscript/pull/795)
+- NodeProgram: move `Env` to `fs/types/effects/node` and add as second parameter [795](https://github.com/functionalscript/functionalscript/pull/795)
 
 ## 0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- NodeProgram: add `env` parameter [795](https://github.com/functionalscript/functionalscript/pull/795)
+
 ## 0.15.0
 
 - Effects: unify `do_`/`doRest` and `Func`/`RestFunc` into a single rest-parameter form; operation payload types are now uniformly tuples ([i121](./issues/README.md)) [794](https://github.com/functionalscript/functionalscript/pull/794)

--- a/fs/fjs/module.f.ts
+++ b/fs/fjs/module.f.ts
@@ -11,7 +11,9 @@ import type { NodeProgram } from '../types/effects/node/module.f.ts'
 
 export const main = async(io: Io): Promise<number> => {
     const { error } = io.console
-    const [command, ...rest] = io.process.argv.slice(2)
+    const { process, asyncImport } = io
+    const { env } = process
+    const [command, ...rest] = process.argv.slice(2)
     const eRun = fromIo(io)
     switch (command) {
         case 'test':
@@ -26,8 +28,8 @@ export const main = async(io: Io): Promise<number> => {
         case 'run':
         case 'r':
             const [file, ...args] = rest
-            const m = await io.asyncImport(file)
-            return eRun((m.default as NodeProgram)(args))
+            const m = await asyncImport(file)
+            return eRun((m.default as NodeProgram)(args, env))
         case undefined:
             error('Error: command is required')
             return Promise.resolve(1)

--- a/fs/io/module.f.ts
+++ b/fs/io/module.f.ts
@@ -1,7 +1,7 @@
 import { normalize } from '../path/module.f.ts'
 import { type Effect } from '../types/effects/module.f.ts'
 import { asyncRun } from '../types/effects/module.ts'
-import type { Server as EffectServer, Headers, IoResult, NodeOp, RequestListener as Erl } from '../types/effects/node/module.f.ts'
+import type { Server as EffectServer, Headers, IoResult, NodeOp, RequestListener as Erl, Env } from '../types/effects/node/module.f.ts'
 import { asBase, asNominal } from '../types/nominal/module.f.ts'
 import { error, ok, type Result } from '../types/result/module.f.ts'
 import { fromVec, listToVec, toVec } from '../types/uint8array/module.f.ts'
@@ -139,13 +139,6 @@ export type Io = {
     readonly asyncTryCatch: <T>(f: () => Promise<T>) => Promise<Result<T, unknown>>
     readonly http: Http
     readonly childProcess: ChildProcess
-}
-
-/**
- * The environment variables.
- */
-export type Env = {
-    readonly [k: string]: string|undefined
 }
 
 export type App = (io: Io) => Promise<number>

--- a/fs/io/module.ts
+++ b/fs/io/module.ts
@@ -46,8 +46,8 @@ export type NodeRun = (p: NodeProgram) => Promise<number>
 
 export const ioRun = (io: Io): NodeRun => {
     const r = fromIo(io)
-    const { argv } = io.process
-    return p => r(p(argv))
+    const { argv, env } = io.process
+    return p => r(p(argv, env))
 }
 
 const effectRun: NodeRun = ioRun(io)

--- a/fs/types/effects/node/module.f.ts
+++ b/fs/types/effects/node/module.f.ts
@@ -185,4 +185,11 @@ export type NodeEffect<T> = Effect<NodeOp, T>
 
 export type NodeOperationMap = ToAsyncOperationMap<NodeOp>
 
-export type NodeProgram = (argv: readonly string[]) => Effect<NodeOp, number>
+/**
+ * The environment variables.
+ */
+export type Env = {
+    readonly [k: string]: string|undefined
+}
+
+export type NodeProgram = (argv: readonly string[], env: Env) => Effect<NodeOp, number>


### PR DESCRIPTION
## Summary

- Moves `Env` type from `fs/io/module.f.ts` to `fs/types/effects/node/module.f.ts`
- Adds `env: Env` as a second parameter of `NodeProgram`
- `ioRun` passes `process.env` directly to the program
- `fjs` passes `env` when invoking a loaded `NodeProgram` via the `run`/`r` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)