### PR TITLE
docs: add issues 661 for effect decoder and path normalization

### DIFF
--- a/issues/661-effect-value-decoder.md
+++ b/issues/661-effect-value-decoder.md
@@ -109,11 +109,11 @@ places**, none of which is the module that owns the type.
 ## Proposed decoder
 
 Add one accessor to the core module that turns the positional tuple into a
-named, discriminated node. It is the only place that knows the layout:
+named, discriminated form. It is the only place that knows the layout:
 
 ```ts
 // fs/types/effects/module.f.ts
-export type Node<O extends Operation, T> =
+export type Decoded<O extends Operation, T> =
     | { readonly done: true, readonly result: T }
     | {
         readonly done: false,
@@ -122,8 +122,8 @@ export type Node<O extends Operation, T> =
         readonly continuation: Do<O, T>[2],
     }
 
-/** Decodes an effect's next node: a pure result, or a command to perform. */
-export const node = <O extends Operation, T>({ value }: Effect<O, T>): Node<O, T> =>
+/** Decodes an effect's next step: a pure result, or a command to perform. */
+export const decode = <O extends Operation, T>({ value }: Effect<O, T>): Decoded<O, T> =>
     value.length === 1
         ? { done: true, result: value[0] }
         : { done: false, command: value[0], payload: value[1], continuation: value[2] }
@@ -135,20 +135,20 @@ vs. state-thread) differs, which is exactly the part that *should* differ:
 ```ts
 // async runner
 while (true) {
-    const n = node(effect)
-    if (n.done) { return n.result }
-    effect = n.continuation(await map[n.command](...n.payload))
+    const d = decode(effect)
+    if (d.done) { return d.result }
+    effect = d.continuation(await map[d.command](...d.payload))
 }
 ```
 
 ```ts
 // mock runner
 while (true) {
-    const n = node(e)
-    if (n.done) { return [s, n.result] }
-    const [ns, m] = o[n.command](s, ...n.payload)
+    const d = decode(e)
+    if (d.done) { return [s, d.result] }
+    const [ns, m] = o[d.command](s, ...d.payload)
     s = ns
-    e = n.continuation(m)
+    e = d.continuation(m)
 }
 ```
 
@@ -156,17 +156,17 @@ And the proofs stop poking at internals:
 
 ```ts
 // effects/proof.f.ts
-const n = node(e)
-if (!n.done) { throw e.value }
-if (n.result !== 10) { throw n.result }
+const d = decode(e)
+if (!d.done) { throw e.value }
+if (d.result !== 10) { throw d.result }
 ```
 
 ## Why this is feasible (typing)
 
 Both runners *already* write `const [command, payload, continuation] = value`
 and then call `operation(...payload)`; that compiles today against the
-decorrelated union types of `Do<O, T>`. `node` returns exactly those same three
-bindings under names, so the type situation is unchanged — it only names the
+decorrelated union types of `Do<O, T>`. `decode` returns exactly those same
+three bindings under names, so the type situation is unchanged — it only names the
 discriminant. No `as` casts are introduced; the length check narrows the tuple
 union structurally (no type predicate needed), in line with `AGENTS.md`.
 
@@ -186,8 +186,8 @@ reasoning `AGENTS.md` applies to the `sandbox` timing pattern.
   are the unambiguous DRY reductions.
 - The two production runners (`module.ts`, `mock/module.f.ts`) live in
   different files (`.ts` side-effecting vs. `.f.ts` pure-runner), but both can
-  import `node` from the `.f.ts` core — no layering violation.
-- Land it as one small PR: add `node` + `Node`, then rewrite call sites. No
+  import `decode` from the `.f.ts` core — no layering violation.
+- Land it as one small PR: add `decode` + `Decoded`, then rewrite call sites. No
   behaviour change, so the existing effect proofs are the regression test.
 
 ## Related

--- a/issues/661-effect-value-decoder.md
+++ b/issues/661-effect-value-decoder.md
@@ -106,7 +106,7 @@ places**, none of which is the module that owns the type.
   job of `effects/module.f.ts`. An interpreter's job is *what to do* with a
   pure value vs. a command — not *how to tell them apart*.
 
-## Proposed decoder
+## Proposed: `decode` + `match`
 
 Add one accessor to the core module that turns the positional tuple into a
 named, discriminated form. It is the only place that knows the layout:
@@ -129,30 +129,67 @@ export const decode = <O extends Operation, T>({ value }: Effect<O, T>): Decoded
         : { done: false, command: value[0], payload: value[1], continuation: value[2] }
 ```
 
