### PR TITLE
refactor: json/rpc — add spec links, destructure dispatch, shorthand error property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `json/rpc`: add JSON-RPC spec links to module and request/response JSDoc; destructure `decodeRequest` result and `message` fields in `dispatch`; use shorthand property in `errorResponseOf` [#1002](https://github.com/functionalscript/functionalscript/pull/1002)
+
 ## 0.30.0
 
 - `ci`: breaking change to the public CI generator: split generated workflows into lightweight platform jobs and canonical Ubuntu ARM jobs, set explicit read-only workflow permissions, pin FunctionalScript smoke-test installs, remove the repository-specific demo compile step, and expand Rust target checks to include release tests and release Clippy (i668-ci-matrix-update).

--- a/fs/json/rpc/module.f.ts
+++ b/fs/json/rpc/module.f.ts
@@ -10,6 +10,8 @@
  * `fs/effects/node`, and concrete method sets such as MCP (i665-mcp), which layer
  * on top of `dispatch`.
  *
+ * https://www.jsonrpc.org/specification
+ *
  * @module
  */
 import { number, string, or, option } from '../../types/rtti/module.f.ts'
@@ -26,6 +28,8 @@ const id = or(string, number, null)
 /**
  * A request or notification envelope. `id` present → request (a response is
  * expected); `id` absent → notification (no response). `params` is optional.
+ *
+ * https://www.jsonrpc.org/specification#request_object
  */
 export const request = {
     jsonrpc,
@@ -54,6 +58,8 @@ export const errorResponse = { jsonrpc, error, id } as const
  * runtime decoder and the static type, with no drift. rtti structs are open
  * (extra keys allowed), so "result XOR error" is not enforced at runtime; in
  * practice the dispatcher only ever constructs one or the other.
+ *
+ * https://www.jsonrpc.org/specification#response_object
  */
 export const response = or(successResponse, errorResponse)
 export type Response = Ts<typeof response>

--- a/fs/json/rpc/module.f.ts
+++ b/fs/json/rpc/module.f.ts
@@ -99,11 +99,11 @@ export const dispatch =
     (handlers: Handlers) =>
     (value: Unknown): Response | null =>
 {
-    const decoded = decodeRequest(value)
-    if (decoded[0] === 'error') {
+    const [t, decoded] = decodeRequest(value)
+    if (t === 'error') {
         return errorResponseOf(null)(invalidRequest)
     }
-    const message = decoded[1]
+    const message = decoded
     const id = message.id
     if (id === undefined) {
         return null
@@ -112,8 +112,8 @@ export const dispatch =
     if (handler === undefined) {
         return errorResponseOf(id)(methodNotFound)
     }
-    const result = handler(message.params)
-    return result[0] === 'ok'
-        ? { jsonrpc, result: result[1], id }
-        : errorResponseOf(id)(result[1])
+    const [t2, result] = handler(message.params)
+    return t2 === 'ok'
+        ? { jsonrpc, result, id }
+        : errorResponseOf(id)(result)
 }

--- a/fs/json/rpc/module.f.ts
+++ b/fs/json/rpc/module.f.ts
@@ -84,8 +84,8 @@ export const methodNotFound = rpcError(-32601)('Method not found')
 export const invalidParams = rpcError(-32602)('Invalid params')
 export const internalError = rpcError(-32603)('Internal error')
 
-const errorResponseOf = (id: Id) => (e: RpcError): Response =>
-    ({ jsonrpc, error: e, id })
+const errorResponseOf = (id: Id) => (error: RpcError): Response =>
+    ({ jsonrpc, error, id })
 
 /**
  * Dispatches an already-parsed JSON-RPC value against `handlers`.
@@ -99,20 +99,19 @@ export const dispatch =
     (handlers: Handlers) =>
     (value: Unknown): Response | null =>
 {
-    const [t, decoded] = decodeRequest(value)
+    const [t, message] = decodeRequest(value)
     if (t === 'error') {
         return errorResponseOf(null)(invalidRequest)
     }
-    const message = decoded
-    const id = message.id
+    const { id, method, params } = message
     if (id === undefined) {
         return null
     }
-    const handler: Handler | undefined = handlers[message.method]
+    const handler: Handler | undefined = handlers[method]
     if (handler === undefined) {
         return errorResponseOf(id)(methodNotFound)
     }
-    const [t2, result] = handler(message.params)
+    const [t2, result] = handler(params)
     return t2 === 'ok'
         ? { jsonrpc, result, id }
         : errorResponseOf(id)(result)


### PR DESCRIPTION
## Summary

- Add JSON-RPC spec links to module and request/response JSDoc
- Destructure `decodeRequest` result and `message` fields in `dispatch` for clarity
- Use shorthand `{ jsonrpc, error, id }` in `errorResponseOf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)