### PR TITLE
Add issue templates for DRY refactoring in ci, bigint, and testing

### DIFF
--- a/issues/66A-ci-cargo-step-factory.md
+++ b/issues/66A-ci-cargo-step-factory.md
@@ -1,0 +1,112 @@
+# 66A-ci-cargo-step-factory. Unify the `cargo*` step builders in `fs/ci/rust`
+
+**Priority:** P4
+**Status:** open
+
+## Problem
+
+`fs/ci/rust/module.f.ts` defines a family of one-line `MetaStep` builders that
+all wrap `cargoCommand(...)` and differ only by which suffixes (`--release`,
+`-- -D warnings`) they concatenate:
+
+```ts
+// fs/ci/rust/module.f.ts:18-39
+const cargoTest = (target?: string, config?: string): MetaStep =>
+    test({ run: cargoCommand('test', target, config) })
+
+const cargoClippy = (target?: string): MetaStep =>
+    test({ run: `${cargoCommand('clippy', target)} -- -D warnings` })
+
+const cargoReleaseClippy = (target?: string): MetaStep =>
+    test({ run: `${cargoCommand('clippy', target)} --release -- -D warnings` })
+
+const cargoTestPair = (target: string, config?: string): readonly MetaStep[] => {
+    const main = cargoCommand('test', target, config)
+    return [
+        cargoTest(target, config),
+        test({ run: `${main} --release` })
+    ]
+}
+
+const cargoReleaseTest = (target?: string): MetaStep =>
+    test({ run: `${cargoCommand('test', target)} --release` })
+```
+
+These four single-step builders (`cargoTest`, `cargoClippy`,
+`cargoReleaseClippy`, `cargoReleaseTest`) — plus the `--release` arm inlined
+inside `cargoTestPair` — are the same construction repeated five times:
+
+> `test({ run: cargoCommand(tool, target, config) + maybe " --release" + maybe " -- -D warnings" })`
+
+They vary along three orthogonal axes only:
+
+| axis | values |
+|------|--------|
+| tool | `'test'` \| `'clippy'` |
+| release | with / without `--release` |
+| warnings | the `-- -D warnings` suffix — **always present iff `tool === 'clippy'`** |
+
+The `warnings` axis is not independent: it is fully determined by `tool`. So
+the entire family is really a 2×2 grid (tool × release) with the warnings
+suffix derived from the tool. Spelling out each cell as its own named builder —
+each re-typing the template string and the suffix concatenation — is the DRY
+smell: adding a new dimension (say a `--features` flag) means editing every
+builder, and the `--release` text is duplicated four times.
+
+## Proposal
+
+Introduce a single `cargoStep` factory parameterized by tool and a small
+options record, and derive the named builders from it. The warnings suffix is
+computed from the tool, not passed in:
+
+```ts
+type CargoOptions = {
+    readonly target?: string
+    readonly config?: string
+    readonly release?: boolean
+}
+
+const cargoStep = (tool: 'test' | 'clippy') => (o: CargoOptions): MetaStep => {
+    const release = o.release ? ' --release' : ''
+    const warnings = tool === 'clippy' ? ' -- -D warnings' : ''
+    return test({ run: `${cargoCommand(tool, o.target, o.config)}${release}${warnings}` })
+}
+
+const cargoTest = (target?: string, config?: string) => cargoStep('test')({ target, config })
+const cargoReleaseTest = (target?: string) => cargoStep('test')({ target, release: true })
+const cargoClippy = (target?: string) => cargoStep('clippy')({ target })
+const cargoReleaseClippy = (target?: string) => cargoStep('clippy')({ target, release: true })
+
+const cargoTestPair = (target: string, config?: string): readonly MetaStep[] =>
+    [cargoTest(target, config), cargoStep('test')({ target, config, release: true })]
+```
+
+Now the `--release` / `-- -D warnings` strings each appear exactly once, the
+"clippy implies warnings" invariant is encoded in one place, and the existing
+public surface (`targetChecks`, `rustTarget`, `wasmTarget`,
+`rustPlatformSteps`, `rustWasmSteps`) is unchanged because the named builders
+keep their signatures. The generated workflow YAML is byte-identical.
+
+`targetChecks` (`:41`) can optionally be re-expressed as the cross product of
+`{ false, true }` (release) × `{ test, clippy }`, but that is a follow-up
+nicety — the core win is collapsing the five hand-spelled templates into one
+factory.
+
+## Tasks
+
+- [ ] Add the `cargoStep` factory and re-derive `cargoTest`,
+      `cargoReleaseTest`, `cargoClippy`, `cargoReleaseClippy`, and the
+      `cargoTestPair` release arm from it in `fs/ci/rust/module.f.ts`.
+- [ ] Confirm the generated CI YAML is unchanged (diff the `ci` output before
+      and after — `npm run ci-update` / inspect `.github/workflows`).
+- [ ] Run `npx tsc` and `fjs t`; ensure `fs/ci` proofs still pass with full
+      coverage.
+
+## Related
+
+- [i170-ci-tool-steps](./170-ci-tool-steps.md) — the sibling DRY cleanup for the
+  Node version-job builders in `fs/ci/node`. Same root cause (per-variant step
+  builders that differ only in command flags), different module; the two are
+  independent and could land separately.
+- [i175-ci-setup-tool](./175-ci-setup-tool.md), [i170-ci-tool-steps](./170-ci-tool-steps.md)
+  — other `fs/ci` step-builder refactors.

