### PR TITLE
ci: add issues for Docker-based Ubuntu CI and Nix investigation

### DIFF
--- a/issues/65Z-ci-nix.md
+++ b/issues/65Z-ci-nix.md
@@ -1,0 +1,110 @@
+# 65Z-ci-nix. Investigate Nix as a package manager for CI environments
+
+**Priority:** P4
+**Status:** open
+
+## Summary
+
+Nix is a purely functional package manager (not a virtualizer) that provides
+reproducible, content-addressed tool environments. It is a candidate for
+replacing inline tool installations (`setup-node`, `setup-bun`, etc.) on
+macOS CI — and potentially Linux — without the overhead of Docker or a VM.
+
+## What Nix is (and is not)
+
+Nix manages tool binaries via a content-addressed store (`/nix/store`). When
+you enter a Nix shell (`nix develop`), `PATH` and related env vars point at
+Nix-managed binaries. **There is no virtualization**: the process runs
+natively on the host OS with the host kernel, syscalls, and filesystem.
+
+On macOS this means:
+- `process.platform === 'darwin'`
+- macOS-specific APIs (Keychain, FSEvents, etc.) are accessible
+- Tests exercise the real macOS environment that users run on
+
+This is the key advantage over Docker on macOS: Docker runs inside a Linux
+VM (via the Docker Desktop hypervisor), so it does not test macOS behaviour.
+
+## How it looks in GitHub Actions
+
+Jobs and steps are unchanged. Only `run:` steps need a Nix wrapper;
+`uses:` actions (including `actions/checkout`) run in the GitHub Actions
+Node.js sidecar and require no changes:
+
+```yaml
+jobs:
+  test:
+    runs-on: macos-26
+    steps:
+      - uses: DeterminateSystems/nix-installer-action@v4
+      - uses: DeterminateSystems/magic-nix-cache-action@v2  # caches Nix store
+      - uses: actions/checkout@v5                           # unchanged
+      - run: npm t
+        shell: nix develop --command bash -e {0}
+      - run: npm run fst
+        shell: nix develop --command bash -e {0}
+```
+
+The `magic-nix-cache-action` transparently caches the Nix store between runs
+so `nix develop` is fast after the first build — similar to Docker image
+caching but at the granularity of individual derivations (only changed
+packages are re-fetched).
+
+Alternatively, each step can be prefixed explicitly:
+```yaml
+      - run: nix develop --command npm t
+```
+
+The CI generator in `fs/ci/` would emit the `shell:` override or the
+`nix develop --command` prefix on `run:` steps; the overall job/step shape
+stays the same.
+
+## Platform support
+
+| Platform | Nix viable? | Notes |
+|---|---|---|
+| Linux (Intel + ARM) | ✅ | Works natively; Docker is the current plan ([i65Z-ci-scenario-docker](./65Z-ci-scenario-docker.md)) |
+| macOS | ✅ | **Best fit** — real macOS environment, no VM overhead |
+| Windows | ❌ | WSL2 only → runs a Linux kernel, not real Windows; no advantage over Docker |
+
+### Why Windows is out of scope
+
+Nix on Windows requires WSL2. Inside WSL2 the kernel is Linux, so
+`process.platform === 'linux'` — Windows-specific behaviour (path
+separators, PowerShell, NTFS, `cmd.exe`) is not tested. GitHub-hosted
+Windows runners also do not have WSL2 pre-enabled, and enabling it in CI
+has known reliability issues. Windows CI therefore stays with inline
+`setup-*` actions for the foreseeable future.
+
+## Playwright caveat
+
+Playwright's browser binaries and their system dependencies (glibc, libX11,
+etc.) are notoriously difficult to express in Nix derivations. This is the
+main reason [i65Z-ci-scenario-docker](./65Z-ci-scenario-docker.md) chose
+Docker for Linux (where Playwright runs) rather than Nix. Nix packaging of
+Playwright may improve over time.
+
+## Proposed split
+
+| Platform | Tool management | Real OS tested? |
+|---|---|---|
+| Linux (Intel + ARM) | Docker image | No (Linux container) |
+| macOS | Nix shell | ✅ Yes |
+| Windows | Inline `setup-*` actions | ✅ Yes |
+
+## Tasks
+
+- [ ] Evaluate `flake.nix` / `shell.nix` for the project's macOS tool set
+      (Node, Bun, Deno, Rust, Wasmtime, Wasmer)
+- [ ] Benchmark cold vs warm `nix develop` times on `macos-26` runners
+- [ ] Integrate `magic-nix-cache-action` and measure cache hit rate
+- [ ] Decide whether the CI generator (`fs/ci/`) emits `shell:` overrides or
+      explicit `nix develop --command` prefixes
+- [ ] Determine if tool versions in `fs/ci/config/module.f.ts` can be
+      single-sourced with `flake.nix` (e.g. via `builtins.fromJSON`)
+
+## Related
+
+- [i65Z-ci-scenario-docker](./65Z-ci-scenario-docker.md) — Docker plan for Linux CI (chose Docker over Nix due to Playwright)
+- [i145](./145-docker-linux-ci.md) — Docker containers for Linux CI jobs
+- [i095](./095-ci-docker.md) — original Docker CI idea

