### PR TITLE
Issues: test framework redesign for Effects (i148, i149, i150)

### DIFF
--- a/issues/148-test-framework-effects.md
+++ b/issues/148-test-framework-effects.md
@@ -2,6 +2,8 @@
 
 The test framework in [`fs/dev/tf/module.f.ts`](../fs/dev/tf/module.f.ts) currently runs on the [`Io`](../fs/io/module.f.ts) interface rather than the Effects system. This blocks running tests in any environment that doesn't implement `Io` (e.g. a browser), and duplicates effect-threading machinery that the rest of the codebase gets for free from the effect runner.
 
+A deeper problem: the test framework cannot test itself. `Io` has no pure in-process mock — testing code that depends on `Io` requires a real runtime environment. Effects, by contrast, can be virtualized entirely within FunctionalScript using the virtual runner, so the test framework becomes testable by its own mechanism.
+
 ## Current design
 
 `main` receives an `Io` and calls `fromIo(io)(loadModuleMap2(...))` to discover test modules, then passes control to `test(input)` where `input` is an `Input<T>`:

--- a/issues/148-test-framework-effects.md
+++ b/issues/148-test-framework-effects.md
@@ -32,7 +32,7 @@ Replace `Input<T>` and the `Io` dependency with a proper Effect program.
 |---------|-------------------|
 | `log(s)` | `Log` (`log`) |
 | `error(s)` | `Error` (`error`) |
-| `io.performance.now()` | `Now` (`now`) — epoch ns as `bigint` |
+| `io.performance.now()` + `tryCatch` | `Sandbox` — runs a plain sync function, catches errors, measures time; new operation |
 | `tryCatch(f)` | new `TryCatch` operation, or handled inline |
 | `env(k)` | already in `NodeProgram` signature as `Env` parameter |
 | `loadModuleMap2(env)` | already `Effect<Access \| Import \| All \| Readdir, ModuleMap>` |
@@ -46,23 +46,53 @@ Replace `Input<T>` and the `Io` dependency with a proper Effect program.
 
 Option 1 is cleaner: `TryCatch` is already a concept in `Io`, and making it an operation allows the virtual runner to control it for deterministic error testing.
 
-### Timing with `Now`
+### Timing with a performance counter
 
-The current `measure` helper calls `io.performance.now()` before and after a test function. With the `Now` effect returning epoch nanoseconds, timing becomes:
+The current `measure` helper calls `io.performance.now()` before and after a test function. `io.performance.now()` is a high-resolution monotonic counter (sub-millisecond, relative to an arbitrary origin) — different from the `Now` effect which returns epoch nanoseconds from `Date.now()`. For timing test execution we need the performance counter, not the wall clock.
+
+Two design options:
+
+**Option A — raw `Perf` counter** (call before and after, compute delta manually, keep `TryCatch` separate):
 
 ```ts
-const before: Effect<Now, bigint> = now()
-// run test
-const after: Effect<Now, bigint> = now()
-// delta = after - before (nanoseconds)
+export type Perf = readonly['perf', () => number]
+export const perf: Func<Perf> = do_('perf')
 ```
+
+```ts
+const timedTest = (f: () => unknown): Effect<Perf | TryCatch, readonly[Result<unknown, unknown>, number]> =>
+    begin
+    .step(() => perf())
+    .step(before => tryCatch(f)
+        .step(result => perf()
+            .step(after => pure([result, after - before] as const))
+        )
+    )
+```
+
+Verbose, requires two separate operations, and the virtual runner must coordinate them independently. Critically, since effects execute as async tasks, the scheduler can insert arbitrary work between the two `perf()` calls, making the measured delta inaccurate.
+
+**Option B — `Trial` effect** (takes a plain sync function, combines try/catch and timing in one operation):
+
+```ts
+export type Trial = ['sandbox', <T>(f: () => T) => readonly[Result<T, unknown>, number]]
+export const sandbox: Func<Trial> = do_('sandbox')
+```
+
+The runner executes `f()`, catches any thrown value, measures elapsed time via `performance.now()`, and returns `[result, delta]`. Usage:
+
+```ts
+sandbox(myTest)  // Effect<Trial, readonly[Result<unknown, unknown>, number]>
+```
+
+Option B is preferred: one operation replaces both `TryCatch` and `Measure`, the runner owns both the clock and the error boundary, and the virtual runner can inject controlled results and deltas for deterministic tests. Only plain sync functions are accepted — no effects, no promises — which matches exactly what test functions are. Because the function runs synchronously inside the operation, the before/after clock reads happen in the same turn of the event loop with no scheduler interleaving, giving accurate timings. The name `sandbox` is intentional: it implies both the try/catch ("sandbox" from "try") and a measured test run. Future parameters (memory limit, time limit) are not expressible inside a JS engine today but can be added to the operation payload later without breaking the API. Implementations that use workers (e.g. a browser runner or a Node worker-threads runner) get isolation and limit enforcement for free from the worker boundary.
 
 ### Target shape
 
 The test program becomes a `NodeProgram` (or effect with a subset of `NodeOp`):
 
 ```ts
-type TestOp = Log | Error | Now | TryCatch | Access | Import | All | Readdir
+type TestOp = Log | Error | Trial | Access | Import | All | Readdir
 
 const testProgram: (argv: readonly string[], env: Env) => Effect<TestOp, number>
 ```

