### PR TITLE
feat: pass NodeProgramOptions to Command handlers (i667-cli-handler-options)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `cli`: change `Command<O>.handler` signature from `(args: readonly string[])` to `(options: NodeProgramOptions)`; `dispatch` now accepts and forwards full `NodeProgramOptions` with `args` trimmed to the remainder after the matched command name; `fs/fjs/module.f.ts` `commands` becomes a module-level constant with `main = dispatch(commands)` point-free (i667-cli-handler-options) [#973](https://github.com/functionalscript/functionalscript/pull/973)
 - `fjs`: `fjs r` now looks up `main` instead of `default` on the imported module; update `fs/ci/module.f.ts`, `fs/website/module.f.ts`, and `fs/dev/index/module.f.ts` from `export default` to `export const main` (i667-fjs-run-main-convention) [#972](https://github.com/functionalscript/functionalscript/pull/972)
-- `cli`: add `fs/cli/module.f.ts` — `Command` / `Commands` types and a `dispatch` function that builds a name→command map, auto-generates a `help` / `h` / `?` command with padded column alignment, and includes available commands in error messages for missing or unknown input; replace `switch`-based dispatch in `fs/fjs/module.f.ts` and `fs/cas/module.f.ts` with `Commands` lists; add `fs/cli/proof.f.ts` with 7 proofs ([i665-command-line-parsing-refactor](./issues/665-command-line-parsing-refactor.md)) [#971](https://github.com/functionalscript/functionalscript/pull/971)
+- `cli`: add `fs/cli/module.f.ts` — `Command` / `Commands` types and a `dispatch` function that builds a name→command map, auto-generates a `help` / `h` / `?` command with padded column alignment, and includes available commands in error messages for missing or unknown input; replace `switch`-based dispatch in `fs/fjs/module.f.ts` and `fs/cas/module.f.ts` with `Commands` lists; add `fs/cli/proof.f.ts` with 7 proofs (i665-command-line-parsing-refactor) [#971](https://github.com/functionalscript/functionalscript/pull/971)
 
 ## 0.25.0
 

--- a/fs/cas/module.f.ts
+++ b/fs/cas/module.f.ts
@@ -8,7 +8,7 @@ import { parse } from '../path/module.f.ts'
 import type { Vec } from '../types/bit_vec/module.f.ts'
 import { cBase32ToVec, vecToCBase32 } from '../cbase32/module.f.ts'
 import { begin, forEachStep, pure, type Effect, type Operation } from '../effects/module.f.ts'
-import { errorExit, log, mkdir, readdir, readFile, writeFile, type Fs, type NodeEffect, type NodeOp, type Write } from '../effects/node/module.f.ts'
+import { errorExit, log, mkdir, readdir, readFile, writeFile, type Fs, type NodeEffect, type NodeOp, type NodeProgramOptions } from '../effects/node/module.f.ts'
 import { dispatch, type Commands } from '../cli/module.f.ts'
 import { toOption } from '../types/nullable/module.f.ts'
 import { unwrap } from '../types/result/module.f.ts'
@@ -93,13 +93,13 @@ export const cas = (sha2: Sha2): <O extends Operation>(_: KvStore<O>) => Cas<O> 
     })
 }
 
-export const main = (args: readonly string[]): Effect<NodeOp, number> => {
+export const main = (options: NodeProgramOptions): Effect<NodeOp, number> => {
     const c = cas(sha256)(fileKvStore('.'))
     const commands: Commands<NodeOp> = [
         {
             names: ['add'],
             description: 'Store file content and print its hash',
-            handler: ([path, ...rest]) => {
+            handler: ({ args: [path, ...rest] }) => {
                 if (path === undefined || rest.length !== 0) {
                     return errorExit("'cas add' expects one parameter")
                 }
@@ -113,7 +113,7 @@ export const main = (args: readonly string[]): Effect<NodeOp, number> => {
         {
             names: ['get'],
             description: 'Restore content by hash into a file',
-            handler: ([hashCBase32, path, ...rest]) => {
+            handler: ({ args: [hashCBase32, path, ...rest] }) => {
                 if (hashCBase32 === undefined || path === undefined || rest.length !== 0) {
                     return errorExit("'cas get' expects two parameters")
                 }
@@ -143,5 +143,5 @@ export const main = (args: readonly string[]): Effect<NodeOp, number> => {
                     .step(() => pure(0)),
         },
     ]
-    return dispatch(commands)(args)
+    return dispatch(commands)(options)
 }

--- a/fs/cas/proof.f.ts
+++ b/fs/cas/proof.f.ts
@@ -5,64 +5,75 @@ import type { Vec } from '../types/bit_vec/module.f.ts'
 import { pure } from '../effects/module.f.ts'
 import { run } from '../effects/mock/module.f.ts'
 import { emptyState, virtual } from '../effects/node/virtual/module.f.ts'
+import type { NodeProgramOptions } from '../effects/node/module.f.ts'
+
+const makeOptions = (args: readonly string[]): NodeProgramOptions => ({
+    args,
+    env: {},
+    std: { stdout: { isTTY: false }, stderr: { isTTY: false } },
+    testContext: { test: async () => {} },
+    bunTestContext: { test: async () => {} },
+    playwrightTestContext: { test: async () => {} },
+    engine: 'node' as const,
+})
 
 export const proof = {
     mainAdd: () => {
         const content = vec8(0x2An)
         const state = { ...emptyState, root: { myfile: content } }
-        const [finalState, exitCode] = virtual(state)(main(['add', 'myfile']))
+        const [finalState, exitCode] = virtual(state)(main(makeOptions(['add', 'myfile'])))
         if (exitCode !== 0) { throw ['expected exit 0', exitCode] }
         if (finalState.stdout.length === 0) { throw 'expected hash in stdout' }
     },
     mainAddWrongArgs: () => {
-        const [finalState, exitCode] = virtual(emptyState)(main(['add']))
+        const [finalState, exitCode] = virtual(emptyState)(main(makeOptions(['add'])))
         if (exitCode !== 1) { throw ['expected exit 1', exitCode] }
         if (finalState.stderr.length === 0) { throw 'expected error in stderr' }
     },
     mainGetFound: () => {
         const content = vec8(0x2An)
         const state = { ...emptyState, root: { myfile: content } }
-        const [state1, exitCode1] = virtual(state)(main(['add', 'myfile']))
+        const [state1, exitCode1] = virtual(state)(main(makeOptions(['add', 'myfile'])))
         if (exitCode1 !== 0) { throw ['expected add exit 0', exitCode1] }
         const hashStr = state1.stdout.trim()
-        const [, exitCode2] = virtual(state1)(main(['get', hashStr, 'output']))
+        const [, exitCode2] = virtual(state1)(main(makeOptions(['get', hashStr, 'output'])))
         if (exitCode2 !== 0) { throw ['expected get exit 0', exitCode2] }
     },
     mainGetNotFound: () => {
         // valid cBase32 hash that has not been stored
         const content = vec8(0x2An)
         const state = { ...emptyState, root: { myfile: content } }
-        const [state1] = virtual(state)(main(['add', 'myfile']))
+        const [state1] = virtual(state)(main(makeOptions(['add', 'myfile'])))
         const hashStr = state1.stdout.trim()
         // use an empty store so the hash is not found
-        const [finalState, exitCode] = virtual(emptyState)(main(['get', hashStr, 'output']))
+        const [finalState, exitCode] = virtual(emptyState)(main(makeOptions(['get', hashStr, 'output'])))
         if (exitCode !== 1) { throw ['expected exit 1', exitCode] }
         if (finalState.stderr.length === 0) { throw 'expected error in stderr' }
     },
     mainGetWrongArgs: () => {
-        const [finalState, exitCode] = virtual(emptyState)(main(['get']))
+        const [finalState, exitCode] = virtual(emptyState)(main(makeOptions(['get'])))
         if (exitCode !== 1) { throw ['expected exit 1', exitCode] }
         if (finalState.stderr.length === 0) { throw 'expected error in stderr' }
     },
     mainGetInvalidHash: () => {
-        const [finalState, exitCode] = virtual(emptyState)(main(['get', 'not-a-valid-hash', 'output']))
+        const [finalState, exitCode] = virtual(emptyState)(main(makeOptions(['get', 'not-a-valid-hash', 'output'])))
         if (exitCode !== 1) { throw ['expected exit 1', exitCode] }
         if (finalState.stderr.length === 0) { throw 'expected error in stderr' }
     },
     mainList: () => {
         const content = vec8(0x2An)
         const state = { ...emptyState, root: { myfile: content } }
-        const [state1] = virtual(state)(main(['add', 'myfile']))
-        const [, exitCode] = virtual(state1)(main(['list']))
+        const [state1] = virtual(state)(main(makeOptions(['add', 'myfile'])))
+        const [, exitCode] = virtual(state1)(main(makeOptions(['list'])))
         if (exitCode !== 0) { throw ['expected exit 0', exitCode] }
     },
     mainNoCmd: () => {
-        const [finalState, exitCode] = virtual(emptyState)(main([]))
+        const [finalState, exitCode] = virtual(emptyState)(main(makeOptions([])))
         if (exitCode !== 1) { throw ['expected exit 1', exitCode] }
         if (finalState.stderr.length === 0) { throw 'expected error in stderr' }
     },
     mainUnknownCmd: () => {
-        const [finalState, exitCode] = virtual(emptyState)(main(['bogus']))
+        const [finalState, exitCode] = virtual(emptyState)(main(makeOptions(['bogus'])))
         if (exitCode !== 1) { throw ['expected exit 1', exitCode] }
         if (finalState.stderr.length === 0) { throw 'expected error in stderr' }
     },

--- a/fs/cli/module.f.ts
+++ b/fs/cli/module.f.ts
@@ -1,18 +1,18 @@
-import { errorExit, log, type NodeOp, type Write } from '../effects/node/module.f.ts'
+import { errorExit, log, type NodeOp, type NodeProgramOptions, type Write } from '../effects/node/module.f.ts'
 import { pure, type Effect } from '../effects/module.f.ts'
 
 export type Command<O extends NodeOp> = {
     readonly names: readonly string[]
     readonly description: string
-    readonly handler: (args: readonly string[]) => Effect<O, number>
+    readonly handler: (options: NodeProgramOptions) => Effect<O, number>
 }
 
 export type Commands<O extends NodeOp> = readonly Command<O>[]
 
 const helpMeta = { names: ['help', 'h', '?'], description: 'Print this help message' }
 
-export const dispatch = <O extends NodeOp>(commands: Commands<O>) => (args: readonly string[]): Effect<O | Write, number> => {
-    const [cmd, ...rest] = args
+export const dispatch = <O extends NodeOp>(commands: Commands<O>) => (options: NodeProgramOptions): Effect<O | Write, number> => {
+    const [cmd, ...rest] = options.args
     const rows = [...commands, helpMeta]
     const nameCol = rows.map(c => c.names.join(', '))
     const width = Math.max(...nameCol.map(s => s.length))
@@ -30,5 +30,5 @@ export const dispatch = <O extends NodeOp>(commands: Commands<O>) => (args: read
     if (found === undefined) {
         return errorExit(`Error: unknown command "${cmd}".\n${helpText}`)
     }
-    return found.handler(rest)
+    return found.handler({ ...options, args: rest })
 }

--- a/fs/cli/proof.f.ts
+++ b/fs/cli/proof.f.ts
@@ -1,18 +1,28 @@
 import { pure } from '../effects/module.f.ts'
-import { type NodeOp } from '../effects/node/module.f.ts'
+import { type NodeOp, type NodeProgramOptions } from '../effects/node/module.f.ts'
 import { emptyState, virtual } from '../effects/node/virtual/module.f.ts'
 import { dispatch, type Commands } from './module.f.ts'
+
+const makeOptions = (args: readonly string[]): NodeProgramOptions => ({
+    args,
+    env: {},
+    std: { stdout: { isTTY: false }, stderr: { isTTY: false } },
+    testContext: { test: async () => {} },
+    bunTestContext: { test: async () => {} },
+    playwrightTestContext: { test: async () => {} },
+    engine: 'node' as const,
+})
 
 const echoCommands: Commands<NodeOp> = [
     {
         names: ['echo', 'e'],
         description: 'Print the first argument',
-        handler: ([arg = '']) => pure(arg.length),
+        handler: ({ args: [arg = ''] }) => pure(arg.length),
     },
 ]
 
 const run = (commands: Commands<NodeOp>) => (args: readonly string[]) =>
-    virtual(emptyState)(dispatch(commands)(args))
+    virtual(emptyState)(dispatch(commands)(makeOptions(args)))
 
 export const proof = {
     knownCommand: () => {
@@ -48,7 +58,7 @@ export const proof = {
         const commands: Commands<NodeOp> = [{
             names: ['grab'],
             description: 'Capture args',
-            handler: (args): import('../effects/module.f.ts').Effect<NodeOp, number> => {
+            handler: ({ args }): import('../effects/module.f.ts').Effect<NodeOp, number> => {
                 captured.push(...args)
                 return pure(0)
             },

--- a/fs/fjs/module.f.ts
+++ b/fs/fjs/module.f.ts
@@ -9,31 +9,33 @@ import { main as casMain } from '../cas/module.f.ts'
 import { import_, type NodeOp, type NodeProgram } from '../effects/node/module.f.ts'
 import { dispatch, type Commands } from '../cli/module.f.ts'
 
-export const main: NodeProgram = options => {
-    const commands: Commands<NodeOp> = [
-        {
-            names: ['test', 't'],
-            description: 'Run the FunctionalScript test suite',
-            handler: args => testMain({ ...options, args }),
-        },
-        {
-            names: ['compile', 'c'],
-            description: 'Compile a FunctionalScript module to JavaScript',
-            handler: compile,
-        },
-        {
-            names: ['cas', 's'],
-            description: 'Content-addressable storage operations',
-            handler: casMain,
-        },
-        {
-            names: ['run', 'r'],
-            description: 'Run a FunctionalScript module as a NodeProgram',
-            handler: ([file, ...args]) => import_(file).step(([s, v]) => {
+const commands: Commands<NodeOp> = [
+    {
+        names: ['test', 't'],
+        description: 'Run the FunctionalScript test suite',
+        handler: testMain,
+    },
+    {
+        names: ['compile', 'c'],
+        description: 'Compile a FunctionalScript module to JavaScript',
+        handler: ({ args }) => compile(args),
+    },
+    {
+        names: ['cas', 's'],
+        description: 'Content-addressable storage operations',
+        handler: casMain,
+    },
+    {
+        names: ['run', 'r'],
+        description: 'Run a FunctionalScript module as a NodeProgram',
+        handler: options => {
+            const [file, ...args] = options.args
+            return import_(file).step(([s, v]) => {
                 if (s === 'error') { throw v }
                 return (v.main as NodeProgram)({ ...options, args })
-            }),
+            })
         },
-    ]
-    return dispatch(commands)(options.args)
-}
+    },
+]
+
+export const main: NodeProgram = dispatch(commands)

--- a/issues/667-cli-handler-options.md
+++ b/issues/667-cli-handler-options.md
@@ -1,7 +1,7 @@
 # 667-cli-handler-options. Pass full options to Command handlers
 
 **Priority:** P3
-**Status:** open
+**Status:** done
 
 ## Background
 


### PR DESCRIPTION
## Summary

- Change `Command<O>.handler` signature from `(args: readonly string[]) => Effect<O, number>` to `(options: NodeProgramOptions) => Effect<O, number>`
- Change `dispatch` to accept `NodeProgramOptions` instead of `readonly string[]`; passes `{ ...options, args: rest }` to matched handler
- Update `fs/cas/module.f.ts`: handlers destructure `{ args: [...] }` from options
- Update `fs/fjs/module.f.ts`: `commands` becomes a module-level constant (no closure needed); `main = dispatch(commands)` is point-free
- Add `makeOptions` helper to `fs/cli/proof.f.ts` and `fs/cas/proof.f.ts` for constructing minimal `NodeProgramOptions` in tests

Closes i667-cli-handler-options.

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes (all proofs including `fs/cli/proof.f.ts` and `fs/cas/proof.f.ts`)
- [ ] `dispatch` tests in `fs/cli/proof.f.ts` exercise `knownCommand`, `alias`, `noArgs`, `unknownCommand`, `help`, `errorIncludesAvailable`, `handlerReceivesRemainingArgs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)