### PR TITLE
feat: extract Phantom<S,T> type, remove WithOut alias, add memory effect issue

### DIFF
--- a/fs/json/schema/module.f.ts
+++ b/fs/json/schema/module.f.ts
@@ -7,13 +7,14 @@
  * @module
  */
 import { type Const, type Type as RttiType, array, option, or, record, string } from '../../types/rtti/module.f.ts'
-import type { Ts, WithOut } from '../../types/rtti/ts/module.f.ts'
+import type { Ts } from '../../types/rtti/ts/module.f.ts'
+import type { Phantom } from '../../types/phantom/module.f.ts'
 import { unknown as jsonUnknown } from '../module.f.ts'
 
 const unknownThunk = () => ['const', unknownConst] as const
 
 /** rtti schema for a JSON Schema (draft 2020-12) document. */
-export const unknown: WithOut<typeof unknownThunk, UnknownConst> = unknownThunk
+export const unknown: Phantom<typeof unknownThunk, UnknownConst> = unknownThunk
 
 /** A JSON Schema (draft 2020-12) document — the subset of keywords that `toJsonSchema` emits. */
 export type Unknown = Ts<typeof unknown>

--- a/fs/types/phantom/module.f.ts
+++ b/fs/types/phantom/module.f.ts
@@ -1,0 +1,23 @@
+/**
+ * Phantom type — attaches a compile-time type annotation `T` to `S` with zero
+ * runtime representation, analogous to Rust's `PhantomData<T>`.
+ *
+ * The phantom field uses a unique symbol key so it is excluded from string index
+ * signatures (`{ readonly [K in string]: ... }`), making `Phantom<S, T>` valid
+ * for any `S` regardless of its index signature constraints.
+ *
+ * @module
+ */
+
+declare const phantomKey: unique symbol
+
+export type { phantomKey }
+
+/**
+ * Intersects `S` with a phantom field carrying type `T`.
+ *
+ * The field is optional (`?`) so it never needs to be present at runtime.
+ * Use `phantomKey` to read the phantom type back out via a conditional type:
+ * `S extends Phantom<unknown, infer T> ? T : never`.
+ */
+export type Phantom<S, T> = S & { readonly [phantomKey]?: T }

--- a/fs/types/rtti/common/module.f.ts
+++ b/fs/types/rtti/common/module.f.ts
@@ -57,8 +57,8 @@ export const verror = (message: string): Error<ValidationError> =>
     error({ path: [], message })
 
 /** Prepends `key` to the error's path, used to build the path bottom-up. */
-export const prependPath = (key: string, r: Error<ValidationError>): Error<ValidationError> =>
-    error({ path: [key, ...r[1].path], message: r[1].message })
+export const prependPath = (key: string, [,r]: Error<ValidationError>): Error<ValidationError> =>
+    error({ path: [key, ...r.path], message: r.message })
 
 /** Validates a `Tag0` primitive schema using `typeof`. */
 export const primitive0Validate = <K extends Primitive0, T extends Info0<K>>(tag: K): Validate<T> =>

--- a/fs/types/rtti/ts/module.f.ts
+++ b/fs/types/rtti/ts/module.f.ts
@@ -11,6 +11,7 @@ import { type Equal, primitive, union, printer as tsPrinter } from '../../ts/mod
 import type { Tag0, Tag1, Const, Or, String as RttiString, Struct, Tuple, Type, ConstObject } from '../module.f.ts'
 import type { ReadonlyRecord } from '../../object/module.f.ts'
 import type { Assert } from '../../../asserts/module.f.ts'
