### PR TITLE
add issue 165: layered parser

### DIFF
--- a/issues/165-layered-parser.md
+++ b/issues/165-layered-parser.md
@@ -1,0 +1,17 @@
+# Layered Parser
+
+A tokenizer accepts a sequence of code-points as input tokens together with meta information (file name, position). It uses our BNF parser to output new tokens.
+
+Each token type is represented by a single symbol, e.g. `s` for string, `n` for number, `i` for identifier. All other information (actual value, position, etc.) is carried as meta information. This sequence of tokens is then the input into a new parser layer.
+
+```
+code-points + meta ==BNF==> tokens(symbol + meta) ==BNF==> AST
+```
+
+Both layers reuse the same BNF engine.
+
+## Open Questions
+
+- **Keyword disambiguation**: identifiers and keywords may share the same symbol. Options: separate token type per keyword, or grammar rules that inspect meta info.
+- **Meta info propagation**: when the upper parser reduces a sequence of tokens, how does meta info (e.g. source span) combine into the parent node?
+- **Error reporting**: lower-layer errors (bad token) and upper-layer errors (bad structure) need a unified error representation that carries the right meta info.

--- a/issues/README.md
+++ b/issues/README.md
@@ -320,6 +320,7 @@
 - [ ] [162-rtti-parse-container-factories](./162-rtti-parse-container-factories.md). DRY: `rtti/validate` factors its array/record and tuple/struct handlers into two factories, but `rtti/parse` hand-writes all four. Mirror the factory pair in `parse` (with a `rebuild` callback for the transformed output).
 - [ ] [163-reporter-test-method](./163-reporter-test-method.md). Add `test(throws, f)` to `Reporter<O>` so the walker delegates test execution to the reporter; removes the hardcoded `Sandbox` dependency from `runModule` and enables `module.ts` to reuse the Effects walker without its own scan loop.
 - [ ] [164-uncurry-accumulators](./164-uncurry-accumulators.md). P5. Generalize the `StateScan` uncurry refactor (763) to the other state-threading accumulator types: `Fold`/`Reduce` and `sorted_list`'s `ReduceOp`/`TailReduce` still curry their data parameters, inviting per-element/accumulator closures that are meaningless to cache and a state-leak hazard. Uncurry to `(input, acc) => …`; keep `Binary`/`Equal`/`Unary` curried.
+- [ ] [165-layered-parser](./165-layered-parser.md). Layered parser: a BNF-driven tokenizer maps code-points (plus file/position meta) to single-symbol tokens (`s`, `n`, `i`, …) carrying value/position as meta information, feeding a second BNF parser layer. Open questions: keyword disambiguation, meta-info propagation through reductions, unified error representation across layers.
 
 ## Language Specification
 


### PR DESCRIPTION
Adds `issues/165-layered-parser.md` describing the layered parser design: a BNF-driven tokenizer that emits single-symbol tokens with meta information (value, position, file), feeding into a second BNF parser layer. Includes open questions on keyword disambiguation, meta info propagation, and error reporting.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSjzC7RFA3dr53LxWeZBS9)_