### PR TITLE
Add issue 164: Uncurry state-threading accumulator types

### DIFF
--- a/issues/164-uncurry-accumulators.md
+++ b/issues/164-uncurry-accumulators.md
@@ -1,0 +1,46 @@
+# 164. Uncurry state-threading accumulator types (`Fold`/`Reduce`, `ReduceOp`/`TailReduce`)
+
+**Priority: low**
+
+## Problem
+
+`StateScan` was refactored ([763](https://github.com/functionalscript/functionalscript/pull/763)) from a curried `(value) => (state) => …` form to an uncurried `(input, prior) => …` form. The motivation: both parameters are *data* (a stream element and the threaded state), not operator/config parameters. Currying them only invites partial application that captures a per-element value or an accumulator — meaningless to cache, and a state-leak hazard.
+
+Several sibling accumulator types still curry their data parameters, contradicting that precedent:
+
+```ts
+// fs/types/function/operator/module.f.ts
+export type Fold<I, O> = Binary<I, O, O>   // (input: I) => (acc: O) => O
+export type Reduce<T>  = Fold<T, T>        // (value: T) => (acc: T) => T
+
+// fs/types/sorted_list/module.f.ts
+export type ReduceOp<T, S>   = (state: S) => (a: T) => (b: T) => readonly[Nullable<T>, Sign, S]
+export type TailReduce<T, S> = (state: S) => (tail: List<T>) => List<T>
+```
+
+In all of these, the curried parameters (`input`/`acc`, `state`/`a`/`b`, `state`/`tail`) are data threaded through iteration, not stable operator configuration. As with the old `StateScan`, partially applying over them produces a per-step closure that captures a stream value or accumulator state — never something you'd want to cache, and dangerous if cached.
+
+## Proposed change
+
+Uncurry the *data* parameters:
+
+```ts
+export type Fold<I, O> = (input: I, acc: O) => O
+export type Reduce<T>  = Fold<T, T>
+
+export type ReduceOp<T, S>   = (state: S, a: T, b: T) => readonly[Nullable<T>, Sign, S]
+export type TailReduce<T, S> = (state: S, tail: List<T>) => List<T>
+```
+
+This removes the partial-application footgun and drops one closure allocation per element.
+
+## Considerations / tradeoffs
+
+- **Broad mechanical refactor.** ~20+ operator definitions written in `a => b => …` form become `(a, b) => …`, across `bigint`, `prime_field`, `bit_vec`, `string`, `monoid`, `number`, `range_map`, plus `operator` itself and the `foldToScan` / `reduceToScan` / `fold` / `reduce` plumbing in `list`. `genericMerge` / `cmpReduce` / `mergeTail` in `sorted_list` and the `range_map` merge consumers change accordingly.
+- **`Fold` can no longer be `Binary<I, O, O>`.** It would be defined standalone. This is arguably a feature: it draws a clean line between *combinators where currying is genuinely useful and harmless* (`Binary` / `Equal` / `Unary` — e.g. `strictEqual(a)` as a reusable predicate) and *accumulators where currying is dangerous* (`Fold` / `Reduce` / `StateScan` / `ReduceOp` / `TailReduce`). Recommendation: keep `Binary` / `Equal` / `Unary` curried; only uncurry the state-threading types.
+- Could be split: `Fold`/`Reduce` in one change, `sorted_list`'s `ReduceOp`/`TailReduce` as a follow-up.
+
+## Related
+
+- [763](https://github.com/functionalscript/functionalscript/pull/763) — the `StateScan` uncurry refactor this generalizes.
+- [158-sorted-binary-search](./158-sorted-binary-search.md) — also touches the `sorted_list` / comparator vocabulary.

--- a/issues/README.md
+++ b/issues/README.md
@@ -319,6 +319,7 @@
 - [ ] [161-keyed-btree-collection](./161-keyed-btree-collection.md). DRY/architecture: `string_set` and `ordered_map` are parallel thin wrappers over the same string-keyed B-tree. Propose a shared `keyedCollection(keyOf, keyCmp)` core, making explicit that a set is a map whose key is its value.
 - [ ] [162-rtti-parse-container-factories](./162-rtti-parse-container-factories.md). DRY: `rtti/validate` factors its array/record and tuple/struct handlers into two factories, but `rtti/parse` hand-writes all four. Mirror the factory pair in `parse` (with a `rebuild` callback for the transformed output).
 - [ ] [163-reporter-test-method](./163-reporter-test-method.md). Add `test(throws, f)` to `Reporter<O>` so the walker delegates test execution to the reporter; removes the hardcoded `Sandbox` dependency from `runModule` and enables `module.ts` to reuse the Effects walker without its own scan loop.
+- [ ] [164-uncurry-accumulators](./164-uncurry-accumulators.md). P5. Generalize the `StateScan` uncurry refactor (763) to the other state-threading accumulator types: `Fold`/`Reduce` and `sorted_list`'s `ReduceOp`/`TailReduce` still curry their data parameters, inviting per-element/accumulator closures that are meaningless to cache and a state-leak hazard. Uncurry to `(input, acc) => …`; keep `Binary`/`Equal`/`Unary` curried.
 
 ## Language Specification
 


### PR DESCRIPTION
## Summary

This PR documents issue 164, which proposes uncurrying data parameters in state-threading accumulator types (`Fold`, `Reduce`, `ReduceOp`, `TailReduce`) to align with the precedent set by the `StateScan` refactor in PR #763.

## Changes

- **Added `issues/164-uncurry-accumulators.md`**: Comprehensive issue document outlining:
  - The problem: several accumulator types still curry their data parameters despite `StateScan` being refactored to uncurried form
  - Proposed changes: uncurry `Fold<I, O>`, `Reduce<T>`, `ReduceOp<T, S>`, and `TailReduce<T, S>` to remove partial-application footguns and reduce closure allocations
  - Scope: ~20+ operator definitions across multiple modules (`bigint`, `prime_field`, `bit_vec`, `string`, `monoid`, `number`, `range_map`, `operator`, `list`, `sorted_list`)
  - Key consideration: `Fold` can no longer be defined as `Binary<I, O, O>` and should be standalone, drawing a clean line between genuinely useful currying (combinators like `Binary`, `Equal`, `Unary`) and dangerous currying (state-threading types)

- **Updated `issues/README.md`**: Added entry for issue 164 to the backlog list

## Rationale

This issue generalizes the principle established in PR #763: currying data parameters that are threaded through iteration (stream elements, accumulator state) is dangerous because partial application captures per-step values that should never be cached, creating state-leak hazards. Uncurrying these parameters removes the footgun and improves performance by eliminating unnecessary closure allocations.

https://claude.ai/code/session_014iLxbCjWfsjVmpZvtWvLmm