### PR TITLE
fs/path: add non-normalizing `join` and route inline segment joins through it

### DIFF
--- a/fs/cas/module.f.ts
+++ b/fs/cas/module.f.ts
@@ -4,7 +4,7 @@
  * @module
  */
 import { computeSync, sha256, type Sha2 } from '../crypto/sha2/module.f.ts'
-import { parse } from '../path/module.f.ts'
+import { join, parse } from '../path/module.f.ts'
 import type { Vec } from '../types/bit_vec/module.f.ts'
 import { cBase32ToVec, vecToCBase32 } from '../cbase32/module.f.ts'
 import { forEachStep, pure, type Effect, type Operation } from '../effects/module.f.ts'
@@ -36,7 +36,7 @@ const toPath = (key: Vec): string => {
     const s = vecToCBase32(key)
     const [a, bc] = split(s)
     const [b, c] = split(bc)
-    return `${prefix}/${a}/${b}/${c}`
+    return join(prefix)(join(a)(join(b)(c)))
 }
 
 /**
@@ -49,10 +49,10 @@ export const fileKvStore = (path: string): KvStore<Fs> => ({
     write: (key: Vec, value: Vec): Effect<Fs, void> => {
         const p = toPath(key)
         const parts = parse(p)
-        const dir = `${path}/${parts.slice(0, -1).join('/')}`
+        const dir = join(path)(parts.slice(0, -1).join('/'))
         // TODO: error handling
         return mkdir(dir, { recursive: true })
-            .step(() => writeFile(`${path}/${p}`, value))
+            .step(() => writeFile(join(path)(p), value))
             .step(() => pure(undefined))
     },
     list: (): Effect<Fs, readonly Vec[]> =>

--- a/fs/cas/module.f.ts
+++ b/fs/cas/module.f.ts
@@ -36,7 +36,7 @@ const toPath = (key: Vec): string => {
     const s = vecToCBase32(key)
     const [a, bc] = split(s)
     const [b, c] = split(bc)
-    return join(prefix)(join(a)(join(b)(c)))
+    return join(prefix, a, b, c)
 }
 
 /**
@@ -49,10 +49,10 @@ export const fileKvStore = (path: string): KvStore<Fs> => ({
     write: (key: Vec, value: Vec): Effect<Fs, void> => {
         const p = toPath(key)
         const parts = parse(p)
-        const dir = join(path)(parts.slice(0, -1).join('/'))
+        const dir = join(path, ...parts.slice(0, -1))
         // TODO: error handling
         return mkdir(dir, { recursive: true })
-            .step(() => writeFile(join(path)(p), value))
+            .step(() => writeFile(join(path, p), value))
             .step(() => pure(undefined))
     },
     list: (): Effect<Fs, readonly Vec[]> =>

--- a/fs/dev/module.f.ts
+++ b/fs/dev/module.f.ts
@@ -57,7 +57,7 @@ const allFiles = (
             for (const i of unwrap(d)) {
                 const { name } = i
                 if (name.startsWith('.')) { continue }
-                const file = join(p)(name)
+                const file = join(p, name)
                 if (!i.isFile) {
                     if (name === 'node_modules') { continue }
                     result = [...result, load(file)]

--- a/fs/dev/module.f.ts
+++ b/fs/dev/module.f.ts
@@ -16,7 +16,7 @@ import {
 import { cmp as strCmp } from '../types/string/module.f.ts'
 import { unwrap } from '../types/result/module.f.ts'
 import { pure, type Effect } from '../effects/module.f.ts'
-import { relativize, toPosix } from '../path/module.f.ts'
+import { join, relativize, toPosix } from '../path/module.f.ts'
 
 export type Module = {
     readonly proof?: unknown
@@ -57,7 +57,7 @@ const allFiles = (
             for (const i of unwrap(d)) {
                 const { name } = i
                 if (name.startsWith('.')) { continue }
-                const file = `${p}/${name}`
+                const file = join(p)(name)
                 if (!i.isFile) {
                     if (name === 'node_modules') { continue }
                     result = [...result, load(file)]

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -129,7 +129,7 @@ const readdir = (base: string, recursive: boolean) => readOperation((dir, path):
             const isFile = typeof content !== 'object'
             result = [...result, { name, parentPath, isFile }]
             if (!isFile && recursive) {
-                result = [...result, ...f(join(parentPath)(name), content as Dir)]
+                result = [...result, ...f(join(parentPath, name), content as Dir)]
             }
         }
         return result

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -4,7 +4,7 @@
  * @module
  */
 import { todo } from '../../../asserts/module.f.ts'
