### PR TITLE
djs/sgr/virtual: replace uint8array with utf8/utf8ToString; deprecate uint8array module; remove anyLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `uint8array`: mark module deprecated — use `utf8`/`utf8ToString` from `fs/text` and `bit_vec` directly; replace all internal usages in `djs`, `sgr`, and virtual runner
+- `tf`: remove unused `anyLog` helper
 - Effects: retire `Log`/`Error`/`Console` operation types; replace with `log`/`error` helpers built on `write` — `log(s)` writes to `stdout`, `error(s)` to `stderr`, both UTF-8-encoded with `\n` [822](https://github.com/functionalscript/functionalscript/pull/822)
 - Effects: add `Write` effect (`write(stream, data)`) and `WriteConsoles` to `NodeOp`; add `std` to `NodeProgramOptions` for startup TTY constants; add `csiWrite` to `fs/text/sgr` for TTY-aware UTF-8 writes; wire `write` handler in `fromIo` and virtual runner ([i152](./issues/152-write-effect.md)) [816](https://github.com/functionalscript/functionalscript/pull/816)
 - IO: add `write(stream, data)` to `Io` with backpressure via `stream.write()` + `once(stream, 'drain')`; add `WriteConsoles` type ([i153](./issues/153-write-queue.md)) [821](https://github.com/functionalscript/functionalscript/pull/821)

--- a/fs/dev/tf/module.f.ts
+++ b/fs/dev/tf/module.f.ts
@@ -148,9 +148,4 @@ const test = async(io: Io): Promise<number> => {
     return ts.fail !== 0 ? 1 : 0
 }
 
-export const anyLog = (f: (s: string) => void) => (s: string) => <T>(state: T): T => {
-    f(s)
-    return state
-}
-
 export const main = test

--- a/fs/djs/module.f.ts
+++ b/fs/djs/module.f.ts
@@ -7,7 +7,6 @@ import type { Primitive as JsonPrimitive } from '../json/module.f.ts'
 import { transpile } from './transpiler/module.f.ts'
 import { stringify, stringifyAsTree } from './serializer/module.f.ts'
 import { sort } from '../types/object/module.f.ts'
-import { encodeUtf8, toVec } from '../types/uint8array/module.f.ts'
 import { type Effect, pure } from '../types/effects/module.f.ts'
 import {
     writeFile,
@@ -15,6 +14,7 @@ import {
     type Write,
     error,
 } from '../types/effects/node/module.f.ts'
+import { utf8 } from '../text/module.f.ts'
 
 export type Object = {
    readonly [k in string]: Unknown
@@ -45,7 +45,7 @@ export const compile: (args: readonly string[]) => Effect<CompileOp, number>
             const content = outputFileName.endsWith('.json')
                 ? stringifyAsTree(sort)(result[1])
                 : stringify(sort)(result[1])
-            return writeFile(outputFileName, toVec(encodeUtf8(content)))
+            return writeFile(outputFileName, utf8(content))
                 .step(() => pure(0))
         })
     }

--- a/fs/djs/module.f.ts
+++ b/fs/djs/module.f.ts
@@ -31,18 +31,21 @@ type CompileOp = ReadFile | WriteFile | Write
 export const compile: (args: readonly string[]) => Effect<CompileOp, number>
     = args => {
         if (args.length < 2) {
-            return error('Error: Requires 2 or more arguments').step(() => pure(1))
+            return error('Error: Requires 2 or more arguments')
+                .step(() => pure(1))
         }
         const inputFileName = args[0]
         const outputFileName = args[1]
         return transpile(inputFileName).step((result): Effect<CompileOp, number> => {
             if (result[0] === 'error') {
                 const metadata = result[1].metadata
-                return error(`${metadata?.path}:${metadata?.line}:${metadata?.column} - error: ${result[1].message}`).step(() => pure(0))
+                return error(`${metadata?.path}:${metadata?.line}:${metadata?.column} - error: ${result[1].message}`)
+                    .step(() => pure(0))
             }
             const content = outputFileName.endsWith('.json')
                 ? stringifyAsTree(sort)(result[1])
                 : stringify(sort)(result[1])
-            return writeFile(outputFileName, toVec(encodeUtf8(content))).step(() => pure(0))
+            return writeFile(outputFileName, toVec(encodeUtf8(content)))
+                .step(() => pure(0))
         })
     }

--- a/fs/djs/test.f.ts
+++ b/fs/djs/test.f.ts
@@ -1,14 +1,12 @@
 import { compile } from './module.f.ts'
 import { virtual, emptyState } from '../types/effects/node/virtual/module.f.ts'
-import { encodeUtf8, toVec, fromVec, decodeUtf8 } from '../types/uint8array/module.f.ts'
-import { isVec, type Vec } from '../types/bit_vec/module.f.ts'
-
-const fileVec = (s: string): Vec => toVec(encodeUtf8(s))
+import { isVec } from '../types/bit_vec/module.f.ts'
+import { utf8, utf8ToString } from '../text/module.f.ts'
 
 const readOutput = (root: typeof emptyState.root, path: string): string => {
     const file = root[path]
     if (!isVec(file)) { throw `${path} is not a file` }
-    return decodeUtf8(fromVec(file))
+    return utf8ToString(file)
 }
 
 export default {
@@ -25,14 +23,14 @@ export default {
         },
     },
     success: () => {
-        const root = { 'input.f.js': fileVec('export default 42') }
+        const root = { 'input.f.js': utf8('export default 42') }
         const [state, code] = virtual({ ...emptyState, root })(compile(['input.f.js', 'output.f.js']))
         if (code !== 0) { throw code }
         const content = readOutput(state.root, 'output.f.js')
         if (content !== 'export default 42') { throw content }
     },
     jsonOutput: () => {
-        const root = { 'input.f.js': fileVec('export default 42') }
+        const root = { 'input.f.js': utf8('export default 42') }
         const [state, code] = virtual({ ...emptyState, root })(compile(['input.f.js', 'output.json']))
         if (code !== 0) { throw code }
         const content = readOutput(state.root, 'output.json')
@@ -44,7 +42,7 @@ export default {
         if (!state.stderr.includes('file not found')) { throw state.stderr }
     },
     parseError: () => {
-        const root = { 'bad.f.js': fileVec('export default @') }
+        const root = { 'bad.f.js': utf8('export default @') }
         const [state, code] = virtual({ ...emptyState, root })(compile(['bad.f.js', 'output.f.js']))
         if (code !== 0) { throw code }
         if (state.stderr === '') { throw 'expected error output' }

--- a/fs/djs/transpiler/module.f.ts
+++ b/fs/djs/transpiler/module.f.ts
@@ -12,9 +12,9 @@ import { stringToList } from '../../text/utf16/module.f.ts'
 import { concat as pathConcat } from '../../path/module.f.ts'
 import { type ParseError, parseFromTokens } from '../parser/module.f.ts'
 import { run, type AstModule } from '../ast/module.f.ts'
-import { decodeUtf8, fromVec } from '../../types/uint8array/module.f.ts'
 import { type Effect, pure } from '../../types/effects/module.f.ts'
 import { readFile, type ReadFile } from '../../types/effects/node/module.f.ts'
+import { utf8ToString } from '../../text/module.f.ts'
 
 export type ParseContext = {
     readonly complete: OrderedMap<djsResult>
@@ -43,7 +43,7 @@ const parseModule
         if (result[0] === 'error') {
             return pure(error({ message: 'file not found', metadata: null }))
         }
-        const tokens = tokenize(stringToList(decodeUtf8(fromVec(result[1]))))(path)
+        const tokens = tokenize(stringToList(utf8ToString(result[1])))(path)
         return pure(parseFromTokens(tokens))
     })
 

--- a/fs/djs/transpiler/test.f.ts
+++ b/fs/djs/transpiler/test.f.ts
@@ -2,10 +2,7 @@ import { sort } from '../../types/object/module.f.ts'
 import { transpile } from './module.f.ts'
 import { stringifyAsTree } from '../serializer/module.f.ts'
 import { virtual, emptyState, type Dir } from '../../types/effects/node/virtual/module.f.ts'
-import { encodeUtf8, toVec } from '../../types/uint8array/module.f.ts'
-import type { Vec } from '../../types/bit_vec/module.f.ts'
-
-const fileVec = (s: string): Vec => toVec(encodeUtf8(s))
+import { utf8 } from '../../text/module.f.ts'
 
 const run = (root: Dir) => (path: string) => {
     const [_, result] = virtual({ ...emptyState, root })(transpile(path))
@@ -14,38 +11,38 @@ const run = (root: Dir) => (path: string) => {
 
 export default {
     parse: () => {
-        const result = run({ a: fileVec('export default 1') })('a')
+        const result = run({ a: utf8('export default 1') })('a')
         if (result[0] === 'error') { throw result[1] }
         const s = stringifyAsTree(sort)(result[1])
         if (s !== '1') { throw s }
     },
     parseWithSubModule: () => {
-        const result = run({ a: { b: fileVec('import c from "c"\nexport default c'), c: fileVec('export default 2') } })('a/b')
+        const result = run({ a: { b: utf8('import c from "c"\nexport default c'), c: utf8('export default 2') } })('a/b')
         if (result[0] === 'error') { throw result[1] }
         const s = stringifyAsTree(sort)(result[1])
         if (s !== '2') { throw s }
     },
     parseWithSubModules: () => {
         const result = run({
-            a: fileVec('import b from "b"\nimport c from "c"\nexport default [b,c,b]'),
-            b: fileVec('import d from "d"\nexport default [0,d]'),
-            c: fileVec('import d from "d"\nexport default [1,d]'),
-            d: fileVec('export default 2'),
+            a: utf8('import b from "b"\nimport c from "c"\nexport default [b,c,b]'),
+            b: utf8('import d from "d"\nexport default [0,d]'),
+            c: utf8('import d from "d"\nexport default [1,d]'),
+            d: utf8('export default 2'),
         })('a')
         if (result[0] === 'error') { throw result[1] }
         const s = stringifyAsTree(sort)(result[1])
         if (s !== '[[0,2],[1,2],[0,2]]') { throw s }
     },
     parseWithFileNotFoundError: () => {
-        const result = run({ a: fileVec('import b from "b"\nexport default b') })('a')
+        const result = run({ a: utf8('import b from "b"\nexport default b') })('a')
         if (result[0] !== 'error') { throw result }
         if (result[1].message !== 'file not found') { throw result }
     },
     parseWithCycleError: () => {
         const result = run({
-            a: fileVec('import b from "b"\nimport c from "c"\nexport default [b,c,b]'),
-            b: fileVec('import c from "c"\nexport default c'),
-            c: fileVec('import b from "b"\nexport default b'),
+            a: utf8('import b from "b"\nimport c from "c"\nexport default [b,c,b]'),
+            b: utf8('import c from "c"\nexport default c'),
+            c: utf8('import b from "b"\nexport default b'),
         })('a')
         if (result[0] !== 'error') { throw result }
         if (result[1].message !== 'circular dependency') { throw result }

--- a/fs/text/sgr/module.f.ts
+++ b/fs/text/sgr/module.f.ts
@@ -11,7 +11,7 @@
 import type { Io, Writable } from "../../io/module.f.ts"
 import { write, type Write, type WriteConsoles, type NodeProgramOptions } from '../../types/effects/node/module.f.ts'
 import { type Effect } from '../../types/effects/module.f.ts'
-import { encodeUtf8, toVec } from '../../types/uint8array/module.f.ts'
+import { utf8 } from "../module.f.ts"
 
 export const backspace: string = '\x08'
 
@@ -111,5 +111,5 @@ export const stderr = (io: Io): CsiConsole => console(io)(io.process.stderr)
 export const csiWrite = (o: NodeProgramOptions) => (stream: WriteConsoles) => {
     const toStr = str(o.std[stream].isTTY)
     return (s: string): Effect<Write, void> =>
-        write(stream, toVec(encodeUtf8(toStr(s))))
+        write(stream, utf8(toStr(s)))
 }

--- a/fs/types/effects/node/virtual/module.f.ts
+++ b/fs/types/effects/node/virtual/module.f.ts
@@ -5,9 +5,9 @@
  */
 import { todo } from '../../../../dev/module.f.ts'
 import { parse } from '../../../../path/module.f.ts'
+import { utf8ToString } from '../../../../text/module.f.ts'
 import { isVec, type Vec } from '../../../bit_vec/module.f.ts'
 import { error, ok } from '../../../result/module.f.ts'
-import { decodeUtf8, fromVec } from '../../../uint8array/module.f.ts'
 import { run, type MemOperationMap, type RunInstance } from '../../mock/module.f.ts'
 import type { Dirent, IoResult, NodeOp } from '../module.f.ts'
 
@@ -165,7 +165,7 @@ const map: MemOperationMap<NodeOp, State> = {
         return [state, { result, duration: 0 }]
     },
     write: (state, stream, data) => {
-        const s = decodeUtf8(fromVec(data))
+        const s = utf8ToString(data)
         return [{ ...state, [stream]: `${state[stream]}${s}` }, undefined] as const
     },
 }

--- a/fs/types/uint8array/module.f.ts
+++ b/fs/types/uint8array/module.f.ts
@@ -1,5 +1,11 @@
 /**
- * Conversions between Uint8Array values and bit vectors.
+ * Conversions between `Uint8Array` values and bit vectors.
+ *
+ * @deprecated FunctionalScript represents byte data as `bigint`-based bit
+ * vectors (`Vec` from `fs/types/bit_vec`). Use `utf8`/`utf8ToString` from
+ * `fs/text` for string encoding, and the `bit_vec` module directly for raw
+ * byte manipulation. `Uint8Array` interop belongs at Node.js boundaries only
+ * (e.g. `fromVec`/`toVec` when reading or writing files).
  *
  * @module
  */


### PR DESCRIPTION
## Summary

- **`fs/types/uint8array`**: mark module `@deprecated` — FunctionalScript uses `bigint`-based `Vec` throughout; `Uint8Array` interop belongs only at Node.js I/O boundaries (`fromVec`/`toVec`)
- **`fs/djs`**, **`fs/djs/transpiler`**: replace `encodeUtf8`/`toVec`/`decodeUtf8`/`fromVec` with `utf8`/`utf8ToString` from `fs/text`; remove `fileVec` helper
- **`fs/text/sgr`**: same replacement in `csiWrite`
- **Virtual runner**: replace `decodeUtf8`/`fromVec` with `utf8ToString` in `write` handler
- **`fs/dev/tf`**: remove unused `anyLog` helper

## Test plan

- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)