--- a/issues/66A-divup8-bits-to-bytes.md
+++ b/issues/66A-divup8-bits-to-bytes.md
@@ -1,0 +1,97 @@
+# 66A-divup8-bits-to-bytes. Share `divUp8` / `roundUp8` bit→byte rounding in `types/bigint`
+
+**Priority:** P4
+**Status:** open
+
+## Problem
+
+Two independent modules define the *same* bit-length → byte-length helper by
+specialising `divUpE2(3n)` (divide by `2^3 == 8`, rounding up):
+
+```ts
+// fs/crypto/sign/module.f.ts:14-16
+const roundUp8: Unary = roundUpE2(3n)
+const divUp8 = divUpE2(3n)
+```
+
+```ts
+// fs/asn.1/module.f.ts:68
+const divUp8 = divUpE2(3n)
+```
+
+Both modules already `import { divUpE2 } from '../../types/bigint/module.f.ts'`
+(and `sign` also imports `roundUpE2`), then re-derive the identical `3n`
+specialisation locally. This is a textbook DRY violation: the same expression,
+the same magic exponent `3n`, copied into two consumers.
+
+The duplicated helpers are real, exercised code, not speculative:
+
+- `sign`: `int2octets = vec(roundUp8(qlen))` (`:39`) and
+  `rep = repeat(divUp8(hf.hashLength))` (`:78`).
+- `asn.1`: `vec(max(divUp8(bitLength(tag)))(1n) << 3n)(tag)` (`:71`) and
+  `const byteLen = divUp8(length)` (`:134`).
+
+So there are **two real consumers today** — the threshold AGENTS.md sets for
+extracting a shared helper ("only extract once the second real consumer
+exists") is met.
+
+`divUpE2` / `roundUpE2` themselves already live in
+`fs/types/bigint/module.f.ts` (`:269` / `:280`), so the `3n` specialisation
+belongs in the same module next to them, not re-pinned in each caller. Pinning
+`8` (= `2^3`) is a generic bigint concern (bit count → byte count), with no
+crypto- or ASN.1-specific meaning.
+
+## Proposal
+
+Export the two specialisations from `fs/types/bigint/module.f.ts`, immediately
+after `divUpE2` / `roundUpE2`:
+
+```ts
+// bits -> bytes (divide by 8, rounding up)
+export const divUp8: Unary = divUpE2(3n)
+export const roundUp8: Unary = roundUpE2(3n)
+```
+
+Then in both consumers, drop the local definitions and import the shared ones:
+
+```ts
+// fs/crypto/sign/module.f.ts
+import { bitLength, divUp8, roundUp8, type Unary } from '../../types/bigint/module.f.ts'
+// (delete the two local `const divUp8`/`roundUp8` lines)
+```
+
+```ts
+// fs/asn.1/module.f.ts
+import { bitLength, divUp8 } from '../types/bigint/module.f.ts'
+// (delete the local `const divUp8` line)
+```
+
+Add a one-line JSDoc on each new export documenting the "bits → bytes,
+rounding up" intent (and that the `8` is `2^3` bits per byte), so the magic
+exponent is explained once in the canonical place. Cover the new exports in
+`fs/types/bigint/proof.f.ts` so the 100% proof requirement still holds.
+
+This is a small, low-risk reuse: the runtime behaviour at every call site is
+byte-identical; only the definition site moves.
+
+## Tasks
+
+- [ ] Add `divUp8` / `roundUp8` exports (with JSDoc) to
+      `fs/types/bigint/module.f.ts`, next to `divUpE2` / `roundUpE2`.
+- [ ] Import them in `fs/crypto/sign/module.f.ts` and delete the two local
+      definitions.
+- [ ] Import `divUp8` in `fs/asn.1/module.f.ts` and delete the local
+      definition.
+- [ ] Extend `fs/types/bigint/proof.f.ts` to exercise the new exports
+      (full line/branch coverage).
+- [ ] Run `npx tsc` and `fjs t`; confirm `sign`, `asn.1`, and `bigint` proofs
+      still pass.
+
+## Related
+
+- [i113-bigint-bitlen-proposal](./113-bigint-bitlen-proposal.md) — adjacent
+  bit-length work in the same `types/bigint` module (the ECMAScript
+  `BigInt.bitLen()` proposal). `bitLength` is the input these `divUp8` calls
+  consume; both belong to the same bit-arithmetic concern.
+- AGENTS.md, *"When a sibling module already has the type or helper you need,
+  import it … rather than duplicating it"* — the governing rule here.

--- a/issues/66A-emergent-add-result.md
+++ b/issues/66A-emergent-add-result.md
@@ -1,0 +1,79 @@
+# 66A-emergent-add-result. Merge `addPass` / `addFail` into one `TestState` updater
+
+**Priority:** P5
+**Status:** open
+
+## Problem
+
+`fs/emergent_testing/module.f.ts` defines two `TestState` updaters that are
+identical except for the counter field they increment:
+
+```ts
+// fs/emergent_testing/module.f.ts:43-47
+const addPass = (delta: number) => (ts: TestState): TestState =>
+    ({ ...ts, time: ts.time + delta, pass: ts.pass + 1 })
+
+const addFail = (delta: number) => (ts: TestState): TestState =>
+    ({ ...ts, time: ts.time + delta, fail: ts.fail + 1 })
+```
+
+where
+
+```ts
+// :37-41
+type TestState = {
+    readonly time: number,
+    readonly pass: number,
+    readonly fail: number,
+}
+```
+
+The two bodies share the spread, the `time: ts.time + delta` accumulation, and
+the `+ 1` increment; they differ only in whether `pass` or `fail` is the
+incremented key. This is the "same algorithm, one varying constant" shape that
+DRY targets — and if a third outcome counter were ever added (e.g. `skip`), the
+copy would multiply.
+
+Both helpers are real, exercised code: `addPass(duration)(zero)` /
+`addFail(duration)(zero)` feed the `runModule` walk
+(`fs/emergent_testing/module.f.ts:199-205`).
+
+## Proposal
+
+Parameterize over the counter key with a typed computed property, keeping the
+type checker's exhaustiveness (`'pass' | 'fail'` is a closed union, so a typo
+is a compile error):
+
+```ts
+const addResult = (key: 'pass' | 'fail') => (delta: number) => (ts: TestState): TestState =>
+    ({ ...ts, time: ts.time + delta, [key]: ts[key] + 1 })
+
+const addPass = addResult('pass')
+const addFail = addResult('fail')
+```
+
+The two named helpers are kept as point-free derivations so every call site
+(`addPass(duration)(zero)`, `addFail(duration)(zero)`) is unchanged and still
+reads at the grammar level. No `as` cast is needed — `ts[key]` is `number` for
+both members of the union, and the computed-key literal is checked against the
+`TestState` shape.
+
+This is a small, single-module change. It is borderline against the AGENTS.md
+DRY-vs-readability guidance (the originals are short and clear), which is why
+it is filed at **P5** — worth doing if the file is being touched anyway, or as
+a prerequisite if a third counter is introduced, but not on its own.
+
+## Tasks
+
+- [ ] Replace `addPass` / `addFail` with the `addResult` factory + two
+      derivations in `fs/emergent_testing/module.f.ts`.
+- [ ] Confirm `fs/emergent_testing` proofs still pass (`fjs t`) with full
+      branch coverage and `npx tsc` is clean.
+
+## Related
+
+- [i65Z-tf-test-tree-walker](./65Z-tf-test-tree-walker.md) — adjacent
+  `fs/emergent_testing` DRY cleanup (sharing the dynamic test-tree walk between
+  `runModule` and `registerModule`). Same module; independent change. Note that
+  walker also consumes `addPass`/`mergeState`, so landing this first keeps the
+  updater surface stable for that refactor.


