### PR TITLE
tf: add issue 154 — eliminate double sandbox call in parseTestSet

### DIFF
--- a/issues/154-parseset-throws.md
+++ b/issues/154-parseset-throws.md
@@ -1,0 +1,88 @@
+# 154. `parseTestSet`: eliminate double `sandbox` call for throw-tests
+
+## Problem
+
+When a test function is expected to throw (either because the enclosing tree
+node is named `'throw'`, or because `throws` is already `true`), `parseTestSet`
+currently returns a *wrapper* function:
+
+```ts
+return () => {
+    const { result: [tag, value] } = sandbox(xt)  // inner sandbox
+    if (tag === 'ok') { throw value }
+    return value
+}
+```
+
+The caller then runs `sandbox` on that wrapper:
+
+```ts
+const { result: [s, r], duration: delta } = sandbox(set)  // outer sandbox
+```
+
+Two problems follow:
+
+1. **Double cost** — `sandbox` is invoked twice for every throw-test.
+2. **Wrong timing** — the outer duration includes the overhead of the inner
+   `sandbox` call, not just the test function itself.
+
+## Solution
+
+Return a *record* instead of a bare function, bundling the test function with a
+boolean that declares whether a throw is expected:
+
+```ts
+export type TestEntry = {
+    readonly fn: Test
+    readonly throws: boolean
+}
+```
+
+`parseTestSet` becomes:
+
+```ts
+// before (throws === false, name !== 'throw'):
+return xt
+
+// before (throw-test):
+return () => { ... sandbox(xt) ... }
+
+// after (both cases):
+return { fn: xt, throws: throws || xt.name === 'throw' }
+```
+
+The caller runs `sandbox` exactly once and interprets the result using the flag:
+
+```ts
+const { result: [s, r], duration: delta } = sandbox(set.fn)
+const passed = set.throws ? s === 'error' : s === 'ok'
+```
+
+## Distinguishing `TestEntry` from `readonly(readonly[string, unknown])[]`
+
+The new `TestSet` union is:
+
+```ts
+export type TestSet = TestEntry | readonly(readonly[string, unknown])[]
+```
+
+`TestEntry` is a plain object; the other branch is always an array.
+`Array.isArray` is the natural discriminant — no tag field needed:
+
+```ts
+if (Array.isArray(set)) {
+    // tree of named children
+} else {
+    // TestEntry — run sandbox(set.fn) once
+}
+```
+
+Previously the check was `typeof set === 'function'`; it becomes
+`!Array.isArray(set)`.
+
+## Impact
+
+- `parseTestSet` no longer creates wrapper functions.
+- The caller in `test` handles the `throws` inversion directly.
+- Timing reported per test is accurate (single `sandbox` call).
+- `TestSet` and `TestEntry` are the only exported type changes.

--- a/issues/README.md
+++ b/issues/README.md
@@ -309,6 +309,7 @@
 - [x] [151-transpiler-effects](./151-transpiler-effects.md). Convert DJS transpiler (`fs/djs/transpiler/module.f.ts`) from legacy `Fs`/`readFileSync` to `ReadFile` effect; update tests to use the virtual effect runner instead of `createVirtualIo`. Unblocks deletion of `fs/io/virtual/module.f.ts`.
 - [X] [152-write-effect](./152-write-effect.md). `Write` effect and TTY-aware console: `write(stream, data)` with `WriteConsoles = 'stdout' | 'stderr'`; `csiWrite` wrapper reads `isTTY` from `NodeProgramOptions.std`; supersedes i150.
 - [X] [153-write-queue](./153-write-queue.md). Async write with backpressure: use `stream.write()` + `once(stream, 'drain')` for atomic, backpressure-aware writes to `stdout`/`stderr`.
+- [ ] [154-parseset-throws](./154-parseset-throws.md). `parseTestSet`: eliminate double `sandbox` call for throw-tests; return `TestEntry = { fn, throws }` instead of a wrapper function; discriminate from the array branch via `Array.isArray`.
 
 ## Language Specification
 


### PR DESCRIPTION
## Summary

- Adds [i154](./issues/154-parseset-throws.md): proposes replacing the throw-test wrapper function in `parseTestSet` with a `TestEntry = { fn, throws }` record, eliminating the double `sandbox` call and fixing inaccurate timing
- Registers i154 in `issues/README.md`

## Key design points

- `TestEntry = { readonly fn: Test, readonly throws: boolean }` replaces the wrapper; `parseTestSet` always returns `{ fn: xt, throws: throws || xt.name === 'throw' }`
- `Array.isArray` discriminates `TestEntry` from `readonly(readonly[string, unknown])[]` — no tag field needed
- Caller runs `sandbox(set.fn)` once and evaluates pass/fail as `set.throws ? s === 'error' : s === 'ok'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)