### PR TITLE
Clarify documentation on avoiding duplication in timing pattern

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ where `<...Module documentation...>` should be documentation for the module.
       Why this pattern is good:
       - The two `after = performance.now()` calls are necessary on the critical path — extracting them into a helper would measure the helper function's overhead instead of just the operation.
       - TypeScript tracks uninitialized values: declaring `let after: number` without initialization lets the type checker verify that `after` is assigned in all code paths before the final `return` statement.
-      - We still avoid duplication of non-critical computations: the `result` object is formed once, not duplicated. Only the timing capture (which must be immediate) appears twice.
+      - We still avoid duplication of non-critical computations: the return value of the function (`{ result, duration: after - before }`) is formed once, not duplicated. Only the timing capture (which must be immediate) appears twice.
   - Separation of concerns — move logic to its natural module even with a single consumer when the logic is conceptually distinct (e.g. path manipulation belongs in `fs/path`, not inline in a loader). First search for an appropriate existing module; create a new one only if no good fit exists. This is different from DRY extraction: it is always appropriate.
   - Avoid side effects and mutability.
 - When a sibling module already has the type or helper you need, import it — add `export` to the existing declaration if it's not yet exported, rather than duplicating it (e.g. `parse` reuses `Path`, `ValidationError`, `verror`, `prependPath`, `primitive0Validate`, `constPrimitiveValidate` from `validate`).


### PR DESCRIPTION
## Summary
Updated the AGENTS.md documentation to more precisely describe what is being formed once versus what appears twice in the critical timing pattern example.

## Changes
- Clarified the explanation of the timing pattern to specify that the return value object (`{ result, duration: after - before }`) is formed once, rather than the more vague reference to "the `result` object"
- This makes it clearer that only the timing capture operations (`performance.now()` calls) appear twice on the critical path, while the final object construction happens once

## Details
The change improves the accuracy of the documentation by being more explicit about which part of the code is duplicated (the timing measurements) versus which part is not (the return value construction). This helps readers better understand the rationale behind this code pattern.

https://claude.ai/code/session_01LRmbgnaFEpEDEJv3KV3vkW