### PR TITLE
Add comprehensive test cases for main command handlers

### DIFF
--- a/fs/cas/proof.f.ts
+++ b/fs/cas/proof.f.ts
@@ -19,6 +19,53 @@ export const proof = {
         if (exitCode !== 1) { throw ['expected exit 1', exitCode] }
         if (finalState.stderr.length === 0) { throw 'expected error in stderr' }
     },
+    mainGetFound: () => {
+        const content = vec8(0x2An)
+        const state = { ...emptyState, root: { myfile: content } }
+        const [state1, exitCode1] = virtual(state)(main(['add', 'myfile']))
+        if (exitCode1 !== 0) { throw ['expected add exit 0', exitCode1] }
+        const hashStr = state1.stdout.trim()
+        const [, exitCode2] = virtual(state1)(main(['get', hashStr, 'output']))
+        if (exitCode2 !== 0) { throw ['expected get exit 0', exitCode2] }
+    },
+    mainGetNotFound: () => {
+        // valid cBase32 hash that has not been stored
+        const content = vec8(0x2An)
+        const state = { ...emptyState, root: { myfile: content } }
+        const [state1] = virtual(state)(main(['add', 'myfile']))
+        const hashStr = state1.stdout.trim()
+        // use an empty store so the hash is not found
+        const [finalState, exitCode] = virtual(emptyState)(main(['get', hashStr, 'output']))
+        if (exitCode !== 1) { throw ['expected exit 1', exitCode] }
+        if (finalState.stderr.length === 0) { throw 'expected error in stderr' }
+    },
+    mainGetWrongArgs: () => {
+        const [finalState, exitCode] = virtual(emptyState)(main(['get']))
+        if (exitCode !== 1) { throw ['expected exit 1', exitCode] }
+        if (finalState.stderr.length === 0) { throw 'expected error in stderr' }
+    },
+    mainGetInvalidHash: () => {
+        const [finalState, exitCode] = virtual(emptyState)(main(['get', 'not-a-valid-hash', 'output']))
+        if (exitCode !== 1) { throw ['expected exit 1', exitCode] }
+        if (finalState.stderr.length === 0) { throw 'expected error in stderr' }
+    },
+    mainList: () => {
+        const content = vec8(0x2An)
+        const state = { ...emptyState, root: { myfile: content } }
+        const [state1] = virtual(state)(main(['add', 'myfile']))
+        const [, exitCode] = virtual(state1)(main(['list']))
+        if (exitCode !== 0) { throw ['expected exit 0', exitCode] }
+    },
+    mainNoCmd: () => {
+        const [finalState, exitCode] = virtual(emptyState)(main([]))
+        if (exitCode !== 1) { throw ['expected exit 1', exitCode] }
+        if (finalState.stderr.length === 0) { throw 'expected error in stderr' }
+    },
+    mainUnknownCmd: () => {
+        const [finalState, exitCode] = virtual(emptyState)(main(['bogus']))
+        if (exitCode !== 1) { throw ['expected exit 1', exitCode] }
+        if (finalState.stderr.length === 0) { throw 'expected error in stderr' }
+    },
     casWrite: () => {
         const store = {
             read: (_key: Vec) => pure(undefined as Vec | undefined),


### PR DESCRIPTION
## Summary
Added seven new test cases to the proof object to provide comprehensive coverage of the main command handler functionality, including success paths, error conditions, and edge cases.

## Key Changes
- **mainGetFound**: Tests successful retrieval of a file that was previously added to the store
- **mainGetNotFound**: Tests error handling when attempting to retrieve a hash that doesn't exist in the store
- **mainGetWrongArgs**: Tests error handling when the `get` command is called without required arguments
- **mainGetInvalidHash**: Tests error handling when an invalid hash format is provided to the `get` command
- **mainList**: Tests successful listing of stored files
- **mainNoCmd**: Tests error handling when no command is provided
- **mainUnknownCmd**: Tests error handling when an unknown/invalid command is provided

## Implementation Details
All test cases follow the existing pattern in the proof object:
- Use virtual state execution to test command behavior
- Verify exit codes (0 for success, 1 for errors)
- Validate stderr output for error cases
- Test both happy paths and error conditions
- Reuse common test utilities like `vec8()`, `emptyState`, and `virtual()`

https://claude.ai/code/session_01BAZBCNqCBeQmEDYr6euRNy