### PR TITLE
nullable: add fromUndefined helper; share between array.at and object.at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `types/nullable`: add `fromUndefined(v)` — names the JS-host ↔ FunctionalScript `undefined`→`null` boundary in one helper; `array.at` collapses to `fromUndefined(a[i])` and `object.at` composes `map(d => d.value)` over `fromUndefined(getOwnPropertyDescriptor(...))` ([i188](./issues/188-nullable-from-undefined.md)) [919](https://github.com/functionalscript/functionalscript/pull/919)
 - `effects/node`: add `errorExit(s)` — the canonical "write an error line to stderr, yield exit code 1" `NodeOp` program; replaces a private `e` helper in `fs/cas/module.f.ts` (5 sites) and two inline `error(...).step(() => pure(1))` copies in `fs/fjs/module.f.ts` ([i192](./issues/192-error-exit-effect.md)) [917](https://github.com/functionalscript/functionalscript/pull/917)
 
 ## 0.20.0

--- a/fs/types/array/module.f.ts
+++ b/fs/types/array/module.f.ts
@@ -4,7 +4,7 @@
  * @module
  */
 
-import { map } from '../nullable/module.f.ts'
+import { fromUndefined, map } from '../nullable/module.f.ts'
 
 export const isArray = (value: unknown): value is readonly unknown[] =>
     value instanceof Array
@@ -62,10 +62,8 @@ const uncheckTail = <T>(a: readonly T[]): readonly T[] =>
 const uncheckHead = <T>(a: readonly T[]): readonly T[] =>
     a.slice(0, -1)
 
-export const at = (i: number) => <T>(a: readonly T[]): T | null => {
-    const r = a[i]
-    return r === undefined ? null : r
-}
+export const at = (i: number) => <T>(a: readonly T[]): T | null =>
+    fromUndefined(a[i])
 
 export const first: <T>(_: readonly T[]) => T | null
     = at(0)

--- a/fs/types/nullable/module.f.ts
+++ b/fs/types/nullable/module.f.ts
@@ -14,3 +14,12 @@ export const match: <T, R>(f: (_: T) => R) => (none: () => R) => (_: Nullable<T>
     = f => none => value => value === null ? none() : f(value)
 
 export const toOption = <T>(value: Nullable<T>): Option<T> => value === null ? [] : [value]
+
+/**
+ * Normalizes a possibly-`undefined` value into the codebase's `null` convention.
+ *
+ * The boundary rule between JavaScript hosts (which return `undefined` from
+ * property/index lookups) and FunctionalScript (which uses `null` for absence).
+ */
+export const fromUndefined = <T>(value: T | undefined): Nullable<T> =>
+    value === undefined ? null : value

--- a/fs/types/nullable/proof.f.ts
+++ b/fs/types/nullable/proof.f.ts
@@ -1,4 +1,4 @@
-import { map, match, toOption } from './module.f.ts'
+import { fromUndefined, map, match, toOption } from './module.f.ts'
 
 export const proof = [
     () => {
@@ -18,5 +18,12 @@ export const proof = [
         const double = match((v: number) => v * 2)(() => -1)
         if (double(3) !== 6) { throw double(3) }
         if (double(null) !== -1) { throw double(null) }
-    }
+    },
+    () => {
+        if (fromUndefined(undefined) !== null) { throw 0 }
+        if (fromUndefined(5) !== 5) { throw 1 }
+        if (fromUndefined(0) !== 0) { throw 2 }
+        if (fromUndefined(null) !== null) { throw 3 }
+        if (fromUndefined('') !== '') { throw 4 }
+    },
 ]

--- a/fs/types/object/module.f.ts
+++ b/fs/types/object/module.f.ts
@@ -7,6 +7,7 @@
  */
 import { isArray } from '../array/module.f.ts'
 import { iterable, type List } from '../list/module.f.ts'
+import { fromUndefined, map } from '../nullable/module.f.ts'
 import { entries as mapEntries, fromEntries as mapFromEntries, type OrderedMap } from '../ordered_map/module.f.ts'
 
 const { getOwnPropertyDescriptor, fromEntries: objectFromEntries } = Object
@@ -18,10 +19,8 @@ export type Map<T> = {
 export type Entry<T> = readonly[string, T]
 
 export const at: (name: string) => <T>(object: Map<T>) => T|null
-    = name => object => {
-        const r = getOwnPropertyDescriptor(object, name)
-        return r === undefined ? null : r.value
-    }
+    = name => object =>
+        map(<T>(d: TypedPropertyDescriptor<T>) => d.value)(fromUndefined(getOwnPropertyDescriptor(object, name)))
 
 export const sort: <T>(e: List<Entry<T>>) => List<Entry<T>>
     = e => mapEntries(mapFromEntries(e))

--- a/issues/188-nullable-from-undefined.md
+++ b/issues/188-nullable-from-undefined.md
@@ -1,7 +1,7 @@
 # 188. `nullable.fromUndefined`: one place for "`undefined` → `null`" normalization
 
 **Priority:** P3
-**Status:** open
+**Status:** done
 
 Two modules independently normalize a JavaScript lookup that may yield
 `undefined` into the codebase's `Nullable` (`null`) convention:


### PR DESCRIPTION
## Summary

Closes [i188](./issues/188-nullable-from-undefined.md).

- Adds `fromUndefined` to `fs/types/nullable`, naming the JS-host ↔ FunctionalScript boundary ("host returns `undefined`; we speak `null`") in one place.
- `array.at` now collapses to `fromUndefined(a[i])`.
- `object.at` composes `map(d => d.value)` over `fromUndefined(getOwnPropertyDescriptor(...))`, removing its bespoke `r === undefined ? null : r.value` ternary.
- Adds a proof case for `fromUndefined` covering `undefined`, `null`, and falsy non-undefined values (`0`, `''`).

Behaviour-preserving — both `at` call sites return exactly the same values as before.

## Test plan

- [x] `npx tsc` clean
- [x] `npm run fst` in `fs/types/nullable`, `fs/types/array`, `fs/types/object`
- [x] `npm run fst` in `fs/types` (593 tests pass)


---
_Generated by [Claude Code](https://claude.ai/code/session_01G7rvMz6pzEGbXihS5bdZYN)_