### PR TITLE
Add issue specs for BNF data helpers and CI job factory refactors

### DIFF
--- a/issues/669-bnf-data-shared-helpers.md
+++ b/issues/669-bnf-data-shared-helpers.md
@@ -1,0 +1,117 @@
+# 669-bnf-data-shared-helpers. Hoist and share repeated helpers in `bnf/data`
+
+**Priority:** P4
+**Status:** open
+
+## Problem
+
+`fs/bnf/data/module.f.ts` carries two distinct DRY / hoisting smells in its
+parser machinery. Neither is covered by the existing fold-children work in
+[i665-bnf-data-fold-children](./665-bnf-data-fold-children.md) (that issue is
+about the `sequence` / `variant` AST-fold helpers, a different pair of
+functions).
+
+### 1. `mrSuccess` / `mrFail` match-result constructors
+
+Both `descentParser` (lines 384-385) and `parserRuleSet` (lines 452-453) define
+a local pair of match-result constructors *inside* their recursive `f`
+callback:
+
+```ts
+// descentParser, inside f (383-385)
+const mrSuccess = (tag: AstTag, sequence: AstSequenceMeta<T>, idx: number): DescentMatchResult<T> => [{tag, sequence}, true, idx]
+const mrFail    = (tag: AstTag, sequence: AstSequenceMeta<T>, idx: number): DescentMatchResult<T> => [{tag, sequence}, false, idx]
+
+// parserRuleSet, inside f (452-453)
+const mrSuccess = (tag: AstTag, sequence: AstSequence, r: Remainder): MatchResult => [{tag, sequence}, true, r]
+const mrFail    = (tag: AstTag, sequence: AstSequence, r: Remainder): MatchResult => [{tag, sequence}, false, r]
+```
+
+Two problems:
+
+- **Hoisting.** These helpers capture no local state — they are pure functions
+  of their arguments — yet they are redeclared on *every* recursive call of `f`.
+  `AGENTS.md` says: "Hoist helpers to module scope when they don't capture local
+  state — don't redeclare them inside another function on every call."
+- **DRY.** All four constructors are the same shape: `[{ tag, sequence },
+  success, third]`. They differ only in the type of the third tuple element
+  (`number` index vs `Remainder`) and the sequence type — both of which a
+  generic parameter captures.
+
+### 2. `emptyTagMapAdd` branch duplication + mutable accumulators
+
+`emptyTagMapAdd` (lines 336-359) has an Array branch and a Variant/Object branch
+that share almost their entire body — seed `map[name] = true`, fold over the
+children threading `map` and an `emptyTag`, then return
+`[ruleSet, { ...map, [name]: emptyTag }, emptyTag]`:
+
+```ts
+} else if (rule instanceof Array) {
+    map = { ...map, [name]: true}
+    let emptyTag: EmptyTagEntry = rule.length == 0
+    for (const item of rule) {
+        const [,newMap,itemEmptyTag] = emptyTagMapAdd(ruleSet)(map)(item)
+        map = newMap
+        if (emptyTag === false) { emptyTag = itemEmptyTag !== false }
+    }
+    return [ruleSet, { ...map, [name]: emptyTag }, emptyTag]
+} else {
+    map = { ...map, [name]: true}
+    const entries = Object.entries(rule)
+    let emptyTag: EmptyTagEntry = false
+    for (const [tag, item] of entries) {
+        const [,newMap,itemEmptyTag] = emptyTagMapAdd(ruleSet)(map)(item)
+        map = newMap
+        if (itemEmptyTag !== false) { emptyTag = tag }
+    }
+    return [ruleSet, { ...map, [name]: emptyTag }, emptyTag]
+}
+```
+
+Both branches additionally reassign the `map` parameter and a `let emptyTag`
+accumulator in place inside a `for` loop, which contradicts the codebase's
+"don't reassign accumulators / build new values" convention.
+
+The only real differences are: (a) the seed `emptyTag` (`rule.length == 0` vs
+`false`), (b) what is iterated (the array's items vs `Object.entries`), and
+(c) the per-item combine (`emptyTag ||= itemEmptyTag !== false` vs
+`itemEmptyTag !== false ? tag : emptyTag`).
+
+## Proposal
+
+1. **Hoist a single match-result constructor** to module scope, generic over the
+   sequence and third-element types, and derive `mrSuccess` / `mrFail` (or call
+   it directly with the success flag) in both parsers:
+
+   ```ts
+   const mr = <S, R>(success: boolean) =>
+       (tag: AstTag, sequence: S, r: R): readonly [{ readonly tag: AstTag, readonly sequence: S }, boolean, R] =>
+           [{ tag, sequence }, success, r]
+   ```
+
+   `descentParser` uses `mr<AstSequenceMeta<T>, number>`; `parserRuleSet` uses
+   `mr<AstSequence, Remainder>`. Both `f` bodies drop their four local
+   declarations.
+
+2. **Unify the `emptyTagMapAdd` branches** into one fold over a list of child
+   items, parameterized by the seed `emptyTag` and the combine function, and
+   replace the `let`/reassignment loop with a `reduce` that threads
+   `{ map, emptyTag }` immutably. This collapses the two near-identical bodies to
+   one and removes the in-place mutation.
+
+Both are local, single-module refactors with no cross-module coordination.
+
+## Tasks
+
+- [ ] Hoist the shared `mr` constructor to module scope; update both `f` bodies.
+- [ ] Extract a shared child-fold for `emptyTagMapAdd`; thread the accumulator
+      immutably instead of reassigning `map` / `emptyTag`.
+- [ ] Run `npx tsc`, `fjs t`, and confirm `fs/bnf/data/proof.f.ts` still passes
+      with full coverage.
+
+## Related
+
+- [i665-bnf-data-fold-children](./665-bnf-data-fold-children.md) — the adjacent
+  `sequence` / `variant` AST-fold extraction (different functions, same module).
+- [i667-bnf-repeat-flatten](./667-bnf-repeat-flatten.md) — other `bnf/data`
+  cleanups.

--- a/issues/669-ci-ubuntu-job-factory.md
+++ b/issues/669-ci-ubuntu-job-factory.md
@@ -1,0 +1,64 @@
+# 669-ci-ubuntu-job-factory. Factor out the `ubuntu` / `ubuntuArm` Job builders
+
+**Priority:** P4
+**Status:** open
+
+## Problem
+
+`fs/ci/common/module.f.ts:98-106` defines two exported Job builders that differ
+only in a single image constant:
+
+```ts
+export const ubuntu = (ms: readonly MetaStep[]): Job => ({
+    'runs-on': images.ubuntu.intel,
+    steps: toSteps(ms)
+})
+
+export const ubuntuArm = (ms: readonly MetaStep[]): Job => ({
+    'runs-on': images.ubuntu.arm,
+    steps: toSteps(ms)
+})
+```
+
+The entire body — the `Job` shape, the `steps: toSteps(ms)` call — is repeated
+verbatim. The only thing that varies is `'runs-on'` (`images.ubuntu.intel` vs
+`images.ubuntu.arm`). This is the textbook DRY case `AGENTS.md` calls out: "two
+nearly-identical functions differ only in a constant". Today there are two
+runners; a third image (e.g. a future macOS or Windows runner, or a pinned
+container) would mean a third copy of the same three lines.
+
+## Proposal
+
+Introduce a private factory parameterized by the image, then derive the two
+public exports from it. This keeps the public API (`ubuntu`, `ubuntuArm`)
+unchanged while removing the duplicated body:
+
+```ts
+const job = (runsOn: string) => (ms: readonly MetaStep[]): Job => ({
+    'runs-on': runsOn,
+    steps: toSteps(ms),
+})
+
+export const ubuntu = job(images.ubuntu.intel)
+export const ubuntuArm = job(images.ubuntu.arm)
+```
+
+The factory makes adding a new runner a one-liner (`export const macos =
+job(images.macos.arm)`), and it documents that "a Job is just a runner image
+plus the standard step pipeline" in one place instead of implying it twice.
+
+This is a single-module, zero-coordination change — no other module needs to
+know `job` exists.
+
+## Tasks
+
+- [ ] Add the private `job` factory in `fs/ci/common/module.f.ts`.
+- [ ] Re-express `ubuntu` and `ubuntuArm` in terms of `job`.
+- [ ] Confirm `proof.f.ts` coverage still exercises both exports (they remain
+      distinct exported values, so existing proofs should pass unchanged).
+- [ ] Run `npx tsc` and `fjs t`.
+
+## Related
+
+- [i170-ci-tool-steps](./170-ci-tool-steps.md) — the `MetaStep` → `Step`
+  pipeline (`toSteps`) these builders wrap.


### PR DESCRIPTION
## Summary

This PR adds two issue specification documents outlining refactoring opportunities in the codebase to improve code quality and reduce duplication.

## Issues Added

### 669-bnf-data-shared-helpers
Proposes hoisting and sharing repeated helper functions in `fs/bnf/data/module.f.ts`:

- **Match-result constructors**: `mrSuccess` and `mrFail` are redeclared on every recursive call in both `descentParser` and `parserRuleSet`, despite being pure functions with no local state. Proposes extracting a single generic `mr` constructor to module scope.
- **Branch duplication in `emptyTagMapAdd`**: The Array and Variant/Object branches share nearly identical logic but use mutable accumulators (`let` reassignments). Proposes unifying into a single fold with immutable accumulator threading.

### 669-ci-ubuntu-job-factory
Proposes factoring out the `ubuntu` and `ubuntuArm` Job builders in `fs/ci/common/module.f.ts`:

- Both functions are identical except for a single image constant (`images.ubuntu.intel` vs `images.ubuntu.arm`)
- Proposes introducing a private `job` factory parameterized by the image, then deriving the two public exports from it
- Makes the pattern extensible for future runners (e.g., macOS, Windows) as one-liners

## Implementation Notes

Both refactors are single-module changes with no cross-module coordination required. They follow established patterns in `AGENTS.md` for hoisting stateless helpers and eliminating near-identical function duplication.

https://claude.ai/code/session_01FHmkisdcNybVkN3E2oFmzZ