### PR TITLE
Add proof tests for filterMap function

### DIFF
--- a/fs/types/list/proof.f.ts
+++ b/fs/types/list/proof.f.ts
@@ -349,5 +349,15 @@ export const proof = {
         if (length(null) !== 0) { throw 0 }
         if (length(flat([[1, 3], null, () => [3], concat([12])([4, 89])])) !== 6) { throw 6 }
     },
+    filterMap: [
+        () => {
+            const result = str(filterMap((x: number) => x % 2 === 0 ? x * 10 : null)([1, 2, 3, 4, 5]))
+            if (result !== '[20,40]') { throw result }
+        },
+        () => {
+            const result = str(filterMap((x: number) => x > 3 ? x : null)([1, 2, 3]))
+            if (result !== '[]') { throw result }
+        },
+    ],
     // stress
 }


### PR DESCRIPTION
## Summary
Added comprehensive proof tests for the `filterMap` function to validate its behavior with different filtering and mapping scenarios.

## Key Changes
- Added two test cases for `filterMap` in the proof object:
  - Test filtering even numbers and multiplying by 10, expecting `[20,40]` from input `[1, 2, 3, 4, 5]`
  - Test filtering numbers greater than 3, expecting empty array `[]` from input `[1, 2, 3]`

## Implementation Details
- Tests verify that `filterMap` correctly combines filtering (returning `null` for non-matching elements) and mapping (transforming matching elements)
- Uses the existing `str` utility to convert results to string format for assertion comparison
- Follows the existing proof test pattern with inline function definitions and throw-based error reporting

https://claude.ai/code/session_01RkPNVRZUeoPn7PmxqhCS49