### PR TITLE
tf: discover proofs by exported `proof` property (step 1)

### DIFF
--- a/fs/asn.1/proof.f.ts
+++ b/fs/asn.1/proof.f.ts
@@ -48,7 +48,7 @@ const ch = (r: SupportedRecord, v: Vec) => {
     ch0(r, v, vec(16n)(0x2345n))
 }
 
-export default {
+export const proof = {
     encodeSmall: () => {
         const v = vec8(0x13n)
         const x = encodeRaw([integer, v])

--- a/fs/base128/proof.f.ts
+++ b/fs/base128/proof.f.ts
@@ -10,7 +10,7 @@ const test = (a: bigint, b: Vec) => {
     if (rest !== empty) { throw `rest: ${asBase(rest).toString(16)}, expected: ${asBase(empty).toString(16)}` }
 }
 
-export default () => {
+export const proof = () => {
     test(0n, vec8(0n))
     test(1n, vec8(1n))
     test(0x7Fn, vec8(0x7Fn))

--- a/fs/bnf/data/proof.f.ts
+++ b/fs/bnf/data/proof.f.ts
@@ -14,7 +14,7 @@ const descentParserCpOnly = (m: DescentMatch<unknown>, name: string, cp: readonl
     return m(name, cpm)
 }
 
-export default {
+export const proof = {
     rangeDecode: () => {
         const decoded1 = stringify(sort)(rangeDecode(0x000079_000087))
         if (decoded1 !== '[121,135]') { throw decoded1 }

--- a/fs/bnf/proof.f.ts
+++ b/fs/bnf/proof.f.ts
@@ -1,6 +1,6 @@
 import { classic, deterministic } from './testlib.f.ts'
 
-export default {
+export const proof = {
     test: () => {
         classic()
         deterministic()

--- a/fs/cas/proof.f.ts
+++ b/fs/cas/proof.f.ts
@@ -1,1 +1,1 @@
-export default () => {}
+export const proof = () => {}

--- a/fs/cbase32/proof.f.ts
+++ b/fs/cbase32/proof.f.ts
@@ -17,7 +17,7 @@ const check = (s: string, v: Vec) => {
     if (vr !== v) { throw [vr, v] }
 }
 
-export default {
+export const proof = {
     roundtrip5x: () => {
         check5x("", empty)
         check5x("0", vec(5n)(0b00000n))

--- a/fs/ci/proof.f.ts
+++ b/fs/ci/proof.f.ts
@@ -30,7 +30,7 @@ const run = (rust: boolean, nodeExtra: (o: Os) => readonly MetaStep[] = () => []
     return unwrap(parseGitHubAction(jsonParse(utf8ToString(file))))
 }
 
-export default {
+export const proof = {
     rust: () => {
         assert(hasRun('cargo')(run(true)), 'expected Rust steps')
     },

--- a/fs/crypto/hmac/proof.f.ts
+++ b/fs/crypto/hmac/proof.f.ts
@@ -3,7 +3,7 @@ import { uint, vec } from '../../types/bit_vec/module.f.ts'
 import { sha256, sha384, sha512 } from '../sha2/module.f.ts'
 import { hmac } from './module.f.ts'
 
-export default {
+export const proof = {
     example: () => {
         const r = hmac(sha256)(utf8('key'))(utf8('The quick brown fox jumps over the lazy dog'))
         if (r !== vec(256n)(0xf7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8n)) { throw r }

--- a/fs/crypto/secp/proof.f.ts
+++ b/fs/crypto/secp/proof.f.ts
@@ -53,7 +53,7 @@ const poker = (param: Curve) => () => {
     }
 }
 
-export default {
+export const proof = {
     example: () => {
         const curveParams: Init = {
             p: 23n,

--- a/fs/crypto/sha2/proof.f.ts
+++ b/fs/crypto/sha2/proof.f.ts
@@ -23,7 +23,7 @@ const checkEmpty = ({ init, end, hashLength }: Sha2) => (x: bigint) => {
 // https://en.wikipedia.org/wiki/SHA-2#Test_vectors
 //
 // https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/Secure-Hashing
-export default {
+export const proof = {
     base: {
         b32: () => {
             const { fromV8, compress, chunkLength } = base32

--- a/fs/crypto/sign/proof.f.ts
+++ b/fs/crypto/sign/proof.f.ts
@@ -18,7 +18,7 @@ const v600 = vec(600n)
 const r32 = repeat(32n)
 const hmac256 = hmac(sha256)
 
-export default {
+export const proof = {
     bits2int: () => {
         if (all(7n).bits2int(vec(5n)(0b10100n)) !== 0b101n) { throw new Error("fail") }
         if (all(17n).bits2int(vec(3n)(0b101n)) !== 0b101n) { throw new Error("fail") }

--- a/fs/dev/module.f.ts
+++ b/fs/dev/module.f.ts
@@ -39,7 +39,7 @@ export const assertEq = <T>(a: T, b: T): void =>
     assert(a === b, [a, b])
 
 export type Module = {
-    readonly default?: unknown
+    readonly proof?: unknown
     readonly [k: string]: unknown
 }
 

--- a/fs/dev/proof.f.ts
+++ b/fs/dev/proof.f.ts
@@ -1,10 +1,9 @@
 import { todo, env } from './module.f.ts'
 
-export const shouldPass = () => ({
-    then: () => undefined
-})
-
-export default {
+export const proof = {
+    shouldPass: () => ({
+        then: () => undefined
+    }),
     ctor: () => {
         const c = (() => { })['constructor']
         const f = c('return 5')

--- a/fs/dev/tf/module.f.ts
+++ b/fs/dev/tf/module.f.ts
@@ -210,7 +210,9 @@ const { entries } = Object
  */
 export const runModuleMap = <O extends Operation>(reporter: Reporter<O>) => (moduleMap: ModuleMap): Effect<O | All, number> => {
     const { summary } = reporter
-    const modules = entries(moduleMap).filter(([k]) => isTest(k))
+    const modules = entries(moduleMap)
+        .filter(([k]) => isTest(k))
+        .flatMap(([k, v]) => v.proof !== undefined ? [[k, v.proof] as const] : [])
     return all(...modules.map(([k, v]) => runModule(reporter)(k, v)(zero)))
     .step(m => pure(m.reduce(mergeState, zero)))
     .step(ts => summary(ts.pass, ts.fail, ts.time)
@@ -231,7 +233,9 @@ export const testAll = <O extends Operation>(reporter: Reporter<O>): Program<O |
  */
 export const registerModuleMap =
     (ctx: TestContext, moduleMap: ModuleMap): Effect<Test | All | Await, void> => {
-        const modules = entries(moduleMap).filter(([k]) => isTest(k))
+        const modules = entries(moduleMap)
+            .filter(([k]) => isTest(k))
+            .flatMap(([k, v]) => v.proof !== undefined ? [[k, v.proof] as const] : [])
         if (modules.length === 0) { return pure(undefined) }
         return all(...modules.map(([k, v]) => registerModule(ctx, k, v))).step(() => pure(undefined))
     }

--- a/fs/dev/tf/proof.f.ts
+++ b/fs/dev/tf/proof.f.ts
@@ -61,7 +61,7 @@ const runMain = (dir: Record<string, JsModule>, github = false): readonly[string
 // flat object: two passing tests
 export const flat = () => {
     const [events, exit] = run({
-        'a.proof.f.ts': () => ({ a: ok0, b: ok1 }),
+        'a.proof.f.ts': () => ({ proof: { a: ok0, b: ok1 } }),
     })
     assertEq(exit, 0)
     const [e0, e1, e2] = events
@@ -76,7 +76,7 @@ export const flat = () => {
 // nested object: leaf tests carry the full path including the sub-tree key
 export const nested = () => {
     const [events, exit] = run({
-        'n.proof.f.ts': () => ({ math: { add: ok0, sub: ok0 } }),
+        'n.proof.f.ts': () => ({ proof: { math: { add: ok0, sub: ok0 } } }),
     })
     assertEq(exit, 0)
     const [e0, e1, e2] = events
@@ -91,7 +91,7 @@ export const nested = () => {
 // throw key: tests inside 'throw' pass on error result
 export const throwKey = () => {
     const [events, exit] = run({
-        't.proof.f.ts': () => ({ throw: { a: fail0 } }),
+        't.proof.f.ts': () => ({ proof: { throw: { a: fail0 } } }),
     })
     assertEq(exit, 0)
     const [e0, e1] = events
@@ -105,7 +105,7 @@ export const throwKey = () => {
 // throw key fails when test does not throw (returns ok in throw context)
 export const throwKeyFail = () => {
     const [events, exit] = run({
-        't.proof.f.ts': () => ({ throw: { a: ok0 } }),
+        't.proof.f.ts': () => ({ proof: { throw: { a: ok0 } } }),
     })
     assertEq(exit, 1)
     const [e0, e1] = events
@@ -118,7 +118,7 @@ export const throwKeyFail = () => {
 // mixed pass/fail updates summary counts
 export const mixedPassFail = () => {
     const [events, exit] = run({
-        'm.proof.f.ts': () => ({ good: ok0, bad: fail0 }),
+        'm.proof.f.ts': () => ({ proof: { good: ok0, bad: fail0 } }),
     })
     assertEq(exit, 1)
     const summary = events[events.length - 1]
@@ -132,12 +132,12 @@ export const mixedPassFail = () => {
 export const returnValueSubTree = () => {
     const inner: () => unknown = () => ({ result: ['ok', undefined] as const, duration: 0 })
     const [events, exit] = run({
-        'r.proof.f.ts': () => ({
+        'r.proof.f.ts': () => ({ proof: {
             outer: (): unknown => ({
                 result: ['ok', { inner }] as const,
                 duration: 0,
             }),
-        }),
+        } }),
     })
     // outer passes, then inner (from return value) also passes
     assertEq(exit, 0)
@@ -151,7 +151,7 @@ export const returnValueSubTree = () => {
 // integer-indexed array keys appear as numeric path segments
 export const arrayKeys = () => {
     const [events, exit] = run({
-        'a.proof.f.ts': () => ({ arr: [ok0, ok0] }),
+        'a.proof.f.ts': () => ({ proof: { arr: [ok0, ok0] } }),
     })
     assertEq(exit, 0)
     const passEvents = events.filter(e => e[0] === 'result')
@@ -164,7 +164,7 @@ export const arrayKeys = () => {
 export const nonTestFilesSkipped = () => {
     const [events, exit] = run({
         'helper.ts': () => ({ a: ok0 }),
-        'b.proof.f.ts': () => ({ x: ok0 }),
+        'b.proof.f.ts': () => ({ proof: { x: ok0 } }),
     })
     assertEq(exit, 0)
     const results = events.filter(e => e[0] === 'result')
@@ -175,8 +175,8 @@ export const nonTestFilesSkipped = () => {
 // multiple test files each produce result events
 export const multipleFiles = () => {
     const [events, exit] = run({
-        'a.proof.f.ts': () => ({ x: ok0 }),
-        'b.proof.f.ts': () => ({ y: ok0 }),
+        'a.proof.f.ts': () => ({ proof: { x: ok0 } }),
+        'b.proof.f.ts': () => ({ proof: { y: ok0 } }),
     })
     assertEq(exit, 0)
     const results = events.filter(e => e[0] === 'result')
@@ -192,7 +192,7 @@ export const throwByFunctionName = () => {
     // const named = ({ throw: () => fail0() }).throw
     const x = { throw: () => fail0() }
     const [events, exit] = run({
-        't.proof.f.ts': () => ({ here: x.throw }),
+        't.proof.f.ts': () => ({ proof: { here: x.throw } }),
     })
     assertEq(exit, 0)
     const passEvents = events.filter(e => e[0] === 'result')
@@ -200,22 +200,22 @@ export const throwByFunctionName = () => {
     assertEq(passEvents[0][2][0], 'here')
 }
 
-// every module export — `default` and named — becomes a top-level path segment
+// only the `proof` export is used; other module properties are ignored
 export const namedExports = () => {
     const [events, exit] = run({
-        'e.proof.f.ts': () => ({ default: ok0, helper: ok0 }),
+        'e.proof.f.ts': () => ({ proof: { a: ok0, b: ok0 }, other: ok0 }),
     })
     assertEq(exit, 0)
     const passEvents = events.filter(e => e[0] === 'result')
-    assertEq(passEvents.length, 2)
-    assertEq(passEvents[0][2][0], 'default')
-    assertEq(passEvents[1][2][0], 'helper')
+    assertEq(passEvents.length, 2) // `other` is ignored
+    assertEq(passEvents[0][2][0], 'a')
+    assertEq(passEvents[1][2][0], 'b')
 }
 
 // the default (non-GitHub) reporter formats module/pass/summary lines on stdout
 export const defaultReporterOutput = () => {
     const [stdout, stderr, exit] = runMain({
-        'a.proof.f.ts': () => ({ x: ok0 }),
+        'a.proof.f.ts': () => ({ proof: { x: ok0 } }),
     })
     assertEq(exit, 0)
     assertEq(stderr, '')
@@ -230,7 +230,7 @@ export const defaultReporterOutput = () => {
 // a failure on the non-GitHub reporter writes the error to stderr, not stdout
 export const defaultReporterFailOutput = () => {
     const [, stderr, exit] = runMain({
-        'a.proof.f.ts': () => ({ bad: fail0 }),
+        'a.proof.f.ts': () => ({ proof: { bad: fail0 } }),
     })
     assertEq(exit, 1)
     assertEq(stderr, 'import("./a.proof.f.ts").bad(): error, 0.0000 ms\noops\n')
@@ -240,7 +240,7 @@ export const defaultReporterFailOutput = () => {
 // title (the JSON path) and message
 export const githubReporterOutput = () => {
     const [, stderr, exit] = runMain({
-        's.proof.f.ts': () => ({ 'a:b,c%d': fail0 }),
+        's.proof.f.ts': () => ({ proof: { 'a:b,c%d': fail0 } }),
     }, true)
     assertEq(exit, 1)
     assertEq(
@@ -312,3 +312,5 @@ export const helpers = {
         assertEq(ghEscape('a%b:c,d'), 'a%25b%3Ac%2Cd')
     },
 }
+
+export const proof = { flat,nested,throwKey,throwKeyFail,mixedPassFail,returnValueSubTree,arrayKeys,nonTestFilesSkipped,multipleFiles,throwByFunctionName,namedExports,defaultReporterOutput,defaultReporterFailOutput,githubReporterOutput,helpers }

--- a/fs/dev/version/proof.f.ts
+++ b/fs/dev/version/proof.f.ts
@@ -81,7 +81,7 @@ const e = '{\n' +
     '  }\n' +
     '}'
 
-export default {
+export const proof = {
     new: () => {
         const w = (name: string) => {
             const fn = `${name}.json`

--- a/fs/djs/ast/proof.f.ts
+++ b/fs/djs/ast/proof.f.ts
@@ -2,7 +2,7 @@ import { sort } from '../../types/object/module.f.ts'
 import { run } from './module.f.ts'
 import { stringifyAsTree } from '../serializer/module.f.ts'
 
-export default {
+export const proof = {
     test: () => {
         const djs = run([1])([])
         const result = stringifyAsTree(sort)(djs)

--- a/fs/djs/parser/proof.f.ts
+++ b/fs/djs/parser/proof.f.ts
@@ -12,7 +12,7 @@ const tokenizeString
 
 const stringifyDjsModule = stringifyAsTree(sort)
 
-export default {
+export const proof = {
     valid: [
         () => {
             const tokenList = tokenizeString('export default null')

--- a/fs/djs/proof.f.ts
+++ b/fs/djs/proof.f.ts
@@ -9,7 +9,7 @@ const readOutput = (root: typeof emptyState.root, path: string): string => {
     return utf8ToString(file)
 }
 
-export default {
+export const proof = {
     tooFewArgs: {
         noArgs: () => {
             const [state, code] = virtual(emptyState)(compile([]))

--- a/fs/djs/serializer/proof.f.ts
+++ b/fs/djs/serializer/proof.f.ts
@@ -3,7 +3,7 @@ import { sort } from '../../types/object/module.f.ts'
 import { identity } from '../../types/function/module.f.ts'
 import { setProperty } from '../../json/module.f.ts'
 
-export default {
+export const proof = {
     stringify: [
         {
             testPrimitives: () => {

--- a/fs/djs/tokenizer-new/proof.f.ts
+++ b/fs/djs/tokenizer-new/proof.f.ts
@@ -146,7 +146,7 @@ const getTokensFromAstRule
     }
 
 
-export default {
+export const proof = {
     isValid: [() => {
             const m = descentParser(jsGrammar())
 

--- a/fs/djs/tokenizer/proof.f.ts
+++ b/fs/djs/tokenizer/proof.f.ts
@@ -18,7 +18,7 @@ const withoutMetada
     : (tokenWithMetada: DjsTokenWithMetadata) => DjsToken
     = tokenWithMetada => { return tokenWithMetada.token }
 
-export default {
+export const proof = {
     djs: [
         () => {
             const result = stringify(tokenizeString(''))

--- a/fs/djs/transpiler/proof.f.ts
+++ b/fs/djs/transpiler/proof.f.ts
@@ -9,7 +9,7 @@ const run = (root: Dir) => (path: string) => {
     return result
 }
 
-export default {
+export const proof = {
     parse: () => {
         const result = run({ a: utf8('export default 1') })('a')
         if (result[0] === 'error') { throw result[1] }

--- a/fs/fsc/proof.f.ts
+++ b/fs/fsc/proof.f.ts
@@ -18,7 +18,7 @@ const withName = (name: string): () => undefined =>
     // translated into one command: define a `function [name]() { return undefined }`
     (Object.getOwnPropertyDescriptor({[name]: () => undefined}, name) as any).value
 
-export default {
+export const proof = {
     a: () => {
         const x = f('1')
         if (x !== '["1"]') { throw x }

--- a/fs/fsm/proof.f.ts
+++ b/fs/fsm/proof.f.ts
@@ -34,7 +34,7 @@ const buildDfa = () => {
     return dfa(grammar)
 }
 
-export default {
+export const proof = {
     dfa: () => {
         const dfa = buildDfa()
         const entries = Object.entries(dfa)

--- a/fs/html/proof.f.ts
+++ b/fs/html/proof.f.ts
@@ -1,6 +1,6 @@
 import { htmlToString, type Element } from "./module.f.ts"
 
-export default {
+export const proof = {
     empty: () => {
         const r = htmlToString(['html'])
         if (r !== '<!DOCTYPE html><html></html>') { throw `empty: ${r}` }

--- a/fs/js/tokenizer/proof.f.ts
+++ b/fs/js/tokenizer/proof.f.ts
@@ -18,7 +18,7 @@ const withoutMetada
     : (tokenWithMetada: JsTokenWithMetadata) => JsToken
     = tokenWithMetada => tokenWithMetada.token
 
-export default {
+export const proof = {
     djs: [
         () => {
             const result = stringify(tokenizeString(''))

--- a/fs/json/parser/proof.f.ts
+++ b/fs/json/parser/proof.f.ts
@@ -11,7 +11,7 @@ const tokenizeString
 
 const stringify = jsonStringify(sort)
 
-export default {
+export const proof = {
     valid: [
         () => {
             const tokenList = tokenizeString('null')

--- a/fs/json/proof.f.ts
+++ b/fs/json/proof.f.ts
@@ -2,7 +2,7 @@ import { setProperty, stringify } from './module.f.ts'
 import { sort } from '../types/object/module.f.ts'
 import { identity } from '../types/function/module.f.ts'
 
-export default {
+export const proof = {
     setProperty: () => {
         if (setProperty("Hello")([])({}) !== "Hello") { throw 'error' }
     },

--- a/fs/json/serializer/proof.f.ts
+++ b/fs/json/serializer/proof.f.ts
@@ -3,7 +3,7 @@ import * as list from '../../types/list/module.f.ts'
 
 const { toArray } = list
 
-export default {
+export const proof = {
     arrayWrap: [
         () => {
             const result = JSON.stringify(toArray(arrayWrap(null)))

--- a/fs/json/tokenizer/proof.f.ts
+++ b/fs/json/tokenizer/proof.f.ts
@@ -10,7 +10,7 @@ const tokenizeString
 
 const stringify = stringifyAsTree(sort)
 
-export default {
+export const proof = {
     json: [
         () => {
             const result = stringify(tokenizeString(''))

--- a/fs/path/proof.f.ts
+++ b/fs/path/proof.f.ts
@@ -1,6 +1,6 @@
 import { concat, normalize, relativize } from "./module.f.ts"
 
-export const normalizeTest = [
+const normalizeTest = [
     () => {
         const norm = normalize("dir/file.json")
         if (norm !== "dir/file.json") { throw norm }
@@ -19,7 +19,7 @@ export const normalizeTest = [
     },
 ]
 
-export const concatTest = [
+const concatTest = [
     () => {
         const c = concat("a")("b")
         if (c !== "a/b") { throw c }
@@ -34,7 +34,7 @@ export const concatTest = [
     },
 ]
 
-export const relativizeTest = [
+const relativizeTest = [
     () => {
         const r = relativize('/repo', '/repo/fs/a.ts')
         if (r !== './fs/a.ts') { throw r }
@@ -48,3 +48,4 @@ export const relativizeTest = [
         if (r !== './fs/a.ts') { throw r }
     },
 ]
+export const proof = { normalizeTest, concatTest, relativizeTest }

--- a/fs/sul/id/proof.f.ts
+++ b/fs/sul/id/proof.f.ts
@@ -20,7 +20,7 @@ assertEq(asBase(level3Id(0n)), 0n)
 assertEq(asBase(hashId(0n)), 1n << 0xFFn)
 assertEq(asBase(hFF), mask(0x100n))
 
-export default {
+export const proof = {
     // Two level-3 literals whose combined bit vectors fit inline (≤ 253 bits)
     inline_00_00: () => assertEq(compress(level3Id(0x00n), level3Id(0x00n)), rawId(vec(16n)(0x0000n))),
     inline_00_01: () => assertEq(compress(level3Id(0x00n), level3Id(0x01n)), rawId(vec(16n)(0x0001n))),

--- a/fs/sul/level/hash/proof.f.ts
+++ b/fs/sul/level/hash/proof.f.ts
@@ -27,7 +27,7 @@ const verifyStorage = (storage: NodeList) => {
 const s0 = level3Id(0n)
 const s1 = level3Id(1n)
 
-export default {
+export const proof = {
     // Minimum word [s0, t] with t == s0
     min_equal: () => {
         const [out, storage] = runWord([s0, s0])

--- a/fs/sul/level/literal/proof.f.ts
+++ b/fs/sul/level/literal/proof.f.ts
@@ -59,7 +59,7 @@ const w = (symbol: bigint, expected: Vec) => {
     if (out !== symbol) throw out
 }
 
-export default {
+export const proof = {
     x2: () => {
         const { c, n } = tests(0n)
         c(-1n, 0n)

--- a/fs/sul/proof.f.ts
+++ b/fs/sul/proof.f.ts
@@ -18,7 +18,7 @@ const id = (bits: readonly bigint[]): Id => run(bits)[0]
 
 const zeros = (n: number): readonly bigint[] => new Array(n).fill(0n)
 
-export default {
+export const proof = {
     deterministic: () => {
         assertEq(id(zeros(16)), id(zeros(16)))
     },

--- a/fs/text/ascii/proof.f.ts
+++ b/fs/text/ascii/proof.f.ts
@@ -4,7 +4,7 @@ import { sort } from '../../types/object/module.f.ts'
 
 const stringify = jsonStringify(sort)
 
-export default {
+export const proof = {
     range: () => {
         const r = stringify(range("A"))
         if (r !== '[65,65]') { throw r }

--- a/fs/text/proof.f.ts
+++ b/fs/text/proof.f.ts
@@ -1,7 +1,7 @@
 import { flat, utf8, utf8ToString, type Block } from './module.f.ts'
 import { join } from '../types/string/module.f.ts'
 
-export default {
+export const proof = {
     block: () => {
         const text: Block = [
             'a',

--- a/fs/text/sgr/proof.f.ts
+++ b/fs/text/sgr/proof.f.ts
@@ -1,6 +1,6 @@
 import { fgRed, createConsoleText, backspace } from './module.f.ts'
 
-export default [
+export const proof = [
     () => {
         if (fgRed !== '\x1b[31m') {
             throw new Error('Test failed: sgr(0)')

--- a/fs/text/utf16/proof.f.ts
+++ b/fs/text/utf16/proof.f.ts
@@ -13,7 +13,7 @@ import { toArray } from '../../types/list/module.f.ts'
 const stringify = (a: readonly Unknown[]) =>
     jsonStringify(sort)(a)
 
-export default {
+export const proof = {
     toCodePointList: [
         () => {
             const result = stringify(toArray(toCodePointList([-1, 65536])))

--- a/fs/text/utf8/proof.f.ts
+++ b/fs/text/utf8/proof.f.ts
@@ -5,7 +5,7 @@ import { toArray } from '../../types/list/module.f.ts'
 
 const stringify = jsonStringify(sort)
 
-export default {
+export const proof = {
     toCodePoint: [
         () => {
             const result = stringify(toArray(toCodePointList([-1, 256])))

--- a/fs/types/array/proof.f.ts
+++ b/fs/types/array/proof.f.ts
@@ -4,7 +4,7 @@ import { sort } from '../object/module.f.ts'
 
 const stringify = jsonStringify(sort)
 
-export default {
+export const proof = {
     stringify: () => {
         const result = stringify([1, 20, 300])
         if (result !== '[1,20,300]') { throw result }

--- a/fs/types/bigfloat/proof.f.ts
+++ b/fs/types/bigfloat/proof.f.ts
@@ -1,6 +1,6 @@
 import { decToBin } from './module.f.ts'
 
-export default {
+export const proof = {
     decToBin: [
         () => {
             const result = decToBin([0n, 0])

--- a/fs/types/bigint/proof.f.ts
+++ b/fs/types/bigint/proof.f.ts
@@ -164,7 +164,7 @@ const benchmarkSmall: Benchmark = f => () => {
     } while (c !== 0n)
 }
 
-export default {
+export const proof = {
     example: () => {
         const total = sum([1n, 2n, 3n]) // 6n
         if (total !== 6n) { throw total }

--- a/fs/types/bit_vec/proof.f.ts
+++ b/fs/types/bit_vec/proof.f.ts
@@ -62,7 +62,7 @@ const concat = (e: BitOrder) => (r: Vec) => () => {
     if (ab !== r) { throw ab }
 }
 
-export default {
+export const proof = {
     examples: {
         vec: () => {
             const vec4 = vec(4n)

--- a/fs/types/btree/find/proof.f.ts
+++ b/fs/types/btree/find/proof.f.ts
@@ -116,4 +116,4 @@ const test = () => {
     }
 }
 
-export default test
+export const proof = test

--- a/fs/types/btree/proof.f.ts
+++ b/fs/types/btree/proof.f.ts
@@ -68,7 +68,7 @@ const test = () => {
     }
 }
 
-export default {
+export const proof = {
     valueTest1,
     valuesTest2,
     findTrue,

--- a/fs/types/btree/remove/proof.f.ts
+++ b/fs/types/btree/remove/proof.f.ts
@@ -485,7 +485,7 @@ const test2 = () => {
     }
 }
 
-export default {
+export const proof = {
     test,
     test2,
 }

--- a/fs/types/btree/set/proof.f.ts
+++ b/fs/types/btree/set/proof.f.ts
@@ -351,4 +351,4 @@ const test = [
     }
 ]
 
-export default test
+export const proof = test

--- a/fs/types/byte_set/proof.f.ts
+++ b/fs/types/byte_set/proof.f.ts
@@ -6,7 +6,7 @@ import { sort } from '../object/module.f.ts'
 const stringify: (a: readonly Unknown[]) => string
     = jsonStringify(sort)
 
-export default {
+export const proof = {
     has: [
         () => {
             if (has(0)(empty)) { throw empty }

--- a/fs/types/effects/node/proof.f.ts
+++ b/fs/types/effects/node/proof.f.ts
@@ -3,7 +3,7 @@ import { pure } from "../module.f.ts"
 import { fetch, mkdir, now, readdir, readFile, rm, sandbox, writeFile } from "./module.f.ts"
 import { emptyState, virtual } from "./virtual/module.f.ts"
 
-export default {
+export const proof = {
     map: () => {
         let e = readFile('hello').step(([k, v]) => {
             if (k === 'error') { throw v }

--- a/fs/types/effects/proof.f.ts
+++ b/fs/types/effects/proof.f.ts
@@ -1,6 +1,6 @@
 import { foldStep, forEachStep, pure } from './module.f.ts'
 
-export default {
+export const proof = {
     foldStep: {
         empty: () => {
             const e = foldStep

--- a/fs/types/function/compare/proof.f.ts
+++ b/fs/types/function/compare/proof.f.ts
@@ -1,6 +1,6 @@
 import { cmp } from './module.f.ts'
 
-export default () => {
+export const proof = () => {
     {
         const result = cmp(true)(false)
         if (result !== 1) { throw result }

--- a/fs/types/function/operator/proof.f.ts
+++ b/fs/types/function/operator/proof.f.ts
@@ -11,47 +11,47 @@ import {
     reduceToScan,
 } from './module.f.ts'
 
-export const joinTest = () => {
+const joinTest = () => {
     const result = join(', ')('world')('hello')
     if (result !== 'hello, world') { throw result }
 }
 
-export const concatTest = () => {
+const concatTest = () => {
     const result = concat('world')('hello')
     if (result !== 'helloworld') { throw result }
 }
 
-export const logicalNotTest = () => {
+const logicalNotTest = () => {
     if (logicalNot(true) !== false) { throw 'expected false' }
     if (logicalNot(false) !== true) { throw 'expected true' }
 }
 
-export const strictEqualTest = () => {
+const strictEqualTest = () => {
     if (!strictEqual(1)(1)) { throw 'expected true' }
     if (strictEqual(1)(2)) { throw 'expected false' }
 }
 
-export const additionTest = () => {
+const additionTest = () => {
     const result = addition(3)(4)
     if (result !== 7) { throw result }
 }
 
-export const minTest = () => {
+const minTest = () => {
     if (min(3)(5) !== 3) { throw 'min(3)(5)' }
     if (min(7)(2) !== 2) { throw 'min(7)(2)' }
 }
 
-export const maxTest = () => {
+const maxTest = () => {
     if (max(3)(5) !== 5) { throw 'max(3)(5)' }
     if (max(7)(2) !== 7) { throw 'max(7)(2)' }
 }
 
-export const incrementTest = () => {
+const incrementTest = () => {
     if (increment(4) !== 5) { throw 'increment(4)' }
     if (increment(0) !== 1) { throw 'increment(0)' }
 }
 
-export const foldToScanTest = () => {
+const foldToScanTest = () => {
     const scan = foldToScan(addition)(0)
     const [v1, scan2] = scan(3)
     if (v1 !== 3) { throw v1 }
@@ -59,10 +59,12 @@ export const foldToScanTest = () => {
     if (v2 !== 7) { throw v2 }
 }
 
-export const reduceToScanTest = () => {
+const reduceToScanTest = () => {
     const scan = reduceToScan(addition)
     const [v0, scan2] = scan(10)
     if (v0 !== 10) { throw v0 }
     const [v1] = scan2(5)
     if (v1 !== 15) { throw v1 }
 }
+
+export const proof = { joinTest, concatTest, logicalNotTest, strictEqualTest, additionTest, minTest, maxTest, incrementTest, foldToScanTest, reduceToScanTest }

--- a/fs/types/function/proof.f.ts
+++ b/fs/types/function/proof.f.ts
@@ -1,6 +1,6 @@
 import { fn } from './module.f.ts'
 
-export default () => {
+export const proof = () => {
     const f: (x: string) => readonly[string]
         = x => [x]
     const g: (x: readonly[string]) => readonly[number]

--- a/fs/types/list/proof.f.ts
+++ b/fs/types/list/proof.f.ts
@@ -299,7 +299,7 @@ const stress = () => ({
 
 })
 
-export default {
+export const proof = {
     stringifyTest,
     cycle: cycleTest,
     countdown: countdownTest,

--- a/fs/types/map/proof.f.ts
+++ b/fs/types/map/proof.f.ts
@@ -1,6 +1,6 @@
 import { mapSet, mapDelete } from './module.f.ts'
 
-export default {
+export const proof = {
     set: () => {
         const map = mapSet(new Map(), 'a', 'b')
         if (map.get('a') !== 'b') { throw 'error' }

--- a/fs/types/monoid/proof.f.ts
+++ b/fs/types/monoid/proof.f.ts
@@ -1,6 +1,6 @@
 import { repeat, type Monoid } from "./module.f.ts";
 
-export default {
+export const proof = {
     numberAdd: () => {
         const add: Monoid<number> = {
              identity: 0,

--- a/fs/types/nibble_set/proof.f.ts
+++ b/fs/types/nibble_set/proof.f.ts
@@ -1,7 +1,7 @@
 import { every, map, countdown } from '../list/module.f.ts'
 import { empty, has, set, setRange, unset, universe, complement } from './module.f.ts'
 
-export default {
+export const proof = {
     has: () => {
         if (has(0)(empty)) { throw empty }
         if (has(1)(empty)) { throw empty }

--- a/fs/types/nominal/proof.f.ts
+++ b/fs/types/nominal/proof.f.ts
@@ -4,7 +4,7 @@ declare const noCompareBrand: unique symbol
 
 declare const brand: unique symbol
 
-export default {
+export const proof = {
     pre: () => {
         type Str = Nominal<'utf8', 'v0', bigint>
         const strA: Str = asNominal(0b1_11000010_10100010_11000010_10100011n) // "¢£"

--- a/fs/types/nullable/proof.f.ts
+++ b/fs/types/nullable/proof.f.ts
@@ -1,6 +1,6 @@
 import { map, match, toOption } from './module.f.ts'
 
-export default [
+export const proof = [
     () => {
         const optionSq = map((v: number) => v * v)
         const sq3 = optionSq(3)

--- a/fs/types/number/proof.f.ts
+++ b/fs/types/number/proof.f.ts
@@ -1,6 +1,6 @@
 import { sum, min, max, cmp, countOnes } from './module.f.ts'
 
-export default {
+export const proof = {
     sum: () => {
         const result = sum([2, 3, 4, 5])
         if (result !== 14) { throw result }

--- a/fs/types/object/proof.f.ts
+++ b/fs/types/object/proof.f.ts
@@ -2,7 +2,7 @@ import { at } from './module.f.ts'
 
 type E<A, B> = A extends B ? B extends A ? true : false : false
 
-export default {
+export const proof = {
     ctor: () => {
         const a = {}
         const value = at('constructor')(a)

--- a/fs/types/ordered_map/proof.f.ts
+++ b/fs/types/ordered_map/proof.f.ts
@@ -1,7 +1,7 @@
 import { at, setReplace, setReduce, empty, entries, remove, type OrderedMap } from './module.f.ts'
 import { toArray } from '../list/module.f.ts'
 
-export default {
+export const proof = {
     main: [
         () => {
             let m = setReplace('a')(1)(null)

--- a/fs/types/patricia_trie/proof.f.ts
+++ b/fs/types/patricia_trie/proof.f.ts
@@ -138,7 +138,7 @@ const ascending = () => runExample(
     [0, 0, 0, 2, 1, 0, 1, 0, 3, 0, 0, 1, 2, 0, 0, 0],
 )
 
-export default {
+export const proof = {
     empty,
     singleLeaf,
     twoLeaves,

--- a/fs/types/prime_field/proof.f.ts
+++ b/fs/types/prime_field/proof.f.ts
@@ -1,6 +1,6 @@
 import { prime_field, sqrt } from './module.f.ts'
 
-export default {
+export const proof = {
     prime_field_test: () => {
         const p = 0xffffffff_ffffffff_ffffffff_ffffffff_ffffffff_ffffffff_fffffffe_fffffc2fn;
         const f = prime_field(p)

--- a/fs/types/range/proof.f.ts
+++ b/fs/types/range/proof.f.ts
@@ -1,6 +1,6 @@
 import { contains } from './module.f.ts'
 
-export default () => {
+export const proof = () => {
     if (!contains([0, 5])(1)) { throw 1 }
     if (!contains([0, 5])(0)) { throw 0 }
     if (!contains([0, 5])(5)) { throw 5 }

--- a/fs/types/range_map/proof.f.ts
+++ b/fs/types/range_map/proof.f.ts
@@ -17,7 +17,7 @@ const op: Properties<SortedSet<string>>
         def: []
     }
 
-export default {
+export const proof = {
     example: () => {
         const rmOps = rangeMap({
             union: a => b => a | b,

--- a/fs/types/result/proof.f.ts
+++ b/fs/types/result/proof.f.ts
@@ -1,6 +1,6 @@
 import { error, ok, unwrap, invert, type Result } from "./module.f.ts"
 
-export const example = () => {
+const example = () => {
     const success: Result<number, string> = ok(42)
     const failure: Result<number, string> = error('Something went wrong')
 
@@ -11,14 +11,14 @@ export const example = () => {
     if (v !== 'Something went wrong') { throw 'error' }
 }
 
-export const invertTest = () => {
+const invertTest = () => {
     const [k0, v0] = invert(ok(42))
     if (k0 !== 'error' || v0 !== 42) { throw [k0, v0] }
     const [k1, v1] = invert(error('oops'))
     if (k1 !== 'ok' || v1 !== 'oops') { throw [k1, v1] }
 }
 
-export const unwrapError = () => {
+const unwrapError = () => {
     let caught = false
     try { unwrap(error('oops')) } catch (e) {
         if (e !== 'oops') { throw e }
@@ -26,3 +26,5 @@ export const unwrapError = () => {
     }
     if (!caught) { throw 'expected throw' }
 }
+
+export const proof = { example, invertTest, unwrapError }

--- a/fs/types/rtti/parse/proof.f.ts
+++ b/fs/types/rtti/parse/proof.f.ts
@@ -42,7 +42,7 @@ const assertDeepEqual = (a: unknown, b: unknown): void => {
     throw `not deep-equal: ${String(a)} vs ${String(b)}`
 }
 
-export default {
+export const proof = {
     boolean: {
         ok: () => {
             type _ = Assert<Equal<Ts<typeof boolean>, boolean>>

--- a/fs/types/rtti/proof.f.ts
+++ b/fs/types/rtti/proof.f.ts
@@ -12,7 +12,7 @@ const tests: Tests = {
     function: [() => undefined]
 }
 
-export default {
+export const proof = {
     typeof: Object.fromEntries(Object.entries(tests).map(([k, a]) => [k, a.map(v => () => {
         if (typeof v !== k) { throw `typeof ${v} !== ${k}` }
     })])),

--- a/fs/types/rtti/ts/proof.f.ts
+++ b/fs/types/rtti/ts/proof.f.ts
@@ -12,7 +12,7 @@ const eq = (rtti: Type, expected: string) => {
     if (result !== expected) { throw `expected ${JSON.stringify(expected)}, got ${JSON.stringify(result)}` }
 }
 
-export default {
+export const proof = {
     tag0: {
         boolean: () => eq(boolean, 'boolean'),
         number: () => eq(number, 'number'),

--- a/fs/types/rtti/validate/proof.f.ts
+++ b/fs/types/rtti/validate/proof.f.ts
@@ -17,7 +17,7 @@ const assertErrorPath = (expected: readonly string[]) =>
         }
     }
 
-export default {
+export const proof = {
     boolean: {
         ok: () => {
             type _ = Assert<Equal<Ts<typeof boolean>, boolean>>

--- a/fs/types/sorted_list/proof.f.ts
+++ b/fs/types/sorted_list/proof.f.ts
@@ -10,7 +10,7 @@ const str: (a: readonly Unknown[]) => string
 
 const reverseCmp = flip(cmp)
 
-export default {
+export const proof = {
     sortedMergre: [
         () => {
             const result = str(toArray(merge(cmp)([2, 3, 4])([1, 3, 5])))

--- a/fs/types/sorted_set/proof.f.ts
+++ b/fs/types/sorted_set/proof.f.ts
@@ -10,7 +10,7 @@ const str: (a: readonly Unknown[]) => string
 
 const reverseCmp = flip(cmp)
 
-export default {
+export const proof = {
     example: () => {
         const cmp = (a: number) => (b: number) => a < b ? -1 : a > b ? 1 : 0
 

--- a/fs/types/string/proof.f.ts
+++ b/fs/types/string/proof.f.ts
@@ -1,7 +1,7 @@
 import { join, concat, repeat, cmp, splitAt } from './module.f.ts'
 import { repeat as repeatList } from '../list/module.f.ts'
 
-export default {
+export const proof = {
     example: () => {
         const words = ['hello', 'world']
         if (join(' ')(words) !== 'hello world') { throw 0 }

--- a/fs/types/string_set/proof.f.ts
+++ b/fs/types/string_set/proof.f.ts
@@ -1,6 +1,6 @@
 import { contains, fromValues, remove, set } from './module.f.ts'
 
-export default {
+export const proof = {
     example: () => {
         let mySet = fromValues(['apple', 'banana', 'cherry']);
         if (!contains('banana')(mySet)) { throw '1' }

--- a/fs/types/ts/proof.f.ts
+++ b/fs/types/ts/proof.f.ts
@@ -92,3 +92,5 @@ export const printerMutableRecord = () => {
     const r = mut.record('number')
     if (r !== '{[k:string]:number}') { throw r }
 }
+
+export const proof = { primitiveNull,primitiveBigint,primitiveString,primitiveNumberFinite,primitiveNumberInfinite,primitiveUndefined,primitiveBoolean,unionEmpty,unionSingle,unionMulti,printerReadonlyTuple,printerReadonlyStruct,printerReadonlyArray,printerReadonlyRecord,printerMutableTuple,printerMutableStruct,printerMutableArray,printerMutableRecord }

--- a/fs/types/uint8array/proof.f.ts
+++ b/fs/types/uint8array/proof.f.ts
@@ -13,7 +13,7 @@ const assertArrayEq = (a: Uint8Array, b: Uint8Array) => {
     }
 }
 
-export default {
+export const proof = {
     empty: () => {
         const input = new Uint8Array()
         const vec = toVec(input)

--- a/issues/demo/sample/proof.f.js
+++ b/issues/demo/sample/proof.f.js
@@ -7,7 +7,7 @@ const arrayOfTests = [
   }
 ]
 
-export default {
+export const proof = {
   arrayOfTests,
   generatingTests: () => arrayOfTests,
 }

--- a/issues/proof.f.ts
+++ b/issues/proof.f.ts
@@ -6,7 +6,7 @@ const utf8 = (...x: [readonly string[]]) => x
 
 type TemplateType = `<html>${string}</html>`
 
-export default {
+export const proof = {
     literal: () => {
         const x = utf8`17`
         const m: TemplateType = '<html>Hello</html>'

--- a/nanvm-lib/tests/proof.f.ts
+++ b/nanvm-lib/tests/proof.f.ts
@@ -13,7 +13,7 @@ const nanRes = (op: (n: unknown) => unknown) => (n: unknown): void => {
     }
 }
 
-export default {
+export const proof = {
     eq: () => {
         const e = (a: unknown) => (b: unknown): void => {
             if (a === b) { } else { throw [a, '===', b] }

--- a/nanvm-lib/tests/vm/proof.f.ts
+++ b/nanvm-lib/tests/vm/proof.f.ts
@@ -1,6 +1,6 @@
 const stringCoercion = String
 
-export default {
+export const proof = {
     stringCoercion: {
         number: () => {
             if (stringCoercion(123) !== '123') { throw [123, 'toString', '123'] }


### PR DESCRIPTION
## Summary

Implements step 1 of [i65Y-proof-by-export](./issues/65Y-proof-by-export.md): the runner now discovers proof trees by looking for an exported `proof` property on each module, rather than walking all module exports (including `default`).

### Changes

**Runner** (`fs/dev/module.f.ts`, `fs/dev/tf/module.f.ts`):
- `Module` type: `default?` → `proof?`
- `runModuleMap` / `registerModuleMap`: skip modules without a `proof` export; pass only `v.proof` to the runner — the rest of the module is invisible to the test framework

**Proof files** (81 files):
- Files with `export default { … }` → `export const proof = { … }`
- Files with only named exports: de-exported, wrapped in `export const proof = { … }` using shorthand properties
- `fs/dev/proof.f.ts`: `shouldPass` moved inside `proof`

**Self-tests** (`fs/dev/tf/proof.f.ts`):
- Virtual module fixtures wrapped with `proof:` to match new contract
- `namedExports` test updated: previously verified all module properties are walked; now verifies only `proof` is consumed and other properties are ignored

### Why

A module's proof is now intrinsic to its *content* — `export const proof = …` — rather than an external filename convention. This is the prerequisite for step 2 (widening the load gate to all `.f.ts`/`.f.js` files, enabling co-located white-box proofs).

## Test plan

- [x] `npx tsc` passes
- [x] `npm test` passes (1481 tests, fail 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)