### PR TITLE
io: encapsulate io behind run/runEffect; emergent_testing runs on import (0.23.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.23.0
+
+- **breaking** `io`: encapsulate `io` behind the entry points — rename the default export `effectRun` → `run`; add `runEffect(p)` (the effect runner with `io` and `argv` pre-applied, resolving to the exit code without calling `process.exit`); `run` now wraps `runEffect` with `process.exit`. `fs/emergent_testing/module.ts` drops its `io` / `runProgram` imports and self-executes via top-level `await runEffect(register)` — it no longer exports `run()`, so the external-runner entry becomes a bare side-effect `import 'functionalscript/fs/emergent_testing/module.js'` [942](https://github.com/functionalscript/functionalscript/pull/942)
 - **breaking** `function/compare`: add generic `min`/`max` next to `cmp`, reusing the `Cmp1`/`Cmp2<A, B>` guard so mixed-type calls like `min(1)("a")` fail to compile; retire the duplicated `Reduce<number>`-typed `min`/`max` from `function/operator` and the bigint-typed `min`/`max` from `types/bigint`; consumers (`types/number`, `types/bit_vec`, `asn.1`) now import the single generic pair from `function/compare` [940](https://github.com/functionalscript/functionalscript/pull/940)
 
 ## 0.22.0

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@functionalscript/functionalscript",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "license": "MIT",
   "exports": {
     "./fs/asn.1/module.f.ts": "./fs/asn.1/module.f.ts",

--- a/fs/emergent_testing/README.md
+++ b/fs/emergent_testing/README.md
@@ -51,8 +51,7 @@ every proof module and registers each test case with the active runner:
 
 ```ts
 // all.test.ts
-import { run } from 'functionalscript/fs/dev/tf/module.js'
-await run()
+import 'functionalscript/fs/emergent_testing/module.js'
 ```
 
 `all.test.ts` is the recommended name, but any name works as long as the runner

--- a/fs/emergent_testing/all.test.ts
+++ b/fs/emergent_testing/all.test.ts
@@ -1,4 +1,4 @@
-import { run } from './module.ts'
+import './module.ts'
 
 // we need `await` for Playwright.
-await run()
+// await run()

--- a/fs/emergent_testing/module.ts
+++ b/fs/emergent_testing/module.ts
@@ -1,5 +1,5 @@
-import { io } from '../io/module.ts'
+import { runEffect } from '../io/module.ts'
 import { register } from './module.f.ts'
-import { runProgram } from '../io/module.f.ts'
 
-export const run = () => runProgram(io)([])(register)
+// we need `await` for Playwright.
+await runEffect(register)

--- a/fs/emergent_testing/scenarios/all.ts
+++ b/fs/emergent_testing/scenarios/all.ts
@@ -1,4 +1,1 @@
-import { run } from '../module.ts'
-
-// we need `await` for Playwright.
-await run()
+import '../module.ts'

--- a/fs/fjs/module.ts
+++ b/fs/fjs/module.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
 import { main } from './module.f.ts'
-import effectRun from '../io/module.ts'
+import run from '../io/module.ts'
 
-effectRun(main)
+run(main)

--- a/fs/io/module.ts
+++ b/fs/io/module.ts
@@ -127,11 +127,13 @@ export const io: Io = {
     playwrightTestContext,
     engine: isPlaywright ? 'playwright' : 'Bun' in globalThis ? 'bun' : 'node',
 }
+
 export type NodeRun = (p: NodeProgram) => Promise<never>
 
-const run: NodeRun = async p => {
-    const code = await runProgram(io)(io.process.argv.slice(2))(p)
-    return process.exit(code)
-}
+export const runEffect: (p: NodeProgram) => Promise<number> =
+    runProgram(io)(io.process.argv.slice(2))
+
+const run: NodeRun = async p =>
+    process.exit(await runEffect(p))
 
 export default run

--- a/fs/io/module.ts
+++ b/fs/io/module.ts
@@ -130,9 +130,26 @@ export const io: Io = {
 
 export type NodeRun = (p: NodeProgram) => Promise<never>
 
+/**
+ * Runs a `NodeProgram` against the real Node `io` and process arguments,
+ * resolving to its exit code **without** terminating the process.
+ *
+ * Use this when the caller must stay alive afterwards — e.g. when proofs are
+ * registered under an external test runner (Node `--test`, Bun, Playwright)
+ * that owns the process lifecycle. For a standalone CLI entry point that should
+ * exit with the program's code, use the default {@link run} export instead.
+ */
 export const runEffect: (p: NodeProgram) => Promise<number> =
     runProgram(io)(io.process.argv.slice(2))
 
+/**
+ * CLI entry point: runs a `NodeProgram` via {@link runEffect}, then calls
+ * `process.exit` with its exit code. The `Promise<never>` return type reflects
+ * that control never returns to the caller — the process terminates.
+ *
+ * This is the default export so a `bin` script can simply
+ * `import run from '.../io/module.js'; run(main)`.
+ */
 const run: NodeRun = async p =>
     process.exit(await runEffect(p))
 

--- a/fs/io/module.ts
+++ b/fs/io/module.ts
@@ -129,9 +129,9 @@ export const io: Io = {
 }
 export type NodeRun = (p: NodeProgram) => Promise<never>
 
-const effectRun: NodeRun = async p => {
+const run: NodeRun = async p => {
     const code = await runProgram(io)(io.process.argv.slice(2))(p)
     return process.exit(code)
 }
 
-export default effectRun
+export default run

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "functionalscript",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "functionalscript",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "MIT",
       "bin": {
         "fjs": "fs/fjs/module.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "functionalscript",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "type": "module",
   "files": [
     "**/*.js",


### PR DESCRIPTION
## Summary

Entry-point modules no longer import or wire `io` themselves — `io` is fully
encapsulated behind `run` / `runEffect` in `fs/io/module.ts`. The
`emergent_testing` entry becomes a bare side-effect import.

### `fs/io/module.ts`

- rename the default export `effectRun` → `run`
- add a named export `runEffect: (p: NodeProgram) => Promise<number>` =
  `runProgram(io)(argv)` — the effect runner with `io` and `argv` pre-applied,
  returning the exit code **without** calling `process.exit`
- `run` now wraps `runEffect` with `process.exit(await runEffect(p))`

This gives callers two levels: `runEffect` when they want the exit code (e.g.
to keep the process alive under a test runner), `run` when they want the
process to exit.

### `fs/emergent_testing/module.ts` (breaking)

- drop the direct `io` / `runProgram` imports; import `runEffect` instead
- the module self-executes via top-level `await runEffect(register)` — it no
  longer exports a `run()` function

Consumers change from:

```ts
import { run } from 'functionalscript/fs/emergent_testing/module.js'
await run()
```

to a bare side-effect import:

```ts
import 'functionalscript/fs/emergent_testing/module.js'
```

`all.test.ts` and `scenarios/all.ts` are updated to the new form, and the
README entry-file example follows.

### `fs/fjs/module.ts`

- import `run` (was `effectRun`); call `run(main)`

### Version

`package.json` / `deno.json` → `0.23.0` (breaking: the `run` export is removed).

## Test plan

- [x] `npx tsc` passes
- [x] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)