### PR TITLE
Issue 156: virtual tests for dev/tf

### DIFF
--- a/fs/asn.1/test.f.ts
+++ b/fs/asn.1/test.f.ts
@@ -20,11 +20,11 @@ const cat = listToVec(msb)
 const pop8 = pop(8n)
 
 const check = (tag: bigint, v: Vec, rest: Vec) => {
-        const s = encodeRaw([tag, v])
-        const [[t0, v0], r] = decodeRaw(concat(s)(rest))
-        if (t0 !== tag) { throw `t0: ${t0}` }
-        if (v0 !== v) { throw `v0: ${asBase(v0)}` }
-        if (r !== rest) { throw `r: ${asBase(r)}` }
+    const s = encodeRaw([tag, v])
+    const [[t0, v0], r] = decodeRaw(concat(s)(rest))
+    if (t0 !== tag) { throw `t0: ${t0}` }
+    if (v0 !== v) { throw `v0: ${asBase(v0)}` }
+    if (r !== rest) { throw `r: ${asBase(r)}` }
 }
 
 const integerValueCheck = (i: bigint, v: Vec) => {

--- a/issues/156-tf-virtual-tests.md
+++ b/issues/156-tf-virtual-tests.md
@@ -1,0 +1,53 @@
+# 156. Tests for `dev/tf`: virtual test files + capture reporter
+
+The `dev/tf` test runner currently has no tests of its own. We want to verify the walker, the path threading, the throw semantics, the return-value sub-tree behavior, the pass/fail/total counts in `summary`, and the default reporter's formatting — all without running real test files on disk.
+
+## Proposed design
+
+Run `test(reporter)(options)` inside the virtual node runner (`fs/types/effects/node/virtual`) with:
+
+### Virtual test files via an `import` dictionary
+
+Each "virtual test file" is associated with an unknown JS value (the would-be `default` export, or the whole module). The `import` effect handler, currently `todo` in the virtual runner, becomes a dictionary lookup: `dict[path] → { default: ..., otherExport: ... }`. Loading the test fixture is just a map; nothing is parsed or evaluated.
+
+### Test functions return `SandboxResult` directly
+
+Test functions in virtual fixtures don't throw or perform real work. They return a `SandboxResult<unknown>` (`{ result: ['ok' | 'error', value], duration: number }`). The virtual `sandbox` handler short-circuits: it calls `f()` and returns its value as the `SandboxResult`, with no try/catch and no clock read. This makes tests deterministic — the fixture controls pass/fail and duration explicitly.
+
+### Capture reporter
+
+A `Reporter` that pushes each event into an array of tagged records:
+
+```ts
+type Event =
+    | readonly['moduleStart', string]
+    | readonly['enter', readonly string[]]
+    | readonly['pass', readonly string[], number]
+    | readonly['fail', string, readonly string[], unknown, number]
+    | readonly['summary', number, number, number]
+```
+
+Every method returns `pure(undefined)` after pushing. Tests assert on the event list, which is structural data — no string parsing.
+
+## Anything else
+
+- **Env injection**: `NodeProgramOptions.env` carries `INIT_CWD` (controls which directory `loadModuleMap2` scans) and `GITHUB_ACTION` (selects the GitHub reporter path in `main`). Both must be settable per test.
+- **Virtual filesystem stubs**: even with the import-dictionary trick, `loadModuleMap2` calls `readdir` and `access` to discover what looks like a test file (`*.test.f.js` / `*.test.f.ts`). The virtual `state.root` must be populated with the file paths from the dictionary so discovery succeeds; their contents (`Vec`) can be empty since `import` ignores them.
+- **Write capture**: the virtual runner already accumulates `state.stdout` / `state.stderr` via the `write` handler. For tests that exercise `main` (not just `test(reporter)`), assert on these strings to verify the default reporter's formatting (including the GitHub `::error` annotations and percent-encoding).
+- **Extract the default reporter** into a named exported factory (e.g. `defaultReporter(options): Reporter`). Without this, the GitHub format path can only be tested end-to-end via `main`. With it, we can feed synthetic events into the reporter and assert on the resulting `Write` effects directly.
+- **Coverage targets** (the test fixtures we should write):
+    - flat object of tests
+    - nested objects (`{ math: { add: …, sub: … } }`)
+    - `throw` key marking (both nested under a `throw` parent and via function `.name === 'throw'`)
+    - return-value sub-trees (test fn returns an object → walked at same path)
+    - special-character keys (containing `:`, `,`, `%`, quotes — verify path encoding and GitHub escaping)
+    - integer-indexed keys (arrays — verify integer/identifier formatter)
+    - non-default named exports (each becomes a top-level path segment)
+    - mixed pass/fail to verify `summary` counts
+- **Path-format helpers** (`fmtPath`, `fmtTerm`, `ghEscape`, `isInteger`, `isIdentifier`) should also get direct unit tests — they're pure functions and currently only exercised end-to-end.
+
+## Related
+
+- [i148](./148-test-framework-effects.md) — the Effect-based runner; this issue's tests are only possible because the runner is an Effect program.
+- [i149](./149-sandbox.md) — the `Sandbox` effect; this issue depends on the virtual runner's `sandbox` handler being pluggable (already is).
+- [i155](./155-test-runner-integration.md) — the "extract default reporter" item above is also called out as a follow-up there.

--- a/issues/README.md
+++ b/issues/README.md
@@ -311,6 +311,7 @@
 - [X] [153-write-queue](./153-write-queue.md). Async write with backpressure: use `stream.write()` + `once(stream, 'drain')` for atomic, backpressure-aware writes to `stdout`/`stderr`.
 - [x] [154-parseset-throws](./154-parseset-throws.md). `parseTestSet`: eliminate double `sandbox` call for throw-tests; return `TestEntry = { fn, throws }` instead of a wrapper function; discriminate from the array branch via `Array.isArray`.
 - [ ] [155-test-runner-integration](./155-test-runner-integration.md). Three problems: (1) `module.f.ts` and `module.ts` duplicate the test-tree walk; (2) `isGitHub` branching hardcodes a CI environment inside the walker; (3) Bun silently drops dynamically-registered subtests — fix by running generated sub-trees inline.
+- [ ] [156-tf-virtual-tests](./156-tf-virtual-tests.md). Test the `dev/tf` runner itself: virtual test files via an `import`-dictionary lookup, test functions that return `SandboxResult` directly (deterministic, no clock), a capture reporter that records structured events. Covers walker, path formatting, throw semantics, return-value sub-trees, summary counts.
 
 ## Language Specification
 


### PR DESCRIPTION
## Summary

New backlog issue [156-tf-virtual-tests](https://github.com/functionalscript/functionalscript/blob/non-default-tests/issues/156-tf-virtual-tests.md) describing how to test the `dev/tf` runner itself using the virtual node-effect runner.

Core design (from discussion):

- Virtual test files live in an `import`-effect dictionary — `dict[path] → module value`. No real disk, no parsing.
- Test functions return `SandboxResult` directly. The virtual `sandbox` handler short-circuits: no try/catch, no clock — fixtures dictate pass/fail and duration deterministically.
- A capture `Reporter` records each event (`moduleStart`, `enter`, `pass`, `fail`, `summary`) into a structured event log; assertions are made against the log, not parsed strings.

Additional items called out in the issue:

- Env injection for `INIT_CWD` and `GITHUB_ACTION`
- Filesystem stubs for `loadModuleMap2`'s discovery calls (`readdir`/`access`)
- `state.stdout` / `state.stderr` capture for end-to-end output assertions
- Extract `defaultReporter(options)` into a named factory so the GitHub format path can be tested without going through `main`
- A concrete fixture-coverage list (nested, throw markers, return-value sub-trees, special chars, integer keys, named exports, mixed pass/fail)
- Direct unit tests for the pure helpers `fmtPath` / `fmtTerm` / `ghEscape` / `isInteger` / `isIdentifier`

This PR is documentation only — no implementation. (The branch also carries a small unrelated whitespace cleanup in `fs/asn.1/test.f.ts`.)

## Test plan

- [ ] Issue renders cleanly on GitHub
- [ ] Linked from `issues/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)