### PR TITLE
Add CAS proof tests for write and read operations

### DIFF
--- a/fs/cas/proof.f.ts
+++ b/fs/cas/proof.f.ts
@@ -1,1 +1,33 @@
-export const proof = () => {}
+import { cas } from './module.f.ts'
+import { sha256 } from '../crypto/sha2/module.f.ts'
+import { empty, length } from '../types/bit_vec/module.f.ts'
+import type { Vec } from '../types/bit_vec/module.f.ts'
+import { pure } from '../types/effects/module.f.ts'
+import { run } from '../types/effects/mock/module.f.ts'
+
+export const proof = {
+    casWrite: () => {
+        const store = {
+            read: (_key: Vec) => pure(undefined as Vec | undefined),
+            write: (_key: Vec, _value: Vec) => pure(undefined as void),
+            list: () => pure([] as readonly Vec[]),
+        }
+        const c = cas(sha256)(store)
+        const [, hash] = run<never, undefined>({})(undefined)(c.write(empty))
+        // sha256 of empty input produces a 256-bit hash
+        if (length(hash) !== 256n) { throw ['expected 256-bit hash', length(hash)] }
+    },
+    casReadPassthrough: () => {
+        const stored = empty
+        const store = {
+            read: (_key: Vec) => pure(stored as Vec | undefined),
+            write: (_key: Vec, _value: Vec) => pure(undefined as void),
+            list: () => pure([stored] as readonly Vec[]),
+        }
+        const c = cas(sha256)(store)
+        const [, readResult] = run<never, undefined>({})(undefined)(c.read(empty))
+        if (readResult !== stored) { throw ['read should pass through', readResult] }
+        const [, listResult] = run<never, undefined>({})(undefined)(c.list())
+        if (listResult.length !== 1) { throw ['list should pass through', listResult] }
+    },
+}


### PR DESCRIPTION
## Summary
Implement proof-of-concept tests for the Content Addressable Storage (CAS) module, replacing the empty stub with functional test cases that verify core CAS operations.

## Key Changes
- **casWrite test**: Validates that writing empty input to CAS produces the expected 256-bit SHA256 hash
- **casReadPassthrough test**: Verifies that read and list operations correctly pass through stored values from the underlying store
- Added necessary imports for CAS module, SHA256 hashing, bit vector utilities, and effect system
- Converted `proof` from a function to an object containing named test cases

## Implementation Details
- Tests use a mock store implementation with configurable read/write/list operations
- Leverages the effect system (`pure`, `run`) to execute CAS operations in a controlled test environment
- Validates hash output length and data passthrough behavior with explicit error messages for debugging
- Tests are self-contained and don't require external dependencies beyond the module interfaces

https://claude.ai/code/session_018PLVka82LTzSEGpwzdWVRF