### PR TITLE
Update Node.js and TypeScript Native Preview versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,11 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26.2.0"
+            "node-version": "26.3.0"
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.2"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260601.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -206,11 +206,11 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26.2.0"
+            "node-version": "26.3.0"
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.2"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260601.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -374,11 +374,11 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26.2.0"
+            "node-version": "26.3.0"
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.2"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260601.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -542,11 +542,11 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26.2.0"
+            "node-version": "26.3.0"
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.2"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260601.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -710,11 +710,11 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26.2.0"
+            "node-version": "26.3.0"
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.2"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260601.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -884,11 +884,11 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26.2.0"
+            "node-version": "26.3.0"
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260527.2"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260601.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -1053,7 +1053,7 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26.2.0"
+            "node-version": "26.3.0"
           }
         },
         {

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -32,7 +32,7 @@ export const playwright = '1.60.0'
 
 // https://nodejs.org/en/download
 export const node = {
-    default: '26.2.0',
+    default: '26.3.0',
     others: ['24.16.0'],
 } as const
 
@@ -43,7 +43,7 @@ export const wasmtime = '45.0.0'
 export const wasmer = '7.1.0'
 
 // https://www.npmjs.com/package/@typescript/native-preview?activeTab=versions
-export const tsgo = '7.0.0-dev.20260527.2'
+export const tsgo = '7.0.0-dev.20260601.1'
 
 // GitHub Action versions used by CI step builders. The key is the action
 // `owner/name`; call sites compose the full ref as


### PR DESCRIPTION
## Summary
This PR updates the CI configuration and module dependencies to use newer versions of Node.js and the TypeScript Native Preview package.

## Key Changes
- **Node.js**: Updated from `26.2.0` to `26.3.0` across all CI workflows
- **TypeScript Native Preview (@typescript/native-preview)**: Updated from `7.0.0-dev.20260527.2` to `7.0.0-dev.20260601.1`

## Details
The changes are applied consistently across:
- `.github/workflows/ci.yml`: Updated in 7 different workflow job configurations
- `fs/ci/config/module.f.ts`: Updated the source configuration file that defines these versions

These are routine dependency updates to keep the CI environment current with the latest stable releases.

https://claude.ai/code/session_01C7ocqaBBUhwiz3kEghusQi