### PR TITLE
IO: add write(stream, data) to Io with backpressure (i153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- IO: add `write(stream, data)` to `Io` with backpressure via `stream.write()` + `once(stream, 'drain')`; add `WriteConsoles` type ([i153](./issues/153-write-queue.md))
+
 ## 0.17.0
 
 - Effects: replace `NodeProgram`'s two positional parameters with `NodeProgramOptions` — `{ args, env }` [814](https://github.com/functionalscript/functionalscript/pull/814)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- IO: add `write(stream, data)` to `Io` with backpressure via `stream.write()` + `once(stream, 'drain')`; add `WriteConsoles` type ([i153](./issues/153-write-queue.md))
+- IO: add `write(stream, data)` to `Io` with backpressure via `stream.write()` + `once(stream, 'drain')`; add `WriteConsoles` type ([i153](./issues/153-write-queue.md)) [821](https://github.com/functionalscript/functionalscript/pull/821)
 
 ## 0.17.0
 

--- a/fs/io/module.f.ts
+++ b/fs/io/module.f.ts
@@ -18,8 +18,10 @@ import type {
     NodeOp,
     RequestListener as Erl,
     Env,
-    SandboxResult
+    SandboxResult,
+    WriteConsoles,
 } from '../types/effects/node/module.f.ts'
+import type { Vec } from '../types/bit_vec/module.f.ts'
 import { asBase, asNominal } from '../types/nominal/module.f.ts'
 import { error, ok, type Result } from '../types/result/module.f.ts'
 import { fromVec, listToVec, toVec } from '../types/uint8array/module.f.ts'
@@ -154,6 +156,7 @@ export type Io = {
     readonly childProcess: ChildProcess
     readonly now: () => number
     readonly sandbox: Sandbox
+    readonly write: (stream: WriteConsoles, data: Vec) => Promise<void>
 }
 
 export type App = (io: Io) => Promise<number>

--- a/fs/io/module.ts
+++ b/fs/io/module.ts
@@ -2,14 +2,27 @@ import http from 'node:http'
 import childProcess from 'node:child_process'
 import fs from 'node:fs'
 import process from 'node:process'
+import { once } from 'node:events'
 import { fromIo, type Io, type Run, run } from './module.f.ts'
 import { concat } from '../path/module.f.ts'
-import type { Module, NodeProgram, NodeProgramOptions } from '../types/effects/node/module.f.ts'
+import type { Module, NodeProgram, NodeProgramOptions, WriteConsoles } from '../types/effects/node/module.f.ts'
 import { error, ok, type Result } from '../types/result/module.f.ts'
+import { fromVec } from '../types/uint8array/module.f.ts'
 
 const prefix = 'file:///'
 
 const { now } = Date
+
+const streams: { readonly [k in WriteConsoles]: NodeJS.WritableStream } = {
+    stdout: process.stdout,
+    stderr: process.stderr,
+}
+
+const writeAll = async (stream: NodeJS.WritableStream, data: Uint8Array): Promise<void> => {
+    if (!stream.write(data)) {
+        await once(stream, 'drain')
+    }
+}
 
 export const asyncImport = (v: string): Promise<Module> => import(v)
 
@@ -55,6 +68,7 @@ export const io: Io = {
         }
         return { result, duration: after - before }
     },
+    write: (stream, data) => writeAll(streams[stream], fromVec(data)),
 }
 
 export const legacyRun: Run = run(io)

--- a/fs/io/module.ts
+++ b/fs/io/module.ts
@@ -13,11 +13,26 @@ const prefix = 'file:///'
 
 const { now } = Date
 
+/** Maps `WriteConsoles` names to the corresponding Node.js writable streams. */
 const streams: { readonly [k in WriteConsoles]: NodeJS.WritableStream } = {
     stdout: process.stdout,
     stderr: process.stderr,
 }
 
+/**
+ * Writes `data` to `stream` respecting Node.js backpressure.
+ *
+ * `stream.write()` returns `false` when the internal buffer is full; the data
+ * is already buffered at that point (no retry needed) but the caller must not
+ * issue more writes until the `'drain'` event fires. Waiting here throttles the
+ * producer to the speed of the OS consumer, preventing unbounded memory growth
+ * when many large messages arrive faster than they can be flushed.
+ *
+ * When the buffer is not full `write()` returns `true` and we return
+ * immediately, so large computations with occasional prints never stall.
+ *
+ * @see {@link https://nodejs.org/api/stream.html#writablewritechunk}
+ */
 const writeAll = async (stream: NodeJS.WritableStream, data: Uint8Array): Promise<void> => {
     if (!stream.write(data)) {
         await once(stream, 'drain')

--- a/fs/types/effects/node/module.f.ts
+++ b/fs/types/effects/node/module.f.ts
@@ -261,6 +261,8 @@ export type Env = {
     readonly [k: string]: string|undefined
 }
 
+export type WriteConsoles = 'stdout' | 'stderr'
+
 export type NodeProgramOptions = {
     readonly args: readonly string[]
     readonly env: Env


### PR DESCRIPTION
## Summary

- Adds `WriteConsoles = 'stdout' | 'stderr'` to `fs/types/effects/node/module.f.ts`
- Adds `write: (stream: WriteConsoles, data: Vec) => Promise<void>` to the `Io` interface in `fs/io/module.f.ts`
- Implements `write` in `fs/io/module.ts` using `stream.write()` + `once(stream, 'drain')` for backpressure — avoids unbounded queue growth when many large messages are written concurrently

Closes [i153](./issues/153-write-queue.md).

## Test plan

- [ ] `npm test` passes
- [ ] No unused imports or type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)