### PR TITLE
Fix GitHub Actions reporter detection

### DIFF
--- a/fs/emergent_testing/module.f.ts
+++ b/fs/emergent_testing/module.f.ts
@@ -330,7 +330,7 @@ const fmtResultLine = (file: string, path: Path, color: string, label: string, d
 /**
  * The terminal/GitHub reporter used by `fjs t`. Output goes through
  * `csiWrite`, so ANSI styles are stripped on non-TTY streams. When
- * `GITHUB_ACTION` is set, failures are emitted as `::error` workflow
+ * `GITHUB_ACTIONS` is set, failures are emitted as `::error` workflow
  * annotations instead of colored lines. Exported as a factory so the
  * GitHub format path can be exercised directly from tests.
  */
@@ -342,7 +342,7 @@ export const defaultReporter = (options: NodeProgramOptions): Reporter<Write|San
     }
     const csiLog = line('stdout')
     const csiError = line('stderr')
-    const isGitHub = options.env['GITHUB_ACTION'] !== undefined
+    const isGitHub = options.env['GITHUB_ACTIONS'] !== undefined
     return {
         // https://github.com/OndraM/ci-detector/blob/main/src/Ci/GitHubActions.php
         result: (file, path, { result: [s, v], duration }, throws) =>

--- a/fs/emergent_testing/proof.f.ts
+++ b/fs/emergent_testing/proof.f.ts
@@ -33,7 +33,7 @@ const noopTestContext = { test: todo }
 
 const options = (initCwd: string, github = false): NodeProgramOptions => ({
     args: [],
-    env: { INIT_CWD: initCwd, ...(github ? { GITHUB_ACTION: 'true' } : {}) },
+    env: { INIT_CWD: initCwd, ...(github ? { GITHUB_ACTIONS: 'true' } : {}) },
     std: { stdout: { isTTY: false }, stderr: { isTTY: false } },
     testContext: noopTestContext,
     bunTestContext: noopTestContext,

--- a/issues/211-reporter-modes.md
+++ b/issues/211-reporter-modes.md
@@ -9,11 +9,11 @@ reporter implementations follow naturally.
 
 ## GitHub Actions reporter
 
-`module.f.ts` currently reads `options.env['GITHUB_ACTION']` at startup and switches
+`module.f.ts` currently reads `options.env['GITHUB_ACTIONS']` at startup and switches
 output format for the entire run:
 
 ```ts
-const isGitHub = options.env['GITHUB_ACTION'] !== undefined
+const isGitHub = options.env['GITHUB_ACTIONS'] !== undefined
 if (isGitHub) {
     return csiError(`::error file=${k},line=1,title=${i}()::${r}`)
 } else {


### PR DESCRIPTION
### Motivation
- The test reporter incorrectly checked `GITHUB_ACTION` and therefore did not emit GitHub Actions `::error` workflow annotations; switch to the standard `GITHUB_ACTIONS` variable so CI annotations are produced when appropriate.

### Description
- Change runtime detection in `defaultReporter` to use `options.env['GITHUB_ACTIONS']` instead of `GITHUB_ACTION` in `fs/emergent_testing/module.f.ts`.
- Update the virtual reporter proof fixture to set `GITHUB_ACTIONS` when exercising the GitHub output path in `fs/emergent_testing/proof.f.ts`.
- Update the design/issue note to document the corrected environment variable in `issues/211-reporter-modes.md`.

### Testing
- Ran `npx tsc && npm test && cargo test && cargo clippy && cargo fmt -- --check` and all automated checks completed successfully (npm emitted a Node engine warning about required Node >= 24 but it did not cause test failures).
- Ran `npm run update` which completed successfully (same engine warning observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2535221c1c832babfab8a1828f8d58)