### PR TITLE
refactor(emergent_testing): extract `proofEntries` helper (i664-tf-proof-entry-filter)

### DIFF
--- a/fs/emergent_testing/module.f.ts
+++ b/fs/emergent_testing/module.f.ts
@@ -211,6 +211,10 @@ const runModule =
 
 const { entries } = Object
 
+const proofEntries = (moduleMap: ModuleMap): readonly (readonly [string, unknown])[] =>
+    entries(moduleMap)
+        .flatMap(([k, v]) => v.proof !== undefined ? [[k, v.proof] as const] : [])
+
 /**
  * Runs all test modules in `moduleMap` whose names pass `isTest`, accumulates
  * pass/fail/time via `reporter`, and returns an exit code (0 = all passed,
@@ -218,8 +222,7 @@ const { entries } = Object
  */
 export const runModuleMap = <O extends Operation>(reporter: Reporter<O>) => (moduleMap: ModuleMap): Effect<O | All, number> => {
     const { summary } = reporter
-    const modules = entries(moduleMap)
-        .flatMap(([k, v]) => v.proof !== undefined ? [[k, v.proof] as const] : [])
+    const modules = proofEntries(moduleMap)
     return all(...modules.map(([k, v]) => runModule(reporter)(k, v)(zero)))
     .step(m => pure(m.reduce(mergeState, zero)))
     .step(ts => summary(ts.pass, ts.fail, ts.time)
@@ -241,8 +244,7 @@ export const testAll = <O extends Operation>(reporter: Reporter<O>): Program<O |
 const registerModuleMap =
     (ctx: TestContext, star: string) => (moduleMap: ModuleMap): Effect<Test | All | Await, void> =>
 {
-    const modules = entries(moduleMap)
-        .flatMap(([k, v]) => v.proof !== undefined ? [[k, v.proof] as const] : [])
+    const modules = proofEntries(moduleMap)
     if (modules.length === 0) { return pure(undefined) }
     return all(...modules.map(([k, v]) => registerModule(ctx, k, v, star))).step(() => pure(undefined))
 }

--- a/issues/664-tf-proof-entry-filter.md
+++ b/issues/664-tf-proof-entry-filter.md
@@ -1,7 +1,7 @@
 # 664-tf-proof-entry-filter. `emergent_testing`: extract the duplicated "modules that export a proof" filter
 
 **Priority:** P4
-**Status:** open
+**Status:** done
 
 ## Problem
 


### PR DESCRIPTION
## Summary

- Resolves [i664-tf-proof-entry-filter](../blob/main/issues/664-tf-proof-entry-filter.md).
- `fs/emergent_testing/module.f.ts` had two byte-identical `entries(moduleMap).flatMap(([k, v]) => v.proof !== undefined ? [[k, v.proof] as const] : [])` blocks — one in `runModuleMap` (the self-hosted runner) and one in `registerModuleMap` (the external-framework registration path).
- Hoisted them into a single private `proofEntries(moduleMap)` helper so the "which modules count as tests" rule has one home; both consumers now collapse to `const modules = proofEntries(moduleMap)`.
- Pure refactor — no behavior change. Marked the issue **Status: done**.

## Test plan

- [x] `npx tsc` — clean.
- [x] `npm test` — 1632 / 1632 passing, including all `fs/emergent_testing/proof.f.ts` cases (`flat`, `nested`, `throwKey`, `mixedPassFail`, `returnValueSubTree`, `registerSuffixes`, etc.) that exercise both `runModuleMap` and `registerModuleMap`.


---
_Generated by [Claude Code](https://claude.ai/code/session_011hMwf2uVnSkMp481qwzhjb)_