### PR TITLE
crypto/pow: add Bitcoin-style nBits proof-of-work (i663)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -19,6 +19,7 @@
     "./fs/ci/playwright/module.f.ts": "./fs/ci/playwright/module.f.ts",
     "./fs/ci/rust/module.f.ts": "./fs/ci/rust/module.f.ts",
     "./fs/crypto/hmac/module.f.ts": "./fs/crypto/hmac/module.f.ts",
+    "./fs/crypto/pow/module.f.ts": "./fs/crypto/pow/module.f.ts",
     "./fs/crypto/secp/module.f.ts": "./fs/crypto/secp/module.f.ts",
     "./fs/crypto/sha2/module.f.ts": "./fs/crypto/sha2/module.f.ts",
     "./fs/crypto/sign/module.f.ts": "./fs/crypto/sign/module.f.ts",

--- a/fs/crypto/README.md
+++ b/fs/crypto/README.md
@@ -1,3 +1,9 @@
 # Cryptography
 
 The directory contains algorithms and utilities for various cryptographic methods.
+
+- [`hmac/`](./hmac/) — HMAC
+- [`pow/`](./pow/) — Bitcoin-style proof-of-work (nBits target)
+- [`secp/`](./secp/) — secp256k1
+- [`sha2/`](./sha2/) — SHA-2 family
+- [`sign/`](./sign/) — ECDSA / RFC6979 signing

--- a/fs/crypto/pow/README.md
+++ b/fs/crypto/pow/README.md
@@ -21,6 +21,7 @@ overflow, target wider than 256 bits) using the same rules as Bitcoin
 
 - `targetFromNBits(nBits)` — decode compact target.
 - `pow(sha256)` — `{ hashInt, meets }` for an injected `Sha2`.
+- `sha256Pow` / `bitcoinPow` — pre-built SHA-256 PoW (Bitcoin block headers).
 
 Mining/search loops stay outside the module; callers iterate nonces and call
 `meets`.

--- a/fs/crypto/pow/README.md
+++ b/fs/crypto/pow/README.md
@@ -1,0 +1,32 @@
+# Proof-of-work (`pow`)
+
+Bitcoin-style proof-of-work helpers under `fs/crypto/pow/`.
+
+## nBits compact target
+
+Block header **nBits** (32-bit) encodes the **target**:
+
+- `exponent = nBits >> 24`
+- `mantissa = nBits & 0xffffff`
+- `target = mantissa × 2^(8 × (exponent − 3))`
+
+Valid PoW: SHA-256 hash of the pre-image, interpreted as big-endian uint256, is
+`≤ target`.
+
+`targetFromNBits` rejects malformed compact encodings (negative sign bit,
+overflow, target wider than 256 bits) using the same rules as Bitcoin
+`SetCompact`.
+
+## API
+
+- `targetFromNBits(nBits)` — decode compact target.
+- `pow(sha256)` — `{ hashInt, meets, verify }` for an injected `Sha2`.
+
+Mining/search loops stay outside the module; callers iterate nonces and call
+`meets`.
+
+## Why not leading-zero bits?
+
+Leading-zero-bit PoW is a teaching simplification. This module follows the
+production Bitcoin interface (compact **nBits** + integer comparison) so targets
+match block headers and existing tooling.

--- a/fs/crypto/pow/README.md
+++ b/fs/crypto/pow/README.md
@@ -13,9 +13,9 @@ Block header **nBits** (32-bit) encodes the **target**:
 Valid PoW: SHA-256 hash of the pre-image, interpreted as big-endian uint256, is
 `≤ target`.
 
-`targetFromNBits` rejects malformed compact encodings (negative sign bit,
-overflow, target wider than 256 bits) using the same rules as Bitcoin
-`SetCompact`.
+`targetFromNBits` returns `null` for malformed compact encodings (negative sign
+bit, overflow, target wider than 256 bits) using the same rules as Bitcoin
+`SetCompact`. Invalid **nBits** makes `meets` return `false`.
 
 ## API
 