+import { type Phantom, type phantomKey } from '../../phantom/module.f.ts'
 
 /**
  * The set of primitive literal types representable as rtti `Const` values.
@@ -82,8 +83,6 @@ type RequiredFields<T extends Struct> = {
 export type StructTs<T extends Struct> =
     (keyof OptionalFields<T> extends never ? unknown : OptionalFields<T>) &
     (keyof RequiredFields<T> extends never ? unknown : RequiredFields<T>)
-
-import { type Phantom, type phantomKey } from '../../phantom/module.f.ts'
 
 /**
  * Attaches a phantom output type `Out` to a schema `S`.

--- a/fs/types/rtti/ts/module.f.ts
+++ b/fs/types/rtti/ts/module.f.ts
@@ -11,7 +11,7 @@ import { type Equal, primitive, union, printer as tsPrinter } from '../../ts/mod
 import type { Tag0, Tag1, Const, Or, String as RttiString, Struct, Tuple, Type, ConstObject } from '../module.f.ts'
 import type { ReadonlyRecord } from '../../object/module.f.ts'
 import type { Assert } from '../../../asserts/module.f.ts'
-import { type Phantom, type phantomKey } from '../../phantom/module.f.ts'
+import { type phantomKey } from '../../phantom/module.f.ts'
 
 /**
  * The set of primitive literal types representable as rtti `Const` values.
@@ -85,19 +85,24 @@ export type StructTs<T extends Struct> =
     (keyof RequiredFields<T> extends never ? unknown : RequiredFields<T>)
 
 /**
- * Attaches a phantom output type `Out` to a schema `S`.
- *
- * `Ts<WithOut<S, Out>>` short-circuits to `Out` via the `phantomKey` branch without
- * recursing through the schema body — solving TS2589 for recursive struct schemas
- * where `StructTs` would otherwise expand infinitely.
- */
-export type WithOut<S, Out> = Phantom<S, Out>
-
-/**
  * Converts a schema `Type` to its corresponding TypeScript type.
  *
  * - `Thunk` → evaluates the returned `Info` via `InfoTs`
  * - `Const` → resolves via `ConstTs` (primitives map to themselves; structs/tuples recurse)
+ *
+ * **Recursive schemas and TS2589:** when a schema is self-referential, `StructTs` would
+ * expand infinitely and TypeScript raises TS2589. Break the cycle by annotating the
+ * schema value with `Phantom<typeof myThunk, MyType>` from `fs/types/phantom/module.f.ts`.
+ * `Ts<>` detects the phantom key and returns `MyType` directly without recursing:
+ *
+ * ```ts
+ * import { type Phantom } from '../types/phantom/module.f.ts'
+ *
+ * type MyType = { readonly self?: MyType }
+ * const myThunk = () => ['const', myConst] as const
+ * export const my: Phantom<typeof myThunk, MyType> = myThunk
+ * // Ts<typeof my>  →  MyType
+ * ```
  *
  * @example
  * ```ts

--- a/fs/types/rtti/ts/module.f.ts
+++ b/fs/types/rtti/ts/module.f.ts
@@ -83,26 +83,16 @@ export type StructTs<T extends Struct> =
     (keyof OptionalFields<T> extends never ? unknown : OptionalFields<T>) &
     (keyof RequiredFields<T> extends never ? unknown : RequiredFields<T>)
 
-/**
- * Private unique symbol used as the phantom key in WithOut.
- * A symbol key is excluded from string index signatures ({ readonly [K in string]: Type }),
- * so WithOut<Struct, Out> is valid for any Out regardless of whether Out extends Type.
- */
-declare const withOutKey: unique symbol
+import { type Phantom, type phantomKey } from '../../phantom/module.f.ts'
 
 /**
  * Attaches a phantom output type `Out` to a schema `S`.
  *
- * `Ts<WithOut<S, Out>>` short-circuits to `Out` via the `withOutKey` branch without
+ * `Ts<WithOut<S, Out>>` short-circuits to `Out` via the `phantomKey` branch without
  * recursing through the schema body — solving TS2589 for recursive struct schemas
  * where `StructTs` would otherwise expand infinitely.
- *
- * The `withOutKey` field is phantom: it is `undefined` at runtime and only exists in the
- * type system. Using a unique symbol as the key means it cannot conflict with struct
- * schemas' string index signature (`{ readonly [K in string]: Type }`), so `WithOut`
- * is valid for any schema `S`, not just thunks.
  */
