### PR TITLE
Effects: add Write effect, NodeProgramOptions.std, and csiWrite (i152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Effects: add `Write` effect (`write(stream, data)`) and `WriteConsoles` to `NodeOp`; add `std` to `NodeProgramOptions` for startup TTY constants; add `csiWrite` to `fs/text/sgr` for TTY-aware UTF-8 writes; wire `write` handler in `fromIo` and virtual runner ([i152](./issues/152-write-effect.md)) [816](https://github.com/functionalscript/functionalscript/pull/816)
 - IO: add `write(stream, data)` to `Io` with backpressure via `stream.write()` + `once(stream, 'drain')`; add `WriteConsoles` type ([i153](./issues/153-write-queue.md)) [821](https://github.com/functionalscript/functionalscript/pull/821)
 
 ## 0.17.0

--- a/fs/fjs/module.f.ts
+++ b/fs/fjs/module.f.ts
@@ -7,12 +7,26 @@ import { fromIo, type Io } from '../io/module.f.ts'
 import { compile } from '../djs/module.f.ts'
 import { main as testMain } from '../dev/tf/module.f.ts'
 import { main as casMain } from '../cas/module.f.ts'
-import { import_, type NodeProgram, type NodeProgramOptions } from '../types/effects/node/module.f.ts'
+import { import_, type NodeProgram } from '../types/effects/node/module.f.ts'
+
+export const runProgram = (io: Io) => {
+    const { process: { env, stdout, stderr } } = io
+    const f = fromIo(io)
+    return (args: readonly string[]) => (program: NodeProgram): Promise<number> =>
+        f(program({
+            args,
+            env,
+            std: {
+                stdout: { isTTY: stdout.isTTY },
+                stderr: { isTTY: stderr.isTTY },
+            },
+        }))
+}
 
 export const main = async(io: Io): Promise<number> => {
     const { error } = io.console
     const { process } = io
-    const { env } = process
+    const { env, stdout, stderr: stderrStream } = process
     const [command, ...rest] = process.argv.slice(2)
     const eRun = fromIo(io)
     switch (command) {
@@ -28,10 +42,9 @@ export const main = async(io: Io): Promise<number> => {
         case 'run':
         case 'r':
             const [file, ...args] = rest
-            return eRun(import_(file).step(result => {
-                if (result[0] === 'error') { throw result[1] }
-                const options: NodeProgramOptions = { args, env }
-                return (result[1].default as NodeProgram)(options)
+            return runProgram(io)(args)(o => import_(file).step(([s, v]) => {
+                if (s === 'error') { throw v }
+                return (v.default as NodeProgram)(o)
             }))
         case undefined:
             error('Error: command is required')

--- a/fs/fjs/module.f.ts
+++ b/fs/fjs/module.f.ts
@@ -3,30 +3,15 @@
  *
  * @module
  */
-import { fromIo, type Io } from '../io/module.f.ts'
+import { fromIo, runProgram, type Io } from '../io/module.f.ts'
 import { compile } from '../djs/module.f.ts'
 import { main as testMain } from '../dev/tf/module.f.ts'
 import { main as casMain } from '../cas/module.f.ts'
 import { import_, type NodeProgram } from '../types/effects/node/module.f.ts'
 
-export const runProgram = (io: Io) => {
-    const { process: { env, stdout, stderr } } = io
-    const f = fromIo(io)
-    return (args: readonly string[]) => (program: NodeProgram): Promise<number> =>
-        f(program({
-            args,
-            env,
-            std: {
-                stdout: { isTTY: stdout.isTTY },
-                stderr: { isTTY: stderr.isTTY },
-            },
-        }))
-}
-
 export const main = async(io: Io): Promise<number> => {
     const { error } = io.console
     const { process } = io
-    const { env, stdout, stderr: stderrStream } = process
     const [command, ...rest] = process.argv.slice(2)
     const eRun = fromIo(io)
     switch (command) {

--- a/fs/io/module.f.ts
+++ b/fs/io/module.f.ts
@@ -18,7 +18,8 @@ import type {
     NodeOp,
     RequestListener as Erl,
     Env,
-    SandboxResult
+    SandboxResult,
+    NodeProgram
 } from '../types/effects/node/module.f.ts'
 import { asBase, asNominal } from '../types/nominal/module.f.ts'
 import { error, ok, type Result } from '../types/result/module.f.ts'
@@ -263,4 +264,18 @@ export const fromIo = ({
         write: async (stream, data) => { writeSync(stream === 'stdout' ? 1 : 2, decodeUtf8(fromVec(data))) },
     })
     return result
+}
+
+export const runProgram = (io: Io) => {
+    const { process: { env, stdout, stderr } } = io
+    const f = fromIo(io)
+    return (args: readonly string[]) => (program: NodeProgram): Promise<number> =>
+        f(program({
+            args,
+            env,
+            std: {
+                stdout: { isTTY: stdout.isTTY },
+                stderr: { isTTY: stderr.isTTY },
+            },
+        }))
 }

--- a/fs/io/module.f.ts
+++ b/fs/io/module.f.ts
@@ -22,7 +22,7 @@ import type {
 } from '../types/effects/node/module.f.ts'
 import { asBase, asNominal } from '../types/nominal/module.f.ts'
 import { error, ok, type Result } from '../types/result/module.f.ts'
-import { fromVec, listToVec, toVec } from '../types/uint8array/module.f.ts'
+import { decodeUtf8, fromVec, listToVec, toVec } from '../types/uint8array/module.f.ts'
 
 /**
  * Represents a directory entry (file or directory) in the filesystem
@@ -53,7 +53,7 @@ export type ReadDir =
  * @see https://nodejs.org/api/fs.html
  */
 export type Fs = {
-    readonly writeSync: (fd:number, s: string) => void
+    readonly writeSync: (fd: number, s: string) => void
     readonly writeFileSync: (file: string, data: Uint8Array) => void
     readonly readFileSync: (path: string) => Uint8Array | null
     readonly promises: {
@@ -196,7 +196,7 @@ const collect = async <T>(v: AsyncIterable<T>): Promise<readonly T[]> => {
 
 export const fromIo = ({
     console: { error: logError, log },
-    fs: { promises: { mkdir, readFile, readdir, writeFile, rm, access } },
+    fs: { writeSync, promises: { mkdir, readFile, readdir, writeFile, rm, access } },
     fetch,
     http: { createServer },
     childProcess,
@@ -260,6 +260,7 @@ export const fromIo = ({
         forever: () => new Promise(() => {}),
         now: async () => ioNow(),
         sandbox: async f => ioSandbox(f),
+        write: async (stream, data) => { writeSync(stream === 'stdout' ? 1 : 2, decodeUtf8(fromVec(data))) },
     })
     return result
 }

--- a/fs/io/module.f.ts
+++ b/fs/io/module.f.ts
@@ -198,6 +198,7 @@ const collect = async <T>(v: AsyncIterable<T>): Promise<readonly T[]> => {
 export const fromIo = ({
     console: { error: logError, log },
     fs: { writeSync, promises: { mkdir, readFile, readdir, writeFile, rm, access } },
+    process: { stdout: { fd: stdoutFd }, stderr: { fd: stderrFd } },
     fetch,
     http: { createServer },
     childProcess,
@@ -261,7 +262,7 @@ export const fromIo = ({
         forever: () => new Promise(() => {}),
         now: async () => ioNow(),
         sandbox: async f => ioSandbox(f),
-        write: async (stream, data) => { writeSync(stream === 'stdout' ? 1 : 2, decodeUtf8(fromVec(data))) },
+        write: async (stream, data) => { writeSync(stream === 'stdout' ? stdoutFd : stderrFd, decodeUtf8(fromVec(data))) },
     })
     return result
 }

--- a/fs/io/module.f.ts
+++ b/fs/io/module.f.ts
@@ -25,7 +25,7 @@ import type {
 import type { Vec } from '../types/bit_vec/module.f.ts'
 import { asBase, asNominal } from '../types/nominal/module.f.ts'
 import { error, ok, type Result } from '../types/result/module.f.ts'
-import { decodeUtf8, fromVec, listToVec, toVec } from '../types/uint8array/module.f.ts'
+import { fromVec, listToVec, toVec } from '../types/uint8array/module.f.ts'
 
 /**
  * Represents a directory entry (file or directory) in the filesystem
@@ -200,14 +200,14 @@ const collect = async <T>(v: AsyncIterable<T>): Promise<readonly T[]> => {
 
 export const fromIo = ({
     console: { error: logError, log },
-    fs: { writeSync, promises: { mkdir, readFile, readdir, writeFile, rm, access } },
-    process: { stdout: { fd: stdoutFd }, stderr: { fd: stderrFd } },
+    fs: { promises: { mkdir, readFile, readdir, writeFile, rm, access } },
     fetch,
     http: { createServer },
     childProcess,
     asyncImport,
     now: ioNow,
     sandbox: ioSandbox,
+    write: ioWrite,
 }: Io): EffectToPromise => {
     const result: EffectToPromise = asyncRun({
         all: async (...effects) => await Promise.all(effects.map(result)),
@@ -265,7 +265,7 @@ export const fromIo = ({
         forever: () => new Promise(() => {}),
         now: async () => ioNow(),
         sandbox: async f => ioSandbox(f),
-        write: async (stream, data) => { writeSync(stream === 'stdout' ? stdoutFd : stderrFd, decodeUtf8(fromVec(data))) },
+        write: ioWrite,
     })
     return result
 }

--- a/fs/io/module.ts
+++ b/fs/io/module.ts
@@ -2,11 +2,10 @@ import http from 'node:http'
 import childProcess from 'node:child_process'
 import fs from 'node:fs'
 import process from 'node:process'
-import { type Io, type Run, run } from './module.f.ts'
+import { type Io, type Run, run, runProgram } from './module.f.ts'
 import { concat } from '../path/module.f.ts'
 import type { Module, NodeProgram } from '../types/effects/node/module.f.ts'
 import { error, ok, type Result } from '../types/result/module.f.ts'
-import { runProgram } from '../fjs/module.f.ts'
 
 const prefix = 'file:///'
 
@@ -62,9 +61,7 @@ export const legacyRun: Run = run(io)
 
 export type NodeRun = (p: NodeProgram) => Promise<number>
 
-export const ioRun = (io: Io): NodeRun =>
+const effectRun: NodeRun =
     runProgram(io)(io.process.argv.slice(2))
-
-const effectRun: NodeRun = ioRun(io)
 
 export default effectRun

--- a/fs/io/module.ts
+++ b/fs/io/module.ts
@@ -2,10 +2,11 @@ import http from 'node:http'
 import childProcess from 'node:child_process'
 import fs from 'node:fs'
 import process from 'node:process'
-import { fromIo, type Io, type Run, run } from './module.f.ts'
+import { type Io, type Run, run } from './module.f.ts'
 import { concat } from '../path/module.f.ts'
-import type { Module, NodeProgram, NodeProgramOptions } from '../types/effects/node/module.f.ts'
+import type { Module, NodeProgram } from '../types/effects/node/module.f.ts'
 import { error, ok, type Result } from '../types/result/module.f.ts'
+import { runProgram } from '../fjs/module.f.ts'
 
 const prefix = 'file:///'
 
@@ -61,12 +62,8 @@ export const legacyRun: Run = run(io)
 
 export type NodeRun = (p: NodeProgram) => Promise<number>
 
-export const ioRun = (io: Io): NodeRun => {
-    const r = fromIo(io)
-    const { argv, env } = io.process
-    const options: NodeProgramOptions = { args: argv.slice(2), env }
-    return p => r(p(options))
-}
+export const ioRun = (io: Io): NodeRun =>
+    runProgram(io)(io.process.argv.slice(2))
 
 const effectRun: NodeRun = ioRun(io)
 

--- a/fs/text/sgr/module.f.ts
+++ b/fs/text/sgr/module.f.ts
@@ -80,8 +80,11 @@ export const createConsoleText = (stdout: Stdout): WriteText => {
 
 export type CsiConsole = (s: string) => void
 
+const str = (isTTY: boolean) => (s: string) =>
+    isTTY ? s : s.replace(/\x1b\[[0-9;]*m/g, '')
+
 /**
- * Creates a TTY-aware console function.
+ * Creates a TTY-aware console function. Appends `\n` to each string before writing.
  *
  * For TTY destinations, ANSI SGR sequences are preserved.
  * For non-TTY destinations, ANSI SGR sequences are stripped.
@@ -90,10 +93,8 @@ export type CsiConsole = (s: string) => void
  * @returns A function that targets a writable stream.
  */
 export const console = ({ fs: { writeSync } }: Io) => (w: Writable): CsiConsole => {
-    const { isTTY } = w
-    return isTTY
-        ? (s: string) => writeSync(w.fd, s + '\n')
-        : (s: string) => writeSync(w.fd, s.replace(/\x1b\[[0-9;]*m/g, '') + '\n')
+    const toStr = str(w.isTTY)
+    return (s: string) => writeSync(w.fd, toStr(s) + '\n')
 }
 
 /** Writes to process stdout using a TTY-aware CSI console. */
@@ -102,14 +103,13 @@ export const stdio = (io: Io): CsiConsole => console(io)(io.process.stdout)
 /** Writes to process stderr using a TTY-aware CSI console. */
 export const stderr = (io: Io): CsiConsole => console(io)(io.process.stderr)
 
-const sgrPattern = /\x1b\[[0-9;]*m/g
-
 /**
  * Effect-based TTY-aware write. Strips ANSI SGR sequences when the target
  * stream is not a TTY, then encodes to UTF-8 and emits a `Write` effect.
+ * Does NOT append `\n` — callers are responsible for line termination.
  */
-export const csiWrite =
-    (o: NodeProgramOptions) => (stream: WriteConsoles) => (s: string): Effect<Write, void> => {
-        const line = o.std[stream].isTTY ? s : s.replace(sgrPattern, '')
-        return write(stream, toVec(encodeUtf8(line + '\n')))
-    }
+export const csiWrite = (o: NodeProgramOptions) => (stream: WriteConsoles) => {
+    const toStr = str(o.std[stream].isTTY)
+    return (s: string): Effect<Write, void> =>
+        write(stream, toVec(encodeUtf8(toStr(s))))
+}

--- a/fs/text/sgr/module.f.ts
+++ b/fs/text/sgr/module.f.ts
@@ -9,6 +9,9 @@
 // https://en.wikipedia.org/wiki/ANSI_escape_code#C0_control_codes
 
 import type { Io, Writable } from "../../io/module.f.ts"
+import { write, type Write, type WriteConsoles, type NodeProgramOptions } from '../../types/effects/node/module.f.ts'
+import { type Effect } from '../../types/effects/module.f.ts'
+import { encodeUtf8, toVec } from '../../types/uint8array/module.f.ts'
 
 export const backspace: string = '\x08'
 
@@ -98,3 +101,15 @@ export const stdio = (io: Io): CsiConsole => console(io)(io.process.stdout)
 
 /** Writes to process stderr using a TTY-aware CSI console. */
 export const stderr = (io: Io): CsiConsole => console(io)(io.process.stderr)
+
+const sgrPattern = /\x1b\[[0-9;]*m/g
+
+/**
+ * Effect-based TTY-aware write. Strips ANSI SGR sequences when the target
+ * stream is not a TTY, then encodes to UTF-8 and emits a `Write` effect.
+ */
+export const csiWrite =
+    (o: NodeProgramOptions) => (stream: WriteConsoles) => (s: string): Effect<Write, void> => {
+        const line = o.std[stream].isTTY ? s : s.replace(sgrPattern, '')
+        return write(stream, toVec(encodeUtf8(line + '\n')))
+    }

--- a/fs/types/effects/node/module.f.ts
+++ b/fs/types/effects/node/module.f.ts
@@ -197,6 +197,14 @@ export type Import = ['import', (path: string) => IoResult<Module>]
 
 export const import_: Func<Import> = do_('import')
 
+// write
+
+export type WriteConsoles = 'stdout' | 'stderr'
+
+export type Write = readonly['write', (stream: WriteConsoles, data: Vec) => void]
+
+export const write: Func<Write> = do_('write')
+
 // now
 
 export type Now = readonly['now', () => number]
@@ -249,6 +257,7 @@ export type NodeOp =
     | Import
     | Now
     | Sandbox
+    | Write
 
 export type NodeEffect<T> = Effect<NodeOp, T>
 
@@ -264,6 +273,7 @@ export type Env = {
 export type NodeProgramOptions = {
     readonly args: readonly string[]
     readonly env: Env
+    readonly std: { readonly [k in WriteConsoles]: { readonly isTTY: boolean } }
 }
 
 export type NodeProgram = (options: NodeProgramOptions) => Effect<NodeOp, number>

--- a/fs/types/effects/node/virtual/module.f.ts
+++ b/fs/types/effects/node/virtual/module.f.ts
@@ -7,6 +7,7 @@ import { todo } from '../../../../dev/module.f.ts'
 import { parse } from '../../../../path/module.f.ts'
 import { isVec, type Vec } from '../../../bit_vec/module.f.ts'
 import { error, ok } from '../../../result/module.f.ts'
+import { decodeUtf8, fromVec } from '../../../uint8array/module.f.ts'
 import { run, type MemOperationMap, type RunInstance } from '../../mock/module.f.ts'
 import type { Dirent, IoResult, NodeOp } from '../module.f.ts'
 
@@ -167,6 +168,10 @@ const map: MemOperationMap<NodeOp, State> = {
         let result
         try { result = ok(f()) } catch (e) { result = error(e) }
         return [state, { result, duration: 0 }]
+    },
+    write: (state, stream, data) => {
+        const s = decodeUtf8(fromVec(data))
+        return [{ ...state, [stream]: `${state[stream]}${s}` }, undefined] as const
     },
 }
 

--- a/issues/152-write-effect.md
+++ b/issues/152-write-effect.md
@@ -88,5 +88,9 @@ Defaults `isTTY: false` (strips SGR in tests). Captured output appended to state
 
 ## Migration
 
-- `fs/dev/tf/module.f.ts`: replace `stdio(io)`/`stderr(io)` with `csiWrite(options)('stdout')`/`csiWrite(options)('stderr')`
+- `fs/dev/tf/module.f.ts`: replace `stdio(io)`/`stderr(io)` with `csiWrite(options)('stdout')`/`csiWrite(options)('stderr')` — blocked on [i148](./148-test-framework-effects.md) (test framework must become an Effect program first)
 - Close [i150](./150-tty.md) as superseded — the `IsTty` effect is no longer needed since `isTTY` is a startup constant carried in `NodeProgramOptions`
+
+## Future: retire `Console` effects
+
+Once `tf/module.f.ts` (and any other caller) is fully converted to use `write`, the `Log` and `Error` effects (`Console` union) can be retired. `write('stdout', ...)` and `write('stderr', ...)` subsume them, with the added benefit of raw-byte delivery and TTY-aware SGR stripping at the application level.


### PR DESCRIPTION
## Summary

- **`fs/types/effects/node`**: add `Write` effect (`write(stream, data: Vec) => void`) and `WriteConsoles = 'stdout' | 'stderr'`; add `Write` to `NodeOp`; add `std: { [k in WriteConsoles]: { isTTY: boolean } }` to `NodeProgramOptions` to carry startup TTY constants
- **`fs/text/sgr`**: add `csiWrite(options)(stream)(s)` — Effect-based TTY-aware write that strips ANSI SGR sequences for non-TTY streams, encodes to UTF-8, and emits a `Write` effect; extract shared `str` helper
- **`fs/io/module.f.ts`**: wire `write` handler in `fromIo` using `io.write` (backpressure from [i153](https://github.com/functionalscript/functionalscript/pull/821)); extract `runProgram` helper that populates `NodeProgramOptions.std` from the real process
- **Virtual runner**: add `write` handler — decodes UTF-8 and appends to `state.stdout`/`state.stderr` for assertions

Closes [i152](./issues/152-write-effect.md). Depends on [i153 (#821)](https://github.com/functionalscript/functionalscript/pull/821).

## Test plan

- [ ] `npm test` passes
- [ ] Virtual runner captures `write` output in state

🤖 Generated with [Claude Code](https://claude.com/claude-code)