### PR TITLE
tf: parseTestSet returns TestEntry = { fn, throws } instead of a wrapper (i154)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ where `<...Module documentation...>` should be documentation for the module.
 - When the version is bumped in `deno.json`/`package.json`, create a new `## X.Y.Z` section in `CHANGELOG.md` immediately after `## Unreleased` and move all entries from `## Unreleased` into it, leaving `## Unreleased` empty.
 - Only import other `.f.ts` files from FunctionalScript modules. Avoid references to built-in or external Node modules such as `node:path` in `.f.ts` files.
 - Prefer `.flatMap(e => e !== undefined ? [e] : [])` over `.filter((e): e is T => e !== undefined)` to remove `undefined` entries from an array. Type predicates in `filter` are error-prone: if the element type changes, the predicate silently becomes wrong. `flatMap` narrows correctly without a manual type annotation.
+- Avoid TypeScript type predicates (`(x: T): x is U`). They are error-prone: the compiler trusts the annotation unconditionally, so if the runtime check diverges from the declared type the error is silent. Use `instanceof` for class/constructor discrimination, or restructure the union so a structural check (e.g. `instanceof Array`) narrows correctly without a predicate.
 - Avoid `as` type assertions (except `as const`). They silence the type checker and hide real bugs — if a cast is needed, it usually means the types or the code structure should be improved instead.
 - Use `let` variables only within the function body where they are declared.
 - CLI parameters are preferred over environment variables when adding new features.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `tf`: eliminate double `sandbox` call for throw-tests; `parseTestSet` returns `TestEntry = { fn, throws }` instead of a wrapper; discriminate branches with `instanceof Array`; add `TestEntry` type; document dependency-free test design in README; add no-type-predicate rule to `AGENTS.md` ([i154](./issues/154-parseset-throws.md)) [827](https://github.com/functionalscript/functionalscript/pull/827)
 - `uint8array`: mark module deprecated — use `utf8`/`utf8ToString` from `fs/text` and `bit_vec` directly; replace all internal usages in `djs`, `sgr`, and virtual runner
 - `tf`: remove unused `anyLog` helper
 - Effects: retire `Log`/`Error`/`Console` operation types; replace with `log`/`error` helpers built on `write` — `log(s)` writes to `stdout`, `error(s)` to `stderr`, both UTF-8-encoded with `\n` [822](https://github.com/functionalscript/functionalscript/pull/822)

--- a/fs/dev/tf/README.md
+++ b/fs/dev/tf/README.md
@@ -13,3 +13,72 @@ And then run it as
 - `deno test --allow-env --allow-read`,
 - `node --test`,
 - `bun test`.
+
+## Design: Dependency-Free Tests
+
+Unlike most test frameworks (Jest, Mocha, Vitest, …), test files do **not** import anything from the test framework. A test is just a plain function or object — no `describe`, `it`, `expect`, or assertion library required. This means:
+
+- Tests are **runner-agnostic**: the same test file can be run by any compatible runner without modification.
+- Tests have **no framework dependency**: they remain pure FunctionalScript modules and can be imported, composed, or inspected like any other module.
+
+## Writing Tests
+
+A test file must be named `*.test.f.ts` (or `*.test.f.js`). Its `default` export is the test tree.
+
+### Functions
+
+A zero-parameter function is a test case. It passes if it returns without throwing:
+
+```ts
+export default {
+    myTest: () => 42,         // passes — returns normally
+    failing: () => { throw 'oops' },  // fails — throws unexpectedly
+}
+```
+
+### Nested objects
+
+Objects are traversed recursively. Each key becomes a path segment in the output:
+
+```ts
+export default {
+    math: {
+        add: () => 1 + 1,
+        mul: () => 2 * 2,
+    },
+}
+```
+
+### Throw tests
+
+A node named `throw` (or nested inside one) marks tests that are **expected to throw**. The test passes if the function throws, and fails if it returns normally:
+
+```ts
+export default {
+    throw: {
+        divByZero: () => { throw new Error('division by zero') },  // passes
+        noThrow: () => 42,                                          // fails
+    },
+}
+```
+
+A function named `throw` is also recognised as a throw-test regardless of its position in the tree:
+
+```ts
+const throw = () => { throw 'expected' }
+export default { b: throw }   // passes — function name triggers throw semantics
+```
+
+### Return value as sub-tree
+
+When a non-throw test function returns an object or another function, the return value is walked as a fresh sub-tree. This allows lazy or computed test trees:
+
+```ts
+export default {
+    computed: () => ({
+        nested: () => 99,   // discovered and run after `computed()` returns
+    }),
+}
+```
+
+The `throw` flag does **not** propagate into sub-trees produced by return values.

--- a/fs/dev/tf/module.f.ts
+++ b/fs/dev/tf/module.f.ts
@@ -6,7 +6,6 @@
 import { fold } from '../../types/list/module.f.ts'
 import { reset, fgGreen, fgRed, bold, stdio, stderr } from '../../text/sgr/module.f.ts'
 import type { Io } from '../../io/module.f.ts'
-import type { SandboxResult } from '../../types/effects/node/module.f.ts'
 import { env, loadModuleMap, type Module } from '../module.f.ts'
 
 export const isTest = (s: string): boolean => s.endsWith('test.f.js') || s.endsWith('test.f.ts')
@@ -35,26 +34,19 @@ const timeFormat = (a: number) => {
 
 export type Test = () => unknown
 
-export type TestSet = Test | readonly(readonly[string, unknown])[]
+export type TestEntry = {
+    readonly fn: Test
+    readonly throws: boolean
+}
 
-export const parseTestSet = (sandbox: <R>(f: () => R) => SandboxResult<R>) => (throws: boolean) => (x: unknown): TestSet => {
+export type TestSet = TestEntry | readonly(readonly[string, unknown])[]
+
+export const parseTestSet = (throws: boolean) => (x: unknown): TestSet => {
     switch (typeof x) {
         case 'function': {
             if (x.length === 0) {
                 const xt = x as Test
-                if (!throws && xt.name !== 'throw') {
-                    return xt
-                }
-                // Pass-on-throw: the test passes if it throws. Triggered when the
-                // enclosing tree node is named 'throw' (so any function reference
-                // works, not only inline ones whose inferred name is 'throw').
-                return () => {
-                    const { result: [tag, value] } = sandbox(xt)
-                    if (tag === 'ok') {
-                        throw value
-                    }
-                    return value
-                }
+                return { fn: xt, throws: throws || xt.name === 'throw' }
             }
             break
         }
@@ -75,7 +67,6 @@ const test = async(io: Io): Promise<number> => {
     const { sandbox } = io
     const env_ = env(io)
     const isGitHub = env_('GITHUB_ACTION') !== undefined
-    const parse = parseTestSet(sandbox)
     const f
         : (k: readonly[string, Module]) => (ts: TestState) => TestState
         = ([k, v]) => {
@@ -84,10 +75,20 @@ const test = async(io: Io): Promise<number> => {
             = i => throws => v => ts => {
             const next = test(`${i}| `)
 
-            const set = parse(throws)(v)
-            if (typeof set === 'function') {
-                const { result: [s, r], duration: delta } = sandbox(set)
-                if (s !== 'ok') {
+            const set = parseTestSet(throws)(v)
+            if (set instanceof Array) {
+                const f
+                    : (k: readonly[string|number, unknown]) => (ts: TestState) => TestState
+                    = ([k, v]) => ts => {
+                    log(`${i}${k}:`);
+                    ts = next(throws || k === 'throw')(v)(ts)
+                    return ts
+                }
+                ts = fold(f)(ts)(set)
+            } else {
+                const { result: [s, r], duration: delta } = sandbox(set.fn)
+                const passed = set.throws ? s === 'error' : s === 'ok'
+                if (!passed) {
                     ts = addFail(delta)(ts)
                     if (isGitHub) {
                         // https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions
@@ -102,17 +103,8 @@ const test = async(io: Io): Promise<number> => {
                     log(`${i}() ${fgGreen}ok${reset}, ${timeFormat(delta)}`);
                     // The result of a function is walked as a fresh sub-tree;
                     // the parent's `throws` flag does not propagate into it.
-                    ts = next(false)(r)(ts)
+                    if (!set.throws) { ts = next(false)(r)(ts) }
                 }
-            } else {
-                const f
-                    : (k: readonly[string|number, unknown]) => (ts: TestState) => TestState
-                    = ([k, v]) => ts => {
-                    log(`${i}${k}:`);
-                    ts = next(throws || k === 'throw')(v)(ts)
-                    return ts
-                }
-                ts = fold(f)(ts)(set)
             }
             return ts
         }

--- a/fs/dev/tf/module.f.ts
+++ b/fs/dev/tf/module.f.ts
@@ -86,21 +86,21 @@ const test = async(io: Io): Promise<number> => {
                 }
                 ts = fold(f)(ts)(set)
             } else {
-                const { result: [s, r], duration: delta } = sandbox(set.fn)
+                const { result: [s, r], duration } = sandbox(set.fn)
                 const passed = set.throws ? s === 'error' : s === 'ok'
                 if (!passed) {
-                    ts = addFail(delta)(ts)
+                    ts = addFail(duration)(ts)
                     if (isGitHub) {
                         // https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions
                         // https://github.com/OndraM/ci-detector/blob/main/src/Ci/GitHubActions.php
                         error(`::error file=${k},line=1,title=${i}()::${r}`)
                     } else {
-                        error(`${i}() ${fgRed}error${reset}, ${timeFormat(delta)}`)
+                        error(`${i}() ${fgRed}error${reset}, ${timeFormat(duration)}`)
                         error(`${fgRed}${r}${reset}`)
                     }
                 } else {
-                    ts = addPass(delta)(ts)
-                    log(`${i}() ${fgGreen}ok${reset}, ${timeFormat(delta)}`);
+                    ts = addPass(duration)(ts)
+                    log(`${i}() ${fgGreen}ok${reset}, ${timeFormat(duration)}`);
                     // The result of a function is walked as a fresh sub-tree;
                     // the parent's `throws` flag does not propagate into it.
                     if (!set.throws) { ts = next(false)(r)(ts) }

--- a/fs/dev/tf/module.f.ts
+++ b/fs/dev/tf/module.f.ts
@@ -87,8 +87,14 @@ const test = async(io: Io): Promise<number> => {
                 ts = fold(f)(ts)(set)
             } else {
                 const { result: [s, r], duration } = sandbox(set.fn)
-                const passed = set.throws ? s === 'error' : s === 'ok'
-                if (!passed) {
+                const { throws } = set
+                if (throws !== (s === 'ok')) {
+                    ts = addPass(duration)(ts)
+                    log(`${i}() ${fgGreen}ok${reset}, ${timeFormat(duration)}`);
+                    // The result of a function is walked as a fresh sub-tree;
+                    // the parent's `throws` flag does not propagate into it.
+                    if (!throws) { ts = next(false)(r)(ts) }
+                } else {
                     ts = addFail(duration)(ts)
                     if (isGitHub) {
                         // https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions
@@ -98,12 +104,6 @@ const test = async(io: Io): Promise<number> => {
                         error(`${i}() ${fgRed}error${reset}, ${timeFormat(duration)}`)
                         error(`${fgRed}${r}${reset}`)
                     }
-                } else {
-                    ts = addPass(duration)(ts)
-                    log(`${i}() ${fgGreen}ok${reset}, ${timeFormat(duration)}`);
-                    // The result of a function is walked as a fresh sub-tree;
-                    // the parent's `throws` flag does not propagate into it.
-                    if (!set.throws) { ts = next(false)(r)(ts) }
                 }
             }
             return ts

--- a/fs/dev/tf/module.f.ts
+++ b/fs/dev/tf/module.f.ts
@@ -45,8 +45,8 @@ export const parseTestSet = (throws: boolean) => (x: unknown): TestSet => {
     switch (typeof x) {
         case 'function': {
             if (x.length === 0) {
-                const xt = x as Test
-                return { fn: xt, throws: throws || xt.name === 'throw' }
+                const fn = x as Test
+                return { fn, throws: throws || fn.name === 'throw' }
             }
             break
         }
@@ -79,7 +79,8 @@ const test = async(io: Io): Promise<number> => {
             if (set instanceof Array) {
                 const f
                     : (k: readonly[string|number, unknown]) => (ts: TestState) => TestState
-                    = ([k, v]) => ts => {
+                    = ([k, v]) => ts =>
+                {
                     log(`${i}${k}:`);
                     ts = next(throws || k === 'throw')(v)(ts)
                     return ts

--- a/fs/dev/tf/module.ts
+++ b/fs/dev/tf/module.ts
@@ -42,8 +42,6 @@ const framework: CommonFramework =
     isBun ? createBunFramework(nodeTest) :
         createFramework(nodeTest)
 
-const parse = parseTestSet(io.sandbox)
-
 const scanModule = (x: Test): TestFunc => async(subTestRunner: SubTestRunnerFunc) => {
     let subTests = [x]
     while (true) {
@@ -54,19 +52,25 @@ const scanModule = (x: Test): TestFunc => async(subTestRunner: SubTestRunnerFunc
         subTests = rest
         //
         const [name, value, throws] = first
-        const set = parse(throws)(value)
-        if (typeof set === 'function') {
-            await subTestRunner(name, () => {
-                const r = set()
-                // The result of a function is walked as a fresh sub-tree;
-                // the parent's `throws` flag does not propagate into it.
-                subTests = [...subTests, [`${name}()`, r, false]]
-            })
-        } else {
+        const set = parseTestSet(throws)(value)
+        if (set instanceof Array) {
             for (const [j, y] of set) {
                 const pr = `${name}/${j}`
                 subTests = [...subTests, [pr, y, throws || j === 'throw']]
             }
+        } else {
+            await subTestRunner(name, () => {
+                if (set.throws) {
+                    let threw = false
+                    try { set.fn() } catch (_) { threw = true }
+                    if (!threw) { throw new Error(`${name}() expected to throw`) }
+                } else {
+                    const r = set.fn()
+                    // The result of a function is walked as a fresh sub-tree;
+                    // the parent's `throws` flag does not propagate into it.
+                    subTests = [...subTests, [`${name}()`, r, false]]
+                }
+            })
         }
     }
 }

--- a/issues/README.md
+++ b/issues/README.md
@@ -309,7 +309,7 @@
 - [x] [151-transpiler-effects](./151-transpiler-effects.md). Convert DJS transpiler (`fs/djs/transpiler/module.f.ts`) from legacy `Fs`/`readFileSync` to `ReadFile` effect; update tests to use the virtual effect runner instead of `createVirtualIo`. Unblocks deletion of `fs/io/virtual/module.f.ts`.
 - [X] [152-write-effect](./152-write-effect.md). `Write` effect and TTY-aware console: `write(stream, data)` with `WriteConsoles = 'stdout' | 'stderr'`; `csiWrite` wrapper reads `isTTY` from `NodeProgramOptions.std`; supersedes i150.
 - [X] [153-write-queue](./153-write-queue.md). Async write with backpressure: use `stream.write()` + `once(stream, 'drain')` for atomic, backpressure-aware writes to `stdout`/`stderr`.
-- [ ] [154-parseset-throws](./154-parseset-throws.md). `parseTestSet`: eliminate double `sandbox` call for throw-tests; return `TestEntry = { fn, throws }` instead of a wrapper function; discriminate from the array branch via `Array.isArray`.
+- [x] [154-parseset-throws](./154-parseset-throws.md). `parseTestSet`: eliminate double `sandbox` call for throw-tests; return `TestEntry = { fn, throws }` instead of a wrapper function; discriminate from the array branch via `Array.isArray`.
 
 ## Language Specification
 


### PR DESCRIPTION
## Summary

- **`fs/dev/tf/module.f.ts`**: add `TestEntry = { fn: Test, throws: boolean }`; `parseTestSet` now returns `TestEntry | readonly(readonly[string, unknown])[]` — no wrapper function, no double `sandbox` call; discriminate branches with `set instanceof Array`; caller evaluates pass/fail as `set.throws ? s === 'error' : s === 'ok'`; sub-tree walk skipped for throw-tests
- **`fs/dev/tf/module.ts`**: updated to match — drops stale `parseTestSet(io.sandbox)` call, uses `instanceof Array`, handles `set.throws` inline
- **`AGENTS.md`**: add rule prohibiting TypeScript type predicates (`: x is T`) — use `instanceof` instead

Closes [i154](./issues/154-parseset-throws.md).

## Test plan

- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)