### PR TITLE
array: document isArray2 type guard; add test-conventions and bnf-repeat issues

### DIFF
--- a/fs/types/array/module.f.ts
+++ b/fs/types/array/module.f.ts
@@ -15,6 +15,13 @@ export type Index1 = 0
 
 export type Array2<T> = readonly [T, T]
 
+/**
+ * Currently, TypeScript can't narrow the type of `readonly T[]` to `Array2<T>`
+ * only by checking `a.length === 2`, so we need a user-defined type guard.
+ *
+ * @param a An array of unknown length.
+ * @returns True if `a` has length 2, and `a` is narrowed to `Array2<T>` in that case.
+ */
 export const isArray2 = <T>(a: readonly T[]): a is Array2<T> =>
     a.length === 2
 

--- a/issues/207-bnf-semantic-actions.md
+++ b/issues/207-bnf-semantic-actions.md
@@ -110,6 +110,13 @@ The JSON worked example (§6) uses the positional model.
 
 ### 2.1 List rules: flattening right-recursion
 
+> The unambiguous, schema-free part of this section — detecting 0-or-more
+> right-recursion during `toData` and emitting a `repeat` primitive so the
+> parsers produce a flat AST — is split into
+> [i667-bnf-repeat-flatten](./667-bnf-repeat-flatten.md). The opt-in for the
+> *ambiguous* cases (list vs. right-associative tree) via the `array(itemSchema)`
+> action schema remains here (§5).
+
 "Repeat" is **not** a BNF primitive — the four shapes are only
 `Variant | Sequence | TerminalRange | string`. Only the fixed-count `repeat(n)`
 is flat (it expands to a `Sequence` of `n` copies). Every *unbounded*

--- a/issues/207-bnf-semantic-actions.md
+++ b/issues/207-bnf-semantic-actions.md
@@ -513,6 +513,45 @@ rules; or run full validation in a debug build and trust the schemas in release.
 allocation/short-circuit trade-offs of `validate` vs `parse` are already
 discussed in [i172](./172-rtti-validate-parse-skeleton.md).
 