--- a/issues/65Z-ci-scenario-docker.md
+++ b/issues/65Z-ci-scenario-docker.md
@@ -1,0 +1,78 @@
+# 65Z-ci-scenario-docker. Run scenario tests in CI via a cached Docker image
+
+**Priority:** P3
+**Status:** open
+
+## Problem
+
+The scenario tests (`fs/dev/tf/scenarios/run.sh`) require several tools to be
+installed simultaneously — Node, Deno, Bun, and Playwright — which no single
+existing CI job provides. Today the scenario runner is not executed in CI at
+all, so regressions in scenario behaviour go undetected until a developer runs
+`run.sh` locally.
+
+Installing all four tools inline on every CI run would be slow. Playwright is
+already kept in a dedicated job specifically because its installation (browsers
++ browser deps) is expensive.
+
+## Proposal
+
+Build and cache a Docker image that has every required tool pre-installed and
+run the scenario suite inside it. The image is rebuilt only when a tool version
+changes; between rebuilds it is pulled from the GitHub Actions cache.
+
+### Image contents
+
+The Docker image should be generated from `fs/ci/` so that tool versions stay
+in sync with the rest of the CI matrix. It should include:
+
+| Tool | Version source |
+|------|----------------|
+| Node | `config.node.default` |
+| Deno | `config.deno` |
+| Bun | `config.bun` |
+| Playwright + browsers | `config.playwright` |
+
+Rust, Wasmtime, Wasmer and other build tools are **not** needed for the
+scenario job and should be omitted to keep the image small and the cache warm.
+
+### Cache key
+
+```
+linux-<arch>-scenario-node<NODE>-deno<DENO>-bun<BUN>-playwright<PW>
+```
+
+The key is derived from the version constants in `fs/ci/config/module.f.ts` so
+it is updated automatically whenever any version is bumped.
+
+### Architectures
+
+Run on both `ubuntu-24.04` (Intel x86-64) and `ubuntu-24.04-arm` (ARM64) — the
+same pair used for other Linux jobs — to catch architecture-specific issues.
+macOS and Windows are out of scope: the scenario tests are primarily exercising
+the framework's JavaScript behaviour, not OS-specific I/O.
+
+### Dockerfile
+
+Reuse and clean up the existing `docker/Dockerfile`, or generate a purpose-built
+one from `fs/ci/`. A generated Dockerfile is preferred so that version pins are
+single-sourced in `fs/ci/config/module.f.ts`.
+
+### What to run
+
+```sh
+for scenario in fs/dev/tf/scenarios/*.pass.ts fs/dev/tf/scenarios/*.fail.ts; do
+    for runner in fjs node bun deno playwright; do
+        sh fs/dev/tf/scenarios/run.sh $runner $scenario
+    done
+done
+```
+
+(Or an equivalent driven from the CI generator.)
+
+## Related
+
+- [i095](./095-ci-docker.md) — original Docker CI idea
+- [i145](./145-docker-linux-ci.md) — Docker containers for Linux CI jobs (broader scope)
+- [i183](./183-tf-framework-scenario-tests.md) — scenario test infrastructure
+- [i65Y-scenarios-proof](./65Y-scenarios-proof.md) — scenario files converted to `export const proof`; prerequisite for running them in CI