-import { parse } from '../../../path/module.f.ts'
+import { join, parse } from '../../../path/module.f.ts'
 import { utf8ToString } from '../../../text/module.f.ts'
 import { isVec, type Vec } from '../../../types/bit_vec/module.f.ts'
 import { error, ok } from '../../../types/result/module.f.ts'
@@ -129,7 +129,7 @@ const readdir = (base: string, recursive: boolean) => readOperation((dir, path):
             const isFile = typeof content !== 'object'
             result = [...result, { name, parentPath, isFile }]
             if (!isFile && recursive) {
-                result = [...result, ...f(`${parentPath}/${name}`, content as Dir)]
+                result = [...result, ...f(join(parentPath)(name), content as Dir)]
             }
         }
         return result

--- a/fs/path/module.f.ts
+++ b/fs/path/module.f.ts
@@ -58,13 +58,13 @@ export const concat: Reduce<string>
 }
 
 /**
- * Joins two path fragments with a single POSIX `/` separator, without
+ * Joins path segments with single POSIX `/` separators, without
  * normalization. Unlike {@link concat}, the result is not parsed/collapsed,
  * so absolute roots and `.`/`..` segments are preserved verbatim. Use this
  * for building paths from already-clean segments (directory walks, store
  * layouts); use {@link concat} when normalization is desired.
  */
-export const join: Reduce<string> = a => b => `${a}/${b}`
+export const join = (...list: readonly string[]): string => list.join('/')
 
 /**
  * Returns `path` relative to `base` with a `./` prefix, or `path` unchanged

--- a/fs/path/module.f.ts
+++ b/fs/path/module.f.ts
@@ -5,8 +5,7 @@
  */
 import type { Fold, Reduce, Unary } from '../types/function/operator/module.f.ts'
 import { type List, fold, last, take, length, concat as listConcat, toArray } from '../types/list/module.f.ts'
