### PR TITLE
Upgrade Rust toolchain from 1.95.0 to 1.96.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@
           "run": "sudo apt-get update && sudo apt-get install -y libc6-dev-i386"
         },
         {
-          "uses": "dtolnay/rust-toolchain@1.95.0",
+          "uses": "dtolnay/rust-toolchain@1.96.0",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads,i686-unknown-linux-gnu"
@@ -185,7 +185,7 @@
       "runs-on": "ubuntu-24.04-arm",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.95.0",
+          "uses": "dtolnay/rust-toolchain@1.96.0",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads"
@@ -353,7 +353,7 @@
       "runs-on": "macos-26-intel",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.95.0",
+          "uses": "dtolnay/rust-toolchain@1.96.0",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads"
@@ -521,7 +521,7 @@
       "runs-on": "macos-26",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.95.0",
+          "uses": "dtolnay/rust-toolchain@1.96.0",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads"
@@ -689,7 +689,7 @@
       "runs-on": "windows-2025",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.95.0",
+          "uses": "dtolnay/rust-toolchain@1.96.0",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads,i686-pc-windows-msvc"
@@ -863,7 +863,7 @@
       "runs-on": "windows-11-arm",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.95.0",
+          "uses": "dtolnay/rust-toolchain@1.96.0",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads"

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -65,5 +65,5 @@ export const actions = {
     // https://github.com/wasmerio/setup-wasmer
     'wasmerio/setup-wasmer': 'v3.1',
     // https://rust-lang.org/ - value is Rust version, not action version
-    'dtolnay/rust-toolchain': '1.95.0',
+    'dtolnay/rust-toolchain': '1.96.0',
 } as const


### PR DESCRIPTION
## Summary
This pull request updates the Rust toolchain version used across all CI workflows from 1.95.0 to 1.96.0.

## Key Changes
- Updated `dtolnay/rust-toolchain` action version from `1.95.0` to `1.96.0` in all CI workflow jobs across multiple platforms:
  - Linux (x86_64 and ARM)
  - macOS (Intel and ARM)
  - Windows (x86_64 and ARM)
- Updated the corresponding configuration source in `fs/ci/config/module.f.ts` to reflect the new Rust version

## Details
The Rust toolchain version is consistently updated across all 6 CI job configurations (Linux, macOS Intel, macOS ARM, Windows, and Windows ARM variants) to ensure uniform Rust compiler versions across all build environments.

https://claude.ai/code/session_0119hFgJydj4xsVcpT6HkeZU