### PR TITLE
fjs: convert `run`/`r` command from `asyncImport`/`await` to `import_` effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `fjs`: convert `run`/`r` command from `asyncImport`/`await` to `import_` effect [812](https://github.com/functionalscript/functionalscript/pull/812)
 - DJS transpiler: replace `Fs`/`readFileSync` with `ReadFile` effect; tests use virtual effect runner; delete `fs/io/virtual` ([i151](./issues/151-transpiler-effects.md)) [811](https://github.com/functionalscript/functionalscript/pull/811)
 - IO: expose `sandbox` on `Io` interface; test framework: replace `measure`+`tryCatch` with `sandbox`, eliminating state threading ([i149](./issues/149-sandbox.md)) [809](https://github.com/functionalscript/functionalscript/pull/809)
 - Effects: add `sandbox` operation — runs a plain sync function with try/catch and `performance.now()` timing in one atomic operation; `SandboxResult<T>` carries result and duration ([i149](./issues/149-sandbox.md)) [808](https://github.com/functionalscript/functionalscript/pull/808)

--- a/fs/fjs/module.f.ts
+++ b/fs/fjs/module.f.ts
@@ -7,8 +7,7 @@ import { fromIo, type Io } from '../io/module.f.ts'
 import { compile } from '../djs/module.f.ts'
 import { main as testMain } from '../dev/tf/module.f.ts'
 import { main as casMain } from '../cas/module.f.ts'
-import { import_, type NodeOp, type NodeProgram } from '../types/effects/node/module.f.ts'
-import { type Effect } from '../types/effects/module.f.ts'
+import { import_, type NodeProgram } from '../types/effects/node/module.f.ts'
 
 export const main = async(io: Io): Promise<number> => {
     const { error } = io.console

--- a/fs/fjs/module.f.ts
+++ b/fs/fjs/module.f.ts
@@ -7,11 +7,12 @@ import { fromIo, type Io } from '../io/module.f.ts'
 import { compile } from '../djs/module.f.ts'
 import { main as testMain } from '../dev/tf/module.f.ts'
 import { main as casMain } from '../cas/module.f.ts'
-import type { NodeProgram } from '../types/effects/node/module.f.ts'
+import { import_, type NodeOp, type NodeProgram } from '../types/effects/node/module.f.ts'
+import { type Effect } from '../types/effects/module.f.ts'
 
 export const main = async(io: Io): Promise<number> => {
     const { error } = io.console
-    const { process, asyncImport } = io
+    const { process } = io
     const { env } = process
     const [command, ...rest] = process.argv.slice(2)
     const eRun = fromIo(io)
@@ -28,8 +29,10 @@ export const main = async(io: Io): Promise<number> => {
         case 'run':
         case 'r':
             const [file, ...args] = rest
-            const m = await asyncImport(file)
-            return eRun((m.default as NodeProgram)(args, env))
+            return eRun(import_(file).step(result => {
+                if (result[0] === 'error') { throw result[1] }
+                return (result[1].default as NodeProgram)(args, env)
+            }))
         case undefined:
             error('Error: command is required')
             return Promise.resolve(1)


### PR DESCRIPTION
## Summary

- Replaces `await asyncImport(file)` in the `run`/`r` switch case with `import_(file).step(...)`, using the `import_` effect
- Removes `asyncImport` from `Io` destructuring — no longer needed in `fjs/module.f.ts`
- Consistent with the effect-based `compile` and `cas` commands

## Test plan

- [ ] `fjs c` (compile) and `fjs s` (cas) commands unaffected
- [ ] `fjs r <file>` still dispatches to the module's default export