### PR TITLE
Update Node.js 22 and TypeScript Native Preview versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,7 +449,7 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "22.22.2"
+            "node-version": "22.22.3"
           }
         },
         {
@@ -502,7 +502,7 @@
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260606.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260609.1"
         },
         {
           "uses": "actions/checkout@v6"

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -39,7 +39,7 @@ export const playwright = '1.60.0'
 // https://nodejs.org/en/download
 export const node = {
     default: '26.3.0',
-    node22: '22.22.2',
+    node22: '22.22.3',
     node24: '24.16.0',
 } as const
 
@@ -50,7 +50,7 @@ export const wasmtime = '45.0.0'
 export const wasmer = '7.1.0'
 
 // https://www.npmjs.com/package/@typescript/native-preview?activeTab=versions
-export const tsgo = '7.0.0-dev.20260606.1'
+export const tsgo = '7.0.0-dev.20260609.1'
 
 // GitHub Action versions used by CI step builders. The key is the action
 // `owner/name`; call sites compose the full ref as

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,21 +46,6 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/playwright": {
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,21 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",


### PR DESCRIPTION
## Summary
Updates pinned versions for Node.js 22 and TypeScript Native Preview (@typescript/native-preview) in the CI configuration module.

## Changes
- **Node.js 22**: Bumped from `22.22.2` to `22.22.3` (patch release)
- **TypeScript Native Preview (tsgo)**: Updated from `7.0.0-dev.20260606.1` to `7.0.0-dev.20260609.1` (development build with newer date)

These version updates ensure the CI pipeline uses the latest stable and development builds for improved compatibility and bug fixes.

https://claude.ai/code/session_01NZTcfuSNURRvBXf7oha2cn