### PR TITLE
Refactor MCP session state management to use memory effects

### DIFF
--- a/fs/mcp/module.f.ts
+++ b/fs/mcp/module.f.ts
@@ -17,6 +17,7 @@ import { boolean, string, option, array, record } from '../types/rtti/module.f.t
 import { unknown, type Unknown } from '../json/module.f.ts'
 import type { Ts } from '../types/rtti/ts/module.f.ts'
 import { pure, type Operation, type Effect } from '../effects/module.f.ts'
+import { read, write, type Key, type MemOp } from '../effects/memory/module.f.ts'
 import {
     decodeRequest,
     rpcError, invalidRequest, invalidParams, methodNotFound,
@@ -148,41 +149,38 @@ export type McpConfig = {
 }
 
 /**
- * Pure state-machine step for an MCP session.
+ * State-machine step for an MCP session using memory effects.
  *
- * Given configuration and method handlers, returns a function:
- *   `(value, state) => [Effect<O, Response | null>, newState]`
+ * Given configuration, handlers, and a memory key holding the session state,
+ * returns a function `(value) => Effect<MemOp | O, Response | null>`.
  *
  * Rules:
  * - Notifications (no `id`) are silently accepted in any state; state is unchanged.
- * - `initialize` is accepted in any state and transitions to `initialized`.
+ * - `initialize` is accepted in any state and writes `initialized` to `stateKey`.
  * - Any other method before `initialize` → error -32002 (not initialized).
  * - Methods gated by a capability (e.g. `tools/list`) → -32601 when the capability
  *   is absent.
  */
 export const mcpStep = <O extends Operation>(config: McpConfig) =>
     (handlers: McpHandlers<O>) =>
-    (value: Unknown, state: McpSessionState): readonly [Effect<O, Response | null>, McpSessionState] => {
+    (stateKey: Key<McpSessionState>) =>
+    (value: Unknown): Effect<MemOp | O, Response | null> => {
         const [t, message] = decodeRequest(value)
         if (t === 'error') {
-            return [pure(_errResponse(null)(invalidRequest)), state]
+            return pure(_errResponse(null)(invalidRequest))
         }
         const { id, method, params } = message
 
         // Notifications never receive a response; state is unchanged.
         if (id === undefined) {
-            return [pure(null), state]
+            return pure(null)
         }
 
         // `initialize` is always handled by the lifecycle layer itself.
         if (method === 'initialize') {
             const [pr] = validate(initializeParams)(params)
             if (pr === 'error') {
-                return [pure(_errResponse(id)(invalidParams)), state]
-            }
-            const newInitialized: InitializedState = {
-                protocolVersion: config.protocolVersion,
-                capabilities: config.capabilities,
+                return pure(_errResponse(id)(invalidParams))
             }
             const result: InitializeResult = {
                 protocolVersion: config.protocolVersion,
@@ -190,36 +188,38 @@ export const mcpStep = <O extends Operation>(config: McpConfig) =>
                 serverInfo: config.serverInfo,
                 instructions: undefined,
             }
-            return [
-                pure(_okResponse(id)(result)),
-                ['initialized', newInitialized],
-            ]
+            return write(stateKey, ['initialized', {
+                protocolVersion: config.protocolVersion,
+                capabilities: config.capabilities,
+            }] as McpSessionState).step(() => pure(_okResponse(id)(result)))
         }
 
-        // All other methods require initialized state.
-        if (state[0] === 'uninitialized') {
-            return [pure(_errResponse(id)(notInitialized)), state]
-        }
-
-        const { capabilities } = state[1]
-
-        if (method === 'tools/list') {
-            if (capabilities.tools === undefined) {
-                return [pure(_errResponse(id)(methodNotFound)), state]
+        // All other methods require initialized state — read it first.
+        return read(stateKey).step(state => {
+            if (state[0] === 'uninitialized') {
+                return pure(_errResponse(id)(notInitialized))
             }
-            return [handlers.toolsList().step(r => pure(_okResponse(id)(r))), state]
-        }
 
-        if (method === 'tools/call') {
-            if (capabilities.tools === undefined) {
-                return [pure(_errResponse(id)(methodNotFound)), state]
-            }
-            const pr = validate(toolsCallParams)(message.params)
-            if (pr[0] === 'error') {
-                return [pure(_errResponse(id)(invalidParams)), state]
-            }
-            return [handlers.toolsCall(pr[1]).step(r => pure(_okResponse(id)(r))), state]
-        }
+            const { capabilities } = state[1]
 
-        return [pure(_errResponse(id)(methodNotFound)), state]
+            if (method === 'tools/list') {
+                if (capabilities.tools === undefined) {
+                    return pure(_errResponse(id)(methodNotFound))
+                }
+                return handlers.toolsList().step(r => pure(_okResponse(id)(r)))
+            }
+
+            if (method === 'tools/call') {
+                if (capabilities.tools === undefined) {
+                    return pure(_errResponse(id)(methodNotFound))
+                }
+                const pr = validate(toolsCallParams)(message.params)
+                if (pr[0] === 'error') {
+                    return pure(_errResponse(id)(invalidParams))
+                }
+                return handlers.toolsCall(pr[1]).step(r => pure(_okResponse(id)(r)))
+            }
+
+            return pure(_errResponse(id)(methodNotFound))
+        })
     }

--- a/fs/mcp/proof.f.ts
+++ b/fs/mcp/proof.f.ts
@@ -1,5 +1,5 @@
 import { assert, assertEq } from '../asserts/module.f.ts'
-import { pure } from '../effects/module.f.ts'
+import { pure, type Operation } from '../effects/module.f.ts'
 import type { Effect } from '../effects/module.f.ts'
 import { run, type MemOperationMap } from '../effects/mock/module.f.ts'
 import { asBase, asNominal, create, read, type Key, type MemOp } from '../effects/memory/module.f.ts'
@@ -50,27 +50,34 @@ const handlers: McpHandlers<Op> = {
         pure({ content: [{ type: 'text', text: 'hello' }], isError: undefined }),
 }
 
+type StepResult = readonly [unknown, McpSessionState]
+
 // Run a memory effect against the mock, return the result.
 const runMem = <T>(effect: Effect<MemOp, T>): T =>
     run(mock)(initial)(effect)[1]
 
+// TypeScript infers O = Operation (the upper bound) rather than O = never when
+// O flows through McpHandlers<never>, so we cast the widened type down to MemOp.
+const asMemEffect = <T>(e: Effect<Operation, T>): Effect<MemOp, T> =>
+    e as unknown as Effect<MemOp, T>
+
 // Run one step from uninitializedState, return [response, newState].
-const step1 = (cfg: McpConfig) => (msg: unknown) =>
-    runMem(create(uninitializedState as McpSessionState).step(key =>
+const step1 = (cfg: McpConfig) => (msg: unknown): StepResult =>
+    runMem(asMemEffect(create(uninitializedState as McpSessionState).step(key =>
         mcpStep(cfg)(handlers)(key)(msg as Unknown).step(resp =>
-            read(key).step(state => pure([resp, state] as const))
+            read(key).step(state => pure([resp as unknown, state] as const))
         )
-    ))
+    )))
 
 // Run initialize then a second step, return [response, newState] of the second.
-const step2 = (cfg: McpConfig) => (msg1: unknown) => (msg2: unknown) =>
-    runMem(create(uninitializedState as McpSessionState).step(key =>
+const step2 = (cfg: McpConfig) => (msg1: unknown) => (msg2: unknown): StepResult =>
+    runMem(asMemEffect(create(uninitializedState as McpSessionState).step(key =>
         mcpStep(cfg)(handlers)(key)(msg1 as Unknown).step(() =>
             mcpStep(cfg)(handlers)(key)(msg2 as Unknown).step(resp =>
-                read(key).step(state => pure([resp, state] as const))
+                read(key).step(state => pure([resp as unknown, state] as const))
             )
         )
-    ))
+    )))
 
 // ── Test messages ─────────────────────────────────────────────────────────────
 

--- a/fs/mcp/proof.f.ts
+++ b/fs/mcp/proof.f.ts
@@ -1,12 +1,36 @@
 import { assert, assertEq } from '../asserts/module.f.ts'
 import { pure } from '../effects/module.f.ts'
 import type { Effect } from '../effects/module.f.ts'
+import { run, type MemOperationMap } from '../effects/mock/module.f.ts'
+import { asBase, asNominal, create, read, type Key, type MemOp } from '../effects/memory/module.f.ts'
 import type { Unknown } from '../json/module.f.ts'
 import {
     type ToolsListResult, type ToolsCallParams, type ToolsCallResult,
     type McpHandlers, type McpConfig, type McpSessionState,
     uninitializedState, mcpStep, notInitialized,
 } from './module.f.ts'
+
+// ── Memory mock ────────────────────────────────────────────────────────────────
+
+type MemoryState = {
+    readonly next: number
+    readonly values: { readonly [key: string]: unknown }
+}
+
+const initial: MemoryState = { next: 0, values: {} }
+
+const mock: MemOperationMap<MemOp, MemoryState> = {
+    memCreate: (state, value) => {
+        const id = `k${state.next}`
+        const key: Key<unknown> = asNominal(id)
+        return [{ next: state.next + 1, values: { ...state.values, [id]: value } }, key]
+    },
+    memRead: (state, key) => [state, state.values[asBase(key)]],
+    memWrite: (state, key, value) => {
+        const id = asBase(key)
+        return [{ ...state, values: { ...state.values, [id]: value } }, undefined]
+    },
+}
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -26,31 +50,32 @@ const handlers: McpHandlers<Op> = {
         pure({ content: [{ type: 'text', text: 'hello' }], isError: undefined }),
 }
 
-const step = (value: unknown, state: McpSessionState) =>
-    mcpStep(config)(handlers)(value as Unknown, state)
+// Run a memory effect against the mock, return the result.
+const runMem = <T>(effect: Effect<MemOp, T>): T =>
+    run(mock)(initial)(effect)[1]
 
-const stepNoTools = (value: unknown, state: McpSessionState) =>
-    mcpStep(configNoTools)(handlers)(value as Unknown, state)
+// Run one step from uninitializedState, return [response, newState].
+const step1 = (cfg: McpConfig) => (msg: unknown) =>
+    runMem(create(uninitializedState as McpSessionState).step(key =>
+        mcpStep(cfg)(handlers)(key)(msg as Unknown).step(resp =>
+            read(key).step(state => pure([resp, state] as const))
+        )
+    ))
 
-// Synchronously extract the value from a pure Effect.
-const run = <T>(e: Effect<never, T>): T => {
-    const v = e.value
-    if (v.length !== 1) { throw new Error('expected pure effect') }
-    return v[0] as T
-}
+// Run initialize then a second step, return [response, newState] of the second.
+const step2 = (cfg: McpConfig) => (msg1: unknown) => (msg2: unknown) =>
+    runMem(create(uninitializedState as McpSessionState).step(key =>
+        mcpStep(cfg)(handlers)(key)(msg1 as Unknown).step(() =>
+            mcpStep(cfg)(handlers)(key)(msg2 as Unknown).step(resp =>
+                read(key).step(state => pure([resp, state] as const))
+            )
+        )
+    ))
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+// ── Test messages ─────────────────────────────────────────────────────────────
 
 const initMsg = { jsonrpc: '2.0', method: 'initialize', id: 1,
     params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'client', version: '0.0.1' } } }
-
-function doInit(s: McpSessionState): McpSessionState {
-    return step(initMsg, s)[1]
-}
-
-function doInitNoTools(s: McpSessionState): McpSessionState {
-    return stepNoTools(initMsg, s)[1]
-}
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
@@ -61,13 +86,12 @@ export const proof = {
         },
 
         initializeTransitionsState: () => {
-            const [, newState] = step(initMsg, uninitializedState)
+            const [, newState] = step1(config)(initMsg)
             assertEq(newState[0], 'initialized')
         },
 
         initializeReturnsResult: () => {
-            const [effect] = step(initMsg, uninitializedState)
-            const resp = run(effect as Effect<never, unknown>)
+            const [resp] = step1(config)(initMsg)
             assert(resp !== null && typeof resp === 'object' && 'result' in (resp as object))
             const r = (resp as { result: { protocolVersion: string } }).result
             assertEq(r.protocolVersion, '2024-11-05')
@@ -75,93 +99,77 @@ export const proof = {
 
         initializeWithBadParamsReturnsInvalidParams: () => {
             const bad = { jsonrpc: '2.0', method: 'initialize', id: 2, params: { wrong: true } }
-            const [effect, newState] = step(bad, uninitializedState)
+            const [resp, newState] = step1(config)(bad)
             assertEq(newState[0], 'uninitialized')
-            const resp = run(effect as Effect<never, unknown>) as { error: { code: number } }
-            assertEq(resp.error.code, -32602)
+            assertEq((resp as { error: { code: number } }).error.code, -32602)
         },
 
         notificationReturnNull: () => {
             const notif = { jsonrpc: '2.0', method: 'notifications/initialized' }
-            const [effect, newState] = step(notif, uninitializedState)
+            const [resp, newState] = step1(config)(notif)
             assertEq(newState[0], 'uninitialized')
-            assertEq(run(effect as Effect<never, unknown>), null)
+            assertEq(resp, null)
         },
 
         notificationAfterInitReturnNull: () => {
-            const initialized = doInit(uninitializedState)
             const notif = { jsonrpc: '2.0', method: 'notifications/initialized' }
-            const [effect] = step(notif, initialized)
-            assertEq(run(effect as Effect<never, unknown>), null)
+            const [resp] = step2(config)(initMsg)(notif)
+            assertEq(resp, null)
         },
 
         methodBeforeInitReturnsNotInitialized: () => {
             const msg = { jsonrpc: '2.0', method: 'tools/list', id: 3 }
-            const [effect, newState] = step(msg, uninitializedState)
+            const [resp, newState] = step1(config)(msg)
             assertEq(newState[0], 'uninitialized')
-            const resp = run(effect as Effect<never, unknown>) as { error: { code: number } }
-            assertEq(resp.error.code, notInitialized.code)
+            assertEq((resp as { error: { code: number } }).error.code, notInitialized.code)
         },
 
         invalidEnvelopeReturnsInvalidRequest: () => {
             const bad = { jsonrpc: '1.0', method: 'ping', id: 4 }
-            const [effect] = step(bad, uninitializedState)
-            const resp = run(effect as Effect<never, unknown>) as { error: { code: number }; id: unknown }
-            assertEq(resp.error.code, -32600)
-            assertEq(resp.id, null)
+            const [resp] = step1(config)(bad)
+            assertEq((resp as { error: { code: number }; id: unknown }).error.code, -32600)
+            assertEq((resp as { error: { code: number }; id: unknown }).id, null)
         },
     },
 
     tools: {
         toolsListSucceeds: () => {
-            const initialized = doInit(uninitializedState)
             const msg = { jsonrpc: '2.0', method: 'tools/list', id: 5 }
-            const [effect] = step(msg, initialized)
-            const resp = run(effect as Effect<never, unknown>) as { result: ToolsListResult }
-            assertEq(resp.result.tools.length, 1)
-            assertEq(resp.result.tools[0].name, 'greet')
+            const [resp] = step2(config)(initMsg)(msg)
+            assertEq((resp as { result: ToolsListResult }).result.tools.length, 1)
+            assertEq((resp as { result: ToolsListResult }).result.tools[0].name, 'greet')
         },
 
         toolsCallSucceeds: () => {
-            const initialized = doInit(uninitializedState)
             const msg = { jsonrpc: '2.0', method: 'tools/call', id: 6,
                 params: { name: 'greet', arguments: {} } }
-            const [effect] = step(msg, initialized)
-            const resp = run(effect as Effect<never, unknown>) as { result: ToolsCallResult }
-            assertEq(resp.result.content[0].text, 'hello')
+            const [resp] = step2(config)(initMsg)(msg)
+            assertEq((resp as { result: ToolsCallResult }).result.content[0].text, 'hello')
         },
 
         toolsCallBadParamsReturnsInvalidParams: () => {
-            const initialized = doInit(uninitializedState)
             const msg = { jsonrpc: '2.0', method: 'tools/call', id: 7, params: { missing: true } }
-            const [effect] = step(msg, initialized)
-            const resp = run(effect as Effect<never, unknown>) as { error: { code: number } }
-            assertEq(resp.error.code, -32602)
+            const [resp] = step2(config)(initMsg)(msg)
+            assertEq((resp as { error: { code: number } }).error.code, -32602)
         },
 
         toolsListWithoutCapabilityReturnsMethodNotFound: () => {
-            const initialized = doInitNoTools(uninitializedState)
             const msg = { jsonrpc: '2.0', method: 'tools/list', id: 8 }
-            const [effect] = stepNoTools(msg, initialized)
-            const resp = run(effect as Effect<never, unknown>) as { error: { code: number } }
-            assertEq(resp.error.code, -32601)
+            const [resp] = step2(configNoTools)(initMsg)(msg)
+            assertEq((resp as { error: { code: number } }).error.code, -32601)
         },
 
         toolsCallWithoutCapabilityReturnsMethodNotFound: () => {
-            const initialized = doInitNoTools(uninitializedState)
             const msg = { jsonrpc: '2.0', method: 'tools/call', id: 9,
                 params: { name: 'greet', arguments: {} } }
-            const [effect] = stepNoTools(msg, initialized)
-            const resp = run(effect as Effect<never, unknown>) as { error: { code: number } }
-            assertEq(resp.error.code, -32601)
+            const [resp] = step2(configNoTools)(initMsg)(msg)
+            assertEq((resp as { error: { code: number } }).error.code, -32601)
         },
 
         unknownMethodReturnsMethodNotFound: () => {
-            const initialized = doInit(uninitializedState)
             const msg = { jsonrpc: '2.0', method: 'resources/list', id: 10 }
-            const [effect] = step(msg, initialized)
-            const resp = run(effect as Effect<never, unknown>) as { error: { code: number } }
-            assertEq(resp.error.code, -32601)
+            const [resp] = step2(config)(initMsg)(msg)
+            assertEq((resp as { error: { code: number } }).error.code, -32601)
         },
     },
 }


### PR DESCRIPTION
## Summary
Refactored the MCP session state management from a pure state-machine pattern to one that uses memory effects for state persistence. This change decouples state handling from the core message processing logic and enables more flexible state management strategies.

## Key Changes

- **Memory effect integration**: Added a memory mock implementation (`MemoryState`, `mock`) in `proof.f.ts` to simulate persistent key-value storage for session state.

- **API signature change**: Modified `mcpStep` to accept a memory key (`stateKey: Key<McpSessionState>`) instead of passing state as a parameter and returning it in a tuple. The function now returns `Effect<MemOp | O, Response | null>` instead of `[Effect<O, Response | null>, McpSessionState]`.

- **State operations**: Replaced direct state mutations with memory effect operations:
  - `read(stateKey)` to retrieve current session state
  - `write(stateKey, newState)` to persist state changes
  - State is now read before methods that require initialized state

- **Test infrastructure refactoring**: 
  - Created `runMem` helper to execute memory effects against the mock
  - Introduced `step1` and `step2` helpers to simplify test setup (initialize once or twice)
  - Removed `doInit` and `doInitNoTools` helper functions in favor of composable `step1`/`step2`
  - Simplified test assertions by directly working with responses instead of extracting from effects

- **Notification handling**: Notifications continue to return `null` without state changes, now achieved by returning early from the effect chain rather than tuple unpacking.

## Implementation Details

The refactoring maintains the same business logic and error handling while shifting responsibility for state persistence to the memory effect layer. This allows the core `mcpStep` function to focus purely on message validation and routing, with state management concerns delegated to the effect system. Tests now use a composable pattern where `step1` and `step2` handle the boilerplate of creating memory keys and reading final state.

https://claude.ai/code/session_01Fev4YtgxmEtDvFp8dEXKon