### PR DESCRIPTION
This PR adds three new issue templates documenting DRY (Don't Repeat Yourself) refactoring opportunities across the codebase:

## Summary
Three new issue templates have been added to the `issues/` directory, each identifying a specific code duplication pattern and proposing a concrete refactoring solution. These are low-risk, high-clarity improvements that consolidate repeated logic into shared factories or utilities.

## Issues Added

- **66A-ci-cargo-step-factory**: Unify five hand-spelled `cargo*` step builders in `fs/ci/rust/module.f.ts` into a single parameterized `cargoStep` factory. The builders currently repeat the same template string and suffix concatenation logic (`--release`, `-- -D warnings`) across multiple variants. The refactoring collapses this into one factory while keeping the public API (named builders) unchanged.

- **66A-divup8-bits-to-bytes**: Extract the bit→byte rounding helpers `divUp8` and `roundUp8` (both specializations of `divUpE2(3n)`) into `fs/types/bigint/module.f.ts`. Currently duplicated in `fs/crypto/sign/module.f.ts` and `fs/asn.1/module.f.ts`, these helpers belong in the shared `bigint` module where the generic `divUpE2` / `roundUpE2` functions already live.

- **66A-emergent-add-result**: Merge the nearly-identical `addPass` and `addFail` updaters in `fs/emergent_testing/module.f.ts` into a single `addResult` factory parameterized by counter key (`'pass' | 'fail'`). The two functions differ only in which field they increment; the factory eliminates the duplication while keeping the named helpers as point-free derivations for backward compatibility.

## Implementation Notes

All three refactorings:
- Preserve the existing public API and call sites (no breaking changes)
- Generate byte-identical runtime behavior
- Consolidate repeated strings/logic into single definitions
- Are marked with appropriate priority levels (P4, P4, P5) reflecting their scope and urgency
- Include detailed task checklists and testing requirements

https://claude.ai/code/session_01VkSEVzk7idXHDciCHsRBan