### PR TITLE
Add errorExit helper for consistent error handling in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `effects/node`: add `errorExit(s)` — the canonical "write an error line to stderr, yield exit code 1" `NodeOp` program; replaces a private `e` helper in `fs/cas/module.f.ts` (5 sites) and two inline `error(...).step(() => pure(1))` copies in `fs/fjs/module.f.ts` ([i192](./issues/192-error-exit-effect.md)) [917](https://github.com/functionalscript/functionalscript/pull/917)
+
 ## 0.20.0
 
 - `tf`: step 2 — widen load gate to all `.f.ts`/`.f.js` + vanilla `proof.{ts,js,mts,mjs}`; rename `isTest` → `shouldLoad`; drop filename filter from `runModuleMap`/`registerModuleMap` — `v.proof !== undefined` is the sole gate; enables co-located white-box proofs ([i65Y-proof-by-export](./issues/65Y-proof-by-export.md)) [893](https://github.com/functionalscript/functionalscript/pull/893)

--- a/fs/cas/module.f.ts
+++ b/fs/cas/module.f.ts
@@ -8,7 +8,7 @@ import { parse } from '../path/module.f.ts'
 import type { Vec } from '../types/bit_vec/module.f.ts'
 import { cBase32ToVec, vecToCBase32 } from '../cbase32/module.f.ts'
 import { begin, forEachStep, pure, type Effect, type Operation } from '../types/effects/module.f.ts'
-import { error, log, mkdir, readdir, readFile, writeFile, type Fs, type NodeEffect, type NodeOp } from '../types/effects/node/module.f.ts'
+import { errorExit, log, mkdir, readdir, readFile, writeFile, type Fs, type NodeEffect, type NodeOp } from '../types/effects/node/module.f.ts'
 import { toOption } from '../types/nullable/module.f.ts'
 import { unwrap } from '../types/result/module.f.ts'
 
@@ -92,12 +92,6 @@ export const cas = (sha2: Sha2): <O extends Operation>(_: KvStore<O>) => Cas<O> 
     })
 }
 