+### 5.5 Principle: all transformer schemas are validated at parser instantiation
+
+§5.3 lifts *one* check (the list-item/`array` case) to instantiation time. State
+it as a general principle: **every transformer's schema is validated once, when
+the parser is instantiated — not during parsing.** Concretely, instantiation
+verifies, for each actioned rule:
+
+1. **name resolution** — every actioned rule name (and every rule it references)
+   exists in the grammar; and
+2. **shape compatibility** — the transformer's `in` schema matches the rule's
+   *raw-output* shape (the §2 table, including the §2.1 "list" kind), and its
+   `out` matches what the parent consumes (§5.1).
+
+**Why instantiation is the right phase.** The structural analysis this design
+already performs at runtime — cycle detection and the §2.1 tail-position/list
+recognition — runs exactly once, when the parser is built, and is precisely when
+each rule's raw-output shape becomes known. Folding transformer-compatibility
+into that same pass adds no new traversal: it confronts each declared `in`
+against the shape it will actually receive at the one moment both are available.
+
+**Runtime failure here is acceptable — indeed preferable.** A mis-wired
+transformer is a programming error. Failing at construction means it surfaces
+immediately, deterministically, and on *every* run, before any input is parsed —
+not mid-parse on whatever input first reaches the bad branch. The cost is paid
+once per parser (O(actioned rules)), never in the parse hot path, so the check
+can afford to be thorough.
+
+**Relation to the compile-time check.** This *complements*, not replaces, the
+`Ts<>` static check. For statically-written grammars TypeScript already verifies
+most wiring at compile time; the instantiation-time check is the backstop for
+what the type system cannot see — chiefly the structurally-detected "list"
+raw-output kind (TS has no idea a rule is list-like) and any dynamically
+assembled grammar or name-keyed action map.
+
+The *mechanism* for the shape-compatibility half is the schema-vs-schema
+`subset` predicate of §5.3, gated on [i143](./143-rtti-data.md); until it lands,
+the per-node §5.2 form is the fallback and name resolution can still be checked
+at instantiation independently.
+
 ## 6. Worked example: JSON
 
 Using the grammar from `fs/fsc/json.f.ts` (`character`, `escape`, `string`,
@@ -589,10 +628,14 @@ Pursue **(B) transparent `mapRule` + grammar-directed fold (§3)** with the
 **RTTI contract (§5)** as the type-safety mechanism; do **not** attempt to type
 the grammar↔action boundary in TypeScript (§4 shows it cannot survive cyclic
 grammars). Start with the positional elision model and explicit `out` schemas,
-and the per-node boundary check (§5.2). Once the RTTI `subset` predicate from
-[i143](./143-rtti-data.md) exists, lift the boundary check to grammar
-instantiation (§5.3) so it costs O(actioned rules) once and fails at
-construction. Recognize repetition by **structural right-recursion analysis**
+and the per-node boundary check (§5.2). Treat **instantiation-time validation of every transformer schema as a
+principle** (§5.5): the parser already analyzes cycles and list structure once at
+construction, so transformer compatibility is checked in that same pass and fails
+at construction rather than mid-parse (runtime failure is acceptable because it
+is pre-parse). Once the RTTI `subset` predicate from
+[i143](./143-rtti-data.md) exists, lift the shape-compatibility half to grammar
+instantiation (§5.3) so it costs O(actioned rules) once; until then keep the
+per-node §5.2 fallback while still resolving names at construction. Recognize repetition by **structural right-recursion analysis**
 (§2.1) rather than a helper combinator, so hand-written and combinator-built
 list rules flatten identically; gate the flattening on an `array(item)` schema
 opt-in so right-associative trees are preserved. Define evaluation as a

--- a/issues/667-bnf-repeat-flatten.md
+++ b/issues/667-bnf-repeat-flatten.md
@@ -1,0 +1,76 @@
+# 667-bnf-repeat-flatten. BNF: flatten right-recursive repeat rules
+
+**Priority:** P3
+**Status:** open
+**Blocked by:** [i207-bnf-semantic-actions](./207-bnf-semantic-actions.md)
+
+## Problem
+
+Unbounded repetition in the BNF grammar is encoded as right-recursion — there
+is no primitive `repeat` rule. The four BNF shapes are `Variant | Sequence |
+TerminalRange | string`. Helpers like `repeat0Plus` expand to right-recursive
+`Variant` rules:
+
+```ts
+repeat0Plus(x)  // r = () => option([x, r])  →  Variant { some: [x, r], none: [] }
+```
+
+Hand-written repetition looks the same:
+
+```ts
+characters = () => ({ none, characters: [character, characters] })  // 0-or-more
+members    = () => ({ member, members: [member, ',', members] })    // 1-or-more
+```
+
+The raw output of these rules is a right-nested cons list:
+`{ tag:'some', value:[x0, { tag:'some', value:[x1, { tag:'none', value:[] }] }] }`
+
+Actions and downstream consumers almost always want a flat array `[x0, x1, …]`
+instead.
+
+## Proposal
+
+Detect right-recursion structurally and flatten the raw output opt-in.
+
+**Detection.** A rule `L` is *list-like* when every recursive reference within
+its strongly-connected component (SCC) occurs in **tail position** (the last
+element of a `Sequence`, possibly through a thunk). For each branch, split into:
+- a **prefix** — all items before the optional tail (after noise elision: fixed
+  literals and silent rules drop out), contributing one item;
+- an optional **tail** — a reference back into `L`'s SCC that recurses.
+
+Base branches (no tail) contribute their prefix item and stop. This handles all
+common shapes: empty-base + `[item, ·]` tail, single-item base + `[item, sep, ·]`
+tail (separator elides), and multi-rule SCC splits (`digits`/`digits0`).
+
+A self-reference in **non-tail** position means the rule is a tree (e.g. an
+operator grammar `a = [x, '+', a] | x`) and is left un-flattened.
+
+**Opt-in.** Flat list and right-associative tree share the same grammar shape,
+so structural detection alone cannot decide whether to flatten. Flattening is
+requested by declaring the action's `in`/`out` schema as `array(itemSchema)` (see
+[i207-bnf-semantic-actions](./207-bnf-semantic-actions.md) §5). Detection
+establishes that the rule *can* be presented as a list; the `array` schema opts
+into it. An instantiation-time check verifies the unfolded item schema matches the
+declared element type — a mis-detected or mis-shaped list fails at construction.
+Combinator helpers (`repeat0Plus`, etc.) can declare the `array` schema on the
+caller's behalf, making opt-in automatic for combinator-built lists.
+
+**Flattening** is an unfold performed during the fold evaluation (§3.2 of
+i207): walk the matched branch, emit its prefix item, follow the tail, stop at a
+base branch — yielding a flat array. The parser and generic AST are untouched;
+this is purely a transformation on the raw output of list-like rules.
+
+## Tasks
+
+- [ ] Implement SCC + tail-position analysis to detect list-like rules
+- [ ] Implement the unfold flattening pass in the fold evaluator
+- [ ] Wire opt-in: `array(itemSchema)` schema declaration triggers flattening
+- [ ] Instantiation-time schema check (item shape matches declared element type)
+- [ ] Update `repeat0Plus` (and siblings) to declare `array` schema automatically
+- [ ] Tests: right-recursive lists flatten; right-associative trees do not
+
+## Related
+
+- [i207-bnf-semantic-actions](./207-bnf-semantic-actions.md) §2.1 — origin of this design; §5 for the opt-in schema mechanism
+- `fs/bnf/module.f.ts` — BNF combinators including `repeat0Plus`

