### PR TITLE
ci: move rust-toolchain version into actions config; use uses() helper

### DIFF
--- a/fs/ci/common/module.f.ts
+++ b/fs/ci/common/module.f.ts
@@ -5,11 +5,10 @@
  *
  * @module
  */
-import { actions, images, rust } from '../config/module.f.ts'
+import { actions, images } from '../config/module.f.ts'
 import { option, array, record, string } from '../../types/rtti/module.f.ts'
 import { type Ts } from '../../types/rtti/ts/module.f.ts'
 import { parse as rttiParse } from '../../types/rtti/parse/module.f.ts'
-import type { Unknown } from '../../json/module.f.ts'
 
 export const os = ['ubuntu', 'macos', 'windows'] as const
 
@@ -82,13 +81,7 @@ export const toSteps = (m: readonly MetaStep[]): readonly Step[] => {
     const targets = m.flatMap(v => v.type === 'rust' && v.target !== undefined ? [v.target] : []).join(',')
     return [
         ...(aptGet !== '' ? [{ run: `sudo apt-get update && sudo apt-get install -y ${aptGet}` }] : []),
-        ...(needRust ? [{
-            uses: `dtolnay/rust-toolchain@${rust}`,
-            with: {
-                components: 'rustfmt,clippy',
-                targets
-            }
-        }] : []),
+        ...(needRust ? [uses('dtolnay/rust-toolchain', { components: 'rustfmt,clippy', targets })] : []),
         ...filter('install'),
         uses('actions/checkout'),
         ...filter('test'),

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -30,9 +30,6 @@ export const deno = '2.8.1'
 // https://www.npmjs.com/package/playwright
 export const playwright = '1.60.0'
 
-// https://rust-lang.org/
-export const rust = '1.95.0'
-
 // https://nodejs.org/en/download
 export const node = {
     default: '26.2.0',
@@ -66,5 +63,6 @@ export const actions = {
     'bytecodealliance/actions/wasmtime/setup': 'v1',
     // https://github.com/wasmerio/setup-wasmer
     'wasmerio/setup-wasmer': 'v3.1',
-    'dtolnay/rust-toolchain': rust,
+    // https://rust-lang.org/
+    'dtolnay/rust-toolchain': '1.95.0',
 } as const

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -66,4 +66,5 @@ export const actions = {
     'bytecodealliance/actions/wasmtime/setup': 'v1',
     // https://github.com/wasmerio/setup-wasmer
     'wasmerio/setup-wasmer': 'v3.1',
+    'dtolnay/rust-toolchain': rust,
 } as const


### PR DESCRIPTION
## Summary

Two small cleanups to the CI configuration for Rust:

- **`fs/ci/config/module.f.ts`** — move the `rust` version constant out of the top-level named exports and into the `actions` map as `'dtolnay/rust-toolchain': '1.95.0'`, consistent with how all other tool versions (checkout, setup-node, setup-bun, etc.) are tracked
- **`fs/ci/common/module.f.ts`** — replace the inline `{ uses: \`dtolnay/rust-toolchain@${rust}\`, with: { ... } }` object literal with the existing `uses()` helper, removing the now-unused `rust` import and the `Unknown` type import

No behaviour change — the generated CI YAML is identical.

## Test plan

- [x] `npx tsc` passes
- [x] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)