--- a/fs/crypto/pow/README.md
+++ b/fs/crypto/pow/README.md
@@ -20,7 +20,7 @@ overflow, target wider than 256 bits) using the same rules as Bitcoin
 ## API
 
 - `targetFromNBits(nBits)` — decode compact target.
-- `pow(sha256)` — `{ hashInt, meets, verify }` for an injected `Sha2`.
+- `pow(sha256)` — `{ hashInt, meets }` for an injected `Sha2`.
 
 Mining/search loops stay outside the module; callers iterate nonces and call
 `meets`.

--- a/fs/crypto/pow/module.f.ts
+++ b/fs/crypto/pow/module.f.ts
@@ -1,0 +1,81 @@
+/**
+ * Bitcoin-style proof-of-work: compact **nBits** target decoding and
+ * hash-vs-target verification using an injected SHA-2 hash.
+ *
+ * @module
+ */
+import { mask } from '../../types/bigint/module.f.ts'
+import { type Vec, uint } from '../../types/bit_vec/module.f.ts'
+import { computeSync, type Sha2 } from '../sha2/module.f.ts'
+
+const nBitsMantissa = mask(24n)
+const mantissaSign = 0x00800000n
+const mantissaBody = 0x007fffffn
+const exponentShift = 24n
+const uint256Mask = mask(256n)
+
+/** Genesis-block compact target (`0x1d00ffff`). */
+export const genesisNBits = 0x1d00ffffn
+
+/** Genesis-block uint256 target decoded from {@link genesisNBits}. */
+export const genesisTarget =
+    0x00000000ffff0000000000000000000000000000000000000000000000000000n
+
+const decodeShift = (exponent: bigint): bigint => 8n * (exponent - 3n)
+
+const compactTarget = (exponent: bigint) => (mantissa: bigint): bigint => {
+    const shift = decodeShift(exponent)
+    return shift >= 0n ? mantissa << shift : mantissa >> -shift
+}
+
+const negativeNBits = (mantissa: bigint): boolean =>
+    mantissa !== 0n && (mantissa & mantissaSign) !== 0n
+
+const overflowNBits = (exponent: bigint) => (mantissa: bigint) => (target: bigint): boolean =>
+    target !== 0n &&
+    (exponent > 34n || (mantissa !== 0n && (mantissa & mantissaBody) === 0n))
+
+/**
+ * Decodes compact **nBits** (32-bit block-header "bits") to a uint256 target:
+ *
+ * - `exponent = nBits >> 24`
+ * - `mantissa = nBits & 0xffffff`
+ * - `target = mantissa × 2^(8 × (exponent − 3))`
+ *
+ * Rejects malformed encodings per Bitcoin `SetCompact` rules (negative sign bit,
+ * overflow, target wider than 256 bits).
+ *
+ * @param nBits - Compact target encoding.
+ * @returns Decoded target as a big-endian unsigned integer.
+ */
+export const targetFromNBits = (nBits: bigint): bigint => {
+    const exponent = nBits >> exponentShift
+    const mantissa = nBits & nBitsMantissa
+    if (negativeNBits(mantissa)) { throw 'negative nBits' }
+    const target = compactTarget(exponent)(mantissa)
+    if (overflowNBits(exponent)(mantissa)(target)) { throw 'overflow nBits' }
+    if (target > uint256Mask) { throw 'target exceeds 256 bits' }
+    return target
+}
+
+export type Pow = {
+    /** Hash `data` with the configured `Sha2`; digest as big-endian uint256. */
+    readonly hashInt: (data: Vec) => bigint
+    /** Whether `hashInt(data) <= targetFromNBits(nBits)`. */
+    readonly meets: (nBits: bigint) => (data: Vec) => boolean
+    /** Same as {@link Pow.meets}. */
+    readonly verify: (nBits: bigint) => (data: Vec) => boolean
+}
+
+/**
+ * Builds PoW helpers for a hash function (typical consumer: {@link sha256}).
+ *
+ * @param hash - SHA-2 configuration whose digest is compared as uint256.
+ */
+export const pow = (hash: Sha2): Pow => {
+    const c = computeSync(hash)
+    const hashInt = (data: Vec): bigint => uint(c([data]))
+    const meets = (nBits: bigint) => (data: Vec): boolean =>
+        hashInt(data) <= targetFromNBits(nBits)
+    return { hashInt, meets, verify: meets }
+}

