### PR TITLE
tf: update README to reflect proof export and current file conventions

### DIFF
--- a/fs/dev/tf/README.md
+++ b/fs/dev/tf/README.md
@@ -1,5 +1,19 @@
 # Test Framework
 
+## Installation
+
+Install from npm:
+
+```sh
+npm install functionalscript
+```
+
+or from JSR:
+
+```sh
+npx jsr add @functionalscript/functionalscript
+```
+
 ## Running tests
 
 ### `fjs t` (built-in runner)
@@ -12,7 +26,7 @@ fjs t
 
 ### External runners (Node, Bun, Deno, Playwright)
 
-For external runners, create a file the runner will pick up (e.g. `*.test.ts`, which Node/Bun/Deno/Playwright all load by default):
+For external runners, create an entry file that matches the runner's discovery pattern (many runners pick up files matching `*.test.ts` or `*.test.js` by default):
 
 ```ts
 import { run } from 'functionalscript/fs/dev/tf/module.js'
@@ -26,6 +40,8 @@ Then invoke the runner:
 - `deno test --allow-read --allow-env`
 - `npx playwright test`
 
+Developers can also implement their own runners as long as they follow the proof-tree conventions described below.
+
 ## Design: Dependency-Free Tests
 
 Unlike most test frameworks (Jest, Mocha, Vitest, …), test files do **not** import anything from the test framework. A test is just a plain function or object — no `describe`, `it`, `expect`, or assertion library required. This means:
@@ -37,22 +53,22 @@ Unlike most test frameworks (Jest, Mocha, Vitest, …), test files do **not** im
 
 ### Discovery: the `proof` export
 
-A module is treated as a test module if and only if it exports a property named **`proof`**. Discovery is by value — "does the module export `proof`?" — not by filename alone.
+A module is treated as a test module if and only if it exports a property named **`proof`**. Discovery is by value — "does the module have a proof?" — not by filename alone.
 
 The framework loads modules in two tiers:
 
 | Language | Load gate |
 |----------|-----------|
 | FunctionalScript (`.f.ts` / `.f.js`) | **all** files are loaded — FS modules have no import side effects by construction |
-| Vanilla TypeScript / JavaScript | opt-in by filename: files whose name ends in `proof.ts`, `proof.js`, `proof.mts`, or `proof.mjs` (e.g. `math.proof.ts`, `proof.ts`) |
+| Vanilla TypeScript / JavaScript | opt-in by filename: files whose name ends in `proof.ts`, `proof.js`, `proof.mts`, or `proof.mjs` (e.g. `math.proof.ts`, `proof.js`) |
 
 A loaded file that does not export `proof` is silently skipped; filename alone never causes a file to be executed as a test suite.
 
-This design is intentional: keeping "is this a proof?" as a property of the *module's value* rather than its path means proofs remain self-describing even when files are stored by content hash (no stable filename) in a Merkle DAG.
+This design is intentional: keeping "does the module have a proof?" as a property of the *module's value* rather than its path means proofs remain self-describing even when files are stored by content hash (no stable filename) in a Merkle DAG, or when source code is published and copied as text.
 
 ### The `proof` export
 
-The named export `proof` is the test tree. A **leaf test** is a zero-argument function (`f.length === 0`); functions with parameters are ignored and not called.
+The named export `proof` is the test tree. A zero-argument function (`f.length === 0`) is a test node; functions with parameters are ignored and not called. A test node passes if it returns normally, and fails if it throws. Its return value may itself contain further test nodes (see [Return value as sub-tree](#return-value-as-sub-tree)).
 
 ```ts
 export const proof = {
@@ -63,7 +79,7 @@ export const proof = {
 
 ### Nested objects
 
-Objects (and arrays) are traversed recursively. Each key becomes a path segment in the output:
+Objects (and arrays) are traversed recursively. Each key becomes a path segment in the output. Only **own enumerable keys** are visited (as returned by `Object.entries`); prototype properties are excluded.
 
 ```ts
 export const proof = {
@@ -101,6 +117,21 @@ export const proof = {
 }
 ```
 
+This is useful for generating tests dynamically. The following example produces one named sub-test per input case:
+
+```ts
+const cases: readonly [number, number, number][] = [[1, 1, 2], [0, 0, 0], [2, 3, 5]]
+
+export const proof = {
+    add: () => Object.fromEntries(
+        cases.map(([a, b, expected]) => [
+            `${a}+${b}`,
+            () => { if (a + b !== expected) throw `${a}+${b} !== ${expected}` },
+        ])
+    ),
+}
+```
+
 Only **return values** of non-throw tests are walked as sub-trees, and the `throw` flag always resets to false for the sub-tree. Thrown values are discarded and never traversed, even if they are objects containing zero-parameter functions.
 
 ## Convention: only real Promises are awaited
@@ -118,8 +149,8 @@ A proof's *location* determines what it can see. Three tiers exist:
 | Mechanism | Scope | Runs when | Use for |
 |-----------|-------|-----------|---------|
 | Module-level `assertEq(...)` | public + private | **every module load** | light, cheap, deterministic checks only |
-| `export const proof` co-located in module | public + private | under the runner | white-box unit proofs |
-| Separate module exporting `proof` | public API only | under the runner | black-box / integration |
+| `export const proof` co-located in module | public + private | under the runner | [white-box](https://en.wikipedia.org/wiki/White-box_testing) unit proofs |
+| Separate module exporting `proof` | public API only | under the runner | [black-box](https://en.wikipedia.org/wiki/Black-box_testing) / integration |
 
 **Module-level asserts** (e.g. `assertEq(2 + 2, 4)` at the top level of a module) run on *every import*, not just during a test run. They must be restricted to light, cheap, deterministic checks — never stress tests or benchmarks, as that cost is paid on every module load.
 

--- a/fs/dev/tf/README.md
+++ b/fs/dev/tf/README.md
@@ -1,20 +1,30 @@
 # Test Framework
 
-To enable testing in your project, add a test runner file `all.test.ts` like this:
+## Running tests
+
+### `fjs t` (built-in runner)
+
+FunctionalScript's own runner discovers all proof modules automatically — no entry file required:
+
+```sh
+fjs t
+```
+
+### External runners (Node, Bun, Deno, Playwright)
+
+For external runners, create a file the runner will pick up (e.g. `*.test.ts`, which Node/Bun/Deno/Playwright all load by default):
 
 ```ts
 import { run } from 'functionalscript/fs/dev/tf/module.js'
-
 await run()
 ```
 
-And then run it with any supported runner:
+Then invoke the runner:
 
-- `fjs t` (FunctionalScript's own runner),
-- `node --test`,
-- `bun test`,
-- `deno test --allow-read --allow-env`,
-- `npx playwright test`.
+- `node --test`
+- `bun test`
+- `deno test --allow-read --allow-env`
+- `npx playwright test`
 
 ## Design: Dependency-Free Tests
 
@@ -25,29 +35,35 @@ Unlike most test frameworks (Jest, Mocha, Vitest, …), test files do **not** im
 
 ## Writing Tests
 
-### File naming
+### Discovery: the `proof` export
 
-A test file must export a `proof` property (see below). The framework loads:
+A module is treated as a test module if and only if it exports a property named **`proof`**. Discovery is by value — "does the module export `proof`?" — not by filename alone.
 
-- **Any** `.f.ts` / `.f.js` file (FunctionalScript modules are side-effect-free by construction).
-- Vanilla TypeScript/JavaScript files whose name ends in `proof.ts`, `proof.js`, `proof.mts`, or `proof.mjs` — e.g. `math.proof.ts` or `proof.ts`.
+The framework loads modules in two tiers:
 
-A loaded file is only executed as a test if it exports a `proof` property; all other files are silently skipped.
+| Language | Load gate |
+|----------|-----------|
+| FunctionalScript (`.f.ts` / `.f.js`) | **all** files are loaded — FS modules have no import side effects by construction |
+| Vanilla TypeScript / JavaScript | opt-in by filename: files whose name ends in `proof.ts`, `proof.js`, `proof.mts`, or `proof.mjs` (e.g. `math.proof.ts`, `proof.ts`) |
+
+A loaded file that does not export `proof` is silently skipped; filename alone never causes a file to be executed as a test suite.
+
+This design is intentional: keeping "is this a proof?" as a property of the *module's value* rather than its path means proofs remain self-describing even when files are stored by content hash (no stable filename) in a Merkle DAG.
 
 ### The `proof` export
 
-The named export `proof` is the test tree:
+The named export `proof` is the test tree. A **leaf test** is a zero-argument function (`f.length === 0`); functions with parameters are ignored and not called.
 
 ```ts
 export const proof = {
-    myTest: () => 42,         // passes — returns normally
-    failing: () => { throw 'oops' },  // fails — throws unexpectedly
+    myTest: () => 42,                      // passes — returns normally
+    failing: () => { throw 'oops' },       // fails — throws
 }
 ```
 
 ### Nested objects
 
-Objects are traversed recursively. Each key becomes a path segment in the output:
+Objects (and arrays) are traversed recursively. Each key becomes a path segment in the output:
 
 ```ts
 export const proof = {
@@ -71,12 +87,7 @@ export const proof = {
 }
 ```
 
-A function whose `.name` property is `'throw'` is also recognised as a throw-test regardless of its position in the tree. Because `throw` is a reserved word it cannot be used as a variable name directly; the typical way to obtain such a function is via object property access:
-
-```ts
-const t = { throw: () => { throw 'expected' } }.throw
-export const proof = { b: t }   // passes — function name triggers throw semantics
-```
+The `throw` key can appear at any depth; all tests reachable through it inherit the throw expectation. For example, `import('proof.ts').proof[5].throw.my()` is considered a throw-test because `throw` appears in its path.
 
 ### Return value as sub-tree
 
@@ -99,3 +110,19 @@ When a test function returns a value, the framework checks `value instanceof Pro
 This is intentional. FunctionalScript does not allow direct `Promise` construction; `Promise` objects only arise as the return value of `async` functions (an Effect). A plain `{ then: f }` object in FunctionalScript code is almost certainly a data value, not an async operation, and awaiting it would be surprising.
 
 As a consequence, **exporting a function named `then` from a test module is forbidden**: the module namespace object would become a thenable, corrupting dynamic `import()` resolution. See [issues/lang/3240-export.md](../../issues/lang/3240-export.md).
+
+## Proof location and scope
+
+A proof's *location* determines what it can see. Three tiers exist:
+
+| Mechanism | Scope | Runs when | Use for |
+|-----------|-------|-----------|---------|
+| Module-level `assertEq(...)` | public + private | **every module load** | light, cheap, deterministic checks only |
+| `export const proof` co-located in module | public + private | under the runner | white-box unit proofs |
+| Separate module exporting `proof` | public API only | under the runner | black-box / integration |
+
+**Module-level asserts** (e.g. `assertEq(2 + 2, 4)` at the top level of a module) run on *every import*, not just during a test run. They must be restricted to light, cheap, deterministic checks — never stress tests or benchmarks, as that cost is paid on every module load.
+
+**Co-located `export const proof`** shares the module's lexical scope, including unexported bindings, enabling white-box unit proofs without widening the public API. Note that `proof` itself is a real export and therefore visible in the module's public types and runtime bundle; declaring it as `unknown` (`export const proof: unknown = { … }`) mitigates the type-surface exposure while keeping the runtime value in place.
+
+**A separate `*.proof.f.ts` module** (or any other separately loaded proof file) can only reach the subject module's public exports, making it suitable for black-box and integration proofs that should not depend on internal structure.

--- a/fs/dev/tf/README.md
+++ b/fs/dev/tf/README.md
@@ -8,10 +8,10 @@ Install from npm:
 npm install functionalscript
 ```
 
-or from JSR:
+or from JSR (Deno):
 
 ```sh
-npx jsr add @functionalscript/functionalscript
+deno add jsr:@functionalscript/functionalscript
 ```
 
 ## Running tests
@@ -68,7 +68,7 @@ This design is intentional: keeping "does the module have a proof?" as a propert
 
 ### The `proof` export
 
-The named export `proof` is the test tree. A zero-argument function (`f.length === 0`) is a test node; functions with parameters are ignored and not called. A test node passes if it returns normally, and fails if it throws. Its return value may itself contain further test nodes (see [Return value as sub-tree](#return-value-as-sub-tree)).
+The named export `proof` is the test tree. No framework imports are needed — `proof` is a plain value. A zero-argument function (`f.length === 0`) is a test node; functions with parameters are ignored and not called. A test node passes if it returns normally, and fails if it throws. Its return value may itself contain further test nodes (see [Return value as sub-tree](#return-value-as-sub-tree)).
 
 ```ts
 export const proof = {
@@ -87,6 +87,10 @@ export const proof = {
         add: () => 1 + 1,
         mul: () => 2 * 2,
     },
+    suite: [
+        () => 'first',    // path: suite[0]
+        () => 'second',   // path: suite[1]
+    ],
 }
 ```
 
@@ -132,7 +136,7 @@ export const proof = {
 }
 ```
 
-Only **return values** of non-throw tests are walked as sub-trees, and the `throw` flag always resets to false for the sub-tree. Thrown values are discarded and never traversed, even if they are objects containing zero-parameter functions.
+Only **return values** of non-throw tests are walked as sub-trees. Thrown values are discarded and never traversed, even if they are objects containing zero-parameter functions.
 
 ## Convention: only real Promises are awaited
 

--- a/fs/dev/tf/README.md
+++ b/fs/dev/tf/README.md
@@ -44,7 +44,7 @@ Developers can also implement their own runners as long as they follow the proof
 
 ## Design: Dependency-Free Tests
 
-Unlike most test frameworks (Jest, Mocha, Vitest, …), test files do **not** import anything from the test framework. A test is just a plain function or object — no `describe`, `it`, `expect`, or assertion library required. This means:
+Unlike most test frameworks (Jest, Mocha, Vitest, …), proof files do not need to import anything from the test framework (though they may import the module under test or other helpers). A test is just a plain function or object — no `describe`, `it`, `expect`, or assertion library required. This means:
 
 - Tests are **runner-agnostic**: the same test file can be run by any compatible runner without modification.
 - Tests have **no framework dependency**: they remain pure FunctionalScript modules and can be imported, composed, or inspected like any other module.
@@ -68,7 +68,7 @@ This design is intentional: keeping "does the module have a proof?" as a propert
 
 ### The `proof` export
 
-The named export `proof` is the test tree. No framework imports are needed — `proof` is a plain value. A zero-argument function (`f.length === 0`) is a test node; functions with parameters are ignored and not called. A test node passes if it returns normally, and fails if it throws. Its return value may itself contain further test nodes (see [Return value as sub-tree](#return-value-as-sub-tree)).
+The named export `proof` is the test tree. It is a plain value — no test-framework import required. A zero-argument function (`f.length === 0`) is a test node; functions with parameters are ignored and not called. A test node passes if it returns normally, and fails if it throws. Its return value may itself contain further test nodes (see [Return value as sub-tree](#return-value-as-sub-tree)).
 
 ```ts
 export const proof = {
@@ -84,12 +84,12 @@ Objects (and arrays) are traversed recursively. Each key becomes a path segment 
 ```ts
 export const proof = {
     math: {
-        add: () => 1 + 1,
-        mul: () => 2 * 2,
+        add: () => { if (1 + 1 !== 2) throw '1 + 1 !== 2' },
+        mul: () => { if (2 * 2 !== 4) throw '2 * 2 !== 4' },
     },
     suite: [
-        () => 'first',    // path: suite[0]
-        () => 'second',   // path: suite[1]
+        () => { if (typeof '' !== 'string') throw 'expected string' },  // path: suite[0]
+        () => { if (typeof 0  !== 'number') throw 'expected number' },  // path: suite[1]
     ],
 }
 ```

--- a/fs/dev/tf/README.md
+++ b/fs/dev/tf/README.md
@@ -1,18 +1,20 @@
 # Test Framework
 
-To enable testing in your project, you can add a simple test runner file `all.tets.ts` like this:
+To enable testing in your project, add a test runner file `all.test.ts` like this:
 
 ```ts
-import { run } from 'functionalscript/fs/dev/tf/all.test.js'
+import { run } from 'functionalscript/fs/dev/tf/module.js'
 
 await run()
 ```
 
-And then run it as
+And then run it with any supported runner:
 
-- `deno test --allow-env --allow-read`,
+- `fjs t` (FunctionalScript's own runner),
 - `node --test`,
-- `bun test`.
+- `bun test`,
+- `deno test --allow-read --allow-env`,
+- `npx playwright test`.
 
 ## Design: Dependency-Free Tests
 
@@ -23,14 +25,21 @@ Unlike most test frameworks (Jest, Mocha, Vitest, …), test files do **not** im
 
 ## Writing Tests
 
-A test file must be named `*.test.f.ts` (or `*.test.f.js`). Its `default` export is the test tree.
+### File naming
 
-### Functions
+A test file must export a `proof` property (see below). The framework loads:
 
-A zero-parameter function is a test case. It passes if it returns without throwing:
+- **Any** `.f.ts` / `.f.js` file (FunctionalScript modules are side-effect-free by construction).
+- Vanilla TypeScript/JavaScript files whose name ends in `proof.ts`, `proof.js`, `proof.mts`, or `proof.mjs` — e.g. `math.proof.ts` or `proof.ts`.
+
+A loaded file is only executed as a test if it exports a `proof` property; all other files are silently skipped.
+
+### The `proof` export
+
+The named export `proof` is the test tree:
 
 ```ts
-export default {
+export const proof = {
     myTest: () => 42,         // passes — returns normally
     failing: () => { throw 'oops' },  // fails — throws unexpectedly
 }
@@ -41,7 +50,7 @@ export default {
 Objects are traversed recursively. Each key becomes a path segment in the output:
 
 ```ts
-export default {
+export const proof = {
     math: {
         add: () => 1 + 1,
         mul: () => 2 * 2,
@@ -54,7 +63,7 @@ export default {
 A node named `throw` (or nested inside one) marks tests that are **expected to throw**. The test passes if the function throws, and fails if it returns normally:
 
 ```ts
-export default {
+export const proof = {
     throw: {
         divByZero: () => { throw new Error('division by zero') },  // passes
         noThrow: () => 42,                                          // fails
@@ -62,11 +71,11 @@ export default {
 }
 ```
 
-A function named `throw` is also recognised as a throw-test regardless of its position in the tree:
+A function whose `.name` property is `'throw'` is also recognised as a throw-test regardless of its position in the tree. Because `throw` is a reserved word it cannot be used as a variable name directly; the typical way to obtain such a function is via object property access:
 
 ```ts
-const throw = () => { throw 'expected' }
-export default { b: throw }   // passes — function name triggers throw semantics
+const t = { throw: () => { throw 'expected' } }.throw
+export const proof = { b: t }   // passes — function name triggers throw semantics
 ```
 
 ### Return value as sub-tree
@@ -74,7 +83,7 @@ export default { b: throw }   // passes — function name triggers throw semanti
 When a non-throw test function returns an object or another function, the return value is walked as a fresh sub-tree. This allows lazy or computed test trees:
 
 ```ts
-export default {
+export const proof = {
     computed: () => ({
         nested: () => 99,   // discovered and run after `computed()` returns
     }),


### PR DESCRIPTION
- Fix typo all.tets.ts → all.test.ts; correct import to module.js
- Replace *.test.f.ts / default export with *.proof.f.ts / proof export
- Document vanilla TS/JS opt-in naming (proof.ts, *.proof.ts, etc.)
- Add fjs t and playwright to the supported-runner list; fix deno flag order
- Fix invalid throw-by-name example (throw is a reserved word)

https://claude.ai/code/session_01SsSDUP8rdqFtzQiPbawpyb