### PR TITLE
Update Deno to 2.8.1 and TypeScript native preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,12 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260526.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
           "with": {
-            "deno-version": "2.8.0"
+            "deno-version": "2.8.1"
           }
         },
         {
@@ -210,12 +210,12 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260526.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
           "with": {
-            "deno-version": "2.8.0"
+            "deno-version": "2.8.1"
           }
         },
         {
@@ -378,12 +378,12 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260526.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
           "with": {
-            "deno-version": "2.8.0"
+            "deno-version": "2.8.1"
           }
         },
         {
@@ -546,12 +546,12 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260526.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
           "with": {
-            "deno-version": "2.8.0"
+            "deno-version": "2.8.1"
           }
         },
         {
@@ -714,12 +714,12 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260526.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
           "with": {
-            "deno-version": "2.8.0"
+            "deno-version": "2.8.1"
           }
         },
         {
@@ -888,12 +888,12 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260526.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
           "with": {
-            "deno-version": "2.8.0"
+            "deno-version": "2.8.1"
           }
         },
         {

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -25,7 +25,7 @@ export const images = {
 export const bun = '1.3.14'
 
 // https://deno.com/
-export const deno = '2.8.0'
+export const deno = '2.8.1'
 
 // https://www.npmjs.com/package/playwright
 export const playwright = '1.60.0'
@@ -46,4 +46,4 @@ export const wasmtime = '45.0.0'
 export const wasmer = '7.1.0'
 
 // https://www.npmjs.com/package/@typescript/native-preview?activeTab=versions
-export const tsgo = '7.0.0-dev.20260526.1'
+export const tsgo = '7.0.0-dev.20260527.1'


### PR DESCRIPTION
## Summary
Updates development tool versions in the CI configuration and module configuration file.

## Key Changes
- Updated Deno version from 2.8.0 to 2.8.1 across all CI workflows
- Updated TypeScript native preview package from 7.0.0-dev.20260526.1 to 7.0.0-dev.20260527.1
- Updated corresponding version constants in the module configuration file

## Details
- Modified `.github/workflows/ci.yml` to use the latest Deno 2.8.1 release and updated TypeScript native preview package across all 6 workflow jobs
- Updated `fs/ci/config/module.f.ts` to reflect the new version constants for both `deno` and `tsgo` exports

https://claude.ai/code/session_01D6149Xb7QXBQRomzHc5Jyb