### PR TITLE
tf: extract runModule/runModuleMap; flatten walk signature; rename x to cont

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `tf`: extract `runModule` and `runModuleMap`; filter with `isTest` before reduce; `walk` drops the module-key parameter [841](https://github.com/functionalscript/functionalscript/pull/841)
 - `tf`: virtual tests via `JsModule` + pass-through `sandbox`; `Reporter<O>` generic; `Program<O>` generic type; `LoadModuleOperations` alias; export `defaultReporter`, `fmtPath`, `fmtTerm`, `ghEscape`, `isInteger`, `isIdentifier` ([i156](./issues/156-tf-virtual-tests.md)) [840](https://github.com/functionalscript/functionalscript/pull/840)
 - Effects: Node: Virtual: new file type - JsModule. PR [834](https://github.com/functionalscript/functionalscript/pull/834)
 - `tf`: extract `Reporter` interface (`moduleStart` / `enter` / `pass` / `fail` / `summary`, each an `Effect<NodeOp, void>`); `test` now takes a `Reporter` and returns a `NodeProgram`; `main` builds the default CSI/GitHub reporter and calls `test(reporter)(options)`; `isGitHub` branching moves out of the walker into the default reporter; describe quiet/dynamic-progress reporter modes in [i155](./issues/155-test-runner-integration.md); remove unused `loadModuleMap` from `dev/module.f.ts`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `tf`: extract `runModule`/`runModuleMap`; flatten `walk` signature; filter before reduce; rename pass-continuation to `cont` [842](https://github.com/functionalscript/functionalscript/pull/842)
 - `tf`: extract `runModule` and `runModuleMap`; filter with `isTest` before reduce; `walk` drops the module-key parameter [841](https://github.com/functionalscript/functionalscript/pull/841)
 - `tf`: virtual tests via `JsModule` + pass-through `sandbox`; `Reporter<O>` generic; `Program<O>` generic type; `LoadModuleOperations` alias; export `defaultReporter`, `fmtPath`, `fmtTerm`, `ghEscape`, `isInteger`, `isIdentifier` ([i156](./issues/156-tf-virtual-tests.md)) [840](https://github.com/functionalscript/functionalscript/pull/840)
 - Effects: Node: Virtual: new file type - JsModule. PR [834](https://github.com/functionalscript/functionalscript/pull/834)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - `tf`: extract `runModule`/`runModuleMap`; flatten `walk` signature; filter before reduce; rename pass-continuation to `cont` [842](https://github.com/functionalscript/functionalscript/pull/842)
-- `tf`: extract `runModule` and `runModuleMap`; filter with `isTest` before reduce; `walk` drops the module-key parameter [841](https://github.com/functionalscript/functionalscript/pull/841)
 - `tf`: virtual tests via `JsModule` + pass-through `sandbox`; `Reporter<O>` generic; `Program<O>` generic type; `LoadModuleOperations` alias; export `defaultReporter`, `fmtPath`, `fmtTerm`, `ghEscape`, `isInteger`, `isIdentifier` ([i156](./issues/156-tf-virtual-tests.md)) [840](https://github.com/functionalscript/functionalscript/pull/840)
 - Effects: Node: Virtual: new file type - JsModule. PR [834](https://github.com/functionalscript/functionalscript/pull/834)
 - `tf`: extract `Reporter` interface (`moduleStart` / `enter` / `pass` / `fail` / `summary`, each an `Effect<NodeOp, void>`); `test` now takes a `Reporter` and returns a `NodeProgram`; `main` builds the default CSI/GitHub reporter and calls `test(reporter)(options)`; `isGitHub` branching moves out of the walker into the default reporter; describe quiet/dynamic-progress reporter modes in [i155](./issues/155-test-runner-integration.md); remove unused `loadModuleMap` from `dev/module.f.ts`

--- a/fs/dev/tf/module.f.ts
+++ b/fs/dev/tf/module.f.ts
@@ -74,17 +74,18 @@ export type Reporter<O extends Operation> = {
     readonly summary: (pass: number, fail: number, time: number) => Effect<O, void>
 }
 
-const runModuleMap = <O extends Operation>({ moduleStart, enter, pass, fail, summary }: Reporter<O>) => (moduleMap: ModuleMap): Effect<O|Sandbox, number> => {
+const runModule = <O extends Operation>({ moduleStart, enter, pass, fail }: Reporter<O>) => (k: string, v: unknown) => (ts: TestState): Effect<O|Sandbox, TestState> => {
+    if (!isTest(k)) { return pure(ts) }
     const walk
-        : (k: string) => (path: readonly string[]) => (throws: boolean) => (v: unknown) => (ts: TestState) => Effect<O|Sandbox, TestState>
-        = k => path => throws => v => ts =>
+        : (path: readonly string[]) => (throws: boolean) => (v: unknown) => (ts: TestState) => Effect<O|Sandbox, TestState>
+        = path => throws => v => ts =>
     {
         const set = parseTestSet(throws)(v)
         if (set instanceof Array) {
             return set.reduce(
                 (acc: Effect<O|Sandbox, TestState>, [ck, cv]) => {
                     const sub = [...path, ck]
-                    const recurse = walk(k)(sub)(throws || ck === 'throw')(cv)
+                    const recurse = walk(sub)(throws || ck === 'throw')(cv)
                     // Emit `enter` only for sub-tree values (objects/arrays). Leaf
                     // values (functions, primitives) skip `enter` so the reporter
                     // can combine the key with the pass/fail line.
@@ -104,20 +105,21 @@ const runModuleMap = <O extends Operation>({ moduleStart, enter, pass, fail, sum
                     // thrown values are discarded. The sub-tree's `throws` resets to false.
                     return throws
                         ? pure(ts2)
-                        : walk(k)(path)(false)(r)(ts2)
+                        : walk(path)(false)(r)(ts2)
                 })
             }
             const ts2 = addFail(duration)(ts)
             return fail(k, path, r, duration).step(() => pure(ts2))
         })
     }
+    return moduleStart(k).step(() => walk([])(false)(v)(ts))
+}
+
+const runModuleMap = <O extends Operation>(reporter: Reporter<O>) => (moduleMap: ModuleMap): Effect<O|Sandbox, number> => {
+    const { summary } = reporter
     const entries = Object.entries(moduleMap)
     return entries.reduce(
-        (acc: Effect<O|Sandbox, TestState>, [k, v]) =>
-            acc.step(ts => isTest(k)
-                ? moduleStart(k).step(() => walk(k)([])(false)(v)(ts))
-                : pure(ts)
-            ),
+        (acc: Effect<O|Sandbox, TestState>, [k, v]) => acc.step(runModule(reporter)(k, v)),
         pure({ time: 0, pass: 0, fail: 0 })
     )
     .step(ts => summary(ts.pass, ts.fail, ts.time)

--- a/fs/dev/tf/module.f.ts
+++ b/fs/dev/tf/module.f.ts
@@ -4,9 +4,16 @@
  * @module
  */
 import { reset, fgGreen, fgRed, bold, csiWrite } from '../../text/sgr/module.f.ts'
-import { sandbox, type NodeOp, type NodeProgram, type NodeProgramOptions, type Program, type Sandbox, type Write } from '../../types/effects/node/module.f.ts'
+import {
+    sandbox,
+    type NodeProgram,
+    type NodeProgramOptions,
+    type Program,
+    type Sandbox,
+    type Write
+} from '../../types/effects/node/module.f.ts'
 import { pure, type Effect, type Operation } from '../../types/effects/module.f.ts'
-import { loadModuleMap, type LoadModuleOperations, type Module, type ModuleMap } from '../module.f.ts'
+import { loadModuleMap, type LoadModuleOperations, type ModuleMap } from '../module.f.ts'
 
 export const isTest = (s: string): boolean => s.endsWith('test.f.js') || s.endsWith('test.f.ts')
 
@@ -73,7 +80,6 @@ export type Reporter<O extends Operation> = {
     readonly fail: (file: string, path: readonly string[], result: unknown, duration: number) => Effect<O, void>
     readonly summary: (pass: number, fail: number, time: number) => Effect<O, void>
 }
-
 
 const runModule = <O extends Operation>({ moduleStart, enter, pass, fail }: Reporter<O>) => (k: string, v: unknown) => (ts: TestState): Effect<O | Sandbox, TestState> => {
     const walk

--- a/fs/dev/tf/module.f.ts
+++ b/fs/dev/tf/module.f.ts
@@ -74,8 +74,8 @@ export type Reporter<O extends Operation> = {
     readonly summary: (pass: number, fail: number, time: number) => Effect<O, void>
 }
 
+
 const runModule = <O extends Operation>({ moduleStart, enter, pass, fail }: Reporter<O>) => (k: string, v: unknown) => (ts: TestState): Effect<O|Sandbox, TestState> => {
-    if (!isTest(k)) { return pure(ts) }
     const walk
         : (path: readonly string[]) => (throws: boolean) => (v: unknown) => (ts: TestState) => Effect<O|Sandbox, TestState>
         = path => throws => v => ts =>
@@ -117,7 +117,7 @@ const runModule = <O extends Operation>({ moduleStart, enter, pass, fail }: Repo
 
 const runModuleMap = <O extends Operation>(reporter: Reporter<O>) => (moduleMap: ModuleMap): Effect<O|Sandbox, number> => {
     const { summary } = reporter
-    const entries = Object.entries(moduleMap)
+    const entries = Object.entries(moduleMap).filter(([k]) => isTest(k))
     return entries.reduce(
         (acc: Effect<O|Sandbox, TestState>, [k, v]) => acc.step(runModule(reporter)(k, v)),
         pure({ time: 0, pass: 0, fail: 0 })

--- a/fs/dev/tf/module.f.ts
+++ b/fs/dev/tf/module.f.ts
@@ -111,7 +111,7 @@ export const test = <O extends Operation>({ moduleStart, enter, pass, fail, summ
                 return fail(k, path, r, duration).step(() => pure(ts2))
             })
         }
-        const entries: readonly[string, Module][] = Object.entries(moduleMap)
+        const entries = Object.entries(moduleMap)
         return entries.reduce(
             (acc: Effect<O|Sandbox, TestState>, [k, v]) =>
                 acc.step(ts => {

--- a/fs/dev/tf/module.f.ts
+++ b/fs/dev/tf/module.f.ts
@@ -101,10 +101,8 @@ const runModule = <O extends Operation>({ moduleStart, enter, pass, fail }: Repo
                 return pass(path, duration).step(() => {
                     // Only non-throw tests walk their return value as a fresh sub-tree;
                     // thrown values are discarded. The sub-tree's `throws` resets to false.
-                    const x = throws
-                        ? pure
-                        : walk(path, false, r)
-                    return x(addPass(duration)(ts))
+                    const cont = throws ? pure : walk(path, false, r)
+                    return cont(addPass(duration)(ts))
                 })
             }
             return fail(k, path, r, duration).step(() => pure(addFail(duration)(ts)))

--- a/fs/dev/tf/module.f.ts
+++ b/fs/dev/tf/module.f.ts
@@ -6,7 +6,7 @@
 import { reset, fgGreen, fgRed, bold, csiWrite } from '../../text/sgr/module.f.ts'
 import { sandbox, type NodeOp, type NodeProgram, type NodeProgramOptions, type Program, type Sandbox, type Write } from '../../types/effects/node/module.f.ts'
 import { pure, type Effect, type Operation } from '../../types/effects/module.f.ts'
-import { loadModuleMap, type LoadModuleOperations, type Module } from '../module.f.ts'
+import { loadModuleMap, type LoadModuleOperations, type Module, type ModuleMap } from '../module.f.ts'
 
 export const isTest = (s: string): boolean => s.endsWith('test.f.js') || s.endsWith('test.f.ts')
 
@@ -74,53 +74,55 @@ export type Reporter<O extends Operation> = {
     readonly summary: (pass: number, fail: number, time: number) => Effect<O, void>
 }
 
-export const test = <O extends Operation>({ moduleStart, enter, pass, fail, summary }: Reporter<O>): Program<O|LoadModuleOperations|Sandbox> => options =>
-    loadModuleMap(options.env).step(moduleMap => {
-        const walk
-            : (k: string) => (path: readonly string[]) => (throws: boolean) => (v: unknown) => (ts: TestState) => Effect<O|Sandbox, TestState>
-            = k => path => throws => v => ts =>
-        {
-            const set = parseTestSet(throws)(v)
-            if (set instanceof Array) {
-                return set.reduce(
-                    (acc: Effect<O|Sandbox, TestState>, [ck, cv]) => {
-                        const sub = [...path, ck]
-                        const recurse = walk(k)(sub)(throws || ck === 'throw')(cv)
-                        // Emit `enter` only for sub-tree values (objects/arrays). Leaf
-                        // values (functions, primitives) skip `enter` so the reporter
-                        // can combine the key with the pass/fail line.
-                        return typeof cv === 'object' && cv !== null
-                            ? acc.step(ts => enter(sub).step(() => recurse(ts)))
-                            : acc.step(recurse)
-                    },
-                    pure(ts)
-                )
-            }
-            return sandbox(set.fn).step(({ result: [s, r], duration }) => {
-                const { throws } = set
-                if (throws !== (s === 'ok')) {
-                    return pass(path, duration).step(() => {
-                        const ts2 = addPass(duration)(ts)
-                        // Only non-throw tests walk their return value as a fresh sub-tree;
-                        // thrown values are discarded. The sub-tree's `throws` resets to false.
-                        if (!throws) { return walk(k)(path)(false)(r)(ts2) }
-                        return pure(ts2)
-                    })
-                }
-                const ts2 = addFail(duration)(ts)
-                return fail(k, path, r, duration).step(() => pure(ts2))
-            })
+const runModuleMap = <O extends Operation>({ moduleStart, enter, pass, fail, summary }: Reporter<O>) => (moduleMap: ModuleMap): Effect<O|Sandbox, number> => {
+    const walk
+        : (k: string) => (path: readonly string[]) => (throws: boolean) => (v: unknown) => (ts: TestState) => Effect<O|Sandbox, TestState>
+        = k => path => throws => v => ts =>
+    {
+        const set = parseTestSet(throws)(v)
+        if (set instanceof Array) {
+            return set.reduce(
+                (acc: Effect<O|Sandbox, TestState>, [ck, cv]) => {
+                    const sub = [...path, ck]
+                    const recurse = walk(k)(sub)(throws || ck === 'throw')(cv)
+                    // Emit `enter` only for sub-tree values (objects/arrays). Leaf
+                    // values (functions, primitives) skip `enter` so the reporter
+                    // can combine the key with the pass/fail line.
+                    return typeof cv === 'object' && cv !== null
+                        ? acc.step(ts => enter(sub).step(() => recurse(ts)))
+                        : acc.step(recurse)
+                },
+                pure(ts)
+            )
         }
-        const entries = Object.entries(moduleMap)
-        return entries.reduce(
-            (acc: Effect<O|Sandbox, TestState>, [k, v]) =>
-                acc.step(ts => {
-                    if (!isTest(k)) { return pure(ts) }
-                    return moduleStart(k).step(() => walk(k)([])(false)(v)(ts))
-                }),
-            pure({ time: 0, pass: 0, fail: 0 })
-        ).step(ts => summary(ts.pass, ts.fail, ts.time).step(() => pure(ts.fail !== 0 ? 1 : 0)))
-    })
+        return sandbox(set.fn).step(({ result: [s, r], duration }) => {
+            const { throws } = set
+            if (throws !== (s === 'ok')) {
+                return pass(path, duration).step(() => {
+                    const ts2 = addPass(duration)(ts)
+                    // Only non-throw tests walk their return value as a fresh sub-tree;
+                    // thrown values are discarded. The sub-tree's `throws` resets to false.
+                    if (!throws) { return walk(k)(path)(false)(r)(ts2) }
+                    return pure(ts2)
+                })
+            }
+            const ts2 = addFail(duration)(ts)
+            return fail(k, path, r, duration).step(() => pure(ts2))
+        })
+    }
+    const entries = Object.entries(moduleMap)
+    return entries.reduce(
+        (acc: Effect<O|Sandbox, TestState>, [k, v]) =>
+            acc.step(ts => {
+                if (!isTest(k)) { return pure(ts) }
+                return moduleStart(k).step(() => walk(k)([])(false)(v)(ts))
+            }),
+        pure({ time: 0, pass: 0, fail: 0 })
+    ).step(ts => summary(ts.pass, ts.fail, ts.time).step(() => pure(ts.fail !== 0 ? 1 : 0)))
+}
+
+export const test = <O extends Operation>(reporter: Reporter<O>): Program<O|LoadModuleOperations|Sandbox> => options =>
+    loadModuleMap(options.env).step(runModuleMap(reporter))
 
 const isAlpha = (c: string): boolean =>
     (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c === '_' || c === '$'

--- a/fs/dev/tf/module.f.ts
+++ b/fs/dev/tf/module.f.ts
@@ -102,8 +102,9 @@ const runModuleMap = <O extends Operation>({ moduleStart, enter, pass, fail, sum
                     const ts2 = addPass(duration)(ts)
                     // Only non-throw tests walk their return value as a fresh sub-tree;
                     // thrown values are discarded. The sub-tree's `throws` resets to false.
-                    if (!throws) { return walk(k)(path)(false)(r)(ts2) }
-                    return pure(ts2)
+                    return throws
+                        ? pure(ts2)
+                        : walk(k)(path)(false)(r)(ts2)
                 })
             }
             const ts2 = addFail(duration)(ts)
@@ -113,12 +114,14 @@ const runModuleMap = <O extends Operation>({ moduleStart, enter, pass, fail, sum
     const entries = Object.entries(moduleMap)
     return entries.reduce(
         (acc: Effect<O|Sandbox, TestState>, [k, v]) =>
-            acc.step(ts => {
-                if (!isTest(k)) { return pure(ts) }
-                return moduleStart(k).step(() => walk(k)([])(false)(v)(ts))
-            }),
+            acc.step(ts => isTest(k)
+                ? moduleStart(k).step(() => walk(k)([])(false)(v)(ts))
+                : pure(ts)
+            ),
         pure({ time: 0, pass: 0, fail: 0 })
-    ).step(ts => summary(ts.pass, ts.fail, ts.time).step(() => pure(ts.fail !== 0 ? 1 : 0)))
+    )
+    .step(ts => summary(ts.pass, ts.fail, ts.time)
+    .step(() => pure(ts.fail !== 0 ? 1 : 0)))
 }
 
 export const test = <O extends Operation>(reporter: Reporter<O>): Program<O|LoadModuleOperations|Sandbox> => options =>

--- a/fs/dev/tf/module.f.ts
+++ b/fs/dev/tf/module.f.ts
@@ -39,7 +39,7 @@ export type TestEntry = {
     readonly throws: boolean
 }
 
-export type TestSet = TestEntry | readonly(readonly[string, unknown])[]
+export type TestSet = TestEntry | readonly (readonly [string, unknown])[]
 
 export const parseTestSet = (throws: boolean) => (x: unknown): TestSet => {
     switch (typeof x) {
@@ -75,17 +75,16 @@ export type Reporter<O extends Operation> = {
 }
 
 
-const runModule = <O extends Operation>({ moduleStart, enter, pass, fail }: Reporter<O>) => (k: string, v: unknown) => (ts: TestState): Effect<O|Sandbox, TestState> => {
+const runModule = <O extends Operation>({ moduleStart, enter, pass, fail }: Reporter<O>) => (k: string, v: unknown) => (ts: TestState): Effect<O | Sandbox, TestState> => {
     const walk
-        : (path: readonly string[]) => (throws: boolean) => (v: unknown) => (ts: TestState) => Effect<O|Sandbox, TestState>
-        = path => throws => v => ts =>
+        = (path: readonly string[], throws: boolean, v: unknown) => (ts: TestState): Effect<O | Sandbox, TestState> =>
     {
         const set = parseTestSet(throws)(v)
         if (set instanceof Array) {
             return set.reduce(
-                (acc: Effect<O|Sandbox, TestState>, [ck, cv]) => {
+                (acc: Effect<O | Sandbox, TestState>, [ck, cv]) => {
                     const sub = [...path, ck]
-                    const recurse = walk(sub)(throws || ck === 'throw')(cv)
+                    const recurse = walk(sub, throws || ck === 'throw', cv)
                     // Emit `enter` only for sub-tree values (objects/arrays). Leaf
                     // values (functions, primitives) skip `enter` so the reporter
                     // can combine the key with the pass/fail line.
@@ -100,33 +99,32 @@ const runModule = <O extends Operation>({ moduleStart, enter, pass, fail }: Repo
             const { throws } = set
             if (throws !== (s === 'ok')) {
                 return pass(path, duration).step(() => {
-                    const ts2 = addPass(duration)(ts)
                     // Only non-throw tests walk their return value as a fresh sub-tree;
                     // thrown values are discarded. The sub-tree's `throws` resets to false.
-                    return throws
-                        ? pure(ts2)
-                        : walk(path)(false)(r)(ts2)
+                    const x = throws
+                        ? pure
+                        : walk(path, false, r)
+                    return x(addPass(duration)(ts))
                 })
             }
-            const ts2 = addFail(duration)(ts)
-            return fail(k, path, r, duration).step(() => pure(ts2))
+            return fail(k, path, r, duration).step(() => pure(addFail(duration)(ts)))
         })
     }
-    return moduleStart(k).step(() => walk([])(false)(v)(ts))
+    return moduleStart(k).step(() => walk([], false, v)(ts))
 }
 
-const runModuleMap = <O extends Operation>(reporter: Reporter<O>) => (moduleMap: ModuleMap): Effect<O|Sandbox, number> => {
+const runModuleMap = <O extends Operation>(reporter: Reporter<O>) => (moduleMap: ModuleMap): Effect<O | Sandbox, number> => {
     const { summary } = reporter
     const entries = Object.entries(moduleMap).filter(([k]) => isTest(k))
     return entries.reduce(
-        (acc: Effect<O|Sandbox, TestState>, [k, v]) => acc.step(runModule(reporter)(k, v)),
+        (acc: Effect<O | Sandbox, TestState>, [k, v]) => acc.step(runModule(reporter)(k, v)),
         pure({ time: 0, pass: 0, fail: 0 })
     )
-    .step(ts => summary(ts.pass, ts.fail, ts.time)
-    .step(() => pure(ts.fail !== 0 ? 1 : 0)))
+        .step(ts => summary(ts.pass, ts.fail, ts.time)
+            .step(() => pure(ts.fail !== 0 ? 1 : 0)))
 }
 
-export const test = <O extends Operation>(reporter: Reporter<O>): Program<O|LoadModuleOperations|Sandbox> => options =>
+export const test = <O extends Operation>(reporter: Reporter<O>): Program<O | LoadModuleOperations | Sandbox> => options =>
     loadModuleMap(options.env).step(runModuleMap(reporter))
 
 const isAlpha = (c: string): boolean =>


### PR DESCRIPTION
## Summary

- Extract `runModule` — runs all tests within a single module; `walk` drops the module-key parameter (only needed by `fail`, which stays in `runModule` scope) and flattens its signature from `path => throws => v =>` to `(path, throws, v) =>`
- Extract `runModuleMap` — filters entries with `isTest` before the reduce, then reduces over `runModule` calls
- `test` becomes a two-liner: load the module map, step into `runModuleMap`
- Rename the pass-continuation variable from `x` to `cont` for clarity
- Import `ModuleMap` type for the `runModuleMap` signature

## Test plan

- [ ] `deno check fs/dev/tf/module.f.ts` passes
- [ ] `deno test --allow-read --allow-env fs/dev/tf/all.test.ts` passes (78 tests, 1404 steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)