### PR TITLE
ci: centralise GitHub Action refs in config/module.f.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `ci`: centralise GitHub Action refs in a single `ghActions` record in `fs/ci/config/module.f.ts` — full `owner/name@version` refs as values so call sites are `uses: ghActions.checkout`; version bumps for `checkout`, `setup-node`, `cache`, `setup-deno`, `setup-bun`, `wasmtime/setup`, `setup-wasmer` now touch one file ([i65Y-ci-action-versions-in-config](./issues/65Y-ci-action-versions-in-config.md)) [897](https://github.com/functionalscript/functionalscript/pull/897)
+
 ## 0.20.0
 
 - `tf`: step 2 — widen load gate to all `.f.ts`/`.f.js` + vanilla `proof.{ts,js,mts,mjs}`; rename `isTest` → `shouldLoad`; drop filename filter from `runModuleMap`/`registerModuleMap` — `v.proof !== undefined` is the sole gate; enables co-located white-box proofs ([i65Y-proof-by-export](./issues/65Y-proof-by-export.md)) [893](https://github.com/functionalscript/functionalscript/pull/893)

--- a/fs/ci/bun/module.f.ts
+++ b/fs/ci/bun/module.f.ts
@@ -4,7 +4,7 @@
  *
  * @module
  */
-import { bun } from '../config/module.f.ts'
+import { bun, ghActions } from '../config/module.f.ts'
 import { type Architecture, type MetaStep, type Os, type Step, clean, install, test } from '../common/module.f.ts'
 
 type Tool = {
@@ -20,7 +20,7 @@ const installOnWindowsArm = ({ def, name, path }: Tool) => (v: Os) => (a: Archit
 
 const installBun = installOnWindowsArm({
     def: {
-        uses: 'oven-sh/setup-bun@v2',
+        uses: ghActions.setupBun,
         with: {
             'bun-version': bun
         },

--- a/fs/ci/common/module.f.ts
+++ b/fs/ci/common/module.f.ts
@@ -5,7 +5,7 @@
  *
  * @module
  */
-import { images, rust } from '../config/module.f.ts'
+import { ghActions, images, rust } from '../config/module.f.ts'
 import { option, array, record, string } from '../../types/rtti/module.f.ts'
 import { type Ts } from '../../types/rtti/ts/module.f.ts'
 import { parse as rttiParse } from '../../types/rtti/parse/module.f.ts'
@@ -85,7 +85,7 @@ export const toSteps = (m: readonly MetaStep[]): readonly Step[] => {
             }
         }] : []),
         ...filter('install'),
-        { uses: 'actions/checkout@v5' },
+        { uses: ghActions.checkout },
         ...filter('test'),
     ]
 }

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -47,3 +47,23 @@ export const wasmer = '7.1.0'
 
 // https://www.npmjs.com/package/@typescript/native-preview?activeTab=versions
 export const tsgo = '7.0.0-dev.20260527.1'
+
+// GitHub Action references used by CI step builders. Each value is a full
+// `owner/name@version` ref so call sites can drop it into a step's `uses`
+// field without any string composition.
+export const ghActions = {
+    // https://github.com/marketplace/actions/checkout
+    checkout: 'actions/checkout@v5',
+    // https://github.com/marketplace/actions/setup-node-js-environment
+    setupNode: 'actions/setup-node@v6',
+    // https://github.com/marketplace/actions/cache
+    cache: 'actions/cache@v4',
+    // https://github.com/marketplace/actions/setup-deno
+    setupDeno: 'denoland/setup-deno@v2',
+    // https://github.com/marketplace/actions/setup-bun
+    setupBun: 'oven-sh/setup-bun@v2',
+    // https://github.com/bytecodealliance/actions
+    wasmtime: 'bytecodealliance/actions/wasmtime/setup@v1',
+    // https://github.com/wasmerio/setup-wasmer
+    wasmer: 'wasmerio/setup-wasmer@v3.1',
+} as const

--- a/fs/ci/deno/module.f.ts
+++ b/fs/ci/deno/module.f.ts
@@ -4,12 +4,12 @@
  *
  * @module
  */
-import { deno } from '../config/module.f.ts'
+import { deno, ghActions } from '../config/module.f.ts'
 import { type MetaStep, clean, install, test } from '../common/module.f.ts'
 
 export const denoSteps = (extra: readonly MetaStep[]): readonly MetaStep[] => clean([
     install({
-        uses: 'denoland/setup-deno@v2',
+        uses: ghActions.setupDeno,
         with: { 'deno-version': deno },
     }),
     test({ run: 'deno install' }),

--- a/fs/ci/node/module.f.ts
+++ b/fs/ci/node/module.f.ts
@@ -4,13 +4,13 @@
  *
  * @module
  */
-import { node, tsgo } from '../config/module.f.ts'
+import { ghActions, node, tsgo } from '../config/module.f.ts'
 import { type Jobs, type MetaStep, type Os, clean, findTgz, install, test, ubuntu } from '../common/module.f.ts'
 
 export const major = (v: string): string => v.split('.')[0]
 
 const installNode = (version: string) =>
-    ({ uses: 'actions/setup-node@v6', with: { 'node-version': version } })
+    ({ uses: ghActions.setupNode, with: { 'node-version': version } })
 
 const nodeInstall = (v: string) => [
     install(installNode(v)),

--- a/fs/ci/playwright/module.f.ts
+++ b/fs/ci/playwright/module.f.ts
@@ -4,7 +4,7 @@
  *
  * @module
  */
-import { images, node, playwright } from '../config/module.f.ts'
+import { ghActions, images, node, playwright } from '../config/module.f.ts'
 import { type Job, install, test, toSteps } from '../common/module.f.ts'
 import { basicNode } from '../node/module.f.ts'
 
@@ -14,7 +14,7 @@ export const playwrightJob: Job = {
     'runs-on': playwrightImage,
     steps: toSteps(basicNode(node.default)([
         install({
-            uses: 'actions/cache@v4',
+            uses: ghActions.cache,
             with: {
                 path: '~/.cache/ms-playwright',
                 key: `${playwrightImage}-playwright-${playwright}`,

--- a/fs/ci/rust/module.f.ts
+++ b/fs/ci/rust/module.f.ts
@@ -5,7 +5,7 @@
  *
  * @module
  */
-import { wasmer, wasmtime } from '../config/module.f.ts'
+import { ghActions, wasmer, wasmtime } from '../config/module.f.ts'
 import { type Architecture, type MetaStep, type Os, install, test } from '../common/module.f.ts'
 
 const cargoTest = (target?: string, config?: string): readonly MetaStep[] => {
@@ -46,11 +46,11 @@ export const rustSteps = (v: Os, a: Architecture): readonly MetaStep[] => [
     test({ run: 'cargo clippy -- -D warnings' }),
     ...cargoTest(),
     install({
-        uses: 'bytecodealliance/actions/wasmtime/setup@v1',
+        uses: ghActions.wasmtime,
         with: { version: wasmtime }
     }),
     install({
-        uses: 'wasmerio/setup-wasmer@v3.1',
+        uses: ghActions.wasmer,
         with: { version: `v${wasmer}` },
     }),
     ...wasmTarget('wasm32-wasip1'),

--- a/issues/65Y-ci-action-versions-in-config.md
+++ b/issues/65Y-ci-action-versions-in-config.md
@@ -1,7 +1,7 @@
 # 65Y-ci-action-versions-in-config. Centralise CI action versions in `config/module.f.ts`
 
 **Priority:** P4
-**Status:** open
+**Status:** done
 
 ## Problem
 
@@ -22,22 +22,43 @@ across several modules:
 Bumping any action version requires hunting across multiple files instead of
 changing one line in `config/module.f.ts`.
 
-## Proposal
+## Resolution
 
-Add an `actions` (or `ghActions`) record to `fs/ci/config/module.f.ts`:
+Added a `ghActions` record to `fs/ci/config/module.f.ts`. The design
+diverges from the original draft (which stored bare versions keyed by
+`owner/name`) and stores **full `owner/name@version` refs** instead, so
+call sites drop them straight into a step's `uses` field with no string
+composition:
 
 ```ts
-export const actions = {
-    'actions/checkout':                          'v5',
-    'actions/setup-node':                        'v6',
-    'actions/cache':                             'v4',
-    'denoland/setup-deno':                       'v2',
-    'oven-sh/setup-bun':                         'v2',
-    'bytecodealliance/actions/wasmtime/setup':   'v1',
-    'wasmerio/setup-wasmer':                     'v3.1',
+export const ghActions = {
+    checkout:  'actions/checkout@v5',
+    setupNode: 'actions/setup-node@v6',
+    cache:     'actions/cache@v4',
+    setupDeno: 'denoland/setup-deno@v2',
+    setupBun:  'oven-sh/setup-bun@v2',
+    wasmtime:  'bytecodealliance/actions/wasmtime/setup@v1',
+    wasmer:    'wasmerio/setup-wasmer@v3.1',
 } as const
 ```
 
-The key is the action name; call sites compose the full reference as
-`` `${name}@${actions[name]}` ``. Replace every inline string with such a
-reference.
+Why the full-ref shape was chosen over the original `name → version`
+shape:
+
+- **Call sites are trivial.** `uses: ghActions.checkout` reads cleanly;
+  the alternative `uses: \`actions/checkout@${actions['actions/checkout']}\``
+  forces every site to repeat the action name twice.
+- **Matches the existing config style.** Sibling pins (`bun`, `deno`,
+  `playwright`, `rust`, `wasmtime`, `wasmer`, `tsgo`) are bare strings
+  pinned for use at the call site, not key/value pairs. `ghActions`
+  inherits that shape.
+- **`dtolnay/rust-toolchain` is intentionally excluded.** Its tag *is*
+  the rust toolchain version (already pinned via `rust` in this file),
+  not an action version, so it stays as `dtolnay/rust-toolchain@${rust}`
+  in `fs/ci/common/module.f.ts`.
+
+Each entry carries a marketplace URL comment so version bumps follow the
+same review trail as `bun` / `deno` / `node` etc. Call sites updated in
+`fs/ci/{common,node,playwright,deno,bun,rust}/module.f.ts`. Regenerating
+`.github/workflows/ci.yml` via `npm run ci-update` produces no diff,
+confirming the change is purely structural.


### PR DESCRIPTION
## Summary

Closes [i65Y-ci-action-versions-in-config](../blob/main/issues/65Y-ci-action-versions-in-config.md).

Pulls the seven hardcoded GitHub Action refs (`actions/checkout@v5`, `actions/setup-node@v6`, `actions/cache@v4`, `denoland/setup-deno@v2`, `oven-sh/setup-bun@v2`, `bytecodealliance/actions/wasmtime/setup@v1`, `wasmerio/setup-wasmer@v3.1`) out of the per-tool CI builders into a single `ghActions` record in `fs/ci/config/module.f.ts`, so version bumps now touch one file instead of hunting across `common`/`node`/`playwright`/`deno`/`bun`/`rust`.

## Design note

The issue's original draft proposed `actions: { 'actions/checkout': 'v5', ... }` and composing the ref via template literals at every call site. I stored **full `owner/name@version` refs** as values instead, so call sites read `uses: ghActions.checkout` rather than `uses: \`actions/checkout@${actions['actions/checkout']}\``. Rationale (also captured in the issue file + the JSDoc on `ghActions`):

- Matches the bare-string style of sibling pins (`bun`, `deno`, `playwright`, ...) already in `config/module.f.ts`.
- No name repetition at the call site.
- `dtolnay/rust-toolchain@${rust}` stays inline — its tag *is* the rust toolchain version (already pinned), not an action version.

## Test plan

- [x] `npx tsc` — clean
- [x] `npm run fst` from `fs/ci/` — 4/4 ci proofs pass
- [x] `npm run fst` from repo root — 1481/1481 pass
- [x] `npm run ci-update` produces **no diff** in `.github/workflows/ci.yml` — change is purely structural

https://claude.ai/code/session_01S8HTgU7HAsdmxpya83gGX2

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8HTgU7HAsdmxpya83gGX2)_