### PR TITLE
Upgrade Wasmtime from 44.0.1 to 45.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@
         {
           "uses": "bytecodealliance/actions/wasmtime/setup@v1",
           "with": {
-            "version": "44.0.1"
+            "version": "45.0.0"
           }
         },
         {
@@ -194,7 +194,7 @@
         {
           "uses": "bytecodealliance/actions/wasmtime/setup@v1",
           "with": {
-            "version": "44.0.1"
+            "version": "45.0.0"
           }
         },
         {
@@ -362,7 +362,7 @@
         {
           "uses": "bytecodealliance/actions/wasmtime/setup@v1",
           "with": {
-            "version": "44.0.1"
+            "version": "45.0.0"
           }
         },
         {
@@ -530,7 +530,7 @@
         {
           "uses": "bytecodealliance/actions/wasmtime/setup@v1",
           "with": {
-            "version": "44.0.1"
+            "version": "45.0.0"
           }
         },
         {
@@ -698,7 +698,7 @@
         {
           "uses": "bytecodealliance/actions/wasmtime/setup@v1",
           "with": {
-            "version": "44.0.1"
+            "version": "45.0.0"
           }
         },
         {
@@ -872,7 +872,7 @@
         {
           "uses": "bytecodealliance/actions/wasmtime/setup@v1",
           "with": {
-            "version": "44.0.1"
+            "version": "45.0.0"
           }
         },
         {

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -40,7 +40,7 @@ export const node = {
 } as const
 
 // https://github.com/bytecodealliance/wasmtime/releases
-export const wasmtime = '44.0.1'
+export const wasmtime = '45.0.0'
 
 // https://github.com/wasmerio/wasmer/releases
 export const wasmer = '7.1.0'


### PR DESCRIPTION
## Summary
This pull request upgrades the Wasmtime runtime dependency from version 44.0.1 to 45.0.0 across the project's CI configuration and build tooling.

## Changes
- Updated Wasmtime version in `.github/workflows/ci.yml` from 44.0.1 to 45.0.0 across all 6 workflow jobs that use the bytecodealliance/actions/wasmtime/setup action
- Updated the Wasmtime version constant in `fs/ci/config/module.f.ts` from 44.0.1 to 45.0.0

## Details
The upgrade ensures that all CI workflows and the build configuration use the latest stable Wasmtime release (45.0.0), providing access to any bug fixes, performance improvements, and new features included in this version.

https://claude.ai/code/session_01HB7zB2DfPpGjvEqHALHwQf