### PR TITLE
Run tsgo through pinned npx in generated CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@
           }
         },
         {
+          "run": "npm cache add @typescript/native-preview@7.0.0-dev.20260606.1"
+        },
+        {
           "uses": "denoland/setup-deno@v2",
           "with": {
             "deno-version": "2.8.2"
@@ -211,6 +214,9 @@
           }
         },
         {
+          "run": "npm cache add @typescript/native-preview@7.0.0-dev.20260606.1"
+        },
+        {
           "uses": "denoland/setup-deno@v2",
           "with": {
             "deno-version": "2.8.2"
@@ -377,6 +383,9 @@
           "with": {
             "node-version": "26.3.0"
           }
+        },
+        {
+          "run": "npm cache add @typescript/native-preview@7.0.0-dev.20260606.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -547,6 +556,9 @@
           }
         },
         {
+          "run": "npm cache add @typescript/native-preview@7.0.0-dev.20260606.1"
+        },
+        {
           "uses": "denoland/setup-deno@v2",
           "with": {
             "deno-version": "2.8.2"
@@ -713,6 +725,9 @@
           "with": {
             "node-version": "26.3.0"
           }
+        },
+        {
+          "run": "npm cache add @typescript/native-preview@7.0.0-dev.20260606.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -887,6 +902,9 @@
           "with": {
             "node-version": "26.3.0"
           }
+        },
+        {
+          "run": "npm cache add @typescript/native-preview@7.0.0-dev.20260606.1"
         },
         {
           "uses": "denoland/setup-deno@v2",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,6 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260606.1"
-        },
-        {
           "uses": "denoland/setup-deno@v2",
           "with": {
             "deno-version": "2.8.2"
@@ -136,7 +133,7 @@
           "run": "npm run cov"
         },
         {
-          "run": "tsgo"
+          "run": "npx npm:@typescript/native-preview@7.0.0-dev.20260606.1"
         },
         {
           "run": "npm pack"
@@ -214,9 +211,6 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260606.1"
-        },
-        {
           "uses": "denoland/setup-deno@v2",
           "with": {
             "deno-version": "2.8.2"
@@ -307,7 +301,7 @@
           "run": "npm run cov"
         },
         {
-          "run": "tsgo"
+          "run": "npx npm:@typescript/native-preview@7.0.0-dev.20260606.1"
         },
         {
           "run": "npm pack"
@@ -385,9 +379,6 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260606.1"
-        },
-        {
           "uses": "denoland/setup-deno@v2",
           "with": {
             "deno-version": "2.8.2"
@@ -478,7 +469,7 @@
           "run": "npm run cov"
         },
         {
-          "run": "tsgo"
+          "run": "npx npm:@typescript/native-preview@7.0.0-dev.20260606.1"
         },
         {
           "run": "npm pack"
@@ -556,9 +547,6 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260606.1"
-        },
-        {
           "uses": "denoland/setup-deno@v2",
           "with": {
             "deno-version": "2.8.2"
@@ -649,7 +637,7 @@
           "run": "npm run cov"
         },
         {
-          "run": "tsgo"
+          "run": "npx npm:@typescript/native-preview@7.0.0-dev.20260606.1"
         },
         {
           "run": "npm pack"
@@ -725,9 +713,6 @@
           "with": {
             "node-version": "26.3.0"
           }
-        },
-        {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260606.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -826,7 +811,7 @@
           "run": "npm run cov"
         },
         {
-          "run": "tsgo"
+          "run": "npx npm:@typescript/native-preview@7.0.0-dev.20260606.1"
         },
         {
           "run": "npm pack"
@@ -902,9 +887,6 @@
           "with": {
             "node-version": "26.3.0"
           }
-        },
-        {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260606.1"
         },
         {
           "uses": "denoland/setup-deno@v2",
@@ -994,7 +976,7 @@
           "run": "npm run cov"
         },
         {
-          "run": "tsgo"
+          "run": "npx npm:@typescript/native-preview@7.0.0-dev.20260606.1"
         },
         {
           "run": "npm pack"

--- a/fs/ci/node/module.f.ts
+++ b/fs/ci/node/module.f.ts
@@ -46,8 +46,9 @@ export const nodeVersions: Jobs = Object.fromEntries(node.others.map(v => [
 
 export const nodeMainSteps = (extra: readonly MetaStep[]): readonly MetaStep[] => nodeTests(node.default)([
     // TypeScript Preview
-    install({ run: `npm install -g @typescript/native-preview@${tsgo}`}),
-    test({ run: 'tsgo' }),
+    // install({ run: `npm cache add ${tsgoName}`})
+    // install({ run: `npm install -g @typescript/native-preview@${tsgo}`}),
+    test({ run: `npx npm:@typescript/native-preview@${tsgo}` }),
     // extra
     ...extra,
 ])

--- a/fs/ci/node/module.f.ts
+++ b/fs/ci/node/module.f.ts
@@ -44,11 +44,13 @@ export const nodeVersions: Jobs = Object.fromEntries(node.others.map(v => [
     ubuntu(nodeSteps(v))
 ]))
 
+const tsgoName = `@typescript/native-preview@${tsgo}`
+
 export const nodeMainSteps = (extra: readonly MetaStep[]): readonly MetaStep[] => nodeTests(node.default)([
     // TypeScript Preview
-    // install({ run: `npm cache add ${tsgoName}`})
+    install({ run: `npm cache add ${tsgoName}`}),
     // install({ run: `npm install -g @typescript/native-preview@${tsgo}`}),
-    test({ run: `npx npm:@typescript/native-preview@${tsgo}` }),
+    test({ run: `npx npm:${tsgoName}` }),
     // extra
     ...extra,
 ])

--- a/fs/ci/node/module.f.ts
+++ b/fs/ci/node/module.f.ts
@@ -49,7 +49,6 @@ const tsgoName = `@typescript/native-preview@${tsgo}`
 export const nodeMainSteps = (extra: readonly MetaStep[]): readonly MetaStep[] => nodeTests(node.default)([
     // TypeScript Preview
     install({ run: `npm cache add ${tsgoName}`}),
-    // install({ run: `npm install -g @typescript/native-preview@${tsgo}`}),
     test({ run: `npx npm:${tsgoName}` }),
     // extra
     ...extra,


### PR DESCRIPTION
## Summary
- stop installing `@typescript/native-preview` globally in generated Node CI steps
- run the pinned native-preview TypeScript compiler through `npx npm:@typescript/native-preview@7.0.0-dev.20260606.1`
- update the checked-in generated workflow to match

## Tests
- `git diff --check main...HEAD`