### PR TITLE
tf: remove `Input` intermediary type; `test` takes `Io` directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `tf`: remove `Input` intermediary type; `test` takes `Io` directly [813](https://github.com/functionalscript/functionalscript/pull/813)
 - `fjs`: convert `run`/`r` command from `asyncImport`/`await` to `import_` effect [812](https://github.com/functionalscript/functionalscript/pull/812)
 - DJS transpiler: replace `Fs`/`readFileSync` with `ReadFile` effect; tests use virtual effect runner; delete `fs/io/virtual` ([i151](./issues/151-transpiler-effects.md)) [811](https://github.com/functionalscript/functionalscript/pull/811)
 - IO: expose `sandbox` on `Io` interface; test framework: replace `measure`+`tryCatch` with `sandbox`, eliminating state threading ([i149](./issues/149-sandbox.md)) [809](https://github.com/functionalscript/functionalscript/pull/809)

--- a/fs/dev/tf/module.f.ts
+++ b/fs/dev/tf/module.f.ts
@@ -78,7 +78,7 @@ export const parseTestSet = (sandbox: <R>(f: () => R) => SandboxResult<R>) => (t
     return []
 }
 
-export const test = (input: Input): number => {
+const test = (input: Input): number => {
     const { moduleMap, log, error, sandbox, env } = input
     const isGitHub = env('GITHUB_ACTION') !== undefined
     const parse = parseTestSet(sandbox)

--- a/fs/dev/tf/module.f.ts
+++ b/fs/dev/tf/module.f.ts
@@ -4,20 +4,10 @@
  * @module
  */
 import { fold } from '../../types/list/module.f.ts'
-import { reset, fgGreen, fgRed, bold, type CsiConsole, stdio, stderr } from '../../text/sgr/module.f.ts'
+import { reset, fgGreen, fgRed, bold, stdio, stderr } from '../../text/sgr/module.f.ts'
 import type { Io } from '../../io/module.f.ts'
 import type { SandboxResult } from '../../types/effects/node/module.f.ts'
-import { env, loadModuleMap, type ModuleMap, type Module } from '../module.f.ts'
-
-type Log = CsiConsole
-
-type Input = {
-    readonly moduleMap: ModuleMap,
-    readonly log: Log,
-    readonly error: Log,
-    readonly sandbox: <R>(f: () => R) => SandboxResult<R>,
-    readonly env: (n: string) => string|undefined
- }
+import { env, loadModuleMap, type Module } from '../module.f.ts'
 
 export const isTest = (s: string): boolean => s.endsWith('test.f.js') || s.endsWith('test.f.ts')
 
@@ -78,9 +68,13 @@ export const parseTestSet = (sandbox: <R>(f: () => R) => SandboxResult<R>) => (t
     return []
 }
 
-const test = (input: Input): number => {
-    const { moduleMap, log, error, sandbox, env } = input
-    const isGitHub = env('GITHUB_ACTION') !== undefined
+const test = async(io: Io): Promise<number> => {
+    const moduleMap = await loadModuleMap(io)
+    const log = stdio(io)
+    const error = stderr(io)
+    const { sandbox } = io
+    const env_ = env(io)
+    const isGitHub = env_('GITHUB_ACTION') !== undefined
     const parse = parseTestSet(sandbox)
     const f
         : (k: readonly[string, Module]) => (ts: TestState) => TestState
@@ -159,10 +153,4 @@ export const anyLog = (f: (s: string) => void) => (s: string) => <T>(state: T): 
     return state
 }
 
-export const main = async(io: Io): Promise<number> => test({
-    moduleMap: await loadModuleMap(io),
-    log: stdio(io),
-    error: stderr(io),
-    sandbox: io.sandbox,
-    env: env(io),
-})
+export const main = test


### PR DESCRIPTION
## Summary

- `test` was only called from `main`, so the `Input` wrapper type was unnecessary indirection
- `test` now takes `io: Io` directly, derives `log`, `error`, `sandbox`, and `env` from it, and awaits `loadModuleMap` internally
- `main` simplifies to `export const main = test`
- Removes unused `Input`, `Log`, `ModuleMap`, and `CsiConsole` from the module

## Test plan

- [ ] `fjs t` runs the test suite as before