### PR TITLE
tf: issue 163 — Reporter.test design; export runModuleMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `tf`: issue [i163](./issues/163-reporter-test-method.md) — `Reporter.test` design doc; export `runModuleMap`; experimental `run2` in `module.ts` [843](https://github.com/functionalscript/functionalscript/pull/843)
 - `tf`: extract `runModule`/`runModuleMap`; flatten `walk` signature; filter before reduce; rename pass-continuation to `cont` [842](https://github.com/functionalscript/functionalscript/pull/842)
 - `tf`: virtual tests via `JsModule` + pass-through `sandbox`; `Reporter<O>` generic; `Program<O>` generic type; `LoadModuleOperations` alias; export `defaultReporter`, `fmtPath`, `fmtTerm`, `ghEscape`, `isInteger`, `isIdentifier` ([i156](./issues/156-tf-virtual-tests.md)) [840](https://github.com/functionalscript/functionalscript/pull/840)
 - Effects: Node: Virtual: new file type - JsModule. PR [834](https://github.com/functionalscript/functionalscript/pull/834)

--- a/fs/dev/tf/module.f.ts
+++ b/fs/dev/tf/module.f.ts
@@ -117,7 +117,7 @@ const runModule = <O extends Operation>({ moduleStart, enter, pass, fail }: Repo
     return moduleStart(k).step(() => walk([], false, v)(ts))
 }
 
-const runModuleMap = <O extends Operation>(reporter: Reporter<O>) => (moduleMap: ModuleMap): Effect<O | Sandbox, number> => {
+export const runModuleMap = <O extends Operation>(reporter: Reporter<O>) => (moduleMap: ModuleMap): Effect<O | Sandbox, number> => {
     const { summary } = reporter
     const entries = Object.entries(moduleMap).filter(([k]) => isTest(k))
     return entries.reduce(

--- a/fs/dev/tf/module.ts
+++ b/fs/dev/tf/module.ts
@@ -1,9 +1,13 @@
 import { io } from '../../io/module.ts'
 import { loadModuleMap } from '../module.f.ts'
-import { isTest, parseTestSet } from './module.f.ts'
+import { isTest, parseTestSet, runModuleMap, type Reporter } from './module.f.ts'
 import * as nodeTest from 'node:test'
 import { asyncImport } from '../../io/module.ts'
 import { fromIo } from '../../io/module.f.ts'
+import { pure, type ToAsyncOperationMap } from '../../types/effects/module.f.ts'
+import { asyncRun } from '../../types/effects/module.ts'
+import type { Sandbox } from '../../types/effects/node/module.f.ts'
+import { ok } from '../../types/result/module.f.ts'
 
 //
 
@@ -75,9 +79,33 @@ const scanModule = (x: Test): TestFunc => async(subTestRunner: SubTestRunnerFunc
     }
 }
 
+const noOp = () => pure(undefined)
+
+const reporter: Reporter<never> = {
+    moduleStart: noOp,
+    enter: noOp,
+    pass: noOp,
+    fail: noOp,
+    summary: noOp,
+}
+
+const map: ToAsyncOperationMap<Sandbox> = {
+    sandbox: async(_f) => ({
+        result: ok(undefined),
+        duration: 0,
+    }),
+} as const
+
+export const run2 = async(): Promise<void> => {
+    const fio = fromIo(io)
+    const moduleMap = await fio(loadModuleMap(io.process.env))
+    const runner = runModuleMap(reporter)(moduleMap)
+    asyncRun(map)(runner)
+}
+
 export const run = async(): Promise<void> => {
-    const x = await fromIo(io)(loadModuleMap(io.process.env))
-    for (const [i, v] of Object.entries(x)) {
+    const moduleMap = await fromIo(io)(loadModuleMap(io.process.env))
+    for (const [i, v] of Object.entries(moduleMap)) {
         if (isTest(i)) {
             framework(i, scanModule(['', v.default, false]))
         }

--- a/issues/163-reporter-test-method.md
+++ b/issues/163-reporter-test-method.md
@@ -1,0 +1,53 @@
+# 163. `Reporter.test`: delegate test execution via the reporter
+
+## Problem
+
+The walker in `runModule` (`fs/dev/tf/module.f.ts`) calls `sandbox(set.fn)` directly, hardcoding `Sandbox` as a required effect. This prevents reusing the walker in contexts where test execution is handled differently — in particular, the integrated bridge runner (`fs/dev/tf/module.ts`) which dispatches to Node `--test`, Bun, or Playwright and cannot use `sandbox` (it needs an async framework call instead).
+
+Three alternatives were considered:
+
+1. **New `RunTest` effect** — a new operation type `['runTest', (entry: TestEntry) => SandboxResult<unknown>]` registered in the virtual/real runners.
+2. **Pass an effect creator as a separate parameter** — `runModule(reporter, runTest)` where `runTest: (throws, f) => Effect<O, SandboxResult<unknown>>`.
+3. **Add `test` to `Reporter`** — the reporter already owns the environment boundary; extending it with a `test` method is consistent and requires no extra parameters.
+
+Option 3 is preferred: reporters already encapsulate how events are rendered; making them also encapsulate how a test is _run_ is a natural extension, keeps the parameter count stable, and absorbs `Sandbox` into `O`.
+
+## Proposed design
+
+Add a `test` method to `Reporter<O>`:
+
+```ts
+export type Reporter<O extends Operation> = {
+    readonly moduleStart: (file: string) => Effect<O, void>
+    readonly enter: (path: readonly string[]) => Effect<O, void>
+    readonly pass: (path: readonly string[], duration: number) => Effect<O, void>
+    readonly fail: (file: string, path: readonly string[], result: unknown, duration: number) => Effect<O, void>
+    readonly summary: (pass: number, fail: number, time: number) => Effect<O, void>
+    readonly test: (throws: boolean, f: () => unknown) => Effect<O, SandboxResult<unknown>>
+}
+```
+
+The walker replaces `sandbox(set.fn)` with `reporter.test(set.throws, set.fn)`.
+
+### Reporter implementations
+
+| Reporter | `test` implementation | Effect type |
+|---|---|---|
+| `defaultReporter` (terminal/GitHub) | `(throws, f) => sandbox(f)` | `Reporter<Write \| Sandbox>` |
+| Capture reporter (virtual tests) | `(throws, f) => pure({ result: ['ok', f()], duration: 0 })` or fixture-driven | `Reporter<never>` |
+| Bridge reporter (`module.ts`) | `(throws, f) => ...` using `nodeTest.test()` with throw semantics | `Reporter<SomeAsyncOp>` |
+
+### Effect on `runModule`
+
+`Sandbox` is removed from `runModule`'s effect constraint — it is absorbed into `O` via the reporter. The `sandbox` import in `module.f.ts` moves to `defaultReporter` only.
+
+### Async bridging in `module.ts`
+
+The bridge reporter's `test` method is the single integration point for async framework calls. The walker itself stays synchronous and Effect-based; all async bridging is contained in `reporter.test`. This directly resolves problem 1 from [i155](./155-test-runner-integration.md).
+
+## Related
+
+- [i155](./155-test-runner-integration.md) — identifies code duplication between `module.f.ts` and `module.ts` as a problem; this issue provides the mechanism to fix it.
+- [i149](./149-sandbox.md) — `Sandbox` effect; `reporter.test` wraps it for the default case.
+- [i156](./156-tf-virtual-tests.md) — virtual tests; the capture reporter's `test` method replaces the current pass-through `sandbox` convention.
+- [i21](./021-test-framework-silent-mode.md) — reporter modes; `test` fits alongside the existing reporter methods.

--- a/issues/README.md
+++ b/issues/README.md
@@ -318,6 +318,7 @@
 - [ ] [160-nibble-set-dead-or-factory](./160-nibble-set-dead-or-factory.md). DRY: `nibble_set` duplicates `byte_set`'s bitmask algebra but has zero consumers. Default recommendation: delete the dead module. Alternative (only if a nibble consumer is planned): extract a `bitSet` factory parameterized over the numeric domain.
 - [ ] [161-keyed-btree-collection](./161-keyed-btree-collection.md). DRY/architecture: `string_set` and `ordered_map` are parallel thin wrappers over the same string-keyed B-tree. Propose a shared `keyedCollection(keyOf, keyCmp)` core, making explicit that a set is a map whose key is its value.
 - [ ] [162-rtti-parse-container-factories](./162-rtti-parse-container-factories.md). DRY: `rtti/validate` factors its array/record and tuple/struct handlers into two factories, but `rtti/parse` hand-writes all four. Mirror the factory pair in `parse` (with a `rebuild` callback for the transformed output).
+- [ ] [163-reporter-test-method](./163-reporter-test-method.md). Add `test(throws, f)` to `Reporter<O>` so the walker delegates test execution to the reporter; removes the hardcoded `Sandbox` dependency from `runModule` and enables `module.ts` to reuse the Effects walker without its own scan loop.
 
 ## Language Specification
 


### PR DESCRIPTION
## Summary

- Add [i163](./issues/163-reporter-test-method.md): design doc for adding `test(throws, f)` to `Reporter<O>`, delegating test execution to the reporter and removing the hardcoded `Sandbox` dependency from `runModule`; references i155, i149, i156, i21
- Export `runModuleMap` from `module.f.ts` so `module.ts` can reuse it
- Experimental `run2` in `module.ts` wiring `runModuleMap` through `asyncRun` (work in progress toward i155/i163)

## Test plan

- [ ] `deno test --allow-read --allow-env fs/dev/tf/all.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)