### PR TITLE
Add env() function tests to proof suite

### DIFF
--- a/fs/dev/proof.f.ts
+++ b/fs/dev/proof.f.ts
@@ -1,4 +1,4 @@
-import { todo } from './module.f.ts'
+import { todo, env } from './module.f.ts'
 
 export const shouldPass = () => ({
     then: () => undefined
@@ -55,5 +55,19 @@ export default {
     },
     throw: () => {
         todo()
+    },
+    env: () => {
+        const mockIo = { process: { env: { MY_VAR: 'hello' } } } as any
+        // missing key → undefined
+        const r1 = env(mockIo)('MISSING')
+        if (r1 !== undefined) { throw r1 }
+        // regular value property → returns value
+        const r2 = env(mockIo)('MY_VAR')
+        if (r2 !== 'hello') { throw r2 }
+        // getter property → calls get()
+        const envWithGetter = Object.defineProperty({}, 'GETTER_VAR', { get: () => 'from-getter', enumerable: true, configurable: true })
+        const mockIo2 = { process: { env: envWithGetter } } as any
+        const r3 = env(mockIo2)('GETTER_VAR')
+        if (r3 !== 'from-getter') { throw r3 }
     }
 }


### PR DESCRIPTION
## Summary
Added comprehensive test coverage for the `env()` function to the proof test suite, validating its behavior with environment variables including edge cases with missing keys and getter properties.

## Key Changes
- Imported `env` function from `./module.f.ts` alongside existing `todo` import
- Added new `env()` test case covering three scenarios:
  - Missing environment variable keys return `undefined`
  - Regular value properties return their string values correctly
  - Getter properties are properly invoked and their return values are used

## Implementation Details
The test validates that the `env()` function correctly handles different property types on the environment object:
- Uses a mock IO object structure with `process.env` to simulate the Node.js environment
- Tests both plain object properties and properties defined with `Object.defineProperty()` getters
- Throws the actual returned value if assertions fail, enabling easy debugging

https://claude.ai/code/session_01W8VvmcsqQxC11jU8hbrUJ5