### PR TITLE
Add issue specifications for SHA2 sigma factory and proof entry filter

### DIFF
--- a/issues/664-sha2-sigma-factory.md
+++ b/issues/664-sha2-sigma-factory.md
@@ -1,0 +1,91 @@
+# 664-sha2-sigma-factory. `crypto/sha2`: collapse the `bigSigma`/`smallSigma` rotation mirror
+
+**Priority:** P4
+**Status:** open
+
+## Problem
+
+`fs/crypto/sha2/module.f.ts` defines two sigma mixers inside `base`
+(`fs/crypto/sha2/module.f.ts:77-96`). They are byte-identical except for
+their third XOR operand:
+
+```ts
+const bigSigma = ([a, b, c]: V3) => {
+    const ra = rotr(a)
+    const rb = rotr(b)
+    const rc = rotr(c)
+    return (x: bigint) => ra(x) ^ rb(x) ^ rc(x)
+}
+
+const bigSigma0 = bigSigma(bs0)
+const bigSigma1 = bigSigma(bs1)
+
+const smallSigma = ([a, b, c]: V3) => {
+    const ra = rotr(a)
+    const rb = rotr(b)
+    return (x: bigint) => ra(x) ^ rb(x) ^ (x >> c)
+}
+
+const smallSigma0 = smallSigma(ss0)
+const smallSigma1 = smallSigma(ss1)
+```
+
+The shared structure — precompute `rotr(a)` and `rotr(b)`, precompute a
+third operand from `c`, then XOR the three together — is the whole body
+of each function. The only difference is whether the third operand is
+`rotr(c)` (big sigma) or `>> c` (small sigma). This is the SHA-2
+σ/Σ algebra; both forms have two real consumers each (`*0` and `*1`),
+so the second-consumer bar is well past.
+
+## Proposed abstraction
+
+A single sigma factory parameterized by how the *third* operand is built
+from `c`. Keeping the third operand as a `c => x => …` function preserves
+the existing precomputation (the `rotr(c)` / shift-by-`c` closure is built
+once per sigma, not once per `x`):
+
+```ts
+const sigma =
+    (third: (c: bigint) => (x: bigint) => bigint) =>
+    ([a, b, c]: V3) => {
+        const ra = rotr(a)
+        const rb = rotr(b)
+        const rc = third(c)
+        return (x: bigint) => ra(x) ^ rb(x) ^ rc(x)
+    }
+
+const bigSigma = sigma(rotr)            // third operand: rotate right by c
+const smallSigma = sigma(c => x => x >> c) // third operand: shift right by c
+```
+
+`bigSigma0`/`bigSigma1`/`smallSigma0`/`smallSigma1` are unchanged below
+this point. `rotr` already has exactly the `c => x => …` shape, so
+`sigma(rotr)` reads directly as "the big sigma is the small sigma whose
+tail is another rotation."
+
+## Why this qualifies
+
+- **DRY:** the rotation-setup-plus-XOR body is duplicated verbatim; only
+  one sub-expression differs. AGENTS.md calls out exactly this case —
+  "two or more modules [here, two helpers in one module] share an
+  algorithm and differ only in … small helpers."
+- **Readability:** names the relationship between the two SHA-2 mixers
+  instead of forcing the reader to diff two near-identical blocks (an
+  explicit goal in AGENTS.md's "two code branches share most of their
+  structure" guidance).
+- **No performance regression:** the `c`-derived operand is still
+  computed once when the sigma is specialized (`third(c)`), not per call.
+
+## Caveats
+
+- This is a small, local cleanup (≈ 8 lines saved). It does not change
+  any exported API — `bigSigma*`/`smallSigma*` keep their signatures —
+  and the SHA-256/512 test vectors in `proof.f.ts` must still pass
+  unchanged.
+- `ch`/`maj` (`fs/crypto/sha2/module.f.ts:98-100`) are *not* part of this
+  mirror; they have distinct structure and should be left alone.
+
+## Related
+
+- [i187](./187-byte-rounding-divup.md) — another `crypto`-area
+  micro-DRY (shift-based byte rounding shared by `asn.1`/`sign`).

--- a/issues/664-tf-proof-entry-filter.md
+++ b/issues/664-tf-proof-entry-filter.md
@@ -1,0 +1,79 @@
+# 664-tf-proof-entry-filter. `emergent_testing`: extract the duplicated "modules that export a proof" filter
+
+**Priority:** P4
+**Status:** open
+
+## Problem
+
+`fs/emergent_testing/module.f.ts` selects the entries of a `ModuleMap`
+that export a `proof` property in two places, with byte-identical code:
+
+```ts
+// runModuleMap — fs/emergent_testing/module.f.ts:221-222
+const modules = entries(moduleMap)
+    .flatMap(([k, v]) => v.proof !== undefined ? [[k, v.proof] as const] : [])
+
+// registerModuleMap — fs/emergent_testing/module.f.ts:244-245
+const modules = entries(moduleMap)
+    .flatMap(([k, v]) => v.proof !== undefined ? [[k, v.proof] as const] : [])
+```
+
+Both are the same operation: "given a `ModuleMap`, produce the
+`[name, proof]` pairs for modules that have a proof." The two consumers
+(`runModuleMap`, the runner; `registerModuleMap`, the `fjs t`
+registration path) must stay in lockstep — if the selection rule ever
+changes (e.g. to skip a module flagged as non-test, or to read a
+differently named export), both call sites have to be edited identically.
+
+The selection rule is also referenced from
+[i664-emergent-testing-module-files](./664-emergent-testing-module-files.md),
+which loads plain `module.*` files and relies on exactly this
+`proof !== undefined` check to silently skip files without a proof. That
+issue documents the behaviour but does not remove the duplication; naming
+the operation makes that contract explicit and single-sourced.
+
+## Proposal
+
+Hoist a private module-scope helper that names the operation, and call it
+from both functions:
+
+```ts
+// fs/emergent_testing/module.f.ts (private, module scope)
+const proofEntries = (moduleMap: ModuleMap): readonly (readonly [string, unknown])[] =>
+    entries(moduleMap)
+        .flatMap(([k, v]) => v.proof !== undefined ? [[k, v.proof] as const] : [])
+```
+
+(`ModuleMap` types `proof?: unknown` in `fs/dev/module.f.ts:33`, so each
+pair is `readonly [string, unknown]`.) Then both functions collapse to:
+
+```ts
+// runModuleMap
+const modules = proofEntries(moduleMap)
+
+// registerModuleMap
+const modules = proofEntries(moduleMap)
+```
+
+## Why this qualifies
+
+- **DRY:** exact, verbatim duplication across two consumers in the same
+  module — squarely the case AGENTS.md names as "a core principle of
+  FunctionalScript, not just a stylistic preference."
+- **Separation of concerns:** "which modules count as tests" is one
+  decision. Today it is spread across two functions and implicitly
+  depended on by a third issue's loader change. One helper makes it the
+  single source of truth.
+- The change is purely local, preserves behaviour exactly (the `flatMap`
+  idiom is unchanged — this is *not* a proposal to wrap the
+  `cond ? [x] : []` idiom itself, which AGENTS.md endorses), and keeps the
+  no-mutation, no-`as`-beyond-`as const` constraints.
+
+## Related
+
+- [i664-emergent-testing-module-files](./664-emergent-testing-module-files.md)
+  — relies on this same selection rule when loading `module.*` files;
+  extracting it here makes that contract explicit.
+- [i65Z-tf-test-tree-walker](./65Z-tf-test-tree-walker.md) — a separate,
+  larger DRY target (the `runModule`/`registerModule` *recursion*). This
+  issue is strictly the map-level entry filter and is independent of it.


### PR DESCRIPTION
## Summary

This PR adds two issue specification documents that identify micro-refactoring opportunities in the codebase to reduce code duplication and improve maintainability.

## Changes

- **664-sha2-sigma-factory.md**: Documents a proposal to collapse the duplicated `bigSigma` and `smallSigma` rotation mixers in `crypto/sha2/module.f.ts` into a single parameterized factory function. The two functions are byte-identical except for how they compute the third XOR operand (rotate vs. shift), making them ideal candidates for DRY consolidation.

- **664-tf-proof-entry-filter.md**: Documents a proposal to extract the duplicated "modules that export a proof" filter from `emergent_testing/module.f.ts`. The same `flatMap` logic appears verbatim in both `runModuleMap` and `registerModuleMap`, and extracting it into a named helper (`proofEntries`) would make the selection rule single-sourced and explicit.

## Details

Both issues follow the DRY principle outlined in AGENTS.md:
- Exact code duplication across multiple consumers in the same module
- Differ only in small, parameterizable sub-expressions
- No performance regression (precomputation is preserved)
- No API changes (internal refactoring only)
- Existing test vectors remain unchanged

Both are marked as P4 (low priority) micro-cleanups that improve code clarity without functional changes.

https://claude.ai/code/session_01WLPoPFHutqvSTSkEPrqNmS