### PR TITLE
Effects: retire Log/Error/Console; replace with log/error wrappers over Write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Effects: retire `Log`/`Error`/`Console` operation types; replace with `log`/`error` helpers built on `write` — `log(s)` writes to `stdout`, `error(s)` to `stderr`, both UTF-8-encoded with `\n` [822](https://github.com/functionalscript/functionalscript/pull/822)
 - Effects: add `Write` effect (`write(stream, data)`) and `WriteConsoles` to `NodeOp`; add `std` to `NodeProgramOptions` for startup TTY constants; add `csiWrite` to `fs/text/sgr` for TTY-aware UTF-8 writes; wire `write` handler in `fromIo` and virtual runner ([i152](./issues/152-write-effect.md)) [816](https://github.com/functionalscript/functionalscript/pull/816)
 - IO: add `write(stream, data)` to `Io` with backpressure via `stream.write()` + `once(stream, 'drain')`; add `WriteConsoles` type ([i153](./issues/153-write-queue.md)) [821](https://github.com/functionalscript/functionalscript/pull/821)
 

--- a/fs/djs/module.f.ts
+++ b/fs/djs/module.f.ts
@@ -10,8 +10,10 @@ import { sort } from '../types/object/module.f.ts'
 import { encodeUtf8, toVec } from '../types/uint8array/module.f.ts'
 import { type Effect, pure } from '../types/effects/module.f.ts'
 import {
-    error, writeFile,
-    type Error, type WriteFile, type ReadFile,
+    writeFile,
+    type WriteFile, type ReadFile,
+    type Write,
+    error,
 } from '../types/effects/node/module.f.ts'
 
 export type Object = {
@@ -24,7 +26,7 @@ export type Primitive = JsonPrimitive | bigint | undefined
 
 export type Unknown = Primitive | Object | Array
 
-type CompileOp = ReadFile | WriteFile | Error
+type CompileOp = ReadFile | WriteFile | Write
 
 export const compile: (args: readonly string[]) => Effect<CompileOp, number>
     = args => {

--- a/fs/io/module.f.ts
+++ b/fs/io/module.f.ts
@@ -199,7 +199,6 @@ const collect = async <T>(v: AsyncIterable<T>): Promise<readonly T[]> => {
 }
 
 export const fromIo = ({
-    console: { error: logError, log },
     fs: { promises: { mkdir, readFile, readdir, writeFile, rm, access } },
     fetch,
     http: { createServer },
@@ -211,8 +210,6 @@ export const fromIo = ({
 }: Io): EffectToPromise => {
     const result: EffectToPromise = asyncRun({
         all: async (...effects) => await Promise.all(effects.map(result)),
-        // error: async message => logError(message),
-        //log: async message => log(message),
         fetch: async url => tc(async() => {
             const response = await fetch(url)
             if (!response.ok) {

--- a/fs/io/module.f.ts
+++ b/fs/io/module.f.ts
@@ -211,8 +211,8 @@ export const fromIo = ({
 }: Io): EffectToPromise => {
     const result: EffectToPromise = asyncRun({
         all: async (...effects) => await Promise.all(effects.map(result)),
-        error: async message => logError(message),
-        log: async message => log(message),
+        // error: async message => logError(message),
+        //log: async message => log(message),
         fetch: async url => tc(async() => {
             const response = await fetch(url)
             if (!response.ok) {

--- a/fs/types/effects/node/module.f.ts
+++ b/fs/types/effects/node/module.f.ts
@@ -7,9 +7,11 @@
  *
  * @module
  */
+import { utf8 } from '../../../text/module.f.ts'
 import type { Vec } from '../../bit_vec/module.f.ts'
 import type { Nominal } from '../../nominal/module.f.ts'
 import type { Result } from '../../result/module.f.ts'
+import { encodeUtf8, toVec } from '../../uint8array/module.f.ts'
 import {
     type Effect, type Func, type Operation, type ToAsyncOperationMap, do_
 } from '../module.f.ts'
@@ -119,24 +121,6 @@ export const access: Func<Access> =
 
 export type Fs = Mkdir | ReadFile | Readdir | WriteFile | Rm | Exec | Access
 
-// error
-
-export type Error = ['error', (message: string) => void]
-
-export const error: Func<Error> =
-    do_('error')
-
-// log
-
-export type Log = ['log', (message: string) => void]
-
-export const log: Func<Log> =
-    do_('log')
-
-// Console
-
-export type Console = Log | Error
-
 // Server
 
 export type Server =
@@ -205,6 +189,13 @@ export type Write = readonly['write', (stream: WriteConsoles, data: Vec) => void
 
 export const write: Func<Write> = do_('write')
 
+const writeString = (stream: WriteConsoles) => (s: string): Effect<Write, void> =>
+    write(stream, utf8(s + '\n'))
+
+export const log = writeString('stdout')
+
+export const error = writeString('stderr')
+
 // now
 
 export type Now = readonly['now', () => number]
@@ -250,7 +241,6 @@ export const sandbox: Func<Sandbox> = do_('sandbox')
 export type NodeOp =
     | All
     | Fetch
-    | Console
     | Fs
     | Http
     | Forever

--- a/fs/types/effects/node/module.f.ts
+++ b/fs/types/effects/node/module.f.ts
@@ -1,9 +1,9 @@
 /**
  * Node.js effect operations: filesystem (`mkdir`, `readFile`, `readdir`,
  * `writeFile`, `rm`, `access`), networking (`fetch`, `createServer`, `listen`),
- * subprocess `exec`, console (`log`, `error`), `import_`, `now`, `sandbox`, `forever`,
- * and `all`/`both` parallelism; defines the `NodeOp`/`NodeProgram` types used
- * by the Node runner.
+ * subprocess `exec`, `log`/`error` (wrappers over `write`), `import_`, `now`,
+ * `sandbox`, `forever`, and `all`/`both` parallelism; defines the
+ * `NodeOp`/`NodeProgram` types used by the Node runner.
  *
  * @module
  */
@@ -11,7 +11,6 @@ import { utf8 } from '../../../text/module.f.ts'
 import type { Vec } from '../../bit_vec/module.f.ts'
 import type { Nominal } from '../../nominal/module.f.ts'
 import type { Result } from '../../result/module.f.ts'
-import { encodeUtf8, toVec } from '../../uint8array/module.f.ts'
 import {
     type Effect, type Func, type Operation, type ToAsyncOperationMap, do_
 } from '../module.f.ts'
@@ -189,11 +188,17 @@ export type Write = readonly['write', (stream: WriteConsoles, data: Vec) => void
 
 export const write: Func<Write> = do_('write')
 
+/**
+ * Encodes `s + '\n'` as UTF-8 and emits a `Write` effect to `stream`.
+ * Shared implementation for `log` and `error`.
+ */
 const writeString = (stream: WriteConsoles) => (s: string): Effect<Write, void> =>
     write(stream, utf8(s + '\n'))
 
+/** Writes a line to `stdout`. Replaces the retired `Log` effect. */
 export const log = writeString('stdout')
 
+/** Writes a line to `stderr`. Replaces the retired `Error` effect. */
 export const error = writeString('stderr')
 
 // now

--- a/fs/types/effects/node/virtual/module.f.ts
+++ b/fs/types/effects/node/virtual/module.f.ts
@@ -133,9 +133,6 @@ const rm = operation((dir, path): readonly[Dir, IoResult<void>] => {
     return [rest as Dir, okVoid]
 })
 
-const console = (name: 'stderr'|'stdout') => (state: State, payload: string) =>
-    [{ ...state, [name]: `${state[name]}${payload}\n` }, undefined] as const
-
 const map: MemOperationMap<NodeOp, State> = {
     all: (state, ...a) => {
         let e: readonly unknown[] = []
@@ -146,8 +143,6 @@ const map: MemOperationMap<NodeOp, State> = {
         }
         return [state, e]
     },
-    // error: console('stderr'),
-    // log: console('stdout'),
     fetch: (state, url) => {
         const result = state.internet[url]
         return result === undefined ? [state, error('not found')] : [state, ok(result)]

--- a/fs/types/effects/node/virtual/module.f.ts
+++ b/fs/types/effects/node/virtual/module.f.ts
@@ -146,8 +146,8 @@ const map: MemOperationMap<NodeOp, State> = {
         }
         return [state, e]
     },
-    error: console('stderr'),
-    log: console('stdout'),
+    // error: console('stderr'),
+    // log: console('stdout'),
     fetch: (state, url) => {
         const result = state.internet[url]
         return result === undefined ? [state, error('not found')] : [state, ok(result)]

--- a/issues/README.md
+++ b/issues/README.md
@@ -307,7 +307,7 @@
 - [x] [149-sandbox](./149-sandbox.md). `Sandbox` effect: runs a plain sync function with try/catch and timing in one atomic operation; future fields for memory/stack limits; worker-based implementations enforce hard limits.
 - [ ] [150-tty](./150-tty.md). `IsTty` effect: reports whether a file descriptor is connected to a terminal; used by the test framework to gate ANSI color output.
 - [x] [151-transpiler-effects](./151-transpiler-effects.md). Convert DJS transpiler (`fs/djs/transpiler/module.f.ts`) from legacy `Fs`/`readFileSync` to `ReadFile` effect; update tests to use the virtual effect runner instead of `createVirtualIo`. Unblocks deletion of `fs/io/virtual/module.f.ts`.
-- [ ] [152-write-effect](./152-write-effect.md). `Write` effect and TTY-aware console: `write(stream, data)` with `WriteConsoles = 'stdout' | 'stderr'`; `csiWrite` wrapper reads `isTTY` from `NodeProgramOptions.std`; supersedes i150.
+- [X] [152-write-effect](./152-write-effect.md). `Write` effect and TTY-aware console: `write(stream, data)` with `WriteConsoles = 'stdout' | 'stderr'`; `csiWrite` wrapper reads `isTTY` from `NodeProgramOptions.std`; supersedes i150.
 - [X] [153-write-queue](./153-write-queue.md). Async write with backpressure: use `stream.write()` + `once(stream, 'drain')` for atomic, backpressure-aware writes to `stdout`/`stderr`.
 
 ## Language Specification


### PR DESCRIPTION
## Summary

- **`fs/types/effects/node`**: remove `Error`, `Log`, `Console` operation types and `Console` from `NodeOp`; add `writeString` (private helper) + exported `log`/`error` functions that encode `s + '\n'` as UTF-8 and emit a `Write` effect to `stdout`/`stderr` respectively
- **`fs/djs`**: update `CompileOp` from `ReadFile | WriteFile | Error` to `ReadFile | WriteFile | Write`
- **`fs/io/module.f.ts`**: remove now-unused `console` destructuring from `fromIo`
- **Virtual runner**: remove unused `console` helper and retired `error`/`log` handlers

`log` and `error` are no longer separate effect operations — they are plain functions that compose `write`, so no runner changes are needed for them.

## Test plan

- [ ] `npm test` passes
- [ ] No unused variables or dead code

🤖 Generated with [Claude Code](https://claude.com/claude-code)