### PR TITLE
Update TypeScript native preview to 7.0.0-dev.20260527.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.2"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -210,7 +210,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.2"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -378,7 +378,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.2"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -546,7 +546,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.2"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -714,7 +714,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.2"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -888,7 +888,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.2"
         },
         {
           "uses": "denoland/setup-deno@v2",

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -46,4 +46,4 @@ export const wasmtime = '45.0.0'
 export const wasmer = '7.1.0'
 
 // https://www.npmjs.com/package/@typescript/native-preview?activeTab=versions
-export const tsgo = '7.0.0-dev.20260527.1'
+export const tsgo = '7.0.0-dev.20260527.2'


### PR DESCRIPTION
## Summary
Updates the TypeScript native preview dependency to the latest development version across CI workflows and configuration.

## Changes
- Updated `@typescript/native-preview` from `7.0.0-dev.20260527.1` to `7.0.0-dev.20260527.2` in:
  - CI workflow configuration (`.github/workflows/ci.yml`) - 6 occurrences across different job definitions
  - TypeScript/Go configuration module (`fs/ci/config/module.f.ts`)

This ensures all CI environments and build configurations use the same, latest development version of the TypeScript native preview package.

https://claude.ai/code/session_015vRvKwWRDXqQoHdAkk1Ue5