### PR TITLE
Effects: replace `NodeProgram` positional params with `NodeProgramOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.17.0
+
 - Effects: replace `NodeProgram`'s two positional parameters with `NodeProgramOptions` — `{ args, env }` [814](https://github.com/functionalscript/functionalscript/pull/814)
 - `tf`: remove `Input` intermediary type; `test` takes `Io` directly [813](https://github.com/functionalscript/functionalscript/pull/813)
 - `fjs`: convert `run`/`r` command from `asyncImport`/`await` to `import_` effect [812](https://github.com/functionalscript/functionalscript/pull/812)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Effects: replace `NodeProgram`'s two positional parameters with `NodeProgramOptions` — `{ args, env }` [814](https://github.com/functionalscript/functionalscript/pull/814)
 - `tf`: remove `Input` intermediary type; `test` takes `Io` directly [813](https://github.com/functionalscript/functionalscript/pull/813)
 - `fjs`: convert `run`/`r` command from `asyncImport`/`await` to `import_` effect [812](https://github.com/functionalscript/functionalscript/pull/812)
 - DJS transpiler: replace `Fs`/`readFileSync` with `ReadFile` effect; tests use virtual effect runner; delete `fs/io/virtual` ([i151](./issues/151-transpiler-effects.md)) [811](https://github.com/functionalscript/functionalscript/pull/811)

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@functionalscript/functionalscript",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "license": "MIT",
   "exports": {
     "./fs/asn.1/module.f.ts": "./fs/asn.1/module.f.ts",

--- a/fs/fjs/module.f.ts
+++ b/fs/fjs/module.f.ts
@@ -7,7 +7,7 @@ import { fromIo, type Io } from '../io/module.f.ts'
 import { compile } from '../djs/module.f.ts'
 import { main as testMain } from '../dev/tf/module.f.ts'
 import { main as casMain } from '../cas/module.f.ts'
-import { import_, type NodeProgram } from '../types/effects/node/module.f.ts'
+import { import_, type NodeProgram, type NodeProgramOptions } from '../types/effects/node/module.f.ts'
 
 export const main = async(io: Io): Promise<number> => {
     const { error } = io.console
@@ -30,7 +30,8 @@ export const main = async(io: Io): Promise<number> => {
             const [file, ...args] = rest
             return eRun(import_(file).step(result => {
                 if (result[0] === 'error') { throw result[1] }
-                return (result[1].default as NodeProgram)(args, env)
+                const options: NodeProgramOptions = { args, env }
+                return (result[1].default as NodeProgram)(options)
             }))
         case undefined:
             error('Error: command is required')

--- a/fs/io/module.ts
+++ b/fs/io/module.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs'
 import process from 'node:process'
 import { fromIo, type Io, type Run, run } from './module.f.ts'
 import { concat } from '../path/module.f.ts'
-import type { Module, NodeProgram } from '../types/effects/node/module.f.ts'
+import type { Module, NodeProgram, NodeProgramOptions } from '../types/effects/node/module.f.ts'
 import { error, ok, type Result } from '../types/result/module.f.ts'
 
 const prefix = 'file:///'
@@ -64,7 +64,8 @@ export type NodeRun = (p: NodeProgram) => Promise<number>
 export const ioRun = (io: Io): NodeRun => {
     const r = fromIo(io)
     const { argv, env } = io.process
-    return p => r(p(argv, env))
+    const options: NodeProgramOptions = { args: argv.slice(2), env }
+    return p => r(p(options))
 }
 
 const effectRun: NodeRun = ioRun(io)

--- a/fs/types/effects/node/module.f.ts
+++ b/fs/types/effects/node/module.f.ts
@@ -261,4 +261,9 @@ export type Env = {
     readonly [k: string]: string|undefined
 }
 
-export type NodeProgram = (argv: readonly string[], env: Env) => Effect<NodeOp, number>
+export type NodeProgramOptions = {
+    readonly args: readonly string[]
+    readonly env: Env
+}
+
+export type NodeProgram = (options: NodeProgramOptions) => Effect<NodeOp, number>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "functionalscript",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "functionalscript",
-      "version": "0.16.1",
+      "version": "0.17.0",
       "license": "MIT",
       "bin": {
         "fjs": "fs/fjs/module.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "functionalscript",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "type": "module",
   "files": [
     "**/*.js",


### PR DESCRIPTION
## Summary

- Adds `NodeProgramOptions = { args: readonly string[], env: Env }` to `fs/types/effects/node/module.f.ts`
- Changes `NodeProgram` from `(argv: readonly string[], env: Env)` to `(options: NodeProgramOptions)`
- Updates `ioRun` in `fs/io/module.ts` to construct `NodeProgramOptions` (passing `argv.slice(2)` as `args`)
- Updates `fjs/module.f.ts` to pass `{ args, env }` when dispatching the `run`/`r` command

The options object makes future additions (e.g. `stdoutIsTty`, `stderrIsTty`) non-breaking.

## Test plan

- [ ] `fjs t` runs the test suite
- [ ] `fjs r <file>` dispatches to the module's default export with correct args