### PR TITLE
function/compare: add generic min/max, retire per-type copies (i184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- **breaking** `function/compare`: add generic `min`/`max` next to `cmp`, reusing the `Cmp1`/`Cmp2<A, B>` guard so mixed-type calls like `min(1)("a")` fail to compile; retire the duplicated `Reduce<number>`-typed `min`/`max` from `function/operator` and the bigint-typed `min`/`max` from `types/bigint`; consumers (`types/number`, `types/bit_vec`, `asn.1`) now import the single generic pair from `function/compare` [940](https://github.com/functionalscript/functionalscript/pull/940)
+
 ## 0.22.0
 
 - **breaking** `emergent_testing`: rename `fs/emergent-testing` → `fs/emergent_testing` (snake_case, matching the `bit_vec` / `prime_field` module-naming convention); public exports and the external-runner entry import change from `…/fs/emergent-testing/module.{f.ts,ts,js}` to `…/fs/emergent_testing/module.{f.ts,ts,js}` [924](https://github.com/functionalscript/functionalscript/pull/924)

--- a/fs/asn.1/module.f.ts
+++ b/fs/asn.1/module.f.ts
@@ -4,7 +4,7 @@
  *
  * @module
  */
-import { bitLength, max } from "../types/bigint/module.f.ts"
+import { bitLength } from "../types/bigint/module.f.ts"
 import {
     empty,
     isVec,
@@ -18,6 +18,7 @@ import {
     type Vec
 } from "../types/bit_vec/module.f.ts"
 import { identity } from "../types/function/module.f.ts"
+import { max } from "../types/function/compare/module.f.ts"
 import { encode as b128encode, decode as b128decode } from "../base128/module.f.ts"
 
 const { popFront: pop, listToVec } = msb

--- a/fs/types/bigint/module.f.ts
+++ b/fs/types/bigint/module.f.ts
@@ -13,7 +13,6 @@
  * const logValue = log2(8n) // 3n
  * const bitCount = bitLength(255n) // 8n
  * const bitmask = mask(5n) // 31n
- * const m = min(3n)(13n) // 3n
  * const c = combination([3n, 2n, 1n]) // 60n
  * ```
  */
@@ -205,24 +204,6 @@ export const bitLength = (v: bigint): bigint => log2(abs(v)) + 1n
  */
 export const mask = (len: bigint): bigint =>
     (1n << len) - 1n
-
-/**
- * Returns the smaller of two `bigint` values.
- *
- * @param a - The first bigint.
- * @returns A function that takes the second bigint and returns the smaller value.
- */
-export const min = (a:bigint) => (b: bigint): bigint =>
-    a < b ? a : b
-
-/**
- * Returns the larger of two `bigint` values.
- *
- * @param a - The first bigint.
- * @returns A function that takes the second bigint and returns the larger value.
- */
-export const max = (a: bigint) => (b: bigint): bigint =>
-    a < b ? b : a
 
 /**
  * Calculates the partial factorial `b!/a!`.

--- a/fs/types/bigint/proof.f.ts
+++ b/fs/types/bigint/proof.f.ts
@@ -5,12 +5,12 @@ import {
     log2,
     bitLength,
     mask,
-    min,
     combination,
     factorial,
     divUp,
     roundUp
 } from './module.f.ts'
+import { min } from '../function/compare/module.f.ts'
 
 const oldLog2 = (v: bigint): bigint => {
     if (v <= 0n) { return -1n }

--- a/fs/types/bit_vec/module.f.ts
+++ b/fs/types/bit_vec/module.f.ts
@@ -21,13 +21,13 @@
  *
  * @module
  */
-import { bitLength, divUp, mask, max, min, xor, type Reduce as BigintReduce } from '../bigint/module.f.ts'
+import { bitLength, divUp, mask, xor, type Reduce as BigintReduce } from '../bigint/module.f.ts'
 import { flip, identity } from '../function/module.f.ts'
 import type { Binary, Fold, Reduce as OpReduce } from '../function/operator/module.f.ts'
 import { fold, iterable, map, type List, type Thunk } from '../list/module.f.ts'
 import { asBase, asNominal, type Nominal } from '../nominal/module.f.ts'
 import { repeat as mRepeat } from '../monoid/module.f.ts'
-import { cmp, type Sign } from '../function/compare/module.f.ts'
+import { cmp, max, min, type Sign } from '../function/compare/module.f.ts'
 
 /**
  * A vector of bits represented as a signed `bigint`.

--- a/fs/types/function/compare/module.f.ts
+++ b/fs/types/function/compare/module.f.ts
@@ -34,6 +34,22 @@ export const cmp = <A extends Cmp1>(a: A) => <B extends Cmp2<A, B>>(b: B): Sign 
     a as any < b ? -1 : a as any > b ? 1 : 0
 
 /**
+ * Returns the smaller of two comparable values. The `Cmp2<A, B>` constraint
+ * is the same one `cmp` uses: it rejects calls that mix incompatible primitive
+ * types (e.g. `min(1)("a")`) at compile time.
+ */
+export const min = <A extends Cmp1>(a: A) => <B extends Cmp2<A, B>>(b: B): A | B =>
+    cmp(a)(b) < 0 ? a : b
+
+/**
+ * Returns the larger of two comparable values. The `Cmp2<A, B>` constraint
+ * is the same one `cmp` uses: it rejects calls that mix incompatible primitive
+ * types (e.g. `max(1)("a")`) at compile time.
+ */
+export const max = <A extends Cmp1>(a: A) => <B extends Cmp2<A, B>>(b: B): A | B =>
+    cmp(a)(b) > 0 ? a : b
+
+/**
  * Binary search over `[0, len)`. `probe(mid)` returns the sign of the search
  * key relative to the element at `mid` (`-1` before, `0` at, `1` after). On a
  * hit it returns the matching index; on a miss it returns the converged lower

--- a/fs/types/function/compare/proof.f.ts
+++ b/fs/types/function/compare/proof.f.ts
@@ -1,4 +1,4 @@
-import { cmp } from './module.f.ts'
+import { cmp, min, max } from './module.f.ts'
 
 export const proof = () => {
     {
@@ -29,5 +29,19 @@ export const proof = () => {
         const _ = cmp(a)("hello") // ??? TypeScript changes a type definition of `a`.
         // const f = (a: string|number, b: string|number) => cmp(a)(b) // compilation error
         // const f = (a: number, b: string|number) => cmp(a)(b) // compilation error
+    }
+    {
+        if (min(3)(5) !== 3) { throw 'min(3)(5)' }
+        if (min(7)(2) !== 2) { throw 'min(7)(2)' }
+        if (min(3n)(13n) !== 3n) { throw 'min(3n)(13n)' }
+        if (min("a")("b") !== "a") { throw 'min("a")("b")' }
+        // const _ = min(1)("a") // compilation error
+    }
+    {
+        if (max(3)(5) !== 5) { throw 'max(3)(5)' }
+        if (max(7)(2) !== 7) { throw 'max(7)(2)' }
+        if (max(3n)(13n) !== 13n) { throw 'max(3n)(13n)' }
+        if (max("a")("b") !== "b") { throw 'max("a")("b")' }
+        // const _ = max(1)("a") // compilation error
     }
 }

--- a/fs/types/function/operator/module.f.ts
+++ b/fs/types/function/operator/module.f.ts
@@ -45,12 +45,6 @@ export const reduceToScan = <T>(op: Reduce<T>): Scan<T, T> => init =>
 export const addition: Reduce<number>
     = a => b => a + b
 
-export const min: Reduce<number>
-    = a => b => a < b ? a : b
-
-export const max: Reduce<number>
-    = a => b => a > b ? a : b
-
 export const increment: (b: number) => number
     = addition(1)
 

--- a/fs/types/function/operator/proof.f.ts
+++ b/fs/types/function/operator/proof.f.ts
@@ -4,8 +4,6 @@ import {
     logicalNot,
     strictEqual,
     addition,
-    min,
-    max,
     increment,
     foldToScan,
     reduceToScan,
@@ -36,16 +34,6 @@ const additionTest = () => {
     if (result !== 7) { throw result }
 }
 
-const minTest = () => {
-    if (min(3)(5) !== 3) { throw 'min(3)(5)' }
-    if (min(7)(2) !== 2) { throw 'min(7)(2)' }
-}
-
-const maxTest = () => {
-    if (max(3)(5) !== 5) { throw 'max(3)(5)' }
-    if (max(7)(2) !== 7) { throw 'max(7)(2)' }
-}
-
 const incrementTest = () => {
     if (increment(4) !== 5) { throw 'increment(4)' }
     if (increment(0) !== 1) { throw 'increment(0)' }
@@ -67,4 +55,4 @@ const reduceToScanTest = () => {
     if (v1 !== 15) { throw v1 }
 }
 
-export const proof = { joinTest, concatTest, logicalNotTest, strictEqualTest, additionTest, minTest, maxTest, incrementTest, foldToScanTest, reduceToScanTest }
+export const proof = { joinTest, concatTest, logicalNotTest, strictEqualTest, additionTest, incrementTest, foldToScanTest, reduceToScanTest }

--- a/fs/types/number/module.f.ts
+++ b/fs/types/number/module.f.ts
@@ -5,17 +5,17 @@
  * @module
  */
 import { reduce, type List } from '../list/module.f.ts'
-import { addition, min as minOp, max as maxOp } from '../function/operator/module.f.ts'
-import { type Sign, cmp as uCmp } from '../function/compare/module.f.ts'
+import { addition } from '../function/operator/module.f.ts'
+import { type Sign, cmp as uCmp, min as uMin, max as uMax } from '../function/compare/module.f.ts'
 
 export const sum: (input: List<number>) => number
     = reduce(addition)(0)
 
 export const min: (input: List<number>) => number | null
-    = reduce(minOp)(null)
+    = reduce(uMin<number>)(null)
 
 export const max: (input: List<number>) => number | null
-    = reduce(maxOp)(null)
+    = reduce(uMax<number>)(null)
 
 export const cmp: (a: number) => (b: number) => Sign
     = uCmp

--- a/issues/184-min-max-comparable.md
+++ b/issues/184-min-max-comparable.md
@@ -1,7 +1,7 @@
 # 184. `function`: a generic comparable `min`/`max`, retiring the per-type copies
 
 **Priority:** P3
-**Status:** open
+**Status:** done
 
 The exact same two-line "pick the smaller / larger of two values" algorithm is
 written out in two modules, differing only in the element type.


### PR DESCRIPTION
Fixes [i184](./issues/184-min-max-comparable.md).

## Summary

- Add `min`/`max` to `fs/types/function/compare/module.f.ts` next to `cmp`, reusing the same `Cmp1`/`Cmp2<A, B>` guard so call sites mixing incompatible primitive types (e.g. `min(1)("a")`) fail to compile.
- Retire the duplicated `Reduce<number>`-typed `min`/`max` from `function/operator` and the bigint-typed `min`/`max` from `types/bigint`.
- Point the four consumers (`types/number`, `types/bit_vec`, `asn.1`, `types/bigint/proof`) at the single generic pair. `number.min`/`max` instantiate as `min<number>`/`max<number>` so `reduce` can infer the fold type.
- Tests for `min`/`max` move from `operator/proof.f.ts` to `compare/proof.f.ts`, extended with `bigint` and `string` cases plus commented mixed-type calls that document the compile-time guard.

## Test plan

- [x] `npx tsc` — passes
- [x] `npm test` — same 10 pre-existing failures as `main` (all in `nanvm-lib` / `fs/io`, unrelated)
- [x] New `min`/`max` cases in `compare/proof.f.ts` pass


---
_Generated by [Claude Code](https://claude.ai/code/session_013KbYwgau11sYbmtcVV3ZFN)_