-export type WithOut<S, Out> = S & { readonly [withOutKey]?: Out }
+export type WithOut<S, Out> = Phantom<S, Out>
 
 /**
  * Converts a schema `Type` to its corresponding TypeScript type.
@@ -123,9 +113,9 @@ export type Ts<T extends Type> =
     // to prevent distributive conditional types from expanding across all branches
     // and hitting TS2589 (type instantiation excessively deep).
     unknown extends T ? Unknown :
-    // Phantom output: if the schema carries a `withOutKey` annotation (via WithOut), return
+    // Phantom output: if the schema carries a phantomKey annotation (via WithOut), return
     // it directly — one indexed-access, no structural walk, no TS2589 for recursive schemas.
-    T extends { readonly [withOutKey]?: infer O } ? Exclude<O, undefined> :
+    T extends { readonly [phantomKey]?: infer O } ? Exclude<O, undefined> :
     T extends () => infer I ? (
         I extends readonly['const', infer C] ? ConstTs<C> :
         // Info0

--- a/issues/669-effects-memory.md
+++ b/issues/669-effects-memory.md
@@ -1,0 +1,51 @@
+# Memory Effect
+
+**Priority:** P3
+**Status:** open
+
+A key-value store effect for mutable state that persists across multiple effect steps within a session or computation.
+
+## Design
+
+### Key type
+
+```ts
+import type { Phantom } from '../types/phantom/module.f.ts'
+import type { Nominal } from '../types/nominal/module.f.ts'
+
+type Key<T> = Phantom<Nominal<'MemKey', 'key', string>, T>
+```
+
+- `Nominal<'MemKey', 'key', string>` makes keys opaque — prevents accidental use of arbitrary strings as keys and insulates callers from future representation changes (`number`, `bigint`, etc.).
+- `Phantom<…, T>` carries the value type so `read` and `write` are type-safe without a cast.
+- Real collision prevention comes from randomization at runtime (e.g. `crypto.randomUUID()`), not from the nominal type alone.
+
+### Operations
+
+```ts
+type MemCreate<T> = (value: T) => Effect<MemOp, Key<T>>
+type MemRead<T>   = (key: Key<T>) => Effect<MemOp, T>
+type MemWrite<T>  = (key: Key<T>, value: T) => Effect<MemOp, void>
+```
+
+- `create` allocates a new slot with an initial value and returns its key.
+- `read` retrieves the current value for a key.
+- `write` updates the value for a key.
+
+### Intended use cases
+
+- Tool implementations inside an MCP server that maintain state across calls (e.g. a counter, a cache, a conversation history buffer).
+- Any computation that needs a mutable cell without threading explicit state through every function.
+
+The MCP session state itself (`McpSessionState`) is better kept as explicit state threading `(value, state) => [effect, newState]` — see [669-ci-integration-tests.md](669-ci-integration-tests.md) for context. Memory effect is for *tool-level* state that outlives a single step.
+
+## Future extensions
+
+The initial design stores scalar or plain-object values. In the future we may provide richer mutable value types — for example, a mutable map `Key<Map<K, V>>` where individual entries can be updated without replacing the whole value. This would allow more efficient operations on large collections without requiring a full read-modify-write cycle.
+
+## Plan
+
+- [ ] Define `Key<T>`, `MemOp`, and the three operation types in `fs/effects/memory/module.f.ts`.
+- [ ] Implement a Node.js interpreter (`Map<string, unknown>` backed, keys generated via `crypto.randomUUID()`).
+- [ ] Add proof tests covering create/read/write round-trips and type safety.
+- [ ] Document how to compose `MemOp` with other operation types (e.g. `IoOp | MemOp`).

--- a/issues/669-effects-memory.md
+++ b/issues/669-effects-memory.md
@@ -41,7 +41,7 @@ The MCP session state itself (`McpSessionState`) is better kept as explicit stat
 
 ## Future extensions
 
-The initial design stores scalar or plain-object values. In the future we may provide richer mutable value types — for example, a mutable map `Key<Map<K, V>>` where individual entries can be updated without replacing the whole value. This would allow more efficient operations on large collections without requiring a full read-modify-write cycle.
+The initial design stores scalar or plain-object values. In the future we may support richer value types — for example, a mutable cell holding an immutable map or set (e.g. `Key<BTree<K, V>>` from `fs/types/btree`). Each `write` replaces the whole value, but because the stored value is itself immutable and structurally shared, this is efficient. In the future we may provide richer mutable value types — for example, a mutable map `Key<Map<K, V>>` where individual entries can be updated without replacing the whole value. This would allow more efficient operations on large collections without requiring a full read-modify-write cycle.
 
 ## Plan
 


### PR DESCRIPTION
## Summary

- Extracts `Phantom<S, T>` into `fs/types/phantom/module.f.ts` — a reusable phantom type analogous to Rust's `PhantomData<T>`, using a unique symbol key so it is safe to use with string index signatures
- Removes `WithOut<S, Out>` alias from `fs/types/rtti/ts/module.f.ts` — it was identical to `Phantom<S, Out>`; callers now use `Phantom` directly
- Updates `Ts<T>` docstring with guidance on using `Phantom` to break recursive schema cycles (TS2589)
- Updates `fs/json/schema/module.f.ts` to import `Phantom` from `fs/types/phantom/module.f.ts` instead of `WithOut`
- Adds `issues/669-effects-memory.md` — design for a key-value store memory effect with `Key<T>`, `create`/`read`/`write` operations, and a note on future extensions (mutable map values)

## Test plan

- [ ] `npm t` passes
- [ ] No TypeScript errors in `fs/types/rtti/ts/module.f.ts` or `fs/json/schema/module.f.ts`
- [ ] `WithOut` is no longer exported or referenced anywhere in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)