### PR TITLE
Update TypeScript native preview to 7.0.0-dev.20260605.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260604.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260605.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -210,7 +210,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260604.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260605.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -378,7 +378,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260604.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260605.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -546,7 +546,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260604.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260605.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -714,7 +714,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260604.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260605.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -888,7 +888,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260604.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260605.1"
         },
         {
           "uses": "denoland/setup-deno@v2",

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -43,7 +43,7 @@ export const wasmtime = '45.0.0'
 export const wasmer = '7.1.0'
 
 // https://www.npmjs.com/package/@typescript/native-preview?activeTab=versions
-export const tsgo = '7.0.0-dev.20260604.1'
+export const tsgo = '7.0.0-dev.20260605.1'
 
 // GitHub Action versions used by CI step builders. The key is the action
 // `owner/name`; call sites compose the full ref as

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
Updates the TypeScript native preview dependency to the latest development version across CI configuration and module configuration files.

## Key Changes
- Updated `@typescript/native-preview` from `7.0.0-dev.20260604.1` to `7.0.0-dev.20260605.1` in `.github/workflows/ci.yml` (6 occurrences across different workflow jobs)
- Updated `tsgo` constant in `fs/ci/config/module.f.ts` to match the new version

## Details
This is a routine dependency update to the latest development build of the TypeScript native preview package. The version bump from `20260604.1` to `20260605.1` indicates a daily development build update. All references to this dependency have been synchronized across the CI configuration and module configuration files.

https://claude.ai/code/session_015DqxRiQWMF2qRAr1ZmC6U2