--- a/issues/667-bnf-repeat-flatten.md
+++ b/issues/667-bnf-repeat-flatten.md
@@ -1,4 +1,4 @@
-# 667-bnf-repeat-flatten. BNF: flatten right-recursive repeat rules
+# 667-bnf-repeat-flatten. BNF: a `repeat` primitive in the data representation
 
 **Priority:** P3
 **Status:** open
@@ -7,9 +7,9 @@
 ## Problem
 
 Unbounded repetition in the BNF grammar is encoded as right-recursion — there
-is no primitive `repeat` rule. The four BNF shapes are `Variant | Sequence |
-TerminalRange | string`. Helpers like `repeat0Plus` expand to right-recursive
-`Variant` rules:
+is no primitive `repeat` rule. The data `Rule` (in `fs/bnf/data/module.f.ts`)
+has only three shapes: `Variant | Sequence | TerminalRange`. Helpers like
+`repeat0Plus` expand to right-recursive `Variant` rules:
 
 ```ts
 repeat0Plus(x)  // r = () => option([x, r])  →  Variant { some: [x, r], none: [] }
@@ -19,58 +19,91 @@ Hand-written repetition looks the same:
 
 ```ts
 characters = () => ({ none, characters: [character, characters] })  // 0-or-more
-members    = () => ({ member, members: [member, ',', members] })    // 1-or-more
 ```
 
-The raw output of these rules is a right-nested cons list:
-`{ tag:'some', value:[x0, { tag:'some', value:[x1, { tag:'none', value:[] }] }] }`
-
-Actions and downstream consumers almost always want a flat array `[x0, x1, …]`
-instead.
+So in the data form a list arrives as a right-nested cons structure of nested
+`Variant`/`Sequence` rules rather than a single node that says "this is a
+repetition." Every consumer (the fold evaluator from i207, a future code
+generator, a TypeScript emitter) would otherwise have to re-derive that fact by
+re-analyzing the rule graph.
 
 ## Proposal
 
-Detect right-recursion structurally and flatten the raw output opt-in.
+Introduce a `repeat` primitive into the **data** representation only, and detect
+it during the `toData` transformation. The thunk (functional) representation is
+**unchanged** — `repeat0Plus(x)` still expands to the same right-recursive
+`Variant` at runtime. Only the serialized data form gains the new node.
 
-**Detection.** A rule `L` is *list-like* when every recursive reference within
-its strongly-connected component (SCC) occurs in **tail position** (the last
-element of a `Sequence`, possibly through a thunk). For each branch, split into:
-- a **prefix** — all items before the optional tail (after noise elision: fixed
-  literals and silent rules drop out), contributing one item;
-- an optional **tail** — a reference back into `L`'s SCC that recurses.
+### Encoding: `repeat` is a bare `string`
 
-Base branches (no tail) contribute their prefix item and stop. This handles all
-common shapes: empty-base + `[item, ·]` tail, single-item base + `[item, sep, ·]`
-tail (separator elides), and multi-rule SCC splits (`digits`/`digits0`).
+A `Rule` is currently a `Variant` (object), a `Sequence` (array), or a
+`TerminalRange` (number). A bare `string` is **not** yet a `Rule` shape — rule
+names appear only *inside* `Sequence` / `Variant` values, never as a `Rule`
+itself. So a bare string is a free, unambiguous discriminant:
 
-A self-reference in **non-tail** position means the rule is a tree (e.g. an
-operator grammar `a = [x, '+', a] | x`) and is left un-flattened.
+```ts
+/** The name of the rule to repeat (0 or more times). */
+export type Repeat = string
 
