### PR TITLE
Add listToVec function and test for Uint8Array concatenation

### DIFF
--- a/fs/types/uint8array/test.f.ts
+++ b/fs/types/uint8array/test.f.ts
@@ -1,5 +1,5 @@
 import { vec } from '../bit_vec/module.f.ts'
-import { toVec, fromVec, decodeUtf8, encodeUtf8 } from './module.f.ts'
+import { toVec, fromVec, listToVec, decodeUtf8, encodeUtf8 } from './module.f.ts'
 import { strictEqual } from '../function/operator/module.f.ts'
 import { equal, fromArrayLike } from '../list/module.f.ts'
 
@@ -55,5 +55,9 @@ export default {
         const input = 'FunctionalScript 🐝'
         const output = decodeUtf8(encodeUtf8(input))
         assertEq(output, input)
+    },
+    listToVec: () => {
+        const result = listToVec([Uint8Array.from([1, 2]), Uint8Array.from([3])])
+        assertArrayEq(fromVec(result), Uint8Array.from([1, 2, 3]))
     }
 }


### PR DESCRIPTION
## Summary
This PR adds a new `listToVec` function to the uint8array module that concatenates a list of Uint8Arrays into a single Uint8Array, along with comprehensive test coverage.

## Key Changes
- Added `listToVec` function export to the uint8array module
- Implemented test case for `listToVec` that verifies concatenation of multiple Uint8Arrays
- Test validates that `listToVec([Uint8Array.from([1, 2]), Uint8Array.from([3])])` correctly produces `Uint8Array.from([1, 2, 3])`

## Implementation Details
The new function is imported in the test file and tested by:
1. Creating a list of two Uint8Arrays with values [1, 2] and [3]
2. Passing them to `listToVec` for concatenation
3. Converting the result back to a Uint8Array using `fromVec` and asserting equality with the expected concatenated result

https://claude.ai/code/session_01MsTDfiHM5Pc1Hrztg4dLfv