### PR TITLE
Update TypeScript native preview to 7.0.0-dev.20260603.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260601.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260603.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -210,7 +210,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260601.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260603.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -378,7 +378,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260601.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260603.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -546,7 +546,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260601.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260603.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -714,7 +714,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260601.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260603.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -888,7 +888,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260601.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260603.1"
         },
         {
           "uses": "denoland/setup-deno@v2",

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -43,7 +43,7 @@ export const wasmtime = '45.0.0'
 export const wasmer = '7.1.0'
 
 // https://www.npmjs.com/package/@typescript/native-preview?activeTab=versions
-export const tsgo = '7.0.0-dev.20260601.1'
+export const tsgo = '7.0.0-dev.20260603.1'
 
 // GitHub Action versions used by CI step builders. The key is the action
 // `owner/name`; call sites compose the full ref as


### PR DESCRIPTION
## Summary
Updates the TypeScript native preview dependency version across CI configuration and module configuration files.

## Changes
- Updated `@typescript/native-preview` from `7.0.0-dev.20260601.1` to `7.0.0-dev.20260603.1` in:
  - `.github/workflows/ci.yml` (6 occurrences across different workflow jobs)
  - `fs/ci/config/module.f.ts` (source configuration file)

This is a routine dependency update to the latest development build of the TypeScript native preview package.

https://claude.ai/code/session_018zFb8spKffChF6oPzXER3S