### PR TITLE
Add issue for emergent testing Proof type

### DIFF
--- a/issues/668-emergent-testing-proof-type.md
+++ b/issues/668-emergent-testing-proof-type.md
@@ -26,8 +26,15 @@ Confirm whether returning a nested `Proof` from a function is intended runner
 behaviour. If proof functions are only test leaves today, use a narrower
 function branch and document the choice in JSDoc.
 
+An alternative is to define the proof shape as RTTI and derive the TypeScript
+type from it. That would keep runtime validation and the public type in sync,
+but proof leaves are functions, so this requires extern RTTI support for
+function values before it can model the full proof tree.
+
 ## Tasks
 
+- [ ] Decide whether `Proof` should be a direct TypeScript type or derived from
+  RTTI.
 - [ ] Add the `Proof` type in the natural emergent testing module.
 - [ ] Use the type in runner/registering APIs where it reflects existing
   behaviour.

--- a/issues/668-emergent-testing-proof-type.md
+++ b/issues/668-emergent-testing-proof-type.md
@@ -1,0 +1,44 @@
+# 668-emergent-testing-proof-type. Add an explicit `Proof` type
+
+**Priority:** P3
+**Status:** open
+
+## Problem
+
+Emergent testing documentation describes proofs as ordinary values, but the code
+does not expose a named `Proof` type for modules to use. This makes the expected
+recursive shape implicit in runner code and prose instead of available as a
+type-level contract.
+
+## Proposal
+
+Add and export a `Proof` type near the emergent testing runner API. The type
+should model the recursive proof tree accepted by the runner:
+
+```ts
+export type Proof =
+    | Readonly<Record<string, Proof>>
+    | readonly Proof[]
+    | (() => Proof | undefined)
+```
+
+Confirm whether returning a nested `Proof` from a function is intended runner
+behaviour. If proof functions are only test leaves today, use a narrower
+function branch and document the choice in JSDoc.
+
+## Tasks
+
+- [ ] Add the `Proof` type in the natural emergent testing module.
+- [ ] Use the type in runner/registering APIs where it reflects existing
+  behaviour.
+- [ ] Document proof-tree invariants in JSDoc and keep the README definition in
+  sync.
+- [ ] Add or update proof coverage for accepted object, array, and function
+  proof shapes.
+
+## Related
+
+- [i65Z-tf-test-tree-walker](./65Z-tf-test-tree-walker.md) — planned shared
+  proof-tree traversal.
+- [i665-proof-property-tests](./665-proof-property-tests.md) — future proof
+  shape extension.

--- a/issues/668-emergent-testing-proof-type.md
+++ b/issues/668-emergent-testing-proof-type.md
@@ -47,5 +47,7 @@ function values before it can model the full proof tree.
 
 - [i65Z-tf-test-tree-walker](./65Z-tf-test-tree-walker.md) — planned shared
   proof-tree traversal.
+- [i668-rtti-function-types](./668-rtti-function-types.md) — extern RTTI for
+  function-valued proof leaves.
 - [i665-proof-property-tests](./665-proof-property-tests.md) — future proof
   shape extension.

--- a/issues/668-rtti-function-types.md
+++ b/issues/668-rtti-function-types.md
@@ -1,0 +1,66 @@
+# 668-rtti-function-types. Add RTTI support for function values
+
+**Priority:** P3
+**Status:** open
+
+## Problem
+
+RTTI can describe data shapes, but it cannot currently describe function values
+as first-class schemas. Some consumers need to express a callable value together
+with its parameter and result types, for example emergent testing proof leaves.
+
+Function RTTI has an important limitation: while we can describe the parameter
+and result types, runtime validation of a function itself has limited options.
+A value can be checked as callable, but its full contract can only be observed
+when the function is called.
+
+## Proposal
+
+Add an extern RTTI form for functions. It should be able to describe parameter
+types and result type, while keeping the runtime contract explicit: validating a
+function schema should not pretend it can prove all future calls are valid.
+
+One practical API is a wrapper that validates calls:
+
+```ts
+validateFunc<F extends RttiFunction>(
+    rtti: F,
+    f: (...params: readonly unknown[]) => unknown,
+): (...params: TsParams<F>) => Result<TsResult<F>, unknown>
+```
+
+The wrapper validates parameters before calling `f` and validates the result
+after the call. Errors from validation or from the function body are returned as
+`Result` errors.
+
+For untrusted code, provide a sandboxed wrapper:
+
+```ts
+validateSandboxFunc<F extends RttiFunction>(
+    rtti: F,
+    f: (...params: readonly unknown[]) => unknown,
+): (...params: TsParams<F>) => Effect<Sandbox, Result<TsResult<F>, unknown>>
+```
+
+This preserves the same typed call surface while running the function through a
+sandbox effect, which is better for cases where the function body should not be
+trusted.
+
+## Tasks
+
+- [ ] Design the extern RTTI representation for function schemas.
+- [ ] Define `TsParams<F>` and `TsResult<F>` for function RTTI.
+- [ ] Decide what minimal validation is performed on the raw value before it is
+  wrapped.
+- [ ] Add a call-validating wrapper that returns `Result<TsResult<F>, unknown>`.
+- [ ] Add or design a sandboxed wrapper that returns
+  `Effect<Sandbox, Result<TsResult<F>, unknown>>`.
+- [ ] Document the runtime limitation: function RTTI describes callable
+  contracts, but the contract is enforced at call boundaries.
+
+## Related
+
+- [i668-emergent-testing-proof-type](./668-emergent-testing-proof-type.md) —
+  proof leaves need function-valued schemas if `Proof` is derived from RTTI.
+- [i143-rtti-data](./143-rtti-data.md) — serializable/function-free RTTI data
+  form; extern function schemas may need to remain outside that core form.


### PR DESCRIPTION
## Summary
- add an issue to introduce an explicit recursive `Proof` type for emergent testing
- capture the open design question around whether proof functions may return nested proof trees
- link related proof-tree traversal and property-test issues

## Tests
- `git diff --check main...HEAD`