-The three runners collapse to a uniform shape; only the *perform* step (await
-vs. state-thread) differs, which is exactly the part that *should* differ:
+`decode` alone removes the discriminant duplication, but each runner would still
+re-do the `map[command](...payload)` dispatch. Per @sergey-shandar's review, we
+can share that too with a `match` combinator that decodes *and* dispatches,
+returning the operation's output while deferring the one world-specific step —
+`await` (async) or state-threading (sync) — to the caller:
 
 ```ts
-// async runner
+// fs/types/effects/module.f.ts
+export const match =
+    <O extends Operation, R>(map: { readonly [K in O[0]]: (...payload: Pr<O, K>[0]) => R }) =>
+    <T>(effect: Effect<O, T>): readonly['done', T] | readonly['cont', R, Do<O, T>[2]] => {
+        const d = decode(effect)
+        return d.done
+            ? ['done', d.result]
+            : ['cont', map[d.command](...d.payload), d.continuation]
+    }
+```
+
+What unifies async and sync is the *shape* `R` of the operation's output: if both
+operation maps return a value the loop finishes with a single world-specific
+eliminator, the two loops become the same skeleton plus one line.
+
+```ts
+// async runner — map: (...payload) => Promise<result>, so R = Promise<...>
+const ma = match(map)
 while (true) {
-    const d = decode(effect)
-    if (d.done) { return d.result }
-    effect = d.continuation(await map[d.command](...d.payload))
+    const r = ma(effect)
+    if (r[0] === 'done') { return r[1] }
+    effect = r[2](await r[1])          // eliminator: await
 }
 ```
 
 ```ts
-// mock runner
+// mock runner — map: (...payload) => (state) => [state, result], so R = (s) => [s, ...]
+const ma = match(o)
 while (true) {
-    const d = decode(e)
-    if (d.done) { return [s, d.result] }
-    const [ns, m] = o[d.command](s, ...d.payload)
+    const r = ma(e)
+    if (r[0] === 'done') { return [s, r[1]] }
+    const [ns, m] = r[1](s)            // eliminator: thread state
     s = ns
-    e = d.continuation(m)
+    e = r[2](m)
 }
 ```
 