-import { join } from '../types/string/module.f.ts'
-import { concat as stringConcat } from '../types/string/module.f.ts'
+import { join as listJoin, concat as stringConcat } from '../types/string/module.f.ts'
 
 const foldNormalizeOp: Fold<string, List<string>>
 = input => state => {
@@ -46,7 +45,7 @@ export const parse = (path: string): readonly string[] => {
 export const normalize: Unary<string, string>
 = path => {
     const foldResult = parse(path)
-    return join('/')(foldResult)
+    return listJoin('/')(foldResult)
 }
 
 /**
@@ -57,6 +56,15 @@ export const concat: Reduce<string>
     const s = stringConcat([a, '/', b])
     return normalize(s)
 }
+
+/**
+ * Joins two path fragments with a single POSIX `/` separator, without
+ * normalization. Unlike {@link concat}, the result is not parsed/collapsed,
+ * so absolute roots and `.`/`..` segments are preserved verbatim. Use this
+ * for building paths from already-clean segments (directory walks, store
+ * layouts); use {@link concat} when normalization is desired.
+ */
+export const join: Reduce<string> = a => b => `${a}/${b}`
 
 /**
  * Returns `path` relative to `base` with a `./` prefix, or `path` unchanged

--- a/fs/path/proof.f.ts
+++ b/fs/path/proof.f.ts
@@ -36,20 +36,28 @@ const concatTest = [
 
 const joinTest = [
     () => {
-        const r = join('a')('b')
+        const r = join('a', 'b')
         if (r !== 'a/b') { throw r }
     },
     () => {
-        const r = join('/abs/root')('x')
+        const r = join('/abs/root', 'x')
         if (r !== '/abs/root/x') { throw r }
     },
     () => {
-        const r = join('a')(join('b')('c'))
-        if (r !== 'a/b/c') { throw r }
+        const r = join('a', 'b', 'c', 'd')
+        if (r !== 'a/b/c/d') { throw r }
     },
     () => {
-        const r = join('')('x')
+        const r = join('', 'x')
         if (r !== '/x') { throw r }
+    },
+    () => {
+        const r = join()
+        if (r !== '') { throw r }
+    },
+    () => {
+        const r = join('only')
+        if (r !== 'only') { throw r }
     },
 ]
 

--- a/fs/path/proof.f.ts
+++ b/fs/path/proof.f.ts
@@ -1,4 +1,4 @@
-import { concat, normalize, relativize, toPosix } from "./module.f.ts"
+import { concat, join, normalize, relativize, toPosix } from "./module.f.ts"
 
 const normalizeTest = [
     () => {
@@ -31,6 +31,25 @@ const concatTest = [
     () => {
         const c = concat("a/../b/..")("c")
         if (c !== "c") { throw c }
+    },
+]
+
+const joinTest = [
+    () => {
+        const r = join('a')('b')
+        if (r !== 'a/b') { throw r }
+    },
+    () => {
+        const r = join('/abs/root')('x')
+        if (r !== '/abs/root/x') { throw r }
+    },
+    () => {
+        const r = join('a')(join('b')('c'))
+        if (r !== 'a/b/c') { throw r }
+    },
+    () => {
+        const r = join('')('x')
+        if (r !== '/x') { throw r }
     },
 ]
 
@@ -67,4 +86,4 @@ const toPosixTest = [
     },
 ]
 
-export const proof = { normalizeTest, concatTest, relativizeTest, toPosixTest }
+export const proof = { normalizeTest, concatTest, joinTest, relativizeTest, toPosixTest }

--- a/issues/668-path-join-segments.md
+++ b/issues/668-path-join-segments.md
@@ -1,7 +1,7 @@
 # 668-path-join-segments. `fs/path`: own segment joining instead of inline `` `${a}/${b}` ``
 
 **Priority:** P4
-**Status:** open
+**Status:** done
 
 ## Problem
 


### PR DESCRIPTION
## Summary

Implements [i668-path-join-segments](./issues/668-path-join-segments.md).

- Adds `join: Reduce<string> = a => b => `${a}/${b}`` to `fs/path/module.f.ts`. Unlike `concat`, `join` does **not** parse/normalize the result, so absolute roots and `.`/`..` segments survive verbatim — which is what the CAS store root and recursive `readdir` walks need.
- Replaces the five hand-rolled `` `${a}/${b}` `` joins in `fs/cas`, `fs/dev`, and `fs/effects/node/virtual` with calls to it. This addresses the *Separation of concerns* example in AGENTS.md ("path manipulation belongs in `fs/path`, not inline in a loader").
- Renames the existing `join` import from `fs/types/string` to `listJoin` inside `fs/path/module.f.ts` so the `join` name is free for the path-specific export.
- Adds `joinTest` proof coverage in `fs/path/proof.f.ts`.
- Marks `issues/668-path-join-segments.md` as **done**.

This is a behaviour-preserving refactor — each `join(a)(b)` produces the exact same string the inline template literal produced before.

## Test plan

- [x] `npx tsc` passes
- [x] `fjs t` in `fs/path` — all 18 proofs pass (including new `joinTest`)
- [x] `fjs t` in `fs/cas` — all 11 proofs pass
- [x] `fjs t` in `fs/dev` — all 12 proofs pass
- [x] `fjs t` in `fs/effects` — all 29 proofs pass
- [x] full `fjs t` — 1635/1635 pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mbyd51uSMyFKKYR8kUtWzP)_