### PR TITLE
Docs: add JSDoc @module header to module.f.ts files missing one (i13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Docs: add the required JSDoc `@module` header to every `module.f.ts` that was missing one, so each module has a one-line description on JSR ([i13](./issues/README.md)) [804](https://github.com/functionalscript/functionalscript/pull/804)
+
 ## 0.16.1
 
 - Effects: add `now` operation returning epoch nanoseconds as `bigint` via `Date.now()`; virtual runner exposes `epochNs` for deterministic tests [803](https://github.com/functionalscript/functionalscript/pull/803)

--- a/fs/asn.1/module.f.ts
+++ b/fs/asn.1/module.f.ts
@@ -1,3 +1,9 @@
+/**
+ * ASN.1 BER/DER encoding and decoding over bit vectors. Includes tag/class
+ * helpers, length-prefixed payloads, and OID conversion via Base-128.
+ *
+ * @module
+ */
 import { bitLength, max } from "../types/bigint/module.f.ts"
 import {
     empty,

--- a/fs/ci/bun/module.f.ts
+++ b/fs/ci/bun/module.f.ts
@@ -1,3 +1,9 @@
+/**
+ * CI step builder for Bun: installs the pinned Bun version (with a PowerShell
+ * fallback for Windows ARM) and runs `bun install` and `bun test`.
+ *
+ * @module
+ */
 import { bun } from '../config/module.f.ts'
 import { type Architecture, type MetaStep, type Os, type Step, clean, install, test } from '../common/module.f.ts'
 

--- a/fs/ci/common/module.f.ts
+++ b/fs/ci/common/module.f.ts
@@ -1,3 +1,10 @@
+/**
+ * Shared CI types and helpers: GitHub Actions step/job RTTI schemas, the
+ * `MetaStep` representation used by tool-specific modules, and assemblers like
+ * `install`, `test`, `clean`, `ubuntu`, and `toSteps`.
+ *
+ * @module
+ */
 import { images, rust } from '../config/module.f.ts'
 import { option, array, record, string } from '../../types/rtti/module.f.ts'
 import { type Ts } from '../../types/rtti/ts/module.f.ts'

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -1,3 +1,10 @@
+/**
+ * Centralized version pins and OS images used by the CI generator: runner
+ * images, tool versions (Bun, Deno, Playwright, Rust, Node, Wasmtime, Wasmer,
+ * TSGO).
+ *
+ * @module
+ */
 // https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
 export const images = {
     ubuntu: {

--- a/fs/ci/deno/module.f.ts
+++ b/fs/ci/deno/module.f.ts
@@ -1,3 +1,9 @@
+/**
+ * CI step builder for Deno: installs the pinned Deno version and runs
+ * `deno install` followed by `deno task test`.
+ *
+ * @module
+ */
 import { deno } from '../config/module.f.ts'
 import { type MetaStep, clean, install, test } from '../common/module.f.ts'
 

--- a/fs/ci/node/module.f.ts
+++ b/fs/ci/node/module.f.ts
@@ -1,3 +1,9 @@
+/**
+ * CI step builders for Node.js: setup-node installation, common npm
+ * install/test sequences, per-version job matrices, and the main TSGO step.
+ *
+ * @module
+ */
 import { node, tsgo } from '../config/module.f.ts'
 import { type Jobs, type MetaStep, type Os, clean, findTgz, install, test, ubuntu } from '../common/module.f.ts'
 

--- a/fs/ci/playwright/module.f.ts
+++ b/fs/ci/playwright/module.f.ts
@@ -1,3 +1,9 @@
+/**
+ * CI job that installs Playwright (with a browser-cache step) and runs the
+ * test suite against Chromium, Firefox, and WebKit.
+ *
+ * @module
+ */
 import { images, node, playwright } from '../config/module.f.ts'
 import { type Job, install, test, toSteps } from '../common/module.f.ts'
 import { basicNode } from '../node/module.f.ts'

--- a/fs/ci/rust/module.f.ts
+++ b/fs/ci/rust/module.f.ts
@@ -1,3 +1,10 @@
+/**
+ * CI step builder for the Rust crate: `cargo fmt`, `cargo clippy`, native and
+ * `--release` test runs, plus matrix entries for WASM targets (Wasmtime,
+ * Wasmer) and the 32-bit `i686` targets.
+ *
+ * @module
+ */
 import { wasmer, wasmtime } from '../config/module.f.ts'
 import { type Architecture, type MetaStep, type Os, install, test } from '../common/module.f.ts'
 

--- a/fs/crypto/secp/module.f.ts
+++ b/fs/crypto/secp/module.f.ts
@@ -1,3 +1,10 @@
+/**
+ * Short Weierstrass elliptic-curve arithmetic over a prime field: `curve`
+ * builds point negation, addition, and scalar multiplication for any
+ * `secp`-family curve from its `(p, a, g, n)` parameters.
+ *
+ * @module
+ */
 import type { Equal, Fold, Reduce } from '../../types/function/operator/module.f.ts'
 import { prime_field, sqrt, type PrimeField } from '../../types/prime_field/module.f.ts'
 import { repeat } from '../../types/monoid/module.f.ts'

--- a/fs/dev/index/module.f.ts
+++ b/fs/dev/index/module.f.ts
@@ -1,3 +1,9 @@
+/**
+ * Entry point for the `index` developer program: re-exports `index4` from the
+ * parent `dev` module as the default `NodeProgram`.
+ *
+ * @module
+ */
 import { index4 } from '../module.f.ts'
 
 export default index4

--- a/fs/html/module.f.ts
+++ b/fs/html/module.f.ts
@@ -1,3 +1,9 @@
+/**
+ * HTML serialization helpers: `Element`/`Attributes` builders, void-tag
+ * handling, attribute/text escaping, and a UTF-8 emitter for full documents.
+ *
+ * @module
+ */
 import { map, flatMap, flat, concat as listConcat, type List } from '../types/list/module.f.ts'
 import { concat, concat as stringConcat } from '../types/string/module.f.ts'
 import type { Entry } from '../types/object/module.f.ts'

--- a/fs/io/module.f.ts
+++ b/fs/io/module.f.ts
@@ -1,3 +1,12 @@
+/**
+ * Legacy `Io` interface and adapter (`fromIo`) bridging the old IO API to the
+ * effect runner.
+ *
+ * @deprecated Use `fs/types/effects/node` (see issue
+ * [i139](../../issues/README.md)).
+ *
+ * @module
+ */
 import { normalize } from '../path/module.f.ts'
 import { type Effect } from '../types/effects/module.f.ts'
 import { asyncRun } from '../types/effects/module.ts'

--- a/fs/js/tokenizer/module.f.ts
+++ b/fs/js/tokenizer/module.f.ts
@@ -1,3 +1,10 @@
+/**
+ * JavaScript tokenizer built as a range-map state machine over code points,
+ * producing tokens for keywords, identifiers, punctuators, comments, strings,
+ * and numeric literals (including `BigFloat`).
+ *
+ * @module
+ */
 import { strictEqual, type Scan, type StateScan } from '../../types/function/operator/module.f.ts'
 import { merge, fromRange, get, type RangeMapArray, type RangeMerge } from '../../types/range_map/module.f.ts'
 import { empty, stateScan, flat, toArray, reduce as listReduce, scan, map as listMap, type List } from '../../types/list/module.f.ts'

--- a/fs/json/module.f.ts
+++ b/fs/json/module.f.ts
@@ -1,3 +1,10 @@
+/**
+ * JSON tree types and utilities: `Primitive`/`Unknown` value shapes,
+ * `setProperty` for immutable nested updates, and a `stringify` built from the
+ * serializer wraps.
+ *
+ * @module
+ */
 import { next, flat, map, type List } from '../types/list/module.f.ts'
 import { concat } from '../types/string/module.f.ts'
 import { at, type Entry as ObjectEntry } from '../types/object/module.f.ts'

--- a/fs/text/module.f.ts
+++ b/fs/text/module.f.ts
@@ -1,3 +1,10 @@
+/**
+ * Indented text `Block` rendering and UTF-8 helpers: `flat` flattens a nested
+ * block into prefixed lines, while `utf8`/`utf8ToString` convert between
+ * strings and MSB-first UTF-8 bit vectors.
+ *
+ * @module
+ */
 import { msb, u8List, u8ListToVec, type Vec } from '../types/bit_vec/module.f.ts'
 import { flatMap, type List } from '../types/list/module.f.ts'
 import { fromCodePointList, toCodePointList } from './utf8/module.f.ts'

--- a/fs/text/utf16/module.f.ts
+++ b/fs/text/utf16/module.f.ts
@@ -1,3 +1,10 @@
+/**
+ * UTF-16 utilities: convert between strings, UTF-16 code units, and Unicode
+ * code points, including surrogate-pair encoding/decoding via streaming
+ * `stateScan` operations.
+ *
+ * @module
+ */
 import {
     map,
     flat,

--- a/fs/types/effects/node/module.f.ts
+++ b/fs/types/effects/node/module.f.ts
@@ -1,3 +1,12 @@
+/**
+ * Node.js effect operations: filesystem (`mkdir`, `readFile`, `readdir`,
+ * `writeFile`, `rm`, `access`), networking (`fetch`, `createServer`, `listen`),
+ * subprocess `exec`, console (`log`, `error`), `import_`, `now`, `forever`,
+ * and `all`/`both` parallelism; defines the `NodeOp`/`NodeProgram` types used
+ * by the Node runner.
+ *
+ * @module
+ */
 import type { Vec } from '../../bit_vec/module.f.ts'
 import type { Nominal } from '../../nominal/module.f.ts'
 import type { Result } from '../../result/module.f.ts'

--- a/fs/types/monoid/module.f.ts
+++ b/fs/types/monoid/module.f.ts
@@ -1,3 +1,10 @@
+/**
+ * Monoids: the `Monoid<T>` algebraic structure (identity plus associative
+ * binary operation) and `repeat`, which applies the operation `n` times using
+ * exponentiation by squaring.
+ *
+ * @module
+ */
 import type { Fold, Reduce } from '../function/operator/module.f.ts'
 
 /**

--- a/fs/types/number/module.f.ts
+++ b/fs/types/number/module.f.ts
@@ -1,3 +1,9 @@
+/**
+ * Numeric list reductions (`sum`, `min`, `max`), comparison via `cmp`, and
+ * `countOnes` for 32-bit population count using SWAR.
+ *
+ * @module
+ */
 import { reduce, type List } from '../list/module.f.ts'
 import { addition, min as minOp, max as maxOp } from '../function/operator/module.f.ts'
 import { type Sign, cmp as uCmp } from '../function/compare/module.f.ts'

--- a/fs/types/object/module.f.ts
+++ b/fs/types/object/module.f.ts
@@ -1,3 +1,10 @@
+/**
+ * Plain-object helpers and types: `Map<T>`/`Entry<T>` shapes, safe property
+ * lookup via `at`, conversions between entries and `OrderedMap`, and the
+ * `OneKey`/`SingleProperty`/`NotUnion` utility types.
+ *
+ * @module
+ */
 import { isArray } from '../array/module.f.ts'
 import { iterable, type List } from '../list/module.f.ts'
 import { entries as mapEntries, fromEntries as mapFromEntries, type OrderedMap } from '../ordered_map/module.f.ts'

--- a/fs/types/prime_field/module.f.ts
+++ b/fs/types/prime_field/module.f.ts
@@ -1,3 +1,11 @@
+/**
+ * Prime field arithmetic over `bigint`: `prime_field(p)` builds a `PrimeField`
+ * with negation, addition, subtraction, multiplication, division via modular
+ * inverse, and exponentiation; `sqrt` returns a square-root function when
+ * `p % 4 === 3`.
+ *
+ * @module
+ */
 import type { Unary, Reduce } from '../bigint/module.f.ts'
 import { repeat } from '../monoid/module.f.ts'
 

--- a/fs/types/ts/module.f.ts
+++ b/fs/types/ts/module.f.ts
@@ -1,3 +1,10 @@
+/**
+ * TypeScript source-emitter helpers: the `Equal`/`Assert` compile-time
+ * predicates and a `Printer` that renders tuples, structs, arrays, records,
+ * primitive literals, and unions as TypeScript type expressions.
+ *
+ * @module
+ */
 export type Equal<A, B> =
     (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
         ? true


### PR DESCRIPTION
## Summary

- AGENTS.md requires every module to start with a JSDoc `@module` header, but 22 `module.f.ts` files were missing one. Add a one-line description to each so JSR has a per-module summary and the codebase conforms to its own convention. Progress toward [i13](./issues/README.md) (Docs for JSR).
- `fs/io/module.f.ts` is also documented and tagged `@deprecated`, pointing readers at `fs/types/effects/node` ([i139](./issues/README.md)).

## Test plan

- [x] `npx tsc` passes (no errors).
- [x] `npm test` passes (1480 tests, 0 failures).
- [x] `npm run update` is a no-op after the changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_015xJbCZ3HYoWP1RY2WWR85a)_