-**Opt-in.** Flat list and right-associative tree share the same grammar shape,
-so structural detection alone cannot decide whether to flatten. Flattening is
-requested by declaring the action's `in`/`out` schema as `array(itemSchema)` (see
-[i207-bnf-semantic-actions](./207-bnf-semantic-actions.md) §5). Detection
-establishes that the rule *can* be presented as a list; the `array` schema opts
-into it. An instantiation-time check verifies the unfolded item schema matches the
-declared element type — a mis-detected or mis-shaped list fails at construction.
-Combinator helpers (`repeat0Plus`, etc.) can declare the `array` schema on the
-caller's behalf, making opt-in automatic for combinator-built lists.
+export type Rule = Variant | Sequence | TerminalRange | Repeat
+```
 
-**Flattening** is an unfold performed during the fold evaluation (§3.2 of
-i207): walk the matched branch, emit its prefix item, follow the tail, stop at a
-base branch — yielding a flat array. The parser and generic AST are untouched;
-this is purely a transformation on the raw output of list-like rules.
+Dispatch checks `string` first, before the existing `number` / `Array` / `else`
+chain, so no existing narrowing is touched:
+
+```ts
+if (typeof rule === 'string') { /* Repeat */ }
+else if (typeof rule === 'number') { /* TerminalRange */ }
+else if (rule instanceof Array) { /* Sequence */ }
+else { /* Variant */ }
+```
+
+`Repeat` carries the inner rule's name — `repeat(itemName)` means "`itemName`,
+zero or more times." It is serializable, so the data form stays pure data (the
+whole point of this layer).
+
+### Scope: only `min = 0`, only unambiguous cases
+
+- **No `min` parameter for now.** `repeat` always means 0-or-more. When we later
+  detect `min > 0` (one-or-more), that is an acceptable breaking change to the
+  encoding.
+- **Only obviously-a-list cases.** A flat list and a *right-associative tree*
+  share the same grammar (`a = [x, '+', a] | x` is structurally a separated
+  list). Detection emits `repeat` only where the right-recursion can **only**
+  mean repetition — e.g. an empty base branch (`none`) plus a recursive branch
+  that is exactly `[item, self]` with no other self-reference. Ambiguous shapes
+  (operator-style trees, separated lists) are left as the raw right-recursive
+  `Variant` for now and revisited when an opt-in mechanism (i207 §5,
+  `array(itemSchema)`) is in place.
+- Consumers that do not yet understand `repeat` can treat it as the equivalent
+  right-recursive `Variant` fallback.
+
+### Parser output: flat array
+
+Once the parsers recognize `repeat`, they should also produce a **flat** AST for
+it instead of the nested right-recursive structure. When `descentParser` /
+`parserRuleSet` match a `repeat(item)` node, they match `item` zero or more times
+in a loop and emit a flat `AstSequence` of the matched items — no nested
+`{ tag, sequence }` cons wrapping. This is the payoff: the data node and the AST
+both say "list," so downstream actions get `[x0, x1, …]` directly. The generic
+AST shape is unchanged (still `{ tag, sequence }`); only how a `repeat` rule
+fills its `sequence` differs (a flat run of items rather than a 2-element
+`[item, rest]` nesting).
 
 ## Tasks
 
-- [ ] Implement SCC + tail-position analysis to detect list-like rules
-- [ ] Implement the unfold flattening pass in the fold evaluator
-- [ ] Wire opt-in: `array(itemSchema)` schema declaration triggers flattening
-- [ ] Instantiation-time schema check (item shape matches declared element type)
-- [ ] Update `repeat0Plus` (and siblings) to declare `array` schema automatically
-- [ ] Tests: right-recursive lists flatten; right-associative trees do not
+- [ ] Add `Repeat = string` and extend `Rule` in `fs/bnf/data/module.f.ts`
+- [ ] Add the `typeof rule === 'string'` branch to every dispatch site
+      (`dispatchMap`, `emptyTagMapAdd`, `descentParser`, `parserRuleSet`)
+- [ ] Detect the unambiguous 0-or-more shape during `toData` and emit `repeat`
+- [ ] `descentParser` / `parserRuleSet`: match `repeat(item)` in a loop and emit
+      a flat `AstSequence` of items (no nested cons)
+- [ ] Tests: `repeat0Plus`-built and hand-written 0-or-more lists become a
+      `repeat` node and parse to a flat AST; right-associative trees and
+      separated lists do not
 
 ## Related
 
-- [i207-bnf-semantic-actions](./207-bnf-semantic-actions.md) §2.1 — origin of this design; §5 for the opt-in schema mechanism
+- [i207-bnf-semantic-actions](./207-bnf-semantic-actions.md) §2.1 — origin of this design; §5 for the future `array(itemSchema)` opt-in that will cover the ambiguous cases
+- `fs/bnf/data/module.f.ts` — the data `Rule` type and all dispatch sites
 - `fs/bnf/module.f.ts` — BNF combinators including `repeat0Plus`

--- a/issues/667-test-conventions.md
+++ b/issues/667-test-conventions.md
@@ -1,0 +1,33 @@
+# 667-test-conventions. Test conventions
+
+**Priority:** P2
+**Status:** open
+
+## Problem
+
+The current `npm test` command conflates type-checking, Node's built-in test runner, and coverage into one slow command. The FunctionalScript-native test runner (`fjs t`) is a separate `npm run fst` that developers must remember to run manually. CI has no dedicated coverage step.
+
+Current state:
+```json
+"test": "tsc && node --test --experimental-test-coverage --test-coverage-include=**/module.f.ts"
+"fst":  "node ./fs/fjs/module.ts t"
+```
+
+Desired split:
+- **`npm test`** — fast feedback loop: `tsc && node ./fs/fjs/module.ts t`
+  - Type-checks, then runs the FunctionalScript-native test suite.
+  - Replaces the need for a separate `npm run fst`.
+- **`node --test`** — Node's built-in test runner; run by CI as a separate job/step.
+- **`npm run cov`** — coverage: `node --test --experimental-test-coverage --test-coverage-include=**/module.f.ts`; run by CI as a dedicated step.
+
+## Proposal
+
+1. Change `"test"` in `package.json` to `tsc && node ./fs/fjs/module.ts t`.
+2. Add `"cov": "node --test --experimental-test-coverage --test-coverage-include=**/module.f.ts"`.
+3. Remove `"fst"` (superseded by the new `npm test`).
+4. Update CI (`fs/ci/module.f.ts`) to run both `node --test` and `npm run cov` as separate steps.
+
+## Related
+
+- `package.json` — scripts
+- `fs/ci/module.f.ts` — CI workflow generator


### PR DESCRIPTION
## Summary

- `fs/types/array`: add JSDoc to `isArray2` explaining why a user-defined type guard is needed — TypeScript can't narrow `readonly T[]` to `Array2<T>` from a `length === 2` check alone
- `issues/667-test-conventions.md`: split `npm test` into a fast `tsc && fjs t` loop, add `npm run cov` for coverage, run both `node --test` and coverage in CI, retire `npm run fst`
- `issues/667-bnf-repeat-flatten.md`: introduce a `repeat` primitive in the BNF data representation (encoded as a bare `string`), detected during `toData` for unambiguous 0-or-more cases; parsers emit a flat AST
- `issues/207-bnf-semantic-actions.md`: cross-reference the new i667 split

## Test plan

- [ ] `npx tsc` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)