--- a/issues/65Z-ci-scenario-docker.md
+++ b/issues/65Z-ci-scenario-docker.md
@@ -1,78 +1,76 @@
-# 65Z-ci-scenario-docker. Run scenario tests in CI via a cached Docker image
+# 65Z-ci-scenario-docker. Replace Ubuntu CI jobs with cached Docker images
 
 **Priority:** P3
 **Status:** open
 
 ## Problem
 
-The scenario tests (`fs/dev/tf/scenarios/run.sh`) require several tools to be
-installed simultaneously — Node, Deno, Bun, and Playwright — which no single
-existing CI job provides. Today the scenario runner is not executed in CI at
-all, so regressions in scenario behaviour go undetected until a developer runs
-`run.sh` locally.
+Ubuntu CI jobs currently install every tool (Node, Bun, Deno, Rust, Wasmtime,
+Wasmer, etc.) from scratch on every run. This is slow and duplicates effort
+already paid on the previous run. Additionally:
 
-Installing all four tools inline on every CI run would be slow. Playwright is
-already kept in a dedicated job specifically because its installation (browsers
-+ browser deps) is expensive.
+- Playwright is kept in a **separate** job on Ubuntu solely because its
+  installation is expensive, fragmenting the matrix.
+- The scenario tests (`fs/dev/tf/scenarios/run.sh`) are not run in CI at all
+  because no single job has all required runners (Node, Bun, Deno, Playwright)
+  at once.
 
 ## Proposal
 
-Build and cache a Docker image that has every required tool pre-installed and
-run the scenario suite inside it. The image is rebuilt only when a tool version
-changes; between rebuilds it is pulled from the GitHub Actions cache.
+Replace the Ubuntu jobs with Docker-container jobs that pull a pre-built,
+cached image. The image is rebuilt only when a tool version changes; between
+rebuilds it is pulled from the GitHub Actions cache in seconds.
+
+### What changes
+
+| | Today | After |
+|---|---|---|
+| Ubuntu (Intel + ARM) | installs tools inline each run | pulls cached Docker image |
+| Playwright | separate Ubuntu job | merged into Docker Ubuntu job |
+| Scenario tests | not run in CI | run inside Docker Ubuntu job |
+| macOS / Windows | unchanged | unchanged (no Playwright) |
 
 ### Image contents
 
-The Docker image should be generated from `fs/ci/` so that tool versions stay
-in sync with the rest of the CI matrix. It should include:
+The Dockerfile should be **generated from `fs/ci/`** so that tool versions are
+single-sourced in `fs/ci/config/module.f.ts`. The image must include everything
+needed for Ubuntu CI, matching what macOS and Windows jobs install inline:
 
 | Tool | Version source |
 |------|----------------|
-| Node | `config.node.default` |
+| Node (default) | `config.node.default` |
 | Deno | `config.deno` |
 | Bun | `config.bun` |
 | Playwright + browsers | `config.playwright` |
+| Rust toolchain | `config.actions['dtolnay/rust-toolchain']` |
+| Wasmtime | `config.wasmtime` |
+| Wasmer | `config.wasmer` |
 
-Rust, Wasmtime, Wasmer and other build tools are **not** needed for the
-scenario job and should be omitted to keep the image small and the cache warm.
+`docker/Dockerfile` will be replaced by the generated one. The existing file
+can serve as a reference during implementation.
 
 ### Cache key
 
 ```
-linux-<arch>-scenario-node<NODE>-deno<DENO>-bun<BUN>-playwright<PW>
+linux-<arch>-node<NODE>-deno<DENO>-bun<BUN>-playwright<PW>-rust<RUST>-wasmtime<WT>-wasmer<WM>
 ```
 
