### PR TITLE
Clarify Euler's criterion edge case for quadratic residue check

### DIFF
--- a/fs/types/prime_field/module.f.ts
+++ b/fs/types/prime_field/module.f.ts
@@ -80,6 +80,8 @@ export const prime_field = (p: bigint): PrimeField => {
         return r < 0n ? add(p)(r) : r
     }
     const max = p - 1n
+    // Euler's exponent is `(p - 1) / 2`; use `max`, not `p`, so `p === 2n`
+    // gives exponent `0n` instead of `1n`.
     // 0 is a square mod p; Euler's criterion needs a separate case because 0^e = 0.
     const powHalf = pow(max >> 1n)
     const quadRes = (x: bigint): boolean => {

--- a/fs/types/prime_field/module.f.ts
+++ b/fs/types/prime_field/module.f.ts
@@ -80,8 +80,7 @@ export const prime_field = (p: bigint): PrimeField => {
         return r < 0n ? add(p)(r) : r
     }
     const max = p - 1n
-    // Euler's exponent is `(p - 1) / 2`; use `max`, not `p`, so `p === 2n`
-    // gives exponent `0n` instead of `1n`.
+    // 0 is a square mod p; Euler's criterion needs a separate case because 0^e = 0.
     const powHalf = pow(max >> 1n)
     const quadRes = (x: bigint): boolean => {
         const v = reduce(x)


### PR DESCRIPTION
## Summary
Updated the comment explaining the quadratic residue check in the prime field module to more accurately describe why a special case is needed for zero.

## Key Changes
- Replaced the comment explaining `powHalf` calculation with a clearer explanation that focuses on why zero requires special handling in Euler's criterion
- The new comment explicitly states that "0 is a square mod p" and that "Euler's criterion needs a separate case because 0^e = 0"
- This better documents the mathematical reasoning behind the implementation rather than just noting the edge case with p === 2n

## Implementation Details
The change is purely documentary - no functional code changes were made. The `powHalf` calculation and `quadRes` function behavior remain identical. The improved comment clarifies that the implementation correctly handles zero as a quadratic residue, which is mathematically significant since 0^e always equals 0 regardless of the exponent value.

https://claude.ai/code/session_0115bZor8HzJXFmDHqPTaUdU