### PR TITLE
dev: propagate predicate into allFiles; loadModuleMap accepts predicate

### DIFF
--- a/fs/dev/module.f.ts
+++ b/fs/dev/module.f.ts
@@ -72,7 +72,13 @@ export const shouldLoad = (s: string): boolean =>
     s.endsWith('proof.ts') || s.endsWith('proof.js') ||
     s.endsWith('proof.mts')|| s.endsWith('proof.mjs')
 
-export const allFiles = (s: string): Effect<Readdir | All, readonly string[]> => {
+const isSourceFile = (path: string): boolean =>
+    path.endsWith('.js') || path.endsWith('.ts') || path.endsWith('.mts') || path.endsWith('.mjs')
+
+const allFiles = (
+    s: string,
+    predicate: (path: string) => boolean,
+): Effect<Readdir | All, readonly string[]> => {
     const load = (p: string): Effect<Readdir | All, readonly string[]> => begin
         .step(() => readdir(p, {}))
         .step(d => {
@@ -86,7 +92,7 @@ export const allFiles = (s: string): Effect<Readdir | All, readonly string[]> =>
                     result = [...result, load(file)]
                     continue
                 }
-                if (name.endsWith('.js') || name.endsWith('.ts') || name.endsWith('.mts') || name.endsWith('.mjs')) {
+                if (predicate(file)) {
                     result = [...result, pure([file])]
                 }
             }
@@ -113,22 +119,22 @@ export type LoadModuleOperations = Access | Import | All | Readdir
 const { fromEntries } = Object
 
 /**
- * Discovers all `.f.js` / `.f.ts` / proof modules under `INIT_CWD` (or `.`
- * if unset) and imports them, returning a map from relative path to module
+ * Discovers all source files under `INIT_CWD` (or `.` if unset) that match
+ * `predicate`, imports them, and returns a map from relative path to module
  * exports.
  *
- * The optional `predicate` is applied to each discovered file path before
- * attempting to `import()` it. Files that don't match are skipped entirely
- * (no I/O). The predicate is an additional filter on top of `loadFile`'s
- * own guards (`.f.js`, `.f.ts`, `shouldLoad`); the default `() => true`
- * preserves existing behaviour.
+ * The `predicate` is propagated into `allFiles` so that non-matching files
+ * are excluded before any `import()` is attempted — no wasted I/O.
+ * The default matches all JS/TS source files (`.js`, `.ts`, `.mts`, `.mjs`).
+ * `loadFile`'s own guards (`.f.js`, `.f.ts`, `shouldLoad`) still apply on
+ * top; the predicate only controls which files are discovered.
  *
  * The result is sorted by path key using `string.cmp` so the order is
  * deterministic regardless of filesystem traversal order.
  */
 export const loadModuleMap = (
     env: Env,
-    predicate: (path: string) => boolean = () => true,
+    predicate: (path: string) => boolean = isSourceFile,
 ): Effect<LoadModuleOperations, ModuleMap> => {
     const initCwd = env['INIT_CWD']
     const s = initCwd === undefined ? '.' : `${initCwd.replaceAll('\\', '/')}`
@@ -137,8 +143,8 @@ export const loadModuleMap = (
     //       we should consider optimize them by ALIQ technique or something similar.
     //       For example, we should be able to write it like `allFiles(s).flatMap(loadFile)`,
     //       then an effect runner can batch all file loading operations together.
-    return allFiles(s)
-        .step(files => all(...files.filter(predicate).map(loadFile)))
+    return allFiles(s, predicate)
+        .step(files => all(...files.map(loadFile)))
         .step(entries => pure(fromEntries(
             entries
                 .flat()
@@ -157,10 +163,9 @@ const index2 = begin
     .step(v => pure(unwrap(parseDenoJson(jsonParse(utf8ToString(unwrap(v)))))))
 
 const allFiles2aa = begin
-    .step(() => allFiles('.'))
+    .step(() => allFiles('.', v => v.endsWith('/module.f.ts') || v.endsWith('/module.ts')))
     .step(files => {
-        const list = files.filter(v => v.endsWith('/module.f.ts') || v.endsWith('/module.ts'))
-        const exportsA = list.map(v => [v, `./${v.substring(2)}`] as const)
+        const exportsA = files.map(v => [v, `./${v.substring(2)}`] as const)
         return pure(Object.fromEntries(exportsA))
     })
 

--- a/fs/dev/module.f.ts
+++ b/fs/dev/module.f.ts
@@ -113,13 +113,23 @@ export type LoadModuleOperations = Access | Import | All | Readdir
 const { fromEntries } = Object
 
 /**
- * Discovers all `.f.js` / `.f.ts` modules under `INIT_CWD` (or `.` if unset)
- * and imports them, returning a map from relative path to module exports.
+ * Discovers all `.f.js` / `.f.ts` / proof modules under `INIT_CWD` (or `.`
+ * if unset) and imports them, returning a map from relative path to module
+ * exports.
+ *
+ * The optional `predicate` is applied to each discovered file path before
+ * attempting to `import()` it. Files that don't match are skipped entirely
+ * (no I/O). The predicate is an additional filter on top of `loadFile`'s
+ * own guards (`.f.js`, `.f.ts`, `shouldLoad`); the default `() => true`
+ * preserves existing behaviour.
  *
  * The result is sorted by path key using `string.cmp` so the order is
  * deterministic regardless of filesystem traversal order.
  */
-export const loadModuleMap = (env: Env): Effect<LoadModuleOperations, ModuleMap> => {
+export const loadModuleMap = (
+    env: Env,
+    predicate: (path: string) => boolean = () => true,
+): Effect<LoadModuleOperations, ModuleMap> => {
     const initCwd = env['INIT_CWD']
     const s = initCwd === undefined ? '.' : `${initCwd.replaceAll('\\', '/')}`
     const prefix = s === '.' ? '' : s
@@ -128,7 +138,7 @@ export const loadModuleMap = (env: Env): Effect<LoadModuleOperations, ModuleMap>
     //       For example, we should be able to write it like `allFiles(s).flatMap(loadFile)`,
     //       then an effect runner can batch all file loading operations together.
     return allFiles(s)
-        .step(files => all(...files.map(loadFile)))
+        .step(files => all(...files.filter(predicate).map(loadFile)))
         .step(entries => pure(fromEntries(
             entries
                 .flat()

--- a/issues/65Y-loadmodulemap-predicate.md
+++ b/issues/65Y-loadmodulemap-predicate.md
@@ -1,7 +1,7 @@
 # 65Y-loadmodulemap-predicate. `loadModuleMap` should accept a file predicate
 
 **Priority:** P3
-**Status:** open
+**Status:** done
 
 ## Problem
 


### PR DESCRIPTION
## Summary

Implements and extends [i65Y-loadmodulemap-predicate](./issues/65Y-loadmodulemap-predicate.md): the file-discovery predicate is now propagated all the way into `allFiles` so non-matching files are excluded before any `import()` is attempted.

### Changes

**`fs/dev/module.f.ts`**:
- `isSourceFile` — new module-level constant holding the old hardcoded extension check (`.js`/`.ts`/`.mts`/`.mjs`); shared default
- `allFiles` — takes a required `predicate: (path: string) => boolean`; the hardcoded extension filter is replaced by `predicate(file)`; no longer exported (implementation detail of `loadModuleMap`)
- `loadModuleMap` — accepts optional `predicate` (default `isSourceFile`); passes it to `allFiles` so files that don't match are excluded before any I/O; the redundant `.filter(predicate)` is gone
- `allFiles2aa` (deno.json indexer) — passes its module filter (`/module.f.ts` or `/module.ts`) directly to `allFiles` instead of post-filtering

### Why

Callers that only need a subset of modules (e.g. `shouldLoad` for proof discovery, or the module-filter for `deno.json` export generation) previously loaded all matching files and discarded the rest. Now the predicate is applied at discovery time — no wasted `import()` calls.

## Test plan

- [x] `npx tsc` passes
- [x] `npm test` passes (1481 tests, fail 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)