### PR TITLE
IO: expose `sandbox` on `Io` interface; test framework: replace `measure`+`tryCatch` with `sandbox`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- IO: expose `sandbox` on `Io` interface; test framework: replace `measure`+`tryCatch` with `sandbox`, eliminating state threading ([i149](./issues/149-sandbox.md)) [809](https://github.com/functionalscript/functionalscript/pull/809)
 - Effects: add `sandbox` operation — runs a plain sync function with try/catch and `performance.now()` timing in one atomic operation; `SandboxResult<T>` carries result and duration ([i149](./issues/149-sandbox.md)) [808](https://github.com/functionalscript/functionalscript/pull/808)
 - Docs: add the required JSDoc `@module` header to every `module.f.ts` that was missing one, so each module has a one-line description on JSR ([i13](./issues/README.md)) [804](https://github.com/functionalscript/functionalscript/pull/804)
 

--- a/fs/dev/tf/module.f.ts
+++ b/fs/dev/tf/module.f.ts
@@ -5,25 +5,17 @@
  */
 import { fold } from '../../types/list/module.f.ts'
 import { reset, fgGreen, fgRed, bold, type CsiConsole, stdio, stderr } from '../../text/sgr/module.f.ts'
-import type * as Result from '../../types/result/module.f.ts'
-import type { Io, Performance, TryCatch } from '../../io/module.f.ts'
+import type { Io } from '../../io/module.f.ts'
+import type { SandboxResult } from '../../types/effects/node/module.f.ts'
 import { env, loadModuleMap, type ModuleMap, type Module } from '../module.f.ts'
 
-type DependencyMap = {
-   readonly[k in string]?: Module
-}
+type Log = CsiConsole
 
-type Log<T> = CsiConsole
-
-type Measure<T> = <R>(f: () => R) => (state: T) => readonly[R, number, T]
-
-type Input<T> = {
+type Input = {
     readonly moduleMap: ModuleMap,
-    readonly log: Log<T>,
-    readonly error: Log<T>,
-    readonly measure: Measure<T>,
-    readonly state: T,
-    readonly tryCatch: <R>(f: () => R) => Result.Result<R, unknown>,
+    readonly log: Log,
+    readonly error: Log,
+    readonly sandbox: <R>(f: () => R) => SandboxResult<R>,
     readonly env: (n: string) => string|undefined
  }
 
@@ -41,8 +33,6 @@ const addPass = (delta: number) => (ts: TestState): TestState =>
 const addFail = (delta: number) => (ts: TestState): TestState =>
     ({ ...ts, time: ts.time + delta, fail: ts.fail + 1 })
 
-type FullState<T> = readonly[TestState, T]
-
 const timeFormat = (a: number) => {
     const y = Math.round(a * 10_000).toString()
     const yl = 5 - y.length
@@ -57,7 +47,7 @@ export type Test = () => unknown
 
 export type TestSet = Test | readonly(readonly[string, unknown])[]
 
-export const parseTestSet = (t: TryCatch) => (throws: boolean) => (x: unknown): TestSet => {
+export const parseTestSet = (sandbox: <R>(f: () => R) => SandboxResult<R>) => (throws: boolean) => (x: unknown): TestSet => {
     switch (typeof x) {
         case 'function': {
             if (x.length === 0) {
@@ -69,7 +59,7 @@ export const parseTestSet = (t: TryCatch) => (throws: boolean) => (x: unknown): 
                 // enclosing tree node is named 'throw' (so any function reference
                 // works, not only inline ones whose inferred name is 'throw').
                 return () => {
-                    const [tag, value] = t(xt)
+                    const { result: [tag, value] } = sandbox(xt)
                     if (tag === 'ok') {
                         throw value
                     }
@@ -88,22 +78,21 @@ export const parseTestSet = (t: TryCatch) => (throws: boolean) => (x: unknown): 
     return []
 }
 
-export const test = <T>(input: Input<T>): readonly[number, T] => {
-    let { moduleMap, log, error, measure, tryCatch, env, state } = input
+export const test = (input: Input): number => {
+    const { moduleMap, log, error, sandbox, env } = input
     const isGitHub = env('GITHUB_ACTION') !== undefined
-    const parse = parseTestSet(tryCatch)
+    const parse = parseTestSet(sandbox)
     const f
-        : (k: readonly[string, Module]) => (fs: FullState<T>) => FullState<T>
+        : (k: readonly[string, Module]) => (ts: TestState) => TestState
         = ([k, v]) => {
         const test
-            : (i: string) => (throws: boolean) => (v: unknown) => (fs: FullState<T>) => FullState<T>
-            = i => throws => v => ([ts, state]) => {
+            : (i: string) => (throws: boolean) => (v: unknown) => (ts: TestState) => TestState
+            = i => throws => v => ts => {
             const next = test(`${i}| `)
 
             const set = parse(throws)(v)
             if (typeof set === 'function') {
-                const [[s, r], delta, state0] = measure(() => tryCatch(set))(state)
-                state = state0
+                const { result: [s, r], duration: delta } = sandbox(set)
                 if (s !== 'ok') {
                     ts = addFail(delta)(ts)
                     if (isGitHub) {
@@ -119,24 +108,24 @@ export const test = <T>(input: Input<T>): readonly[number, T] => {
                     log(`${i}() ${fgGreen}ok${reset}, ${timeFormat(delta)}`);
                     // The result of a function is walked as a fresh sub-tree;
                     // the parent's `throws` flag does not propagate into it.
-                    [ts, state] = next(false)(r)([ts, state])
+                    ts = next(false)(r)(ts)
                 }
             } else {
                 const f
-                    : (k: readonly[string|number, unknown]) => (fs: FullState<T>) => FullState<T>
-                    = ([k, v]) => ([time, state]) => {
+                    : (k: readonly[string|number, unknown]) => (ts: TestState) => TestState
+                    = ([k, v]) => ts => {
                     log(`${i}${k}:`);
-                    [time, state] = next(throws || k === 'throw')(v)([time, state])
-                    return [time, state]
+                    ts = next(throws || k === 'throw')(v)(ts)
+                    return ts
                 }
-                [ts, state] = fold(f)([ts, state])(set)
+                ts = fold(f)(ts)(set)
             }
-            return [ts, state]
+            return ts
         }
-        return ([ts, state]) => {
+        return ts => {
             if (isTest(k)) {
                 log(`testing ${k}`);
-                [ts, state] = test('| ')(false)(v.default)([ts, state])
+                ts = test('| ')(false)(v.default)(ts)
                 // Non-default exports are walked as a sibling test group so
                 // a test file can spread its tests across multiple named
                 // exports (see issue 27 in `issues/README.md`). Skip exports
@@ -151,20 +140,18 @@ export const test = <T>(input: Input<T>): readonly[number, T] => {
                     )
                 )
                 if (Object.keys(others).length !== 0) {
-                    [ts, state] = test('| ')(false)(others)([ts, state])
+                    ts = test('| ')(false)(others)(ts)
                 }
             }
-            return [ts, state]
+            return ts
         }
     }
-    let ts
-        : TestState
-        = { time: 0, pass: 0, fail: 0 };
-    [ts, state] = fold(f)([ts, state])(Object.entries(moduleMap))
+    let ts: TestState = { time: 0, pass: 0, fail: 0 }
+    ts = fold(f)(ts)(Object.entries(moduleMap))
     const fgFail = ts.fail === 0 ? fgGreen : fgRed
     log(`${bold}Number of tests: pass: ${fgGreen}${ts.pass}${reset}${bold}, fail: ${fgFail}${ts.fail}${reset}${bold}, total: ${ts.pass + ts.fail}${reset}`)
     log(`${bold}Time: ${timeFormat(ts.time)}${reset}`)
-    return [ts.fail !== 0 ? 1 : 0, state]
+    return ts.fail !== 0 ? 1 : 0
 }
 
 export const anyLog = (f: (s: string) => void) => (s: string) => <T>(state: T): T => {
@@ -172,19 +159,10 @@ export const anyLog = (f: (s: string) => void) => (s: string) => <T>(state: T): 
     return state
 }
 
-export const measure = (p: Performance) => <R>(f: () => R) => <T>(state: T): readonly[R, number, T] => {
-    const b = p.now()
-    const r = f()
-    const e = p.now()
-    return [r, e - b, state]
-}
-
 export const main = async(io: Io): Promise<number> => test({
     moduleMap: await loadModuleMap(io),
-    log: stdio(io), // anyLog(io.console.log),
-    error: stderr(io), // anyLog(io.console.error),
-    measure: measure(io.performance),
-    tryCatch: io.tryCatch,
+    log: stdio(io),
+    error: stderr(io),
+    sandbox: io.sandbox,
     env: env(io),
-    state: undefined,
-})[0]
+})

--- a/fs/dev/tf/module.ts
+++ b/fs/dev/tf/module.ts
@@ -42,7 +42,7 @@ const framework: CommonFramework =
     isBun ? createBunFramework(nodeTest) :
         createFramework(nodeTest)
 
-const parse = parseTestSet(io.tryCatch)
+const parse = parseTestSet(io.sandbox)
 
 const scanModule = (x: Test): TestFunc => async(subTestRunner: SubTestRunnerFunc) => {
     let subTests = [x]

--- a/fs/io/module.f.ts
+++ b/fs/io/module.f.ts
@@ -104,6 +104,8 @@ export type Process = {
 
 export type TryCatch = <T>(f: () => T) => Result<T, unknown>
 
+export type Sandbox = <T>(f: () => T) => SandboxResult<T>
+
 export type Server = {
     readonly listen: (port: number) => void
 }
@@ -151,6 +153,7 @@ export type Io = {
     readonly http: Http
     readonly childProcess: ChildProcess
     readonly now: () => number
+    readonly sandbox: Sandbox
 }
 
 export type App = (io: Io) => Promise<number>
@@ -198,8 +201,8 @@ export const fromIo = ({
     http: { createServer },
     childProcess,
     asyncImport,
-    performance: { now: perfNow },
     now: ioNow,
+    sandbox: ioSandbox,
 }: Io): EffectToPromise => {
     const result: EffectToPromise = asyncRun({
         all: async (...effects) => await Promise.all(effects.map(result)),
@@ -256,19 +259,7 @@ export const fromIo = ({
         },
         forever: () => new Promise(() => {}),
         now: async () => ioNow(),
-        sandbox: async f => {
-            const g = (result: Result<unknown, unknown>, after: number) =>
-                ({ result, duration: after - before } as const)
-            const before = perfNow()
-            try {
-                const value = f()
-                const after = perfNow()
-                return g(ok(value), after)
-            } catch (e) {
-                const after = perfNow()
-                return g(error(e), after)
-            }
-        },
+        sandbox: async f => ioSandbox(f),
     })
     return result
 }

--- a/fs/io/module.ts
+++ b/fs/io/module.ts
@@ -4,12 +4,10 @@ import fs from 'node:fs'
 import process from 'node:process'
 import { fromIo, type Io, type Run, run } from './module.f.ts'
 import { concat } from '../path/module.f.ts'
-import type { Module, NodeProgram, SandboxResult } from '../types/effects/node/module.f.ts'
+import type { Module, NodeProgram } from '../types/effects/node/module.f.ts'
 import { error, ok, type Result } from '../types/result/module.f.ts'
 
 const prefix = 'file:///'
-
-const { now: perfNow } = performance
 
 const { now } = Date
 
@@ -45,22 +43,17 @@ export const io: Io = {
     now,
     sandbox: <T>(f: () => T) => {
         let result: Result<T, unknown>
-        let duration = 0
+        let after: number
+        const before = performance.now()
         try {
-            let value: T
-            let before = 0
-            try {
-                before = perfNow()
-                value = f()
-            } finally {
-                const after = perfNow()
-                duration = after - before
-            }
+            const value = f()
+            after = performance.now()
             result = ok(value)
         } catch (e) {
+            after = performance.now()
             result = error(e)
         }
-        return { result, duration }
+        return { result, duration: after - before }
     },
 }
 

--- a/fs/io/module.ts
+++ b/fs/io/module.ts
@@ -39,6 +39,15 @@ export const io: Io = {
     http,
     childProcess,
     now: () => Date.now(),
+    sandbox: f => {
+        const before = performance.now()
+        try {
+            const value = f()
+            return { result: ok(value), duration: performance.now() - before }
+        } catch (e) {
+            return { result: error(e), duration: performance.now() - before }
+        }
+    },
 }
 
 export const legacyRun: Run = run(io)

--- a/fs/io/module.ts
+++ b/fs/io/module.ts
@@ -4,10 +4,14 @@ import fs from 'node:fs'
 import process from 'node:process'
 import { fromIo, type Io, type Run, run } from './module.f.ts'
 import { concat } from '../path/module.f.ts'
-import type { Module, NodeProgram } from '../types/effects/node/module.f.ts'
-import { error, ok } from '../types/result/module.f.ts'
+import type { Module, NodeProgram, SandboxResult } from '../types/effects/node/module.f.ts'
+import { error, ok, type Result } from '../types/result/module.f.ts'
 
 const prefix = 'file:///'
+
+const { now: perfNow } = performance
+
+const { now } = Date
 
 export const asyncImport = (v: string): Promise<Module> => import(v)
 
@@ -38,15 +42,25 @@ export const io: Io = {
     },
     http,
     childProcess,
-    now: () => Date.now(),
-    sandbox: f => {
-        const before = performance.now()
+    now,
+    sandbox: <T>(f: () => T) => {
+        let result: Result<T, unknown>
+        let duration = 0
         try {
-            const value = f()
-            return { result: ok(value), duration: performance.now() - before }
+            let value: T
+            let before = 0
+            try {
+                before = perfNow()
+                value = f()
+            } finally {
+                const after = perfNow()
+                duration = after - before
+            }
+            result = ok(value)
         } catch (e) {
-            return { result: error(e), duration: performance.now() - before }
+            result = error(e)
         }
+        return { result, duration }
     },
 }
 

--- a/fs/io/virtual/module.f.ts
+++ b/fs/io/virtual/module.f.ts
@@ -6,6 +6,7 @@
 import type { Io, MakeDirectoryOptions, RmOptions } from '../module.f.ts'
 import { at, type OrderedMap } from '../../types/ordered_map/module.f.ts'
 import { todo } from '../../dev/module.f.ts'
+import { error, ok } from '../../types/result/module.f.ts'
 
 export const createVirtualIo = (files: OrderedMap<Uint8Array>): Io => ({
     console: {
@@ -47,5 +48,12 @@ export const createVirtualIo = (files: OrderedMap<Uint8Array>): Io => ({
     },
     childProcess: {
         exec: todo,
+    },
+    sandbox: f => {
+        try {
+            return { result: ok(f()), duration: 0 }
+        } catch (e) {
+            return { result: error(e), duration: 0 }
+        }
     },
 })


### PR DESCRIPTION
## Summary

- Add `sandbox: <T>(f: () => T) => SandboxResult<T>` to the `Io` interface (`fs/io/module.f.ts`)
- Real `io` (`fs/io/module.ts`) implements `sandbox` via `performance.now()` + try/catch
- Virtual `Io` (`fs/io/virtual/module.f.ts`) implements `sandbox` with `duration: 0` for deterministic tests
- `fromIo` delegates its `sandbox` effect handler to the injected `Io.sandbox` (removes inline `performance.now()` usage from `.f.ts`)
- Test framework (`fs/dev/tf/module.f.ts`): replace the separate `measure` + `tryCatch` pair in `Input` with a single `sandbox` field; eliminate the state-threading wrapper (`FullState<T>`) — `TestState` is now threaded directly; update `parseTestSet` to use `sandbox` for pass-on-throw wrapping
- `fs/dev/tf/module.ts`: update `parseTestSet` call to pass `io.sandbox`