### PR TITLE
Add test cases for terminal state and error handling

### DIFF
--- a/fs/fsc/proof.f.ts
+++ b/fs/fsc/proof.f.ts
@@ -1,4 +1,4 @@
-import { init } from './module.f.ts'
+import { init, terminal } from './module.f.ts'
 import { one } from '../text/ascii/module.f.ts'
 import { stringify } from '../json/module.f.ts'
 
@@ -22,6 +22,17 @@ export const proof = {
     a: () => {
         const x = f('1')
         if (x !== '["1"]') { throw x }
+    },
+    b: () => {
+        // exercises toInit: terminal returns empty output and loops back to init
+        const result = init(terminal)
+        if (result[0].length !== 0) { throw result[0] }
+    },
+    c: () => {
+        // exercises unexpectedSymbol: next state after a token returns an error message
+        const next = init(one('1'))[1]
+        const result = next(42)
+        if (result[0][0] !== 'unexpected symbol 42') { throw result[0][0] }
     },
     fn: () => {
         const o = {


### PR DESCRIPTION
## Summary
This PR adds two new test cases to the proof module to improve test coverage of state machine behavior, specifically testing terminal state handling and error conditions.

## Key Changes
- Import `terminal` from the module to enable testing of terminal state behavior
- Add test case `b`: Verifies that the `terminal` state returns empty output and properly loops back to `init`
- Add test case `c`: Verifies that unexpected symbols are properly handled with an error message after processing a token

## Implementation Details
- Test `b` exercises the `toInit` behavior by passing `terminal` to `init()` and asserting the result contains empty output
- Test `c` exercises the `unexpectedSymbol` error path by calling the next state with an invalid input (numeric value `42`) and verifying the error message format

https://claude.ai/code/session_01BEWEibL21nH49PasNpibo3