### PR TITLE
Add match function test for nullable option handling

### DIFF
--- a/fs/types/nullable/test.f.ts
+++ b/fs/types/nullable/test.f.ts
@@ -1,4 +1,4 @@
-import { map, toOption } from './module.f.ts'
+import { map, match, toOption } from './module.f.ts'
 
 export default [
     () => {
@@ -13,5 +13,10 @@ export default [
         if (opt1.length !== 1 || opt1[0] !== 5) { throw opt1 }
         const opt2 = toOption(null)
         if (opt2.length !== 0) { throw opt2 }
+    },
+    () => {
+        const double = match((v: number) => v * 2)(() => -1)
+        if (double(3) !== 6) { throw double(3) }
+        if (double(null) !== -1) { throw double(null) }
     }
 ]


### PR DESCRIPTION
## Summary
Added test coverage for the `match` function to verify its behavior with nullable values and option types.

## Key Changes
- Imported `match` function from the module alongside existing `map` and `toOption` imports
- Added new test case demonstrating `match` function usage:
  - Tests matching on a non-null value (3) that gets doubled to 6
  - Tests matching on a null value that returns the default value of -1
  - Validates that the function correctly handles both success and fallback cases

## Implementation Details
The test verifies that `match` provides a way to handle optional values by accepting:
1. A transformation function for the success case (doubles the input value)
2. A fallback function for the null/empty case (returns -1)

https://claude.ai/code/session_01MJMvYf6n5XBhhw5ENvx4Jz