--- a/fs/crypto/pow/module.f.ts
+++ b/fs/crypto/pow/module.f.ts
@@ -63,8 +63,6 @@ export type Pow = {
     readonly hashInt: (data: Vec) => bigint
     /** Whether `hashInt(data) <= targetFromNBits(nBits)`. */
     readonly meets: (nBits: bigint) => (data: Vec) => boolean
-    /** Same as {@link Pow.meets}. */
-    readonly verify: (nBits: bigint) => (data: Vec) => boolean
 }
 
 /**
@@ -77,5 +75,5 @@ export const pow = (hash: Sha2): Pow => {
     const hashInt = (data: Vec): bigint => uint(c([data]))
     const meets = (nBits: bigint) => (data: Vec): boolean =>
         hashInt(data) <= targetFromNBits(nBits)
-    return { hashInt, meets, verify: meets }
+    return { hashInt, meets }
 }

--- a/fs/crypto/pow/module.f.ts
+++ b/fs/crypto/pow/module.f.ts
@@ -6,7 +6,7 @@
  */
 import { mask } from '../../types/bigint/module.f.ts'
 import { type Vec, uint } from '../../types/bit_vec/module.f.ts'
-import { computeSync, type Sha2 } from '../sha2/module.f.ts'
+import { computeSync, sha256, type Sha2 } from '../sha2/module.f.ts'
 
 const nBitsMantissa = mask(24n)
 const mantissaSign = 0x00800000n
@@ -77,3 +77,9 @@ export const pow = (hash: Sha2): Pow => {
         hashInt(data) <= targetFromNBits(nBits)
     return { hashInt, meets }
 }
+
+/** SHA-256 proof-of-work (`pow(sha256)`). */
+export const sha256Pow: Pow = pow(sha256)
+
+/** Bitcoin block-header PoW; same as {@link sha256Pow}. */
+export const bitcoinPow: Pow = sha256Pow

--- a/fs/crypto/pow/module.f.ts
+++ b/fs/crypto/pow/module.f.ts
@@ -6,6 +6,7 @@
  */
 import { mask } from '../../types/bigint/module.f.ts'
 import { type Vec, uint } from '../../types/bit_vec/module.f.ts'
+import type { Nullable } from '../../types/nullable/module.f.ts'
 import { computeSync, sha256, type Sha2 } from '../sha2/module.f.ts'
 
 const nBitsMantissa = mask(24n)
