### PR TITLE
Update Deno and TypeScript Native Preview versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,12 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260603.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260604.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
           "with": {
-            "deno-version": "2.8.1"
+            "deno-version": "2.8.2"
           }
         },
         {
@@ -210,12 +210,12 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260603.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260604.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
           "with": {
-            "deno-version": "2.8.1"
+            "deno-version": "2.8.2"
           }
         },
         {
@@ -378,12 +378,12 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260603.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260604.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
           "with": {
-            "deno-version": "2.8.1"
+            "deno-version": "2.8.2"
           }
         },
         {
@@ -546,12 +546,12 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260603.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260604.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
           "with": {
-            "deno-version": "2.8.1"
+            "deno-version": "2.8.2"
           }
         },
         {
@@ -714,12 +714,12 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260603.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260604.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
           "with": {
-            "deno-version": "2.8.1"
+            "deno-version": "2.8.2"
           }
         },
         {
@@ -888,12 +888,12 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260603.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260604.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
           "with": {
-            "deno-version": "2.8.1"
+            "deno-version": "2.8.2"
           }
         },
         {

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -25,7 +25,7 @@ export const images = {
 export const bun = '1.3.14'
 
 // https://deno.com/
-export const deno = '2.8.1'
+export const deno = '2.8.2'
 
 // https://www.npmjs.com/package/playwright
 export const playwright = '1.60.0'
@@ -43,7 +43,7 @@ export const wasmtime = '45.0.0'
 export const wasmer = '7.1.0'
 
 // https://www.npmjs.com/package/@typescript/native-preview?activeTab=versions
-export const tsgo = '7.0.0-dev.20260603.1'
+export const tsgo = '7.0.0-dev.20260604.1'
 
 // GitHub Action versions used by CI step builders. The key is the action
 // `owner/name`; call sites compose the full ref as


### PR DESCRIPTION
## Summary
This PR updates the pinned versions of Deno and TypeScript Native Preview tools used in the CI/CD pipeline and configuration.

## Key Changes
- Updated Deno from version `2.8.1` to `2.8.2`
- Updated TypeScript Native Preview (`@typescript/native-preview`) from `7.0.0-dev.20260603.1` to `7.0.0-dev.20260604.1`
- Changes applied consistently across all CI workflow jobs in `.github/workflows/ci.yml`
- Updated corresponding version constants in `fs/ci/config/module.f.ts`

## Details
The version updates are reflected in:
- The CI workflow configuration file with 6 separate job definitions
- The centralized configuration module that serves as the source of truth for tool versions

These are routine dependency updates to ensure the CI pipeline uses the latest available versions of these development tools.

https://claude.ai/code/session_017PsQUEurVmTwKoMGscLqaE