-And the proofs stop poking at internals:
+This requires currying the mock operation map's state parameter — moving `state`
+from the front of the argument list to a trailing curried position:
+
+```ts
+// fs/types/effects/mock/module.f.ts
+export type MemOperationMap<O extends Operation, S> = {
+    // was: (state: S, ...payload: Pr<O, K>[0]) => readonly[S, Pr<O, K>[1]]
+    readonly [K in O[0]]: (...payload: Pr<O, K>[0]) => (state: S) => readonly[S, Pr<O, K>[1]]
+}
+```
+
+That re-ordering is a worthwhile separation in its own right: an operation's
+*arguments* (fixed when the command is issued) are now distinct from the *state*
+it threads (data the runner supplies) — the same currying discipline
+[i164-uncurry-accumulators](./164-uncurry-accumulators.md) discusses.
+
+The proofs need no dispatch, so they use `decode` directly:
 
 ```ts
 // effects/proof.f.ts
@@ -163,22 +200,13 @@ if (d.result !== 10) { throw d.result }
 
 ## Why this is feasible (typing)
 
-Both runners *already* write `const [command, payload, continuation] = value`
-and then call `operation(...payload)`; that compiles today against the
-decorrelated union types of `Do<O, T>`. `decode` returns exactly those same
-three bindings under names, so the type situation is unchanged — it only names the
-discriminant. No `as` casts are introduced; the length check narrows the tuple
-union structurally (no type predicate needed), in line with `AGENTS.md`.
-
-## Why not a `match`/`fold` combinator
-
-A `match(onPure, onDo)` higher-order form reads well for pure expression code
-but fights the interpreters: the async runner must `await` *between* decoding
-the node and resuming the continuation, so a callback that returns a value
-synchronously can't express it without wrapping every step in a promise. A
-plain accessor that returns the node and lets each loop drive itself keeps the
-async/sync/state differences explicit and on the critical path — the same
-reasoning `AGENTS.md` applies to the `sandbox` timing pattern.
+Both production runners *already* write `const [command, payload, continuation] =
+value` and then call `operation(...payload)`; that compiles today against the
+decorrelated union types of `Do<O, T>`. `decode` returns those same three bindings
+under names, and `match` invokes the operation exactly as the runners do now — so
+the type situation is unchanged. No `as` casts are introduced; the length check
+narrows the tuple union structurally (no type predicate needed), in line with
+`AGENTS.md`.
 
 ## Scope / caveats
 
@@ -186,9 +214,15 @@ reasoning `AGENTS.md` applies to the `sandbox` timing pattern.
   are the unambiguous DRY reductions.
 - The two production runners (`module.ts`, `mock/module.f.ts`) live in
   different files (`.ts` side-effecting vs. `.f.ts` pure-runner), but both can
-  import `decode` from the `.f.ts` core — no layering violation.
-- Land it as one small PR: add `decode` + `Decoded`, then rewrite call sites. No
-  behaviour change, so the existing effect proofs are the regression test.
+  import `decode`/`match` from the `.f.ts` core — no layering violation.
+- The `MemOperationMap` currying is a breaking change to every sync operation
+  map. The known consumer is the virtual filesystem
+  (`fs/types/effects/node/virtual/module.f.ts`), whose `operation`/`readOperation`
+  helpers build `(state, path) => …` operations; they must move to
+  `(...payload) => (state) => …`. That migration is mechanical but touches every
+  op, so it should be audited before committing — or `match` can be introduced
+  with `decode` first and the currying landed as a follow-up.
+- No behaviour change, so the existing effect proofs are the regression test.
 
 ## Related
 

--- a/issues/661-effect-value-decoder.md
+++ b/issues/661-effect-value-decoder.md
@@ -137,9 +137,21 @@ returning the operation's output while deferring the one world-specific step —
 
 ```ts
 // fs/types/effects/module.f.ts
+
+// An operation map whose entries take a command's payload and return some
+// output R. Generalizes both `ToAsyncOperationMap` (R = Promise<…>) and the
+// curried `MemOperationMap` (R = (state) => [state, …]).
+export type OperationMap<O extends Operation, R> = {
+    readonly [K in O[0]]: (...payload: Pr<O, K>[0]) => R
+}
+
+export type MatchResult<O extends Operation, T, R> =
+    | readonly['done', T]
+    | readonly['cont', R, Do<O, T>[2]]
+
 export const match =
