### PR TITLE
Effects: add `now` operation returning epoch nanoseconds via `Date.now()`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1070,7 +1070,7 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "24.15.0"
+            "node-version": "26.1.0"
           }
         },
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Effects: add `now` operation returning epoch nanoseconds as `bigint` via `Date.now()`; virtual runner exposes `epochNs` for deterministic tests [803](https://github.com/functionalscript/functionalscript/pull/803)
+
 ## 0.16.0
 
 - RTTI `Ts<>`: optional field inference; CI: derive `Step`/`Job`/`GitHubAction` types from RTTI schemas; allow `--allow-slow-types` in Deno publish ([i147](./issues/README.md)) [798](https://github.com/functionalscript/functionalscript/pull/798)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.16.1
+
 - Effects: add `now` operation returning epoch nanoseconds as `bigint` via `Date.now()`; virtual runner exposes `epochNs` for deterministic tests [803](https://github.com/functionalscript/functionalscript/pull/803)
 
 ## 0.16.0

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@functionalscript/functionalscript",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "license": "MIT",
   "exports": {
     "./fs/asn.1/module.f.ts": "./fs/asn.1/module.f.ts",

--- a/fs/io/module.f.ts
+++ b/fs/io/module.f.ts
@@ -241,7 +241,8 @@ export const fromIo = ({
             const s = asBase(server) as Server
             s.listen(port)
         },
-        forever: () => new Promise(() => {})
+        forever: () => new Promise(() => {}),
+        now: async () => BigInt(Date.now()) * 1_000_000n,
     })
     return result
 }

--- a/fs/types/effects/node/module.f.ts
+++ b/fs/types/effects/node/module.f.ts
@@ -188,6 +188,12 @@ export type Import = ['import', (path: string) => IoResult<Module>]
 
 export const import_: Func<Import> = do_('import')
 
+// now
+
+export type Now = readonly['now', () => bigint]
+
+export const now: Func<Now> = do_('now')
+
 // Node
 
 export type NodeOp =
@@ -198,6 +204,7 @@ export type NodeOp =
     | Http
     | Forever
     | Import
+    | Now
 
 export type NodeEffect<T> = Effect<NodeOp, T>
 

--- a/fs/types/effects/node/test.f.ts
+++ b/fs/types/effects/node/test.f.ts
@@ -1,6 +1,6 @@
 import { empty, isVec, uint, vec8 } from "../../bit_vec/module.f.ts"
 import { pure } from "../module.f.ts"
-import { fetch, mkdir, readdir, readFile, rm, writeFile } from "./module.f.ts"
+import { fetch, mkdir, now, readdir, readFile, rm, writeFile } from "./module.f.ts"
 import { emptyState, virtual } from "./virtual/module.f.ts"
 
 export default {
@@ -222,5 +222,9 @@ export default {
             if (result !== 'invalid path') { throw result }
             if (state.root.tmp === undefined) { throw state.root }
         },
+    },
+    now: () => {
+        const [_, result] = virtual({ ...emptyState, epochNs: 1_000_000n })(now())
+        if (result !== 1_000_000n) { throw result }
     },
 }

--- a/fs/types/effects/node/virtual/module.f.ts
+++ b/fs/types/effects/node/virtual/module.f.ts
@@ -21,6 +21,7 @@ export type State = {
     internet: {
         readonly[url: string]: Vec
     }
+    epochNs: bigint
 }
 
 export const emptyState: State = {
@@ -28,6 +29,7 @@ export const emptyState: State = {
     stderr: '',
     root: {},
     internet: {},
+    epochNs: 0n,
 }
 
 const operation =
@@ -160,6 +162,7 @@ const map: MemOperationMap<NodeOp, State> = {
     createServer: todo,
     listen: todo,
     forever: todo,
+    now: (state) => [state, state.epochNs],
 }
 
 export const virtual: RunInstance<NodeOp, State> = run(map)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "functionalscript",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "functionalscript",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "bin": {
         "fjs": "fs/fjs/module.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "functionalscript",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "type": "module",
   "files": [
     "**/*.js",


### PR DESCRIPTION
## Summary

- Add `Now` effect (`['now', () => bigint]`) to `NodeOp`
- Real runner: `BigInt(Date.now()) * 1_000_000n` (epoch milliseconds → nanoseconds)
- Virtual runner: new `epochNs: bigint` field on `State` for deterministic test control

## Test plan

- [ ] `now` unit test in `fs/types/effects/node/test.f.ts` passes with virtual runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)