### PR TITLE
Add wordToString test case to proof suite

### DIFF
--- a/fs/sul/level/literal/proof.f.ts
+++ b/fs/sul/level/literal/proof.f.ts
@@ -756,6 +756,10 @@ export const proof = {
                 vec(0x008n)(0b1111_1111n))
         }
     },
+    wordToString: () => {
+        const result = wordToString([0n, 1n, 0xABn])
+        if (result !== '0,1,ab') { throw result }
+    },
     pipeline: () => {
         // 4 L1 [0,0] words → 2 L2 [0,0] words → L3 [0,0] word → symbol 0
         // First 7 zero bits accumulate without emitting


### PR DESCRIPTION
## Summary
Added a test case for the `wordToString` function to the proof test suite to verify correct conversion of word arrays to string representation.

## Changes
- Added `wordToString` test function that validates the conversion of a numeric word array `[0n, 1n, 0xABn]` to its expected string representation `'0,1,ab'`
- Test throws an error if the result does not match the expected output, following the existing pattern in the proof suite

## Implementation Details
- The test is inserted into the proof object between the existing `vec` test and the `pipeline` test
- Uses a simple assertion pattern consistent with other tests in the suite: comparing the actual result against the expected string and throwing the result on mismatch

https://claude.ai/code/session_01F6L5pAacJrtbmTqgnmHfWY