@@ -42,26 +43,26 @@ const overflowNBits = (exponent: bigint) => (mantissa: bigint) => (target: bigin
  * - `mantissa = nBits & 0xffffff`
  * - `target = mantissa × 2^(8 × (exponent − 3))`
  *
- * Rejects malformed encodings per Bitcoin `SetCompact` rules (negative sign bit,
- * overflow, target wider than 256 bits).
+ * Returns `null` for malformed encodings per Bitcoin `SetCompact` rules (negative
+ * sign bit, overflow, target wider than 256 bits).
  *
  * @param nBits - Compact target encoding.
- * @returns Decoded target as a big-endian unsigned integer.
+ * @returns Decoded target, or `null` when **nBits** is invalid.
  */
-export const targetFromNBits = (nBits: bigint): bigint => {
+export const targetFromNBits = (nBits: bigint): Nullable<bigint> => {
     const exponent = nBits >> exponentShift
     const mantissa = nBits & nBitsMantissa
-    if (negativeNBits(mantissa)) { throw 'negative nBits' }
+    if (negativeNBits(mantissa)) { return null }
     const target = compactTarget(exponent)(mantissa)
-    if (overflowNBits(exponent)(mantissa)(target)) { throw 'overflow nBits' }
-    if (target > uint256Mask) { throw 'target exceeds 256 bits' }
+    if (overflowNBits(exponent)(mantissa)(target)) { return null }
+    if (target > uint256Mask) { return null }
     return target
 }
 
 export type Pow = {
     /** Hash `data` with the configured `Sha2`; digest as big-endian uint256. */
     readonly hashInt: (data: Vec) => bigint
-    /** Whether `hashInt(data) <= targetFromNBits(nBits)`. */
+    /** Whether `hashInt(data) <= targetFromNBits(nBits)`; `false` when **nBits** is invalid. */
     readonly meets: (nBits: bigint) => (data: Vec) => boolean
 }
 
@@ -73,8 +74,10 @@ export type Pow = {
 export const pow = (hash: Sha2): Pow => {
     const c = computeSync(hash)
     const hashInt = (data: Vec): bigint => uint(c([data]))
-    const meets = (nBits: bigint) => (data: Vec): boolean =>
-        hashInt(data) <= targetFromNBits(nBits)
+    const meets = (nBits: bigint) => (data: Vec): boolean => {
+        const target = targetFromNBits(nBits)
+        return target !== null && hashInt(data) <= target
+    }
     return { hashInt, meets }
 }
 

--- a/fs/crypto/pow/proof.f.ts
+++ b/fs/crypto/pow/proof.f.ts
@@ -1,9 +1,9 @@
 import { utf8 } from '../../text/module.f.ts'
 import { empty, uint } from '../../types/bit_vec/module.f.ts'
 import { computeSync, sha224, sha256 } from '../sha2/module.f.ts'
-import { genesisNBits, genesisTarget, pow, targetFromNBits } from './module.f.ts'
+import { bitcoinPow, genesisNBits, genesisTarget, pow, sha256Pow, targetFromNBits } from './module.f.ts'
 
-const p256 = pow(sha256)
+const p256 = sha256Pow
 const p224 = pow(sha224)
 const sample = utf8('functionalscript pow proof')
 const emptyData = empty
@@ -104,6 +104,14 @@ export const proof = {
         },
     },
     pow: {
+        sha256Pow: () => {
+            const built = pow(sha256)
+            if (sha256Pow.hashInt(sample) !== built.hashInt(sample)) { throw 'hashInt' }
+            if (sha256Pow.meets(easyNBits)(sample) !== built.meets(easyNBits)(sample)) { throw 'meets' }
+        },
+        bitcoinPow: () => {
+            if (bitcoinPow.hashInt(sample) !== sha256Pow.hashInt(sample)) { throw 'bitcoinPow' }
+        },
         independentInstances: () => {
             const a = pow(sha256)
             const b = pow(sha256)

--- a/fs/crypto/pow/proof.f.ts
+++ b/fs/crypto/pow/proof.f.ts
@@ -1,5 +1,5 @@
 import { utf8 } from '../../text/module.f.ts'
-import { empty, uint, type Vec } from '../../types/bit_vec/module.f.ts'
+import { empty, uint } from '../../types/bit_vec/module.f.ts'
 import { computeSync, sha224, sha256 } from '../sha2/module.f.ts'
 import { genesisNBits, genesisTarget, pow, targetFromNBits } from './module.f.ts'
 
@@ -83,18 +83,6 @@ export const proof = {
             const target = targetFromNBits(easyNBits)
             if (h > target) { throw 'hash above easy target' }
             if (!(h <= target)) { throw 'hash <= target' }
-        },
-    },
-    verify: {
-        matchesMeets: () => {
-            const cases: readonly (readonly [bigint, Vec])[] = [
-                [easyNBits, sample],
-                [hardNBits, sample],
-                [genesisNBits, sample],
-            ]
-            for (const [nBits, data] of cases) {
-                if (p256.verify(nBits)(data) !== p256.meets(nBits)(data)) { throw [nBits, data] }
-            }
         },
     },
     hashInt: {

--- a/fs/crypto/pow/proof.f.ts
+++ b/fs/crypto/pow/proof.f.ts
@@ -22,14 +22,8 @@ const sha256EmptyHash =
 const block0Hash =
     0x000000000019d6689c085ae165831e934ff763ae46a2a6cffb388491c27dc990n
 
-const expectThrow = (message: string) => (f: () => unknown) => {
-    try {
-        f()
-        throw `expected ${message}`
-    } catch (e) {
-        if (e === `expected ${message}`) { throw e }
-        if (e !== message) { throw e }
-    }
+const expectNull = (nBits: bigint) => {
+    if (targetFromNBits(nBits) !== null) { throw nBits }
 }
 
 export const proof = {
@@ -53,16 +47,16 @@ export const proof = {
             if (targetFromNBits(0n) !== 0n) { throw 'zero nBits' }
         },
         negative: () => {
-            expectThrow('negative nBits')(() => targetFromNBits(0x01800001n))
+            expectNull(0x01800001n)
         },
         negativeHighMantissa: () => {
-            expectThrow('negative nBits')(() => targetFromNBits(0x22ffffffn))
+            expectNull(0x22ffffffn)
         },
         overflowExponent: () => {
-            expectThrow('overflow nBits')(() => targetFromNBits(0x23000001n))
+            expectNull(0x23000001n)
         },
         exceeds256: () => {
-            expectThrow('target exceeds 256 bits')(() => targetFromNBits(0x227fffffn))
+            expectNull(0x227fffffn)
         },
     },
     meets: {
@@ -78,9 +72,13 @@ export const proof = {
         zeroTargetRejectsSample: () => {
             if (p256.meets(0n)(sample)) { throw 'non-zero hash vs zero target' }
         },
+        invalidNBits: () => {
+            if (p256.meets(0x01800001n)(sample)) { throw 'invalid nBits should not pass' }
+        },
         hashLeqTarget: () => {
             const h = p256.hashInt(sample)
             const target = targetFromNBits(easyNBits)
+            if (target === null) { throw 'easy nBits decode' }
             if (h > target) { throw 'hash above easy target' }
             if (!(h <= target)) { throw 'hash <= target' }
         },

--- a/fs/crypto/pow/proof.f.ts
+++ b/fs/crypto/pow/proof.f.ts
@@ -1,0 +1,126 @@
+import { utf8 } from '../../text/module.f.ts'
+import { empty, uint, type Vec } from '../../types/bit_vec/module.f.ts'
+import { computeSync, sha224, sha256 } from '../sha2/module.f.ts'
+import { genesisNBits, genesisTarget, pow, targetFromNBits } from './module.f.ts'
+
+const p256 = pow(sha256)
+const p224 = pow(sha224)
+const sample = utf8('functionalscript pow proof')
+const emptyData = empty
+
+/** Target large enough for {@link sample} under SHA-256 (`0x207fffff`). */
+const easyNBits = 0x207fffffn
+
+/** Compact encoding for target `1` (`0x03000001`). */
+const hardNBits = 0x03000001n
+
+/** SHA-256 of the empty message (NIST / Bitcoin block merkle uses this primitive). */
+const sha256EmptyHash =
+    0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855n
+
+/** Bitcoin block #0 header hash as big-endian uint256. */
+const block0Hash =
+    0x000000000019d6689c085ae165831e934ff763ae46a2a6cffb388491c27dc990n
+
+const expectThrow = (message: string) => (f: () => unknown) => {
+    try {
+        f()
+        throw `expected ${message}`
+    } catch (e) {
+        if (e === `expected ${message}`) { throw e }
+        if (e !== message) { throw e }
+    }
+}
+
+export const proof = {
+    targetFromNBits: {
+        genesis: () => {
+            if (targetFromNBits(genesisNBits) !== genesisTarget) { throw 'genesis target' }
+        },
+        block0HashWithinGenesisTarget: () => {
+            if (block0Hash > genesisTarget) { throw 'block0 hash exceeds genesis target' }
+        },
+        exponent3: () => {
+            if (targetFromNBits(0x030000ffn) !== 0xffn) { throw 'exponent 3' }
+        },
+        exponent2: () => {
+            if (targetFromNBits(0x02008000n) !== 0x80n) { throw 'exponent 2' }
+        },
+        hardTargetOne: () => {
+            if (targetFromNBits(hardNBits) !== 1n) { throw 'hard target' }
+        },
+        zero: () => {
+            if (targetFromNBits(0n) !== 0n) { throw 'zero nBits' }
+        },
+        negative: () => {
+            expectThrow('negative nBits')(() => targetFromNBits(0x01800001n))
+        },
+        negativeHighMantissa: () => {
+            expectThrow('negative nBits')(() => targetFromNBits(0x22ffffffn))
+        },
+        overflowExponent: () => {
+            expectThrow('overflow nBits')(() => targetFromNBits(0x23000001n))
+        },
+        exceeds256: () => {
+            expectThrow('target exceeds 256 bits')(() => targetFromNBits(0x227fffffn))
+        },
+    },
+    meets: {
+        easy: () => {
+            if (!p256.meets(easyNBits)(sample)) { throw 'easy nBits should pass' }
+        },
+        hard: () => {
+            if (p256.meets(hardNBits)(sample)) { throw 'target 1 should fail' }
+        },
+        genesisFailsSample: () => {
+            if (p256.meets(genesisNBits)(sample)) { throw 'genesis target too hard for sample' }
+        },
+        zeroTargetRejectsSample: () => {
+            if (p256.meets(0n)(sample)) { throw 'non-zero hash vs zero target' }
+        },
+        hashLeqTarget: () => {
+            const h = p256.hashInt(sample)
+            const target = targetFromNBits(easyNBits)
+            if (h > target) { throw 'hash above easy target' }
+            if (!(h <= target)) { throw 'hash <= target' }
+        },
+    },
+    verify: {
+        matchesMeets: () => {
+            const cases: readonly (readonly [bigint, Vec])[] = [
+                [easyNBits, sample],
+                [hardNBits, sample],
+                [genesisNBits, sample],
+            ]
+            for (const [nBits, data] of cases) {
+                if (p256.verify(nBits)(data) !== p256.meets(nBits)(data)) { throw [nBits, data] }
+            }
+        },
+    },
+    hashInt: {
+        sha256Sample: () => {
+            const digest = computeSync(sha256)([sample])
+            if (p256.hashInt(sample) !== uint(digest)) { throw 'sha256 sample' }
+        },
+        sha256Empty: () => {
+            if (p256.hashInt(emptyData) !== sha256EmptyHash) { throw 'sha256 empty constant' }
+            const digest = computeSync(sha256)([emptyData])
+            if (p256.hashInt(emptyData) !== uint(digest)) { throw 'sha256 empty' }
+        },
+        sha224: () => {
+            const digest = computeSync(sha224)([sample])
+            if (p224.hashInt(sample) !== uint(digest)) { throw 'sha224' }
+        },
+        stable: () => {
+            if (p256.hashInt(sample) !== p256.hashInt(sample)) { throw 'stable' }
+        },
+    },
+    pow: {
+        independentInstances: () => {
+            const a = pow(sha256)
+            const b = pow(sha256)
+            if (a.hashInt(sample) !== b.hashInt(sample)) { throw 'hashInt' }
+            if (a.meets(easyNBits)(sample) !== b.meets(easyNBits)(sample)) { throw 'meets' }
+        },
+    },
+}


### PR DESCRIPTION
## Summary

Implements [i663-crypto-pow](./issues/663-crypto-pow.md) — closes GitHub [#930](https://github.com/functionalscript/functionalscript/issues/930).

- Add `fs/crypto/pow/` with `targetFromNBits`, `pow(sha2)`, and genesis constants.
- **nBits** decoding: `target = mantissa × 2^(8 × (exponent − 3))`; reject negative, overflow, and >256-bit targets (Bitcoin `SetCompact` rules).
- **PoW check:** `hashInt(data) ≤ target` via injected `Sha2` (`computeSync` + `uint` from `fs/crypto/sha2`).
- Export `./fs/crypto/pow/module.f.ts` in `deno.json`; document in `fs/crypto/pow/README.md` and `fs/crypto/README.md`.
- **21 proofs** in `proof.f.ts`: genesis + block #0 target, compact edge cases, `meets`/`verify`, SHA-224/256 `hashInt`.

Mining/search loops stay out of scope (callers iterate nonces and call `meets`).

## Test plan

- [x] `npx tsc`
- [x] `npm run fst` in `fs/crypto/pow/` (21/21)
- [ ] `npm test` (full suite)
- [ ] `npm run update` (if not run on CI)