### PR TITLE
Add proof module to validate default export from module

### DIFF
--- a/fs/website/proof.f.ts
+++ b/fs/website/proof.f.ts
@@ -1,0 +1,8 @@
+import defaultExport from './module.f.ts'
+
+export const proof = {
+    default: () => {
+        const program = defaultExport()
+        if (program === undefined) { throw 'expected a program effect' }
+    }
+}


### PR DESCRIPTION
## Summary
Added a new proof module that validates the module's default export returns a valid program effect.

## Key Changes
- Created `fs/website/proof.f.ts` with a proof object that:
  - Imports the default export from `./module.f.ts`
  - Exports a `proof` object with a `default()` function
  - Validates that the imported default export returns a defined program effect
  - Throws an error if the program effect is undefined

## Implementation Details
The proof module serves as a validation/test utility that ensures the module's default export produces a valid program effect, failing fast with a descriptive error message if the expectation is not met.

https://claude.ai/code/session_014veDj7V5kstLCpkU6SBA4r