### PR TITLE
i40: add notes — not actionable inside FunctionalScript today

### DIFF
--- a/issues/README.md
+++ b/issues/README.md
@@ -41,12 +41,18 @@
   - use content (serialization). This can be slow with a non-CA VM. Functions are still hard to serialize.
 - [ ] 38. Rust: bigint: Optimize multiplication https://www.youtube.com/watch?v=AMl6EJHfUWo
 - [ ] [039-radix-encoding.md](./039-radix-encoding.md)
-- [ ] 40. TypeScript doesn't show an error if an exported type references a non-exported type. We need to find a way to detect such cases.
+- [ ] P5 40. TypeScript doesn't show an error if an exported type references a non-exported type. We need to find a way to detect such cases.
 
   ```ts
   type A = number
   export type B = A | string
   ```
+
+  Notes:
+  - FunctionalScript doesn't have RegEx, so an ad-hoc text-scan implementation in `.f.ts` is not possible.
+  - The task is more about an external tool: it requires emitting `.d.ts` via `tsc` and inspecting the output (or driving the TypeScript Compiler API), neither of which belongs inside a FunctionalScript module.
+  - The proper place for this check is a FunctionalScript parser, which is not available yet.
+  - Low priority (P5).
 - [ ] 42. Try mixing serializable BNFs.
 - [ ] 43. state-full parser.
   ```ts


### PR DESCRIPTION
Closing this PR — after discussion, the original approach is the wrong shape for the project:

1. **FunctionalScript doesn't have RegEx**, so an ad-hoc text-scan implementation in `.f.ts` is not possible.
2. The task is really about an **external tool** (drives `tsc` / TypeScript Compiler API), which doesn't belong inside a FunctionalScript module.
3. The proper home for this check is a **FunctionalScript parser**, which is not available yet.
4. The task is **low priority (P5)**.

Branch now contains only a notes update to `issues/README.md` reflecting the above. The detector module (`fs/dev/check-private-types/`), `package.json` script, `deno.json` entry, and CHANGELOG entry have all been reverted.