### PR TITLE
Update TypeScript native preview to 7.0.0-dev.20260606.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260605.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260606.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -217,7 +217,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260605.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260606.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -391,7 +391,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260605.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260606.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -565,7 +565,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260605.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260606.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -739,7 +739,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260605.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260606.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -919,7 +919,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260605.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260606.1"
         },
         {
           "uses": "denoland/setup-deno@v2",

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -43,7 +43,7 @@ export const wasmtime = '45.0.0'
 export const wasmer = '7.1.0'
 
 // https://www.npmjs.com/package/@typescript/native-preview?activeTab=versions
-export const tsgo = '7.0.0-dev.20260605.1'
+export const tsgo = '7.0.0-dev.20260606.1'
 
 // GitHub Action versions used by CI step builders. The key is the action
 // `owner/name`; call sites compose the full ref as


### PR DESCRIPTION
## Summary
Updates the TypeScript native preview dependency version across CI configuration and module configuration files.

## Changes
- Updated `@typescript/native-preview` version from `7.0.0-dev.20260605.1` to `7.0.0-dev.20260606.1` in:
  - `.github/workflows/ci.yml` - Updated in 6 workflow job configurations
  - `fs/ci/config/module.f.ts` - Updated the `tsgo` export constant

This is a routine dependency update to the latest development build of the TypeScript native preview package.

https://claude.ai/code/session_015rody5cve2vYsCndxZ9tdZ