### PR TITLE
Add test for unwrap error handling behavior

### DIFF
--- a/fs/types/result/test.f.ts
+++ b/fs/types/result/test.f.ts
@@ -17,3 +17,12 @@ export const invertTest = () => {
     const [k1, v1] = invert(error('oops'))
     if (k1 !== 'ok' || v1 !== 'oops') { throw [k1, v1] }
 }
+
+export const unwrapError = () => {
+    let caught = false
+    try { unwrap(error('oops')) } catch (e) {
+        if (e !== 'oops') { throw e }
+        caught = true
+    }
+    if (!caught) { throw 'expected throw' }
+}


### PR DESCRIPTION
## Summary
Added a test case to verify that the `unwrap` function properly throws errors when called on an error result.

## Changes
- Added `unwrapError` test function that validates error throwing behavior
  - Verifies that `unwrap(error('oops'))` throws the error value
  - Confirms the thrown value matches the original error message
  - Ensures the exception is actually raised (not silently caught)

## Implementation Details
The test follows the existing pattern in the file by:
- Using try/catch to validate exception behavior
- Checking that the caught error matches the expected value
- Throwing if the expected exception was not raised

https://claude.ai/code/session_01FCaGcXx4YZyGGZhq15b3fj