--- a/issues/148-test-framework-effects.md
+++ b/issues/148-test-framework-effects.md
@@ -1,0 +1,103 @@
+# 148. Test Framework: Redesign for Effects
+
+The test framework in [`fs/dev/tf/module.f.ts`](../fs/dev/tf/module.f.ts) currently runs on the [`Io`](../fs/io/module.f.ts) interface rather than the Effects system. This blocks running tests in any environment that doesn't implement `Io` (e.g. a browser), and duplicates effect-threading machinery that the rest of the codebase gets for free from the effect runner.
+
+## Current design
+
+`main` receives an `Io` and calls `fromIo(io)(loadModuleMap2(...))` to discover test modules, then passes control to `test(input)` where `input` is an `Input<T>`:
+
+```ts
+type Input<T> = {
+    readonly moduleMap: ModuleMap
+    readonly log: Log<T>
+    readonly error: Log<T>
+    readonly measure: Measure<T>
+    readonly state: T
+    readonly tryCatch: <R>(f: () => R) => Result<R, unknown>
+    readonly env: (n: string) => string | undefined
+}
+```
+
+`Input<T>` is a hand-rolled effect monad: it threads `log`, `error`, `measure` (timing via `io.performance`), `tryCatch`, and an opaque `state` through the test walk. This is exactly what the Effects system provides natively — but wired by hand, duplicated per call, and locked to `Io`.
+
+Module loading (`loadModuleMap2`) is already an `Effect<Access | Import | All | Readdir, ModuleMap>`. The coupling to `Io` lives entirely in the test runner itself.
+
+## What needs to change
+
+Replace `Input<T>` and the `Io` dependency with a proper Effect program.
+
+### Operations the test runner needs
+
+| Current | Effect equivalent |
+|---------|-------------------|
+| `log(s)` | `Log` (`log`) |
+| `error(s)` | `Error` (`error`) |
+| `io.performance.now()` | `Now` (`now`) — epoch ns as `bigint` |
+| `tryCatch(f)` | new `TryCatch` operation, or handled inline |
+| `env(k)` | already in `NodeProgram` signature as `Env` parameter |
+| `loadModuleMap2(env)` | already `Effect<Access \| Import \| All \| Readdir, ModuleMap>` |
+
+### TryCatch as an effect
+
+`tryCatch` is currently synchronous (`(f: () => R) => Result<R, unknown>`). The effect runner is async. Options:
+
+1. **Add a `TryCatch` operation** to `NodeOp` — the runner wraps `f()` in a try/catch and returns the `Result`. This keeps the test framework fully within the effect model.
+2. **Keep tryCatch out of effects** — pass it as a plain parameter alongside the effect runner. Simpler but inconsistent.
+
+Option 1 is cleaner: `TryCatch` is already a concept in `Io`, and making it an operation allows the virtual runner to control it for deterministic error testing.
+
+### Timing with `Now`
+
+The current `measure` helper calls `io.performance.now()` before and after a test function. With the `Now` effect returning epoch nanoseconds, timing becomes:
+
+```ts
+const before: Effect<Now, bigint> = now()
+// run test
+const after: Effect<Now, bigint> = now()
+// delta = after - before (nanoseconds)
+```
+
+### Target shape
+
+The test program becomes a `NodeProgram` (or effect with a subset of `NodeOp`):
+
+```ts
+type TestOp = Log | Error | Now | TryCatch | Access | Import | All | Readdir
+
+const testProgram: (argv: readonly string[], env: Env) => Effect<TestOp, number>
+```
+
+The `module.ts` adapter (Node/Bun/Playwright dispatcher) calls `fromIo(io)(testProgram(argv, env))` — a single line, identical to every other Node program in the codebase.
+
+## Browser test runner
+
+Once the test runner is an effect, a `BrowserOp` runner can execute the same `Effect<TestOp, number>` in a browser. The browser runner would:
+
+- Implement `Log`/`Error` by writing to the DOM.
+- Implement `Now` via `BigInt(Date.now()) * 1_000_000n`.
+- Implement `TryCatch` with a try/catch wrapper.
+- Implement `Readdir`/`Access`/`Import` by fetching a pre-built module manifest (a JSON file listing all test modules, generated at build time).
+
+The manifest approach sidesteps the absence of filesystem APIs in the browser: instead of walking the directory tree at runtime, the build step emits a `test-manifest.json` that the browser runner fetches.
+
+## Migration path
+
+1. Add `TryCatch` operation to `NodeOp` and implement in `fromIo` and the virtual runner.
+2. Rewrite the inner test walk (`test(input)`) as a pure function returning `Effect<TestOp, TestState>`.
+3. Replace `main(io)` with `testProgram(argv, env)` returning `Effect<TestOp, number>`.
+4. Update `module.ts` to call `fromIo(io)(testProgram(...))`.
+5. Delete `Input<T>`, `measure`, `anyLog` helpers (now redundant).
+6. Add `BrowserOp` runner and a browser entry point (`dev/test.html`) — see [i29](./README.md) and [i36](./README.md).
+
+## Unblocked by this change
+
+- [i21](./021-test-framework-silent-mode.md) — silent/verbose mode becomes an effect layer, not a threading concern.
+- [i20](./README.md) — running a subset of tests: filter the module map before passing to the effect.
+- [i29](./README.md) — browser testing: run the same effect with a browser runner.
+- [i36](./README.md) — `dev/test.html`: a static HTML page that loads the effect runner and the test manifest.
+
+## Related
+
+- [i139](./README.md) — the task entry tracking this migration.
+- [i803](https://github.com/functionalscript/functionalscript/pull/803) — adds `Now` (epoch ns via `Date.now()`), one of the operations the redesigned framework needs.
+- [i122](./README.md) — `node.f.ts` / `app.f.ts` file type for applications; the redesigned test runner would be such an application.

--- a/issues/148-test-framework-effects.md
+++ b/issues/148-test-framework-effects.md
@@ -34,7 +34,7 @@ Replace `Input<T>` and the `Io` dependency with a proper Effect program.
 |---------|-------------------|
 | `log(s)` | `Log` (`log`) |
 | `error(s)` | `Error` (`error`) |
-| `io.performance.now()` + `tryCatch` | `Sandbox` — runs a plain sync function, catches errors, measures time; new operation |
+| `io.performance.now()` + `tryCatch` | `Sandbox` ([i149](./149-sandbox.md)) — runs a plain sync function, catches errors, measures time; new operation |
 | `tryCatch(f)` | new `TryCatch` operation, or handled inline |
 | `env(k)` | already in `NodeProgram` signature as `Env` parameter |
 | `loadModuleMap2(env)` | already `Effect<Access \| Import \| All \| Readdir, ModuleMap>` |
@@ -137,5 +137,6 @@ The manifest approach sidesteps the absence of filesystem APIs in the browser: i
 ## Related
 
 - [i139](./README.md) — the task entry tracking this migration.
+- [i149](./149-sandbox.md) — the `Sandbox` effect: try/catch + timing in one atomic operation, used by the redesigned test walk.
 - [i803](https://github.com/functionalscript/functionalscript/pull/803) — adds `Now` (epoch ns via `Date.now()`), one of the operations the redesigned framework needs.
 - [i122](./README.md) — `node.f.ts` / `app.f.ts` file type for applications; the redesigned test runner would be such an application.

--- a/issues/148-test-framework-effects.md
+++ b/issues/148-test-framework-effects.md
@@ -74,20 +74,26 @@ const timedTest = (f: () => unknown): Effect<Perf | TryCatch, readonly[Result<un
 
 Verbose, requires two separate operations, and the virtual runner must coordinate them independently. Critically, since effects execute as async tasks, the scheduler can insert arbitrary work between the two `perf()` calls, making the measured delta inaccurate.
 
-**Option B — `Trial` effect** (takes a plain sync function, combines try/catch and timing in one operation):
+**Option B — `Sandbox` effect** (takes a plain sync function, combines try/catch and timing in one operation):
 
 ```ts
-export type Trial = ['sandbox', <T>(f: () => T) => readonly[Result<T, unknown>, number]]
-export const sandbox: Func<Trial> = do_('sandbox')
+export type SandboxResult<T> = {
+    readonly result: Result<T, unknown>
+    readonly duration: bigint  // nanoseconds; future fields: allocatedMemory, maxStack, etc.
+}
+
+export type Sandbox = ['sandbox', <T>(f: () => T) => SandboxResult<T>]
+export const sandbox: Func<Sandbox> = do_('sandbox')
 ```
 
-The runner executes `f()`, catches any thrown value, measures elapsed time via `performance.now()`, and returns `[result, delta]`. Usage:
+`duration` is in nanoseconds (`bigint`) for consistency with the `Now` effect and to avoid floating-point imprecision. `SandboxResult<T>` is intentionally a named record rather than a tuple so future measurements (allocated memory, maximum stack depth, etc.) can be added as new fields without breaking existing consumers. The runner executes `f()` synchronously, catches any thrown value, measures elapsed time via `performance.now()`, and returns the named result. Usage:
 
 ```ts
-sandbox(myTest)  // Effect<Trial, readonly[Result<unknown, unknown>, number]>
+sandbox(myTest)  // Effect<Sandbox, SandboxResult<unknown>>
+const { result, duration } = await run(sandbox(myTest))
 ```
 
-Option B is preferred: one operation replaces both `TryCatch` and `Measure`, the runner owns both the clock and the error boundary, and the virtual runner can inject controlled results and deltas for deterministic tests. Only plain sync functions are accepted — no effects, no promises — which matches exactly what test functions are. Because the function runs synchronously inside the operation, the before/after clock reads happen in the same turn of the event loop with no scheduler interleaving, giving accurate timings. The name `sandbox` is intentional: it implies both the try/catch ("sandbox" from "try") and a measured test run. Future parameters (memory limit, time limit) are not expressible inside a JS engine today but can be added to the operation payload later without breaking the API. Implementations that use workers (e.g. a browser runner or a Node worker-threads runner) get isolation and limit enforcement for free from the worker boundary.
+Option B is preferred: one operation replaces both `TryCatch` and `Measure`, the runner owns both the clock and the error boundary, and the virtual runner can inject controlled results and durations for deterministic tests. Only plain sync functions are accepted — no effects, no promises — which matches exactly what test functions are. Because the function runs synchronously inside the operation, the before/after clock reads happen in the same turn of the event loop with no scheduler interleaving, giving accurate timings. Future parameters (memory limit, time limit) are not expressible inside a JS engine today but can be added to the operation payload later without breaking the API. Implementations that use workers (e.g. a browser runner or a Node worker-threads runner) get isolation and limit enforcement for free from the worker boundary.
 
 ### Target shape
 

--- a/issues/148-test-framework-effects.md
+++ b/issues/148-test-framework-effects.md
@@ -100,32 +100,26 @@ Option B is preferred: one operation replaces both `TryCatch` and `Measure`, the
 The test program becomes a `NodeProgram` (or effect with a subset of `NodeOp`):
 
 ```ts
-type TestOp = Log | Error | Trial | Access | Import | All | Readdir
+type TestOp = Log | Error | Sandbox | Access | Import | All | Readdir
 
 const testProgram: (argv: readonly string[], env: Env) => Effect<TestOp, number>
 ```
 
 The `module.ts` adapter (Node/Bun/Playwright dispatcher) calls `fromIo(io)(testProgram(argv, env))` — a single line, identical to every other Node program in the codebase.
 
-## Browser test runner
+## Multiple runners
 
-Once the test runner is an effect, a `BrowserOp` runner can execute the same `Effect<TestOp, number>` in a browser. The browser runner would:
+A key principle: unit tests must never depend on third-party test frameworks or runners. The Effects-based framework is self-contained — it owns its own output, timing, and exit code. Third-party runners (Node `--test`, Bun, Playwright) are optional integration points, not requirements.
 
-- Implement `Log`/`Error` by writing to the DOM.
-- Implement `Now` via `BigInt(Date.now()) * 1_000_000n`.
-- Implement `TryCatch` with a try/catch wrapper.
-- Implement `Readdir`/`Access`/`Import` by fetching a pre-built module manifest (a JSON file listing all test modules, generated at build time).
-
-The manifest approach sidesteps the absence of filesystem APIs in the browser: instead of walking the directory tree at runtime, the build step emits a `test-manifest.json` that the browser runner fetches.
+Once the test runner is an effect program, any environment that implements `TestOp` can run it. A browser runner, a worker-based runner, or a custom CI runner all become possible by providing a different implementation of the same operation set.
 
 ## Migration path
 
-1. Add `TryCatch` operation to `NodeOp` and implement in `fromIo` and the virtual runner.
+1. Implement `Sandbox` ([i149](./149-sandbox.md)) and `IsTty` ([i150](./README.md)) in `NodeOp`, `fromIo`, and the virtual runner.
 2. Rewrite the inner test walk (`test(input)`) as a pure function returning `Effect<TestOp, TestState>`.
 3. Replace `main(io)` with `testProgram(argv, env)` returning `Effect<TestOp, number>`.
 4. Update `module.ts` to call `fromIo(io)(testProgram(...))`.
 5. Delete `Input<T>`, `measure`, `anyLog` helpers (now redundant).
-6. Add `BrowserOp` runner and a browser entry point (`dev/test.html`) — see [i29](./README.md) and [i36](./README.md).
 
 ## Unblocked by this change
 

--- a/issues/149-sandbox.md
+++ b/issues/149-sandbox.md
@@ -1,0 +1,65 @@
+# 149. `Sandbox` Effect
+
+A `Sandbox` effect that runs a plain synchronous function in an isolated, measured environment. It combines try/catch, timing, and future resource measurement into a single operation.
+
+## Definition
+
+```ts
+export type SandboxResult<T> = {
+    readonly result: Result<T, unknown>
+    readonly duration: bigint  // nanoseconds; future fields: allocatedMemory, maxStack, coverage, etc.
+}
+
+export type Sandbox = ['sandbox', <T>(f: () => T) => SandboxResult<T>]
+export const sandbox: Func<Sandbox> = do_('sandbox')
+```
+
+`SandboxResult<T>` is a named record rather than a tuple so future measurements can be added as new fields without breaking existing consumers.
+
+## Why a single operation
+
+Combining try/catch and timing into one operation rather than two separate effects (`TryCatch` + `Perf`) is necessary for correctness: effects execute as async tasks, so the scheduler can insert arbitrary work between two separate `perf()` calls, making the measured delta inaccurate. Running the function synchronously inside the operation ensures the clock reads happen in the same turn of the event loop with nothing in between.
+
+## Future parameters
+
+Future sandbox constraints (memory limit, time limit) are not expressible inside a JS engine today but can be added to the operation payload later without breaking the API:
+
+```ts
+// future
+export type SandboxOptions = {
+    readonly timeLimit?: bigint    // nanoseconds
+    readonly memoryLimit?: bigint  // bytes
+}
+```
+
+Similarly, `SandboxResult<T>` can grow to include coverage data — which functions, branches, and parameters were executed during the run:
+
+```ts
+// future
+export type Coverage = {
+    readonly functions: readonly string[]
+    readonly branches: readonly string[]
+    // etc.
+}
+
+export type SandboxResult<T> = {
+    readonly result: Result<T, unknown>
+    readonly duration: bigint
+    readonly coverage?: Coverage
+    // readonly allocatedMemory?: bigint
+    // readonly maxStack?: bigint
+}
+```
+
+Coverage information would allow the test framework to aggregate per-test coverage into a full report without relying on external tools like `--experimental-test-coverage`. It also makes coverage a first-class effect result rather than a side channel written to disk.
+
+## Implementations
+
+- **Node.js (simple):** plain try/catch + `performance.now()` in the same synchronous block.
+- **Node.js (worker):** run `f` in a `worker_thread`; enforces time and memory limits via worker termination.
+- **Browser:** run `f` in a `Worker`; same limit enforcement.
+- **Virtual runner:** injects a controlled `SandboxResult` for deterministic tests — both the result and the duration are fully controllable, making the test framework testable by its own mechanism.
+
+## Related
+
+- [i148](./148-test-framework-effects.md) — the test framework redesign that motivated this effect; `Sandbox` replaces `Input<T>`'s `tryCatch` + `measure` combination.

--- a/issues/150-tty.md
+++ b/issues/150-tty.md
@@ -1,0 +1,33 @@
+# 150. `IsTty` Effect
+
+An effect that reports whether a given output stream is connected to a terminal (TTY). Used by the test framework and any other program that wants to emit ANSI escape codes only when the output supports them.
+
+## Definition
+
+```ts
+export type IsTty = ['isTty', (fd: number) => boolean]
+export const isTty: Func<IsTty> = do_('isTty')
+```
+
+`fd` follows the Unix convention: `1` for stdout, `2` for stderr.
+
+## Implementations
+
+- **Node.js:** `process.stdout.isTTY` / `process.stderr.isTTY` (already on `Io.process`).
+- **Browser:** always `false` — output goes to the DOM, not a terminal.
+- **Virtual runner:** configurable; defaults to `false` for deterministic tests.
+
+## Usage in the test framework
+
+The test framework uses ANSI SGR codes (`fgGreen`, `fgRed`, `bold`, `reset`) for colored output. With `IsTty`, the decision is made once at startup and threaded through as a plain boolean — no `Io` dependency required:
+
+```ts
+begin
+    .step(() => isTty(1))
+    .step(tty => testProgram(argv, env, tty))
+```
+
+## Related
+
+- [i148](./148-test-framework-effects.md) — the test framework redesign that requires this effect.
+- [i149](./149-sandbox.md) — `Sandbox` effect, the other new operation needed by the test framework.

--- a/issues/README.md
+++ b/issues/README.md
@@ -305,6 +305,7 @@
 - [ ] 147. Deno slow-types: Deno's JSR publisher requires full explicit type annotations on exported `const`. For complex schemas defined with `as const`, writing out the full type is impractical. A fix via `satisfies` is proposed in [deno_graph#639](https://github.com/denoland/deno_graph/pull/639) and is available in deno_graph 0.107.2, but Deno 2.7.14 still ships deno_graph 0.107.1. Until a Deno release includes deno_graph 0.107.2, add `--allow-slow-types` to the `deno publish` and `deno publish --dry-run` commands. Remove `--allow-slow-types` once the required Deno version is available.
 - [ ] [148-test-framework-effects](./148-test-framework-effects.md). Redesign the test framework (`dev/tf/module.f.ts`) as an Effect program, replacing the hand-rolled `Input<T>` threading and `Io` dependency. Unblocks browser testing (i29, i36), silent mode (i21), and subset runs (i20).
 - [ ] [149-sandbox](./149-sandbox.md). `Sandbox` effect: runs a plain sync function with try/catch and timing in one atomic operation; future fields for memory/stack limits; worker-based implementations enforce hard limits.
+- [ ] [150-tty](./150-tty.md). `IsTty` effect: reports whether a file descriptor is connected to a terminal; used by the test framework to gate ANSI color output.
 
 
 ## Language Specification

--- a/issues/README.md
+++ b/issues/README.md
@@ -272,7 +272,7 @@
 - [ ] 134. A proposal for nominal types in TypeScript. The main reason is that the current `Nominal` type doesn't support type narrowing properly.
 - [ ] 136. CI should have all tools and image versions in a specific file. This file is a kind of `lock` file for the CI. The lock file will be periodically updated. We will also need instructions on how to check the newest tool version in `README.md`.
 - [ ] 138. Implement a script that will update the lock file by reading the latest versions of tools from the internet using the instructions from 136.
-- [ ] 139. Translate the test framework (`dev/tf/module.f.ts`) to Effects. Currently, it threads `log`/`error`/`measure`/`tryCatch`/`state` through a custom `Input<T>` instead of running on the effect runner used by the rest of the codebase. Once it runs on Effects, layered features like silent/verbose mode (21), running a subset of tests (20), and parsing non-default exports (27) become straightforward.
+- [ ] 139. Translate the test framework (`dev/tf/module.f.ts`) to Effects. See [148-test-framework-effects](./148-test-framework-effects.md) for the detailed design.
 - [ ] 140. We should have 100% test coverage for all `module.f.ts` files.
 - [ ] 141. Design for a universal, extensible type system based on custom RTTI. How it should work:
   1. We should define an interface for type validation. For example
@@ -303,6 +303,8 @@
 - [ ] 145. Use Docker containers for Linux CI jobs. Running Linux jobs inside a Docker container allows GitHub Actions to cache the container image, so tool installation (Node, Rust, Bun, Deno, Wasmer, Wasmtime, etc.) is paid once per image rebuild rather than on every CI run. The cache key must include all tool versions and the target architecture. macOS and Windows jobs are unaffected.
 - [ ] [146-rtti-ts-inference](./146-rtti-ts-inference.md). `Ts<T>` walks schema structure on every query, which overflows TS's depth budget for `Ts<any>` and forces `as any` casts in `validate`/`parse`. Compares Zod/Valibot/ArkType approaches and sketches the design space.
 - [ ] 147. Deno slow-types: Deno's JSR publisher requires full explicit type annotations on exported `const`. For complex schemas defined with `as const`, writing out the full type is impractical. A fix via `satisfies` is proposed in [deno_graph#639](https://github.com/denoland/deno_graph/pull/639) and is available in deno_graph 0.107.2, but Deno 2.7.14 still ships deno_graph 0.107.1. Until a Deno release includes deno_graph 0.107.2, add `--allow-slow-types` to the `deno publish` and `deno publish --dry-run` commands. Remove `--allow-slow-types` once the required Deno version is available.
+- [ ] [148-test-framework-effects](./148-test-framework-effects.md). Redesign the test framework (`dev/tf/module.f.ts`) as an Effect program, replacing the hand-rolled `Input<T>` threading and `Io` dependency. Unblocks browser testing (i29, i36), silent mode (i21), and subset runs (i20).
+
 
 ## Language Specification
 

--- a/issues/README.md
+++ b/issues/README.md
@@ -304,6 +304,7 @@
 - [ ] [146-rtti-ts-inference](./146-rtti-ts-inference.md). `Ts<T>` walks schema structure on every query, which overflows TS's depth budget for `Ts<any>` and forces `as any` casts in `validate`/`parse`. Compares Zod/Valibot/ArkType approaches and sketches the design space.
 - [ ] 147. Deno slow-types: Deno's JSR publisher requires full explicit type annotations on exported `const`. For complex schemas defined with `as const`, writing out the full type is impractical. A fix via `satisfies` is proposed in [deno_graph#639](https://github.com/denoland/deno_graph/pull/639) and is available in deno_graph 0.107.2, but Deno 2.7.14 still ships deno_graph 0.107.1. Until a Deno release includes deno_graph 0.107.2, add `--allow-slow-types` to the `deno publish` and `deno publish --dry-run` commands. Remove `--allow-slow-types` once the required Deno version is available.
 - [ ] [148-test-framework-effects](./148-test-framework-effects.md). Redesign the test framework (`dev/tf/module.f.ts`) as an Effect program, replacing the hand-rolled `Input<T>` threading and `Io` dependency. Unblocks browser testing (i29, i36), silent mode (i21), and subset runs (i20).
+- [ ] [149-sandbox](./149-sandbox.md). `Sandbox` effect: runs a plain sync function with try/catch and timing in one atomic operation; future fields for memory/stack limits; worker-based implementations enforce hard limits.
 
 
 ## Language Specification


### PR DESCRIPTION
## Summary

- [i148](./issues/148-test-framework-effects.md): design doc for rewriting the test framework as an Effect program — replaces hand-rolled `Input<T>`/`Io` with `NodeOp` effects; documents `Sandbox` as the key new operation; states the principle that unit tests must never depend on third-party runners
- [i149](./issues/149-sandbox.md): `Sandbox` effect — runs a plain sync function with try/catch and timing in one atomic operation; `SandboxResult<T>` named record extensible with future fields (memory, stack, coverage); worker-based implementations enforce hard limits
- [i150](./issues/150-tty.md): `IsTty` effect — reports whether a file descriptor is a terminal; used by the test framework to gate ANSI color output

## Test plan

- [ ] Issues are consistent and cross-linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)