### PR TITLE
path: extract toPosix; dev loader reuses it (i661)

### DIFF
--- a/fs/dev/module.f.ts
+++ b/fs/dev/module.f.ts
@@ -27,7 +27,7 @@ import { begin, pure, type Effect } from '../types/effects/module.f.ts'
 import { parse as jsonParse } from '../json/module.f.ts'
 import { record, unknown as rttiUnknown } from '../types/rtti/module.f.ts'
 import { parse as rttiParse } from '../types/rtti/parse/module.f.ts'
-import { relativize } from '../path/module.f.ts'
+import { relativize, toPosix } from '../path/module.f.ts'
 
 export type Module = {
     readonly proof?: unknown
@@ -117,7 +117,7 @@ const { fromEntries } = Object
  */
 export const loadModuleMap = (env: Env): Effect<LoadModuleOperations, ModuleMap> => {
     const initCwd = env['INIT_CWD']
-    const s = initCwd === undefined ? '.' : `${initCwd.replaceAll('\\', '/')}`
+    const s = initCwd === undefined ? '.' : toPosix(initCwd)
     const prefix = s === '.' ? '' : s
     // TODO: there are multiple `all` effects here,
     //       we should consider optimize them by ALIQ technique or something similar.

--- a/fs/path/module.f.ts
+++ b/fs/path/module.f.ts
@@ -24,6 +24,11 @@ const foldNormalizeOp: Fold<string, List<string>>
 }
 
 /**
+ * Converts Windows separators (`\`) to POSIX separators (`/`).
+ */
+export const toPosix = (path: string): string => path.replaceAll('\\', '/')
+
+/**
  * Splits a path into normalized segments.
  *
  * Empty (`""`) and current-directory (`"."`) segments are removed, parent-directory
@@ -31,7 +36,7 @@ const foldNormalizeOp: Fold<string, List<string>>
  * separators are converted to POSIX separators.
  */
 export const parse = (path: string): readonly string[] => {
-    const split = path.replaceAll('\\', '/').split('/')
+    const split = toPosix(path).split('/')
     return toArray(fold(foldNormalizeOp)([])(split))
 }
 

--- a/fs/path/proof.f.ts
+++ b/fs/path/proof.f.ts
@@ -1,4 +1,4 @@
-import { concat, normalize, relativize } from "./module.f.ts"
+import { concat, normalize, relativize, toPosix } from "./module.f.ts"
 
 const normalizeTest = [
     () => {
@@ -48,4 +48,23 @@ const relativizeTest = [
         if (r !== './fs/a.ts') { throw r }
     },
 ]
-export const proof = { normalizeTest, concatTest, relativizeTest }
+const toPosixTest = [
+    () => {
+        const p = toPosix('a\\b\\c')
+        if (p !== 'a/b/c') { throw p }
+    },
+    () => {
+        const p = toPosix('a/b/c')
+        if (p !== 'a/b/c') { throw p }
+    },
+    () => {
+        const p = toPosix('C:\\Users\\x')
+        if (p !== 'C:/Users/x') { throw p }
+    },
+    () => {
+        const p = toPosix('')
+        if (p !== '') { throw p }
+    },
+]
+
+export const proof = { normalizeTest, concatTest, relativizeTest, toPosixTest }

--- a/issues/661-path-posix-separators.md
+++ b/issues/661-path-posix-separators.md
@@ -1,7 +1,7 @@
 # 661. `dev` re-implements path normalization that belongs in `fs/path`
 
 **Priority:** P4
-**Status:** open
+**Status:** done
 
 `AGENTS.md` gives "path manipulation belongs in `fs/path`, not inline in a
 loader" as the canonical separation-of-concerns example. There is a live


### PR DESCRIPTION
## Summary

Closes [i661-path-posix-separators](./issues/661-path-posix-separators.md).

- Add `toPosix(path)` to `fs/path/module.f.ts` — the narrow Windows-to-POSIX separator conversion.
- `parse` now calls `toPosix` instead of an inline `replaceAll('\\', '/')`.
- `loadModuleMap` in `fs/dev/module.f.ts` imports and calls `toPosix(initCwd)` instead of duplicating the rule inline.

This is the canonical AGENTS.md separation-of-concerns example: path manipulation belongs in `fs/path`, not inline in a loader.

`normalize` is not a drop-in substitute — it also collapses `.` / `..` and empty segments — so the narrow helper is justified for the loader's path.

## Test plan

- [x] `npx tsc` passes
- [x] `npm test` — same pass/fail count as base (8 pre-existing unrelated nanvm-lib failures)
- [x] `npm run fst` in `fs/path` — all 14 tests pass, including 4 new `toPosixTest` cases
- [x] `npm run fst` in `fs/dev` — all 11 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qn8CqpgT16ttkSrt342mGC)_