### PR TITLE
Add issues for crypto pow and vdf modules

### DIFF
--- a/issues/663-crypto-pow.md
+++ b/issues/663-crypto-pow.md
@@ -1,0 +1,120 @@
+# 663-crypto-pow. Proof-of-work module under `fs/crypto/pow`
+
+**Priority:** P3
+**Status:** open
+
+## Problem
+
+FunctionalScript has SHA-2, HMAC, secp256k1, and signing helpers under
+[`fs/crypto/`](../fs/crypto/README.md), but no module for traditional
+proof-of-work (PoW). Applications that need a hashcash-style or
+Bitcoin-style work challenge — where validity is expressed as an integer
+**difficulty** rather than a leading-zero **bit** count — currently have
+no shared primitive in the crypto tree.
+
+Leading-zero-bit PoW is a common teaching simplification; production systems
+(Bitcoin, hashcash variants used in protocols) compare the hash interpreted
+as a big-endian integer against a **target** derived from a difficulty integer.
+We want that model, not a separate bit-counting API.
+
+## Proposal
+
+Add `fs/crypto/pow/` alongside the existing crypto modules (`sha2`, `hmac`,
+`secp`, `sign`).
+
+### Semantics (Bitcoin-style difficulty integer)
+
+- **`difficulty`** is a positive `bigint`. Higher difficulty ⇒ harder work
+  (smaller target).
+- **`maxTarget`** is a fixed ceiling (Bitcoin's `0x00000000FFFF0000…` compact
+  genesis target, or a documented FunctionalScript constant — pick one and
+  document the choice in the module README).
+- **Target:** `target(difficulty) = maxTarget / difficulty` (integer division;
+  reject `difficulty === 0n`).
+- **Hash input:** caller supplies the pre-image as `Vec` (typically
+  `concat(challenge)(nonceOctets)` built outside the module). The module hashes
+  with an injected `Sha2` (default `sha256`) and interprets the digest as a
+  big-endian unsigned integer via existing `bit_vec` helpers (`uint` / `unpack`).
+- **Valid proof:** `hashValue <= target(difficulty)`.
+- **Verify** recomputes the hash and checks the inequality — no bit scanning.
+
+This deliberately avoids a `leadingZeros(hash) >= n` API. If a caller wants a
+bit threshold, they can derive an equivalent target offline; the module stays
+on integer difficulty.
+
+### API sketch
+
+Home: `fs/crypto/pow/module.f.ts` (standard `@module` JSDoc header).
+
+```ts
+import type { Sha2 } from '../sha2/module.f.ts'
+import type { Vec } from '../../types/bit_vec/module.f.ts'
+
+export type Pow = {
+  /** Documented genesis-style ceiling used for target derivation. */
+  readonly maxTarget: bigint
+  /** `maxTarget / difficulty`; throws or returns error for `difficulty === 0n`. */
+  readonly target: (difficulty: bigint) => bigint
+  /** Hash `data` with the configured `Sha2` and return digest as big-endian integer. */
+  readonly hashInt: (data: Vec) => bigint
+  /** Whether `hashInt(data) <= target(difficulty)`. */
+  readonly meets: (difficulty: bigint) => (data: Vec) => boolean
+  /** Alias shaped for proof verification: same as `meets`. */
+  readonly verify: (difficulty: bigint) => (data: Vec) => boolean
+}
+
+/** Build PoW helpers for a hash function (default consumer: `sha256`). */
+export const pow: (hash: Sha2) => Pow
+```
+
+Optional convenience (only if a second consumer appears — otherwise inline at
+call site):
+
+```ts
+/** Append big-endian `nonce` octets to `prefix` — thin `bit_vec` wrapper. */
+export const withNonce: (prefix: Vec) => (nonce: bigint) => Vec
+```
+
+Keep **`mine` / search loops out of the module** for now: mining is
+effectful/iterative and belongs in application or test code that calls
+`meets` repeatedly. The module provides the pure predicate and target math.
+
+### Module layout
+
+| File | Role |
+|------|------|
+| `fs/crypto/pow/module.f.ts` | `Pow` type, `pow`, `maxTarget`, target/verify |
+| `fs/crypto/pow/proof.f.ts` | Known-vector checks (easy difficulty passes, hard fails) |
+| `fs/crypto/pow/README.md` | Difficulty-vs-target semantics, `maxTarget` rationale |
+
+Register `./fs/crypto/pow/module.f.ts` in `deno.json` `exports`. Update
+[`fs/crypto/README.md`](../fs/crypto/README.md) to list `pow`.
+
+### FunctionalScript constraints
+
+- Reuse `computeSync` / `Sha2` from `fs/crypto/sha2` — no Node `crypto`.
+- Reuse `uint` / `vec` / `concat` from `bit_vec` and `bigint` helpers; no
+  hand-rolled hex parsing in the core module.
+- No mutable accumulators in public helpers; follow patterns in
+  [`fs/crypto/hmac/module.f.ts`](../fs/crypto/hmac/module.f.ts).
+- Tests via `proof.f.ts` + `npm run fst` under `fs/crypto/pow/`.
+
+## Tasks
+
+- [ ] Add `fs/crypto/pow/module.f.ts` with documented `maxTarget` and `pow(sha256)`.
+- [ ] Add `proof.f.ts` with at least: zero/invalid difficulty rejection, a
+  low difficulty that a fixed `(prefix, nonce)` satisfies, and a high difficulty
+  that the same pair fails.
+- [ ] Register export in `deno.json`; extend `fs/crypto/README.md`.
+- [ ] Run `npx tsc`, `npm run fst` in `fs/crypto/pow/`, and `npm run update`.
+
+## Related
+
+- [`fs/crypto/sha2/`](../fs/crypto/sha2/module.f.ts) — hash primitive.
+- [`fs/crypto/hmac/`](../fs/crypto/hmac/module.f.ts) — module layout / `proof.f.ts` pattern.
+- [i052-poker](./052-poker.md) — mentions PoW-adjacent timing; orthogonal to this module.
+
+## References
+
+- Bitcoin difficulty/target: [Developer Reference — Target](https://developer.bitcoin.org/reference/block_chain.html#target)
+- Existing crypto tree: [fs/crypto](https://github.com/functionalscript/functionalscript/tree/main/fs/crypto)

--- a/issues/663-crypto-pow.md
+++ b/issues/663-crypto-pow.md
@@ -1,46 +1,47 @@
 # 663-crypto-pow. Proof-of-work module under `fs/crypto/pow`
 
 **Priority:** P3
-**Status:** open
+**Status:** wip
 
 ## Problem
 
 FunctionalScript has SHA-2, HMAC, secp256k1, and signing helpers under
 [`fs/crypto/`](../fs/crypto/README.md), but no module for traditional
-proof-of-work (PoW). Applications that need a hashcash-style or
-Bitcoin-style work challenge — where validity is expressed as an integer
-**difficulty** rather than a leading-zero **bit** count — currently have
-no shared primitive in the crypto tree.
+proof-of-work (PoW). Applications that need Bitcoin-style work verification —
+compact **nBits** target encoding and hash-vs-target comparison — currently
+have no shared primitive in the crypto tree.
 
-Leading-zero-bit PoW is a common teaching simplification; production systems
-(Bitcoin, hashcash variants used in protocols) compare the hash interpreted
-as a big-endian integer against a **target** derived from a difficulty integer.
-We want that model, not a separate bit-counting API.
+Leading-zero-bit PoW is a common teaching simplification; Bitcoin compares the
+256-bit hash interpreted as a big-endian unsigned integer against a **target**
+decoded from the block header **nBits** field. We want that interface, not a
+separate bit-counting or floating **difficulty** API.
 
 ## Proposal
 
 Add `fs/crypto/pow/` alongside the existing crypto modules (`sha2`, `hmac`,
 `secp`, `sign`).
 
-### Semantics (Bitcoin-style difficulty integer)
+### Semantics (traditional Bitcoin PoW)
 
-- **`difficulty`** is a positive `bigint`. Higher difficulty ⇒ harder work
-  (smaller target).
-- **`maxTarget`** is a fixed ceiling (Bitcoin's `0x00000000FFFF0000…` compact
-  genesis target, or a documented FunctionalScript constant — pick one and
-  document the choice in the module README).
-- **Target:** `target(difficulty) = maxTarget / difficulty` (integer division;
-  reject `difficulty === 0n`).
+**nBits** (block header "bits", 32-bit) compact-encodes the **target**:
+
+- `exponent = nBits >> 24`
+- `mantissa = nBits & 0xffffff`
+- `target = mantissa × 2^(8 × (exponent − 3))`
+
+Valid PoW: `hash` (uint256) `≤ target`.
+
 - **Hash input:** caller supplies the pre-image as `Vec` (typically
-  `concat(challenge)(nonceOctets)` built outside the module). The module hashes
+  `concat(header)(nonceOctets)` built outside the module). The module hashes
   with an injected `Sha2` (default `sha256`) and interprets the digest as a
-  big-endian unsigned integer via existing `bit_vec` helpers (`uint` / `unpack`).
-- **Valid proof:** `hashValue <= target(difficulty)`.
-- **Verify** recomputes the hash and checks the inequality — no bit scanning.
+  big-endian unsigned integer via existing `bit_vec` helpers (`uint` /
+  `unpack`).
+- **Verify** decodes `nBits` → `target`, recomputes the hash, and checks
+  `hash ≤ target` — no bit scanning, no difficulty-to-target conversion.
 
-This deliberately avoids a `leadingZeros(hash) >= n` API. If a caller wants a
-bit threshold, they can derive an equivalent target offline; the module stays
-on integer difficulty.
+Reject malformed **nBits** (e.g. mantissa with high bit set when exponent is
+minimal, or target exceeding 256 bits) per Bitcoin consensus rules; document
+the exact checks in module JSDoc.
 
 ### API sketch
 
@@ -50,42 +51,46 @@ Home: `fs/crypto/pow/module.f.ts` (standard `@module` JSDoc header).
 import type { Sha2 } from '../sha2/module.f.ts'
 import type { Vec } from '../../types/bit_vec/module.f.ts'
 
+/** Decode compact nBits (32-bit) to a 256-bit target. Throws on invalid nBits. */
+export const targetFromNBits: (nBits: bigint) => bigint
+
 export type Pow = {
-  /** Documented genesis-style ceiling used for target derivation. */
-  readonly maxTarget: bigint
-  /** `maxTarget / difficulty`; throws or returns error for `difficulty === 0n`. */
-  readonly target: (difficulty: bigint) => bigint
-  /** Hash `data` with the configured `Sha2` and return digest as big-endian integer. */
+  /** Hash `data` with the configured `Sha2`; digest as big-endian uint256. */
   readonly hashInt: (data: Vec) => bigint
-  /** Whether `hashInt(data) <= target(difficulty)`. */
-  readonly meets: (difficulty: bigint) => (data: Vec) => boolean
-  /** Alias shaped for proof verification: same as `meets`. */
-  readonly verify: (difficulty: bigint) => (data: Vec) => boolean
+  /** Whether `hashInt(data) <= targetFromNBits(nBits)`. */
+  readonly meets: (nBits: bigint) => (data: Vec) => boolean
+  /** Same as `meets` — shaped for proof verification. */
+  readonly verify: (nBits: bigint) => (data: Vec) => boolean
 }
 
 /** Build PoW helpers for a hash function (default consumer: `sha256`). */
 export const pow: (hash: Sha2) => Pow
 ```
 
-Optional convenience (only if a second consumer appears — otherwise inline at
-call site):
-
-```ts
-/** Append big-endian `nonce` octets to `prefix` — thin `bit_vec` wrapper. */
-export const withNonce: (prefix: Vec) => (nonce: bigint) => Vec
-```
-
 Keep **`mine` / search loops out of the module** for now: mining is
 effectful/iterative and belongs in application or test code that calls
-`meets` repeatedly. The module provides the pure predicate and target math.
+`meets` repeatedly. The module provides `targetFromNBits` and the pure
+hash-vs-target predicate.
+
+### Test vectors
+
+Use well-known **nBits** / **target** pairs from Bitcoin (document in
+`proof.f.ts`):
+
+| nBits | target |
+|-------|--------|
+| `0x1d00ffff` (genesis) | `0x00000000ffff0000000000000000000000000000000000000000000000000000` |
+
+Assert `targetFromNBits(0x1d00ffffn)` equals the genesis target, and that a
+fixed header/nonce pair passes or fails `meets` for easy vs hard **nBits**.
 
 ### Module layout
 
 | File | Role |
 |------|------|
-| `fs/crypto/pow/module.f.ts` | `Pow` type, `pow`, `maxTarget`, target/verify |
-| `fs/crypto/pow/proof.f.ts` | Known-vector checks (easy difficulty passes, hard fails) |
-| `fs/crypto/pow/README.md` | Difficulty-vs-target semantics, `maxTarget` rationale |
+| `fs/crypto/pow/module.f.ts` | `targetFromNBits`, `Pow` type, `pow` |
+| `fs/crypto/pow/proof.f.ts` | Genesis nBits decode + meets/verify cases |
+| `fs/crypto/pow/README.md` | nBits compact encoding, hash ≤ target rule |
 
 Register `./fs/crypto/pow/module.f.ts` in `deno.json` `exports`. Update
 [`fs/crypto/README.md`](../fs/crypto/README.md) to list `pow`.
@@ -93,18 +98,17 @@ Register `./fs/crypto/pow/module.f.ts` in `deno.json` `exports`. Update
 ### FunctionalScript constraints
 
 - Reuse `computeSync` / `Sha2` from `fs/crypto/sha2` — no Node `crypto`.
-- Reuse `uint` / `vec` / `concat` from `bit_vec` and `bigint` helpers; no
-  hand-rolled hex parsing in the core module.
+- Reuse `uint` / `unpack` from `bit_vec` and `bigint` helpers for target
+  arithmetic; no hand-rolled hex parsing in the core module.
 - No mutable accumulators in public helpers; follow patterns in
   [`fs/crypto/hmac/module.f.ts`](../fs/crypto/hmac/module.f.ts).
 - Tests via `proof.f.ts` + `npm run fst` under `fs/crypto/pow/`.
 
 ## Tasks
 
-- [ ] Add `fs/crypto/pow/module.f.ts` with documented `maxTarget` and `pow(sha256)`.
-- [ ] Add `proof.f.ts` with at least: zero/invalid difficulty rejection, a
-  low difficulty that a fixed `(prefix, nonce)` satisfies, and a high difficulty
-  that the same pair fails.
+- [ ] Add `targetFromNBits` with genesis-block test vector (`0x1d00ffff`).
+- [ ] Add `fs/crypto/pow/module.f.ts` with `pow(sha256)` (`hashInt`, `meets`, `verify`).
+- [ ] Add `proof.f.ts`: invalid nBits rejection, easy nBits pass, hard nBits fail.
 - [ ] Register export in `deno.json`; extend `fs/crypto/README.md`.
 - [ ] Run `npx tsc`, `npm run fst` in `fs/crypto/pow/`, and `npm run update`.
 
@@ -116,5 +120,5 @@ Register `./fs/crypto/pow/module.f.ts` in `deno.json` `exports`. Update
 
 ## References
 
-- Bitcoin difficulty/target: [Developer Reference — Target](https://developer.bitcoin.org/reference/block_chain.html#target)
+- Bitcoin compact target (nBits): [Developer Reference — Target](https://developer.bitcoin.org/reference/block_chain.html#target)
 - Existing crypto tree: [fs/crypto](https://github.com/functionalscript/functionalscript/tree/main/fs/crypto)

--- a/issues/663-crypto-vdf.md
+++ b/issues/663-crypto-vdf.md
@@ -1,0 +1,118 @@
+# 663-crypto-vdf. Sloth VDF module under `fs/crypto/vdf`
+
+**Priority:** P3
+**Status:** open
+
+## Problem
+
+There is no verifiable delay function (VDF) support under
+[`fs/crypto/`](../fs/crypto/README.md). Sloth is a simple, auditable VDF
+(permutation over a fixed safe prime) used in delay-based protocols — see the
+VDF discussion in [i052-poker](./052-poker.md). Without a shared module,
+callers would copy imperative JavaScript (mutable loops, `**` exponentiation)
+that does not match FunctionalScript's purely functional style or existing
+`prime_field` / `bigint` conventions.
+
+## Proposal
+
+Add `fs/crypto/vdf/` implementing the **Sloth** VDF from
+[hyperhyperspace/pulsar `SlothVDF.ts`](https://github.com/hyperhyperspace/pulsar/blob/main/src/model/SlothVDF.ts),
+adapted from the reference JavaScript in
+[dignity.js `sloth-vdf.js`](https://github.com/jose-compu/dignity.js/blob/main/src/security/sloth-vdf.js)
+and [`vdf.js`](https://github.com/jose-compu/dignity.js/blob/main/src/security/vdf.js).
+
+### Cryptographic core
+
+Fixed safe prime (3072-bit), same constant as the reference:
+
+```ts
+export const p = 170082004324204494273811327264862981553264701145937538369570764779791492622392118654022654452947093285873855529044371650895045691292912712699015605832276411308653107069798639938826015099738961427172366594187783204437869906954750443653318078358839409699824714551430573905637228307966826784684174483831608534979n
+```
+
+Operations (all mod `p`, inputs normalized with `% p`):
+
+| Function | Role |
+|----------|------|
+| `quadRes(x)` | Euler criterion: `x^((p-1)/2) === 1` |
+| `modSqrt(x)` | `(p+1)/4` Tonelli–Shanks shortcut (prime ≡ 3 mod 4); if `x` is non-residue, negate `x` mod `p` first |
+| `eval(steps)(x)` | Apply `modSqrt` exactly `steps` times — **slow** (sequential by design) |
+| `verify(steps)(x)(y)` | Square `y` mod `p` exactly `steps` times; compare to `x` or `-x mod p` after optional negation if non-residue |
+
+Public API names should read as FunctionalScript values (`eval`, `verify`), not
+`generateProofVDF` / `verifyProofVDF` from the reference.
+
+### API sketch
+
+Home: `fs/crypto/vdf/module.f.ts`.
+
+```ts
+export type Sloth = {
+  readonly p: bigint
+  readonly quadRes: (x: bigint) => boolean
+  readonly modSqrt: (x: bigint) => bigint
+  /** Sequential Sloth permutation — intentionally O(steps). */
+  readonly eval: (steps: bigint) => (x: bigint) => bigint
+  /** Fast verification of `eval(steps)(x)`. */
+  readonly verify: (steps: bigint) => (x: bigint) => (y: bigint) => boolean
+}
+
+export const sloth: Sloth
+```
+
+Hex string wrappers (`challengeHex`, `resultHex`) from dignity.js belong in a
+**separate optional layer or caller code**, not in the core module: core API
+works on `bigint` like [`fs/types/prime_field/`](../fs/types/prime_field/module.f.ts).
+
+### Implementation notes
+
+- **Reuse `prime_field(p)`** where it fits (`mul`, `neg`, `pow`, `sub`). Sloth's
+  `modSqrt` and the verify-path squaring loop are Sloth-specific — keep them in
+  `vdf/module.f.ts` rather than extending `prime_field`.
+- **Exponentiation:** prefer `PrimeField.pow` over raw `**` (reference uses both
+  `fastPow` and `value ** BigInt(2)`).
+- **Iteration:** `eval`/`verify` require `steps` sequential modular ops; express
+  loops with the same patterns as [`prime_field` reciprocal](../fs/types/prime_field/module.f.ts)
+  or `repeat` from `monoid` where readable. Avoid `let` mutation in exported
+  surface helpers when a functional fold is clear.
+- **Edge cases:** document behaviour for `steps === 0n` (`eval` returns `x % p`;
+  `verify` checks `y` against `x` / `-x`). Reject negative `steps`.
+- Do **not** port the reference's `class SlothPermutation` or CommonJS exports.
+
+### Module layout
+
+| File | Role |
+|------|------|
+| `fs/crypto/vdf/module.f.ts` | `Sloth` type, constant `p`, `sloth` |
+| `fs/crypto/vdf/proof.f.ts` | Cross-check vectors against reference JS (fixed `x`, `steps`, `y`) |
+| `fs/crypto/vdf/README.md` | Sloth overview, prime source, eval vs verify cost |
+
+Register `./fs/crypto/vdf/module.f.ts` in `deno.json` `exports`. Update
+[`fs/crypto/README.md`](../fs/crypto/README.md) to list `vdf`.
+
+### Test vectors
+
+Capture at least one `(x, steps, y)` triple by running the dignity.js reference
+(or pulsar) and assert `sloth.eval(steps)(x) === y` and
+`sloth.verify(steps)(x)(y) === true` in `proof.f.ts`. Include a negative case
+(wrong `y`).
+
+## Tasks
+
+- [ ] Add `fs/crypto/vdf/module.f.ts` with `p`, `sloth.eval`, `sloth.verify`.
+- [ ] Wire modular arithmetic through `prime_field(p)` where appropriate.
+- [ ] Add `proof.f.ts` with reference-derived vectors and a failure case.
+- [ ] Register export in `deno.json`; extend `fs/crypto/README.md`.
+- [ ] Run `npx tsc`, `npm run fst` in `fs/crypto/vdf/`, and `npm run update`.
+
+## Related
+
+- [i052-poker](./052-poker.md) — protocol sketch using VDF for delayed key reveal.
+- [`fs/types/prime_field/`](../fs/types/prime_field/module.f.ts) — modular `pow` / `mul` / `neg`.
+- [`fs/crypto/sha2/`](../fs/crypto/sha2/module.f.ts) — sibling crypto module layout.
+
+## References
+
+- Reference implementation: [dignity.js `sloth-vdf.js`](https://github.com/jose-compu/dignity.js/blob/main/src/security/sloth-vdf.js), [`vdf.js`](https://github.com/jose-compu/dignity.js/blob/main/src/security/vdf.js)
+- Original adaptation source: [hyperhyperspace/pulsar `SlothVDF.ts`](https://github.com/hyperhyperspace/pulsar/blob/main/src/model/SlothVDF.ts)
+- Sloth VDF paper context: [Boneh et al., verifiable delay functions](https://eprint.iacr.org/2018/623)
+- Existing crypto tree: [fs/crypto](https://github.com/functionalscript/functionalscript/tree/main/fs/crypto)

--- a/issues/663-crypto-vdf.md
+++ b/issues/663-crypto-vdf.md
@@ -1,7 +1,7 @@
 # 663-crypto-vdf. Sloth VDF module under `fs/crypto/vdf`
 
 **Priority:** P3
-**Status:** open
+**Status:** wip
 
 ## Problem
 


### PR DESCRIPTION
## Summary

- Add [i663-crypto-pow](./issues/663-crypto-pow.md): Bitcoin-style PoW with integer difficulty under `fs/crypto/pow`.
- Add [i663-crypto-vdf](./issues/663-crypto-vdf.md): Sloth VDF under `fs/crypto/vdf`.

Related GitHub issues: #930, #931.

## Test plan

- [ ] Review issue proposals and task checklists.