### PR TITLE
dev: replace ad-hoc entry comparator with string.cmp (i199)

### DIFF
--- a/fs/dev/module.f.ts
+++ b/fs/dev/module.f.ts
@@ -4,7 +4,6 @@
  * @module
  */
 import type { Io } from '../io/module.f.ts'
-import type { Sign } from '../types/function/compare/module.f.ts'
 import { updateVersion } from './version/module.f.ts'
 import {
     access,
@@ -21,6 +20,7 @@ import {
     type NodeProgram,
     type Readdir
 } from '../types/effects/node/module.f.ts'
+import { cmp as strCmp } from '../types/string/module.f.ts'
 import { utf8, utf8ToString } from '../text/module.f.ts'
 import { unwrap } from '../types/result/module.f.ts'
 import { begin, pure, type Effect } from '../types/effects/module.f.ts'
@@ -42,11 +42,6 @@ export type Module = {
     readonly default?: unknown
     readonly [k: string]: unknown
 }
-
-type Entry<T> = readonly[string, T]
-
-const cmp = ([a]: Entry<unknown>, [b]: Entry<unknown>): Sign =>
-    a < b ? -1 : a > b ? 1 : 0
 
 export type ModuleMap = {
    readonly[k in string]: Module
@@ -113,7 +108,7 @@ export const loadModuleMap = (env: Env): Effect<LoadModuleOperations, ModuleMap>
             entries
                 .flat()
                 .map(([k, v]) => [relativize(prefix, k), v] as const)
-                .toSorted(cmp)
+                .toSorted(([a], [b]) => strCmp(a)(b))
         )))
 }
 


### PR DESCRIPTION
Resolves [i199](./issues/199-dev-entry-cmp.md).

## Summary

- Drop the local `cmp = ([a], [b]) => a < b ? -1 : a > b ? 1 : 0` in `fs/dev/module.f.ts`.
- Drop the now-unused `Entry<T>` alias and `Sign` import that only existed to type the local helper.
- `toSorted` now calls `strCmp(a)(b)` (curried) from `fs/types/string`, where string comparison belongs.

## Why

String comparison belongs in `fs/types/string`, not inlined into a build/dev module. The expression `a < b ? -1 : a > b ? 1 : 0` is exactly what `string.cmp` already implements, so the inline copy was a duplicate of the existing comparator.

Per the issue's caveat, the call site uses the lightweight inline wrapper `([a], [b]) => strCmp(a)(b)` rather than introducing a speculative `cmpBy` helper — there is only one consumer today.

## Behavior

Behavior-preserving: `a < b ? -1 : a > b ? 1 : 0` and `strCmp(a)(b)` return identical values for any two strings.

## Test plan

- [x] `npx tsc` passes
- [x] `node --experimental-strip-types --test fs/dev/test.f.ts` passes
- [x] `node --experimental-strip-types --test fs/types/string/test.f.ts` passes (sanity check on the comparator being reused)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QGoa9XANdcPaGHqsMSRGxe)_