### PR TITLE
Update GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@
           "run": "sudo apt-get update && sudo apt-get install -y libc6-dev-i386"
         },
         {
-          "uses": "dtolnay/rust-toolchain@1.95.0",
+          "uses": "dtolnay/rust-toolchain@v1",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads,i686-unknown-linux-gnu"
@@ -51,7 +51,7 @@
           }
         },
         {
-          "uses": "actions/checkout@v5"
+          "uses": "actions/checkout@v6"
         },
         {
           "run": "cargo fmt -- --check"
@@ -185,7 +185,7 @@
       "runs-on": "ubuntu-24.04-arm",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.95.0",
+          "uses": "dtolnay/rust-toolchain@v1",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads"
@@ -225,7 +225,7 @@
           }
         },
         {
-          "uses": "actions/checkout@v5"
+          "uses": "actions/checkout@v6"
         },
         {
           "run": "cargo fmt -- --check"
@@ -353,7 +353,7 @@
       "runs-on": "macos-26-intel",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.95.0",
+          "uses": "dtolnay/rust-toolchain@v1",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads"
@@ -393,7 +393,7 @@
           }
         },
         {
-          "uses": "actions/checkout@v5"
+          "uses": "actions/checkout@v6"
         },
         {
           "run": "cargo fmt -- --check"
@@ -521,7 +521,7 @@
       "runs-on": "macos-26",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.95.0",
+          "uses": "dtolnay/rust-toolchain@v1",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads"
@@ -561,7 +561,7 @@
           }
         },
         {
-          "uses": "actions/checkout@v5"
+          "uses": "actions/checkout@v6"
         },
         {
           "run": "cargo fmt -- --check"
@@ -689,7 +689,7 @@
       "runs-on": "windows-2025",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.95.0",
+          "uses": "dtolnay/rust-toolchain@v1",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads,i686-pc-windows-msvc"
@@ -729,7 +729,7 @@
           }
         },
         {
-          "uses": "actions/checkout@v5"
+          "uses": "actions/checkout@v6"
         },
         {
           "run": "cargo fmt -- --check"
@@ -863,7 +863,7 @@
       "runs-on": "windows-11-arm",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.95.0",
+          "uses": "dtolnay/rust-toolchain@v1",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads"
@@ -900,7 +900,7 @@
           "run": "irm bun.sh/install.ps1 | iex; \"$env:USERPROFILE\\.bun\\bin\" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append"
         },
         {
-          "uses": "actions/checkout@v5"
+          "uses": "actions/checkout@v6"
         },
         {
           "run": "cargo fmt -- --check"
@@ -1034,7 +1034,7 @@
           }
         },
         {
-          "uses": "actions/checkout@v5"
+          "uses": "actions/checkout@v6"
         },
         {
           "run": "npm ci"
@@ -1057,7 +1057,7 @@
           }
         },
         {
-          "uses": "actions/cache@v4",
+          "uses": "actions/cache@v5",
           "with": {
             "path": "~/.cache/ms-playwright",
             "key": "ubuntu-24.04-playwright-1.60.0"
@@ -1073,7 +1073,7 @@
           "run": "playwright install"
         },
         {
-          "uses": "actions/checkout@v5"
+          "uses": "actions/checkout@v6"
         },
         {
           "run": "npm ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@
           "run": "sudo apt-get update && sudo apt-get install -y libc6-dev-i386"
         },
         {
-          "uses": "dtolnay/rust-toolchain@v1",
+          "uses": "dtolnay/rust-toolchain@1.95.0",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads,i686-unknown-linux-gnu"
@@ -185,7 +185,7 @@
       "runs-on": "ubuntu-24.04-arm",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@v1",
+          "uses": "dtolnay/rust-toolchain@1.95.0",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads"
@@ -353,7 +353,7 @@
       "runs-on": "macos-26-intel",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@v1",
+          "uses": "dtolnay/rust-toolchain@1.95.0",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads"
@@ -521,7 +521,7 @@
       "runs-on": "macos-26",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@v1",
+          "uses": "dtolnay/rust-toolchain@1.95.0",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads"
@@ -689,7 +689,7 @@
       "runs-on": "windows-2025",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@v1",
+          "uses": "dtolnay/rust-toolchain@1.95.0",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads,i686-pc-windows-msvc"
@@ -863,7 +863,7 @@
       "runs-on": "windows-11-arm",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@v1",
+          "uses": "dtolnay/rust-toolchain@1.95.0",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads"

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -50,11 +50,11 @@ export const tsgo = '7.0.0-dev.20260527.2'
 // `` `${name}@${actions[name]}` ``.
 export const actions = {
     // https://github.com/marketplace/actions/checkout
-    'actions/checkout': 'v5',
+    'actions/checkout': 'v6',
     // https://github.com/marketplace/actions/setup-node-js-environment
     'actions/setup-node': 'v6',
     // https://github.com/marketplace/actions/cache
-    'actions/cache': 'v4',
+    'actions/cache': 'v5',
     // https://github.com/marketplace/actions/setup-deno
     'denoland/setup-deno': 'v2',
     // https://github.com/marketplace/actions/setup-bun
@@ -64,5 +64,5 @@ export const actions = {
     // https://github.com/wasmerio/setup-wasmer
     'wasmerio/setup-wasmer': 'v3.1',
     // https://rust-lang.org/
-    'dtolnay/rust-toolchain': '1.95.0',
+    'dtolnay/rust-toolchain': 'v1',
 } as const

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -48,6 +48,7 @@ export const tsgo = '7.0.0-dev.20260527.2'
 // GitHub Action versions used by CI step builders. The key is the action
 // `owner/name`; call sites compose the full ref as
 // `` `${name}@${actions[name]}` ``.
+// Note: dtolnay/rust-toolchain value is a Rust version, not an action version.
 export const actions = {
     // https://github.com/marketplace/actions/checkout
     'actions/checkout': 'v6',
@@ -63,6 +64,6 @@ export const actions = {
     'bytecodealliance/actions/wasmtime/setup': 'v1',
     // https://github.com/wasmerio/setup-wasmer
     'wasmerio/setup-wasmer': 'v3.1',
-    // https://rust-lang.org/
-    'dtolnay/rust-toolchain': 'v1',
+    // https://rust-lang.org/ - value is Rust version, not action version
+    'dtolnay/rust-toolchain': '1.95.0',
 } as const


### PR DESCRIPTION
## Summary
This PR updates the versions of GitHub Actions used in the CI/CD pipeline to their latest stable releases.

## Key Changes
- **actions/checkout**: Updated from v5 to v6
- **actions/cache**: Updated from v4 to v5

## Details
The changes were made in two files:
1. `.github/workflows/ci.yml` - Updated all workflow job steps to use the new action versions across all CI jobs (Linux, macOS, Windows, and ARM platforms)
2. `fs/ci/config/module.f.ts` - Updated the source configuration file that defines the action versions used to generate the CI workflows

These updates ensure the CI pipeline uses the latest stable versions of these tools, which may include bug fixes, performance improvements, and new features.

https://claude.ai/code/session_013oaT7y55PMTvLVCpqMpfLe