### PR TITLE
Add proof test for one() function empty string handling

### DIFF
--- a/fs/text/ascii/proof.f.ts
+++ b/fs/text/ascii/proof.f.ts
@@ -1,4 +1,4 @@
-import { range } from './module.f.ts'
+import { one, range } from './module.f.ts'
 import { stringify as jsonStringify } from '../../json/module.f.ts'
 import { sort } from '../../types/object/module.f.ts'
 
@@ -8,5 +8,10 @@ export const proof = {
     range: () => {
         const r = stringify(range("A"))
         if (r !== '[65,65]') { throw r }
-    }
+    },
+    oneThrowsOnEmpty: () => {
+        let threw = false
+        try { one('') } catch (_) { threw = true }
+        if (!threw) { throw 'expected throw' }
+    },
 }


### PR DESCRIPTION
## Summary
Added a new proof test to verify that the `one()` function properly throws an error when called with an empty string.

## Changes
- Imported the `one` function from `./module.f.ts`
- Added `oneThrowsOnEmpty` proof test that validates the `one()` function throws an exception when passed an empty string argument

## Implementation Details
The new test follows the existing proof pattern:
- Attempts to call `one('')` within a try-catch block
- Verifies that an exception was thrown
- Throws a descriptive error if the expected exception was not raised

https://claude.ai/code/session_01ELN9JEt3oGqbGawDvrTRyi