### PR TITLE
fjs: convert main to NodeProgram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `fjs`: convert `main` to `NodeProgram`; dispatch sub-commands by returning Effects directly; remove `Io`/`fromIo`/`runProgram` dependency; `module.ts` switches from `legacyRun` to `effectRun` ([i122](./issues/README.md))
 - `tf`: convert `main` to `NodeProgram` — `(options: NodeProgramOptions) => Effect<NodeOp, number>`; replace `Io` dependency with `loadModuleMap2`, `sandbox` effect, and `csiWrite`; sequential test walk uses effectful `.reduce()` + `.step()` instead of synchronous `fold` ([i148](./issues/148-test-framework-effects.md)) [828](https://github.com/functionalscript/functionalscript/pull/828)
 - `tf`: eliminate double `sandbox` call for throw-tests; `parseTestSet` returns `TestEntry = { fn, throws }` instead of a wrapper; discriminate branches with `instanceof Array`; add `TestEntry` type; document dependency-free test design in README; add no-type-predicate rule to `AGENTS.md` ([i154](./issues/154-parseset-throws.md)) [827](https://github.com/functionalscript/functionalscript/pull/827)
 - `uint8array`: mark module deprecated — use `utf8`/`utf8ToString` from `fs/text` and `bit_vec` directly; replace all internal usages in `djs`, `sgr`, and virtual runner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- `fjs`: convert `main` to `NodeProgram`; dispatch sub-commands by returning Effects directly; remove `Io`/`fromIo`/`runProgram` dependency; `module.ts` switches from `legacyRun` to `effectRun` ([i122](./issues/README.md))
+- `fjs`: convert `main` to `NodeProgram`; dispatch sub-commands by returning Effects directly; remove `Io`/`fromIo`/`runProgram` dependency; `module.ts` switches from `legacyRun` to `effectRun` ([i122](./issues/README.md)) [830](https://github.com/functionalscript/functionalscript/pull/830)
 - `tf`: convert `main` to `NodeProgram` — `(options: NodeProgramOptions) => Effect<NodeOp, number>`; replace `Io` dependency with `loadModuleMap2`, `sandbox` effect, and `csiWrite`; sequential test walk uses effectful `.reduce()` + `.step()` instead of synchronous `fold` ([i148](./issues/148-test-framework-effects.md)) [828](https://github.com/functionalscript/functionalscript/pull/828)
 - `tf`: eliminate double `sandbox` call for throw-tests; `parseTestSet` returns `TestEntry = { fn, throws }` instead of a wrapper; discriminate branches with `instanceof Array`; add `TestEntry` type; document dependency-free test design in README; add no-type-predicate rule to `AGENTS.md` ([i154](./issues/154-parseset-throws.md)) [827](https://github.com/functionalscript/functionalscript/pull/827)
 - `uint8array`: mark module deprecated — use `utf8`/`utf8ToString` from `fs/text` and `bit_vec` directly; replace all internal usages in `djs`, `sgr`, and virtual runner

--- a/fs/fjs/module.f.ts
+++ b/fs/fjs/module.f.ts
@@ -3,39 +3,35 @@
  *
  * @module
  */
-import { fromIo, runProgram, type Io } from '../io/module.f.ts'
 import { compile } from '../djs/module.f.ts'
 import { main as testMain } from '../dev/tf/module.f.ts'
 import { main as casMain } from '../cas/module.f.ts'
-import { import_, type NodeProgram } from '../types/effects/node/module.f.ts'
+import { import_, error, type NodeProgram } from '../types/effects/node/module.f.ts'
+import { pure } from '../types/effects/module.f.ts'
 
-export const main = async(io: Io): Promise<number> => {
-    const { error } = io.console
-    const { process } = io
-    const [command, ...rest] = process.argv.slice(2)
-    const eRun = fromIo(io)
+export const main: NodeProgram = options => {
+    const [command, ...rest] = options.args
     switch (command) {
         case 'test':
         case 't':
-            return runProgram(io)(rest)(testMain)
+            return testMain({ ...options, args: rest })
         case 'compile':
         case 'c':
-            return eRun(compile(rest))
+            return compile(rest)
         case 'cas':
         case 's':
-            return eRun(casMain(rest))
+            return casMain(rest)
         case 'run':
-        case 'r':
+        case 'r': {
             const [file, ...args] = rest
-            return runProgram(io)(args)(o => import_(file).step(([s, v]) => {
+            return import_(file).step(([s, v]) => {
                 if (s === 'error') { throw v }
-                return (v.default as NodeProgram)(o)
-            }))
+                return (v.default as NodeProgram)({ ...options, args })
+            })
+        }
         case undefined:
-            error('Error: command is required')
-            return Promise.resolve(1)
+            return error('Error: command is required').step(() => pure(1))
         default:
-            error(`Error: Unknown command "${command}"`)
-            return Promise.resolve(1)
+            return error(`Error: Unknown command "${command}"`).step(() => pure(1))
     }
 }

--- a/fs/fjs/module.ts
+++ b/fs/fjs/module.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
 import { main } from './module.f.ts'
-import { legacyRun } from '../io/module.ts'
+import effectRun from '../io/module.ts'
 
-legacyRun(main)
+effectRun(main)

--- a/fs/io/module.ts
+++ b/fs/io/module.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs'
 import process from 'node:process'
 import { concat } from '../path/module.f.ts'
 import { once } from 'node:events'
-import { fromIo, type Io, type Run, run, runProgram } from './module.f.ts'
+import { fromIo, type Io, runProgram } from './module.f.ts'
 import type { Module, NodeProgram, NodeProgramOptions, WriteConsoles } from '../types/effects/node/module.f.ts'
 import { error, ok, type Result } from '../types/result/module.f.ts'
 import { fromVec } from '../types/uint8array/module.f.ts'
@@ -85,8 +85,6 @@ export const io: Io = {
     },
     write: (stream, data) => writeAll(streams[stream], fromVec(data)),
 }
-
-export const legacyRun: Run = run(io)
 
 export type NodeRun = (p: NodeProgram) => Promise<number>
 


### PR DESCRIPTION
## Summary

- `fs/fjs/module.f.ts`: `main` converted from `async(io: Io): Promise<number>` to `NodeProgram` — sub-commands dispatch by returning Effects directly; `options.args` replaces `process.argv.slice(2)`; `testMain` receives `{ ...options, args: rest }`; error messages use the `error` effect; `Io`/`fromIo`/`runProgram` imports removed
- `fs/fjs/module.ts`: switches from `legacyRun(main)` to `effectRun(main)` (the default export of `io/module.ts`, which wires `runProgram(io)(process.argv.slice(2))`)

Related to [i122](https://github.com/functionalscript/functionalscript/blob/main/issues/README.md#L255) — application entry files exporting `NodeProgram`.

## Test plan

- [ ] `deno check fs/fjs/module.f.ts` passes
- [ ] `fjs test` runs all tests
- [ ] `fjs compile`, `fjs cas`, `fjs run` commands work
- [ ] Unknown command and missing command print errors to stderr and exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)