### PR TITLE
Add proof tests for assertion utilities

### DIFF
--- a/fs/asserts/proof.f.ts
+++ b/fs/asserts/proof.f.ts
@@ -1,0 +1,39 @@
+import { assert, assertEq, todo } from './module.f.ts'
+
+const throws = (f: () => unknown, expected: unknown): void => {
+    let caught = false
+    try { f() } catch (e) {
+        caught = true
+        if (e !== expected) { throw ['unexpected throw value', e] }
+    }
+    if (!caught) { throw 'expected function to throw but it did not' }
+}
+
+export const proof = {
+    assertPassesOnTrue: () => {
+        assert(true)
+        assert(true, 'with message')
+    },
+    assertThrowsDefaultMsg: () => {
+        throws(() => assert(false), 'assertion failed')
+    },
+    assertThrowsCustomMsg: () => {
+        throws(() => assert(false, 'oops'), 'oops')
+    },
+    assertEqPassesOnEqual: () => {
+        assertEq(1, 1)
+        assertEq('x', 'x')
+    },
+    assertEqThrowsOnUnequal: () => {
+        let caught = false
+        try { assertEq(1, 2) } catch (e) {
+            caught = true
+            const arr = e as readonly [unknown, unknown]
+            if (arr[0] !== 1 || arr[1] !== 2) { throw ['wrong throw value', e] }
+        }
+        if (!caught) { throw 'expected assertEq to throw' }
+    },
+    todoThrows: () => {
+        throws(() => todo(), 'not implemented')
+    },
+}


### PR DESCRIPTION
## Summary
Added a comprehensive test suite for the assertion utility functions (`assert`, `assertEq`, and `todo`) to verify their behavior and error handling.

## Key Changes
- Created `fs/asserts/proof.f.ts` with proof tests for assertion utilities
- Implemented `throws` helper function to verify that functions throw expected errors
- Added test cases covering:
  - `assert()` passes when condition is true
  - `assert()` throws with default message "assertion failed"
  - `assert()` throws with custom message when provided
  - `assertEq()` passes when values are equal
  - `assertEq()` throws with tuple of mismatched values
  - `todo()` throws with "not implemented" message

## Implementation Details
- The `throws` helper validates both that an exception is thrown and that it matches the expected value
- Tests verify both default and custom error messages for `assert()`
- `assertEq()` error handling is tested by catching and validating the thrown array tuple contains the correct values

https://claude.ai/code/session_017US693UzFo1GUwtbYi31Vg