### PR TITLE
Update TypeScript native preview to 7.0.0-dev.20260521.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260519.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260521.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -210,7 +210,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260519.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260521.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -378,7 +378,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260519.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260521.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -546,7 +546,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260519.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260521.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -714,7 +714,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260519.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260521.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -888,7 +888,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260519.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260521.1"
         },
         {
           "uses": "denoland/setup-deno@v2",

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -46,4 +46,4 @@ export const wasmtime = '44.0.1'
 export const wasmer = '7.1.0'
 
 // https://www.npmjs.com/package/@typescript/native-preview?activeTab=versions
-export const tsgo = '7.0.0-dev.20260519.1'
+export const tsgo = '7.0.0-dev.20260521.1'

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,21 +46,6 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/playwright": {
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,21 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",


### PR DESCRIPTION
## Summary
Updates the TypeScript native preview dependency to a newer development version across all CI workflows and configuration files.

## Key Changes
- Updated `@typescript/native-preview` from `7.0.0-dev.20260519.1` to `7.0.0-dev.20260521.1` in:
  - `.github/workflows/ci.yml` (6 workflow job definitions)
  - `fs/ci/config/module.f.ts` (configuration source)

## Details
This is a routine dependency update to the latest development build of the TypeScript native preview package. The version bump from May 19 to May 21 indicates a 2-day advancement in the development timeline. The change is applied consistently across all CI workflow definitions to ensure uniform tooling versions across the build pipeline.

https://claude.ai/code/session_01Paw23UU4qAesbq2puxNRV9