### PR TITLE
Add proof tests for main command add functionality

### DIFF
--- a/fs/cas/proof.f.ts
+++ b/fs/cas/proof.f.ts
@@ -1,11 +1,24 @@
-import { cas } from './module.f.ts'
+import { cas, main } from './module.f.ts'
 import { sha256 } from '../crypto/sha2/module.f.ts'
-import { empty, length } from '../types/bit_vec/module.f.ts'
+import { empty, length, vec8 } from '../types/bit_vec/module.f.ts'
 import type { Vec } from '../types/bit_vec/module.f.ts'
 import { pure } from '../types/effects/module.f.ts'
 import { run } from '../types/effects/mock/module.f.ts'
+import { emptyState, virtual } from '../types/effects/node/virtual/module.f.ts'
 
 export const proof = {
+    mainAdd: () => {
+        const content = vec8(0x2An)
+        const state = { ...emptyState, root: { myfile: content } }
+        const [finalState, exitCode] = virtual(state)(main(['add', 'myfile']))
+        if (exitCode !== 0) { throw ['expected exit 0', exitCode] }
+        if (finalState.stdout.length === 0) { throw 'expected hash in stdout' }
+    },
+    mainAddWrongArgs: () => {
+        const [finalState, exitCode] = virtual(emptyState)(main(['add']))
+        if (exitCode !== 1) { throw ['expected exit 1', exitCode] }
+        if (finalState.stderr.length === 0) { throw 'expected error in stderr' }
+    },
     casWrite: () => {
         const store = {
             read: (_key: Vec) => pure(undefined as Vec | undefined),


### PR DESCRIPTION
## Summary
Added test cases for the `main` command's `add` functionality to the proof module, verifying both successful and error scenarios.

## Key Changes
- Imported `main` function from module and virtual testing utilities (`emptyState`, `virtual`) for testing file system operations
- Added `vec8` import for creating test data
- Implemented `mainAdd` test that verifies:
  - Successfully adding a file to the virtual file system
  - Correct exit code (0) on success
  - Hash output is written to stdout
- Implemented `mainAddWrongArgs` test that verifies:
  - Proper error handling when required arguments are missing
  - Correct exit code (1) on failure
  - Error message is written to stderr

## Implementation Details
The tests use the virtual file system abstraction to simulate command execution without actual I/O, allowing for deterministic testing of the `add` command's behavior with various input scenarios.

https://claude.ai/code/session_01CEvxLCA1kcJAqjoaowYcWn