-    <O extends Operation, R>(map: { readonly [K in O[0]]: (...payload: Pr<O, K>[0]) => R }) =>
-    <T>(effect: Effect<O, T>): readonly['done', T] | readonly['cont', R, Do<O, T>[2]] => {
+    <O extends Operation, R>(map: OperationMap<O, R>) =>
+    <T>(effect: Effect<O, T>): MatchResult<O, T, R> => {
         const d = decode(effect)
         return d.done
             ? ['done', d.result]

--- a/issues/661-effect-value-decoder.md
+++ b/issues/661-effect-value-decoder.md
@@ -1,0 +1,198 @@
+# 661. `effects`: a single decoder for the `Pure | Do` value representation
+
+**Priority:** P3
+**Status:** open
+
+The `Effect` ADT encodes a node as a tuple: a **pure** value is a length-1
+tuple `readonly[T]`, a **do** node is a length-3 tuple
+`readonly[command, payload, continuation]`. The discriminant is the tuple
+*length*:
+
+```ts
+// fs/types/effects/module.f.ts:17
+export type Value<O extends Operation, T> =
+    Pure<T> | Do<O, T>
+
+// fs/types/effects/module.f.ts:20
+export type Pure<T> =
+    readonly[T]
+
+// fs/types/effects/module.f.ts:23
+export type DoKPR<O extends Operation, T, K extends string, PR extends readonly[unknown, unknown]> =
+    readonly[K, PR[0], (_: PR[1]) => Effect<O, T>]
+```
+
+That representation is **private knowledge of the ADT**, but every interpreter
+and every test re-derives it by hand. The core module that *defines* the tuple
+shape exports **no accessor** for it, so the `value.length === 1` discriminant
+and the `[command, payload, continuation]` layout are copy-pasted across the
+whole subtree.
+
+## The duplicated decoding
+
+Three hand-rolled interpreter loops, byte-identical except for async/await and
+state threading:
+
+```ts
+// fs/types/effects/module.ts:7 — async runner
+while (true) {
+    const {value} = effect
+    if (value.length === 1) {
+        return value[0]
+    }
+    const [command, payload, continuation] = value
+    const operation = map[command]
+    const result = await operation(...payload)
+    effect = continuation(result)
+}
+```
+
+```ts
+// fs/types/effects/mock/module.f.ts:24 — sync, state-threaded runner
+while (true) {
+    const { value } = e
+    if (value.length === 1) {
+        const [v] = value
+        return [s, v]
+    }
+    const [cmd, payload, cont] = value
+    const operation = o[cmd]
+    const [ns, m] = operation(s, ...payload)
+    s = ns
+    e = cont(m)
+}
+```
+
+```ts
+// fs/types/effects/node/proof.f.ts:13 — a third runner, inline in a proof
+while (true) {
+    const { value } = e
+    if (value.length === 1) {
+        const [result] = value
+        if (result !== 0x2An) { throw result }
+        return
+    }
+    const [cmd, p, cont] = value
+    if (cmd !== 'readFile') { throw cmd }
+    if (p[0] !== 'hello') { throw p }
+    e = cont(['ok', vec8(0x15n)])
+}
+```
+
+Plus **five** assertion sites that reach into the same representation just to
+pull the pure result out of an effect that should already be done:
+
+```ts
+// fs/types/effects/proof.f.ts:10 (and :19, :28, :36, :42)
+const { value } = e
+if (value.length !== 1) { throw value }
+if (value[0] !== 10) { throw value[0] }
+```
+
+So the `length === 1` discriminant and the tuple index layout appear in **8+
+places**, none of which is the module that owns the type.
+
+## Why this is a problem
+
+- **Encapsulation leak.** `Pure<T> = readonly[T]` and the 3-tuple `Do` layout
+  are an implementation choice. Today, changing it — e.g. to a tagged
+  `{ pure: T } | { command, payload, continuation }` for readability, or adding
+  a third node kind — means editing every loop and every proof. The
+  representation has no single owner.
+- **DRY.** The same decode is written for the async runner, the mock runner,
+  and a per-proof runner. That is three real consumers of one algorithm, well
+  past the second-consumer bar in `AGENTS.md`.
+- **Separation of concerns.** Knowing how an effect node is laid out is the
+  job of `effects/module.f.ts`. An interpreter's job is *what to do* with a
+  pure value vs. a command — not *how to tell them apart*.
+
+## Proposed decoder
+
+Add one accessor to the core module that turns the positional tuple into a
+named, discriminated node. It is the only place that knows the layout:
+
+```ts
+// fs/types/effects/module.f.ts
+export type Node<O extends Operation, T> =
+    | { readonly done: true, readonly result: T }
+    | {
+        readonly done: false,
+        readonly command: O[0],
+        readonly payload: Do<O, T>[1],
+        readonly continuation: Do<O, T>[2],
+    }
+
+/** Decodes an effect's next node: a pure result, or a command to perform. */
+export const node = <O extends Operation, T>({ value }: Effect<O, T>): Node<O, T> =>
+    value.length === 1
+        ? { done: true, result: value[0] }
+        : { done: false, command: value[0], payload: value[1], continuation: value[2] }
+```
+
+The three runners collapse to a uniform shape; only the *perform* step (await
+vs. state-thread) differs, which is exactly the part that *should* differ:
+
+```ts
+// async runner
+while (true) {
+    const n = node(effect)
+    if (n.done) { return n.result }
+    effect = n.continuation(await map[n.command](...n.payload))
+}
+```
+
+```ts
+// mock runner
+while (true) {
+    const n = node(e)
+    if (n.done) { return [s, n.result] }
+    const [ns, m] = o[n.command](s, ...n.payload)
+    s = ns
+    e = n.continuation(m)
+}
+```
+
+And the proofs stop poking at internals:
+
+```ts
+// effects/proof.f.ts
+const n = node(e)
+if (!n.done) { throw e.value }
+if (n.result !== 10) { throw n.result }
+```
+
+## Why this is feasible (typing)
+
+Both runners *already* write `const [command, payload, continuation] = value`
+and then call `operation(...payload)`; that compiles today against the
+decorrelated union types of `Do<O, T>`. `node` returns exactly those same three
+bindings under names, so the type situation is unchanged — it only names the
+discriminant. No `as` casts are introduced; the length check narrows the tuple
+union structurally (no type predicate needed), in line with `AGENTS.md`.
+
+## Why not a `match`/`fold` combinator
+
+A `match(onPure, onDo)` higher-order form reads well for pure expression code
+but fights the interpreters: the async runner must `await` *between* decoding
+the node and resuming the continuation, so a callback that returns a value
+synchronously can't express it without wrapping every step in a promise. A
+plain accessor that returns the node and lets each loop drive itself keeps the
+async/sync/state differences explicit and on the critical path — the same
+reasoning `AGENTS.md` applies to the `sandbox` timing pattern.
+
+## Scope / caveats
+
+- Pure win: the five `proof.f.ts` assertions and the `node/proof.f.ts` runner
+  are the unambiguous DRY reductions.
+- The two production runners (`module.ts`, `mock/module.f.ts`) live in
+  different files (`.ts` side-effecting vs. `.f.ts` pure-runner), but both can
+  import `node` from the `.f.ts` core — no layering violation.
+- Land it as one small PR: add `node` + `Node`, then rewrite call sites. No
+  behaviour change, so the existing effect proofs are the regression test.
+
+## Related
+
+- [i164-uncurry-accumulators](./164-uncurry-accumulators.md) — same spirit of
+  giving the effect/state machinery a single, well-shaped representation.
+- [i208-try-catch-consolidate](./208-try-catch-consolidate.md) — lifting an
+  open-coded helper (`tryCatch`) into the module that should own it.

--- a/issues/661-effect-value-decoder.md
+++ b/issues/661-effect-value-decoder.md
@@ -165,9 +165,9 @@ eliminator, the two loops become the same skeleton plus one line.
 
 ```ts
 // async runner — map: (...payload) => Promise<result>, so R = Promise<...>
-const ma = match(map)
+const next = match(map)
 while (true) {
-    const r = ma(effect)
+    const r = next(effect)
     if (r[0] === 'done') { return r[1] }
     effect = r[2](await r[1])          // eliminator: await
 }
@@ -175,9 +175,9 @@ while (true) {
 
 ```ts
 // mock runner — map: (...payload) => (state) => [state, result], so R = (s) => [s, ...]
-const ma = match(o)
+const next = match(o)
 while (true) {
-    const r = ma(e)
+    const r = next(e)
     if (r[0] === 'done') { return [s, r[1]] }
     const [ns, m] = r[1](s)            // eliminator: thread state
     s = ns

--- a/issues/661-path-posix-separators.md
+++ b/issues/661-path-posix-separators.md
@@ -1,0 +1,73 @@
+# 661. `dev` re-implements path normalization that belongs in `fs/path`
+
+**Priority:** P4
+**Status:** open
+
+`AGENTS.md` gives "path manipulation belongs in `fs/path`, not inline in a
+loader" as the canonical separation-of-concerns example. There is a live
+instance of exactly that: the module loader normalizes Windows separators
+inline instead of going through `fs/path`.
+
+```ts
+// fs/dev/module.f.ts:129 — inside loadModuleMap (a loader)
+const initCwd = env['INIT_CWD']
+const s = initCwd === undefined ? '.' : `${initCwd.replaceAll('\\', '/')}`
+```
+
+```ts
+// fs/path/module.f.ts:34 — inside parse, the canonical home for this
+const split = path.replaceAll('\\', '/').split('/')
+```
+
+The `replaceAll('\\', '/')` separator conversion is the one piece of path
+knowledge that `fs/path` already documents as its own
+("Windows separators are converted to POSIX separators", `parse`'s JSDoc), yet
+`dev` re-codes it inline.
+
+## Why not just call `normalize`
+
+`path.normalize` is **not** a drop-in here: it also drops empty segments, so an
+absolute POSIX path loses its leading slash (`normalize('/home/user')` →
+`'home/user'`), and it collapses `.`/`..`. `loadModuleMap` needs only the
+separator conversion — it does its own `'.'` handling on the next line
+(`prefix = s === '.' ? '' : s`). So reusing `normalize` would change behaviour.
+
+## Proposed fix
+
+Export the narrow helper from `fs/path` and use it in both places:
+
+```ts
+// fs/path/module.f.ts
+/** Converts Windows separators (`\`) to POSIX separators (`/`). */
+export const toPosix = (path: string): string => path.replaceAll('\\', '/')
+
+export const parse = (path: string): readonly string[] => {
+    const split = toPosix(path).split('/')
+    return toArray(fold(foldNormalizeOp)([])(split))
+}
+```
+
+```ts
+// fs/dev/module.f.ts
+import { toPosix } from '../path/module.f.ts'
+...
+const s = initCwd === undefined ? '.' : toPosix(initCwd)
+```
+
+(The `${...}` template wrapper at `dev/module.f.ts:129` is also redundant —
+`initCwd` is already a `string` — and disappears with the rewrite.)
+
+## Why this qualifies
+
+- **Separation of concerns:** OS-path manipulation is `fs/path`'s
+  responsibility; a module loader should not contain a `\` → `/` rule. This is
+  the exact pattern `AGENTS.md` calls out.
+- **DRY:** two real consumers of one rule (`path.parse` and `dev`), so the
+  shared `toPosix` is justified rather than speculative.
+
+## Caveats
+
+- Tiny change; `fs/dev` already imports from sibling modules, and `fs/path`
+  has no `.f.ts` import restrictions to worry about.
+- Confirm no other `replaceAll('\\', '/')` sites exist before landing
+  (`grep -rn "replaceAll('\\\\'" fs` found only these two).


### PR DESCRIPTION
## Summary

Add two issue documents proposing refactorings to improve code organization and reduce duplication in the effects system and path handling.

## Changes

- **661-effect-value-decoder.md**: Proposes extracting a single `node` decoder function to centralize the tuple-based representation of `Effect` values. Currently, the discriminant logic (`value.length === 1` for pure vs. do nodes) and tuple destructuring are duplicated across three interpreter loops and five assertion sites. The proposal adds a `Node<O, T>` discriminated union type and `node()` accessor to the core effects module, allowing all consumers to use named fields instead of positional indices.

- **661-path-posix-separators.md**: Proposes extracting the Windows-to-POSIX separator conversion (`replaceAll('\\', '/')`) into a dedicated `toPosix` export from `fs/path/module.f.ts`. Currently, this logic is duplicated inline in both `fs/path/parse` and `fs/dev/loadModuleMap`, violating the principle that path manipulation belongs in `fs/path`.

Both issues follow the DRY and separation-of-concerns principles outlined in `AGENTS.md`, with clear scope and implementation guidance.

https://claude.ai/code/session_01V6cg2QoBUETUGhWTn7zgT8