### PR TITLE
feat(bigint): add divUpE2/roundUpE2 and fix divUp/roundUp types (#187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `types/bigint`: add shift-based `divUpE2(e)` / `roundUpE2(e)` helpers for power-of-two round-up; retype `divUp` / `roundUp` from `Reduce` to `(b: bigint) => Unary`; migrate `asn.1` and `crypto/sign` from hand-coded `>> 3n` shifts and `divUp(8n)` / `roundUp(8n)` to the new helpers ([i187](./issues/187-byte-rounding-divup.md))
 - `effects/memory`: add typed `create` / `read` / `write` memory operations, a Node `Map`-backed interpreter using `crypto.randomUUID()` keys, virtual-memory composition support, and proofs for round trips and type safety (i669-effects-memory) [#1008](https://github.com/functionalscript/functionalscript/pull/1008)
 - `json/rpc`: add JSON-RPC spec links to module and request/response JSDoc; destructure `decodeRequest` result and `message` fields in `dispatch`; use shorthand property in `errorResponseOf` [#1002](https://github.com/functionalscript/functionalscript/pull/1002)
 

--- a/fs/asn.1/module.f.ts
+++ b/fs/asn.1/module.f.ts
@@ -4,7 +4,7 @@
  *
  * @module
  */
-import { bitLength } from "../types/bigint/module.f.ts"
+import { bitLength, divUpE2 } from "../types/bigint/module.f.ts"
 import {
     empty,
     isVec,
@@ -65,8 +65,10 @@ const parsedTagDecode = (v: Vec): readonly[ParsedTag, Vec] => {
     return [[classPc, number], rest1]
 }
 
+const divUp8 = divUpE2(3n)
+
 const tagEncode = (tag: Tag): Vec =>
-    vec(max((bitLength(tag) + 7n) >> 3n)(1n) << 3n)(tag)
+    vec(max(divUp8(bitLength(tag)))(1n) << 3n)(tag)
 
 const tagDecode = (v: Vec): readonly[Tag, Vec] => {
     const [parsedTag, rest] = parsedTagDecode(v)
@@ -129,7 +131,7 @@ type Round8 = {
 }
 
 const round8 = ({ length, uint }: Unpacked): Round8 => {
-    const byteLen = (length + 7n) >> 3n
+    const byteLen = divUp8(length)
     return { byteLen, v: vec(byteLen << 3n)(uint) }
 }
 

--- a/fs/crypto/sign/module.f.ts
+++ b/fs/crypto/sign/module.f.ts
@@ -4,16 +4,16 @@
  * @module
  */
 import type { Array2 } from '../../types/array/module.f.ts'
-import { bitLength, divUp, roundUp, type Unary } from '../../types/bigint/module.f.ts'
+import { bitLength, divUpE2, roundUpE2, type Unary } from '../../types/bigint/module.f.ts'
 import { empty, length, msb, repeat, unpack, vec, vec8, type Vec } from '../../types/bit_vec/module.f.ts'
 import { hmac } from '../hmac/module.f.ts'
 import type { Curve } from '../secp/module.f.ts'
 import { computeSync, type Sha2 } from '../sha2/module.f.ts'
 
 // qlen to rlen
-const roundUp8: Unary = roundUp(8n)
+const roundUp8: Unary = roundUpE2(3n)
 
-const divUp8 = divUp(8n)
+const divUp8 = divUpE2(3n)
 
 export type All = {
     readonly q: bigint

--- a/fs/types/bigint/module.f.ts
+++ b/fs/types/bigint/module.f.ts
@@ -250,12 +250,34 @@ export const combination = (...k: readonly bigint[]): bigint => {
 
 export const xor: Reduce = a => b => a ^ b
 
-export const divUp: Reduce = b => {
+export const divUp = (b: bigint): Unary => {
     const m = b - 1n
     return v => (v + m) / b
 }
 
-export const roundUp: Reduce = b => {
+export const roundUp = (b: bigint): Unary => {
     const d = divUp(b)
     return v => d(v) * b
+}
+
+/**
+ * Divides a bigint value up to the nearest multiple of 2^e (shift-based, power-of-two only).
+ *
+ * @param e - The exponent (divisor = 2^e).
+ * @returns A function that rounds a value up by the given power of two.
+ */
+export const divUpE2 = (e: bigint): Unary => {
+    const m = mask(e)
+    return v => (v + m) >> e
+}
+
+/**
+ * Rounds a bigint value up to the nearest multiple of 2^e (shift-based, power-of-two only).
+ *
+ * @param e - The exponent (multiple = 2^e).
+ * @returns A function that rounds a value up to the nearest multiple of the given power of two.
+ */
+export const roundUpE2 = (e: bigint): Unary => {
+    const d = divUpE2(e)
+    return v => d(v) << e
 }

--- a/fs/types/bigint/proof.f.ts
+++ b/fs/types/bigint/proof.f.ts
@@ -8,7 +8,9 @@ import {
     combination,
     factorial,
     divUp,
-    roundUp
+    roundUp,
+    divUpE2,
+    roundUpE2
 } from './module.f.ts'
 import { min } from '../function/compare/module.f.ts'
 
@@ -395,5 +397,20 @@ export const proof = {
         if (roundUp(8n)(0b1000n) !== 0b1000n) { throw new Error("fail") }
         if (roundUp(8n)(0b1111n) !== 0b10000n) { throw new Error("fail") }
         if (roundUp(8n)(3n) !== 8n) { throw new Error("fail") }
+    },
+    divUpE2: () => {
+        if (divUpE2(3n)(0b1000n) !== 1n) { throw new Error("fail") }
+        if (divUpE2(3n)(0b1111n) !== 2n) { throw new Error("fail") }
+        if (divUpE2(3n)(0n) !== 0n) { throw new Error("fail") }
+        if (divUpE2(3n)(8n) !== 1n) { throw new Error("fail") }
+        if (divUpE2(3n)(9n) !== 2n) { throw new Error("fail") }
+    },
+    roundUpE2: () => {
+        if (roundUpE2(3n)(0b1000n) !== 0b1000n) { throw new Error("fail") }
+        if (roundUpE2(3n)(0b1111n) !== 0b10000n) { throw new Error("fail") }
+        if (roundUpE2(3n)(3n) !== 8n) { throw new Error("fail") }
+        if (roundUpE2(3n)(0n) !== 0n) { throw new Error("fail") }
+        if (roundUpE2(3n)(8n) !== 8n) { throw new Error("fail") }
+        if (roundUpE2(3n)(9n) !== 16n) { throw new Error("fail") }
     },
 }

--- a/fs/types/bigint/proof.f.ts
+++ b/fs/types/bigint/proof.f.ts
@@ -12,6 +12,7 @@ import {
     divUpE2,
     roundUpE2
 } from './module.f.ts'
+import { assertEq } from '../../asserts/module.f.ts'
 import { min } from '../function/compare/module.f.ts'
 
 const oldLog2 = (v: bigint): bigint => {
@@ -390,27 +391,27 @@ export const proof = {
         if (r !== 69300n) { throw r }
     },
     divUp: () => {
-        if (divUp(8n)(0b1000n) !== 1n) { throw new Error("fail") }
-        if (divUp(8n)(0b1111n) !== 2n) { throw new Error("fail") }
+        assertEq(divUp(8n)(0b1000n), 1n)
+        assertEq(divUp(8n)(0b1111n), 2n)
     },
     roundUp: () => {
-        if (roundUp(8n)(0b1000n) !== 0b1000n) { throw new Error("fail") }
-        if (roundUp(8n)(0b1111n) !== 0b10000n) { throw new Error("fail") }
-        if (roundUp(8n)(3n) !== 8n) { throw new Error("fail") }
+        assertEq(roundUp(8n)(0b1000n), 0b1000n)
+        assertEq(roundUp(8n)(0b1111n), 0b10000n)
+        assertEq(roundUp(8n)(3n), 8n)
     },
     divUpE2: () => {
-        if (divUpE2(3n)(0b1000n) !== 1n) { throw new Error("fail") }
-        if (divUpE2(3n)(0b1111n) !== 2n) { throw new Error("fail") }
-        if (divUpE2(3n)(0n) !== 0n) { throw new Error("fail") }
-        if (divUpE2(3n)(8n) !== 1n) { throw new Error("fail") }
-        if (divUpE2(3n)(9n) !== 2n) { throw new Error("fail") }
+        assertEq(divUpE2(3n)(0b1000n), 1n)
+        assertEq(divUpE2(3n)(0b1111n), 2n)
+        assertEq(divUpE2(3n)(0n), 0n)
+        assertEq(divUpE2(3n)(8n), 1n)
+        assertEq(divUpE2(3n)(9n), 2n)
     },
     roundUpE2: () => {
-        if (roundUpE2(3n)(0b1000n) !== 0b1000n) { throw new Error("fail") }
-        if (roundUpE2(3n)(0b1111n) !== 0b10000n) { throw new Error("fail") }
-        if (roundUpE2(3n)(3n) !== 8n) { throw new Error("fail") }
-        if (roundUpE2(3n)(0n) !== 0n) { throw new Error("fail") }
-        if (roundUpE2(3n)(8n) !== 8n) { throw new Error("fail") }
-        if (roundUpE2(3n)(9n) !== 16n) { throw new Error("fail") }
+        assertEq(roundUpE2(3n)(0b1000n), 0b1000n)
+        assertEq(roundUpE2(3n)(0b1111n), 0b10000n)
+        assertEq(roundUpE2(3n)(3n), 8n)
+        assertEq(roundUpE2(3n)(0n), 0n)
+        assertEq(roundUpE2(3n)(8n), 8n)
+        assertEq(roundUpE2(3n)(9n), 16n)
     },
 }


### PR DESCRIPTION
Add shift-based power-of-two round-up helpers `divUpE2`/`roundUpE2` to
eliminate repeated hand-coded `(x + 7n) >> 3n` patterns in `asn.1` and
`sign`, replacing the slower general-division `divUp(8n)`/`roundUp(8n)`
calls with shift-equivalent operations.

Retype `divUp`/`roundUp` from `Reduce` (fold accumulator) to
`(b: bigint) => Unary`, reflecting that the first parameter is
configuration (divisor), not a list element — matching how `sign`
already uses them.

https://claude.ai/code/session_01USAYmXPTQsbzXELhQvqosz