-The key is derived from the version constants in `fs/ci/config/module.f.ts` so
-it is updated automatically whenever any version is bumped.
+Derived entirely from version constants so it self-updates on any version bump.
 
 ### Architectures
 
-Run on both `ubuntu-24.04` (Intel x86-64) and `ubuntu-24.04-arm` (ARM64) — the
-same pair used for other Linux jobs — to catch architecture-specific issues.
-macOS and Windows are out of scope: the scenario tests are primarily exercising
-the framework's JavaScript behaviour, not OS-specific I/O.
+Both `ubuntu-24.04` (Intel x86-64) and `ubuntu-24.04-arm` (ARM64) run Docker
+jobs — the same pair as the current Ubuntu jobs.
 
-### Dockerfile
+### What runs inside the Docker job
 
-Reuse and clean up the existing `docker/Dockerfile`, or generate a purpose-built
-one from `fs/ci/`. A generated Dockerfile is preferred so that version pins are
-single-sourced in `fs/ci/config/module.f.ts`.
-
-### What to run
-
-```sh
-for scenario in fs/dev/tf/scenarios/*.pass.ts fs/dev/tf/scenarios/*.fail.ts; do
-    for runner in fjs node bun deno playwright; do
-        sh fs/dev/tf/scenarios/run.sh $runner $scenario
-    done
-done
-```
-
-(Or an equivalent driven from the CI generator.)
+All tests that currently run on Ubuntu, plus:
+- Playwright tests (currently a separate job)
+- Scenario tests across all runners: `fjs`, `node`, `bun`, `deno`, `playwright`
 
 ## Related
 
 - [i095](./095-ci-docker.md) — original Docker CI idea
 - [i145](./145-docker-linux-ci.md) — Docker containers for Linux CI jobs (broader scope)
 - [i183](./183-tf-framework-scenario-tests.md) — scenario test infrastructure
-- [i65Y-scenarios-proof](./65Y-scenarios-proof.md) — scenario files converted to `export const proof`; prerequisite for running them in CI
+- [i65Y-scenarios-proof](./65Y-scenarios-proof.md) — scenario files converted to `export const proof`; prerequisite


### PR DESCRIPTION
## Summary

Adds two planning issues for improving CI tool management and enabling scenario tests in CI.

### [i65Z-ci-scenario-docker](./issues/65Z-ci-scenario-docker.md)

Replace Ubuntu CI jobs with Docker-container jobs that pull a pre-built, cached image. Key points:
- Docker image replaces the existing Ubuntu jobs entirely — carries all tools (Node, Bun, Deno, Playwright, Rust, Wasmtime, Wasmer)
- The Dockerfile is **generated from `fs/ci/`** so tool versions are single-sourced in `fs/ci/config/module.f.ts`
- Cache key derived from all tool version constants — auto-updates on any version bump
- Runs on both `ubuntu-24.04` (Intel) and `ubuntu-24.04-arm` (ARM64)
- Merges the standalone Playwright job into the Docker Ubuntu job
- Enables scenario tests (`run.sh`) in CI for all runners: `fjs`, `node`, `bun`, `deno`, `playwright`
- Playwright runs on Linux only; macOS and Windows are unchanged

### [i65Z-ci-nix](./issues/65Z-ci-nix.md)

Investigate Nix as a package manager for macOS CI. Key points:
- Nix is a package manager, not a virtualizer — processes run on the real host OS (`process.platform === 'darwin'`)
- `uses:` actions (including `actions/checkout`) are unchanged; only `run:` steps need a `shell:` override
- Best fit for macOS: real macOS environment without a VM, with granular derivation-level caching
- Not viable for Windows (requires WSL2 → Linux kernel, not real Windows); Windows stays with inline `setup-*` actions
- Playwright is the main caveat on Linux — its browser dependencies are hard to express in Nix, which is why Docker was chosen for Linux
- mise noted as the closest Windows-native alternative for unified tool-version manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)