### PR TITLE
Update TypeScript native preview to 7.0.0-dev.20260524.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260521.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260524.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -210,7 +210,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260521.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260524.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -378,7 +378,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260521.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260524.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -546,7 +546,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260521.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260524.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -714,7 +714,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260521.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260524.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -888,7 +888,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260521.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260524.1"
         },
         {
           "uses": "denoland/setup-deno@v2",

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -46,4 +46,4 @@ export const wasmtime = '44.0.1'
 export const wasmer = '7.1.0'
 
 // https://www.npmjs.com/package/@typescript/native-preview?activeTab=versions
-export const tsgo = '7.0.0-dev.20260521.1'
+export const tsgo = '7.0.0-dev.20260524.1'


### PR DESCRIPTION
## Summary
Updates the TypeScript native preview dependency to a newer development version across all CI workflows and configuration files.

## Key Changes
- Updated `@typescript/native-preview` from `7.0.0-dev.20260521.1` to `7.0.0-dev.20260524.1` in:
  - `.github/workflows/ci.yml` (6 occurrences across different workflow jobs)
  - `fs/ci/config/module.f.ts` (source configuration file)

## Details
This change updates the development version of the TypeScript native preview package to a newer build from May 24, 2026 (compared to the previous May 21, 2026 build). The update is applied consistently across all CI workflow definitions and the source configuration module that likely generates or manages these workflows.

https://claude.ai/code/session_01VHJzevbDgJ2QuiJduQYB2E