-/** Prints an error message and returns exit code `1`. */
-const e = (s: string): Effect<NodeOp, number> =>
-    begin
-        .step(() => error(s))
-        .step(() => pure(1))
-
 /**
  * Runs the CAS CLI.
  *
@@ -112,7 +106,7 @@ export const main = (args: readonly string[]): Effect<NodeOp, number> => {
     switch (cmd) {
         case 'add': {
             if (options.length !== 1) {
-                return e("'cas add' expects one parameter")
+                return errorExit("'cas add' expects one parameter")
             }
             const [path] = options
             return begin
@@ -123,18 +117,18 @@ export const main = (args: readonly string[]): Effect<NodeOp, number> => {
         }
         case 'get': {
             if (options.length !== 2) {
-                return e("'cas get' expects two parameters")
+                return errorExit("'cas get' expects two parameters")
             }
             const [hashCBase32, path] = options
             const hash = cBase32ToVec(hashCBase32)
             if (hash === null) {
-                return e(`invalid hash format: ${hashCBase32}`)
+                return errorExit(`invalid hash format: ${hashCBase32}`)
             }
             return begin
                 .step(() => c.read(hash))
                 .step(v => {
                     const result: NodeEffect<number> = v === undefined
-                        ? e(`no such hash: ${hashCBase32}`)
+                        ? errorExit(`no such hash: ${hashCBase32}`)
                         : begin
                             .step(() => writeFile(path, v))
                             .step(() => pure(0))
@@ -148,9 +142,9 @@ export const main = (args: readonly string[]): Effect<NodeOp, number> => {
                 .step(() => pure(0))
         }
         case undefined: {
-            return e('Error: CAS command requires subcommand')
+            return errorExit('Error: CAS command requires subcommand')
         }
         default:
-            return e(`Error: Unknown CAS subcommand "${args[0]}"`)
+            return errorExit(`Error: Unknown CAS subcommand "${args[0]}"`)
     }
 }

--- a/fs/fjs/module.f.ts
+++ b/fs/fjs/module.f.ts
@@ -6,8 +6,7 @@
 import { compile } from '../djs/module.f.ts'
 import { main as testMain } from '../dev/tf/module.f.ts'
 import { main as casMain } from '../cas/module.f.ts'
-import { import_, error, type NodeProgram } from '../types/effects/node/module.f.ts'
-import { pure } from '../types/effects/module.f.ts'
+import { import_, errorExit, type NodeProgram } from '../types/effects/node/module.f.ts'
 
 export const main: NodeProgram = options => {
     const [command, ...rest] = options.args
@@ -30,8 +29,8 @@ export const main: NodeProgram = options => {
             })
         }
         case undefined:
-            return error('Error: command is required').step(() => pure(1))
+            return errorExit('Error: command is required')
         default:
-            return error(`Error: Unknown command "${command}"`).step(() => pure(1))
+            return errorExit(`Error: Unknown command "${command}"`)
     }
 }

--- a/fs/types/effects/node/module.f.ts
+++ b/fs/types/effects/node/module.f.ts
@@ -12,8 +12,8 @@ import type { Vec } from '../../bit_vec/module.f.ts'
 import type { Nominal } from '../../nominal/module.f.ts'
 import type { Result } from '../../result/module.f.ts'
 import {
-    type Effect, type Func, type Operation, type ToAsyncOperationMap, do_,
-    pure
+    type Effect, type Func, type Operation, type ToAsyncOperationMap, begin,
+    do_, pure
 } from '../module.f.ts'
 
 export type IoResult<T> = Result<T, unknown>
@@ -316,6 +316,16 @@ export type NodeOp =
     | Test
 
 export type NodeEffect<T> = Effect<NodeOp, T>
+
+/**
+ * Writes an error line to `stderr` and yields exit code `1`. The canonical
+ * "fail with a message" program for a `NodeProgram`. For non-`1` exit codes,
+ * compose `error(s).step(() => pure(n))` directly.
+ */
+export const errorExit = (s: string): Effect<NodeOp, number> =>
+    begin
+        .step(() => error(s))
+        .step(() => pure(1))
 
 export type NodeOperationMap = ToAsyncOperationMap<NodeOp>
 

--- a/issues/192-error-exit-effect.md
+++ b/issues/192-error-exit-effect.md
@@ -1,7 +1,7 @@
 # 192. `effects/node`: an `errorExit` helper for "print an error, exit 1"
 
 **Priority:** P3
-**Status:** open
+**Status:** done
 
 Both CLI entry points encode "write an error line, then yield exit code 1" by
 hand:


### PR DESCRIPTION
## Summary
Introduces a reusable `errorExit` helper function to standardize the common pattern of printing an error message and exiting with code 1 across CLI entry points.

## Key Changes
- **New `errorExit` function** in `fs/types/effects/node/module.f.ts`: A canonical helper that writes an error line to stderr and yields exit code 1, eliminating code duplication
- **Updated `fs/cas/module.f.ts`**: Removed the local `e()` helper function and replaced all 6 occurrences with the new `errorExit` import
- **Updated `fs/fjs/module.f.ts`**: Replaced manual `error(s).step(() => pure(1))` chains with `errorExit` calls, removing unnecessary `pure` import
- **Marked issue #192 as done** in the tracking document

## Implementation Details
The `errorExit` function is implemented as:
```typescript
export const errorExit = (s: string): Effect<NodeOp, number> =>
    begin
        .step(() => error(s))
        .step(() => pure(1))
```

This provides a single, well-documented source of truth for the "fail with a message" pattern used throughout the CLI infrastructure, improving maintainability and consistency.

https://claude.ai/code/session_01U9cWAxtu5SNwq3iLABJnEa