### PR TITLE
refactor(cas): reuse string.splitAt instead of local split helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `cas`: drop the private 2-char `split` helper and reuse `splitAt(2)` from `fs/types/string` for the CAS shard path computation (i668-cas-reuse-splitat) [#1014](https://github.com/functionalscript/functionalscript/pull/1014)
 - `types/bigint`: add shift-based `divUpE2(e)` / `roundUpE2(e)` helpers for power-of-two round-up; retype `divUp` / `roundUp` from `Reduce` to `(b: bigint) => Unary`; migrate `asn.1` and `crypto/sign` from hand-coded `>> 3n` shifts and `divUp(8n)` / `roundUp(8n)` to the new helpers ([i187](./issues/187-byte-rounding-divup.md))
 - `effects/memory`: add typed `create` / `read` / `write` memory operations, a Node `Map`-backed interpreter using `crypto.randomUUID()` keys, virtual-memory composition support, and proofs for round trips and type safety (i669-effects-memory) [#1008](https://github.com/functionalscript/functionalscript/pull/1008)
 - `json/rpc`: add JSON-RPC spec links to module and request/response JSDoc; destructure `decodeRequest` result and `message` fields in `dispatch`; use shorthand property in `errorResponseOf` [#1002](https://github.com/functionalscript/functionalscript/pull/1002)

--- a/fs/cas/module.f.ts
+++ b/fs/cas/module.f.ts
@@ -12,6 +12,7 @@ import { errorExit, log, mkdir, readdir, readFile, writeFile, type Fs, type Node
 import { dispatch, type Commands } from '../cli/module.f.ts'
 import { toOption } from '../types/nullable/module.f.ts'
 import { unwrap } from '../types/result/module.f.ts'
+import { splitAt } from '../types/string/module.f.ts'
 
 export type KvStore<O extends Operation> = {
     /** Reads a value by key; returns `undefined` when the key does not exist. */
@@ -27,15 +28,15 @@ export type Kv = readonly[Vec, Vec];
 
 const o = { withFileTypes: true } as const
 
-const split = (s: string) => [s.substring(0, 2), s.substring(2)]
+const split2 = splitAt(2)
 
 const prefix = '.cas'
 
 /** Converts a content key to its sharded relative CAS file path. */
 const toPath = (key: Vec): string => {
     const s = vecToCBase32(key)
-    const [a, bc] = split(s)
-    const [b, c] = split(bc)
+    const [a, bc] = split2(s)
+    const [b, c] = split2(bc)
     return join(prefix, a, b, c)
 }
 

--- a/issues/668-cas-reuse-splitat.md
+++ b/issues/668-cas-reuse-splitat.md
@@ -1,7 +1,7 @@
 # 668-cas-reuse-splitat. `fs/cas`: reuse `string.splitAt` instead of a local `split`
 
 **Priority:** P5
-**Status:** open
+**Status:** done
 
 ## Problem
 


### PR DESCRIPTION
## Summary

Resolves i668-cas-reuse-splitat. `fs/cas/module.f.ts` carried a private `split` helper that was a hand-rolled re-implementation of `splitAt` from the sibling `fs/types/string` module. Per AGENTS.md ("When a sibling module already has the type or helper you need, import it … rather than duplicating it"), the local copy is now replaced with `splitAt(2)`.

- Import `splitAt` from `fs/types/string/module.f.ts`.
- Hoist `splitAt(2)` to a module-scope `split2` constant so the partial application happens once rather than on every `toPath` call.
- Destructurings in `toPath` now pick up `splitAt`'s precise `readonly [string, string]` return type instead of the widened `string[]` the local helper produced.

Output paths from `toPath` are unchanged (still `.cas/<a>/<b>/<c>`).

## Test plan

- [x] `npx tsc` passes
- [x] `node ./fs/fjs/module.ts t` — full suite passes (1648/1648), including all 11 `fs/cas/proof.f.ts` cases (`mainAdd`, `mainAddWrongArgs`, `mainGetFound`, `mainGetNotFound`, `mainGetWrongArgs`, `mainGetInvalidHash`, `mainList`, `mainNoCmd`, `mainUnknownCmd`, `casWrite`, `casReadPassthrough`)

https://claude.ai/code/session_01Pi6mxtgwou5E7ViqhT83XV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pi6mxtgwou5E7ViqhT83XV)_