### PR TITLE
Extract divUp8/roundUp8 utilities to shared bigint module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `types/bigint`: export `divUp8` / `roundUp8` (bits → bytes, rounding up) and reuse them in `crypto/sign` and `asn.1` instead of locally re-deriving `divUpE2(3n)` / `roundUpE2(3n)` in each consumer (i66A-divup8-bits-to-bytes) [#1018](https://github.com/functionalscript/functionalscript/pull/1018)
 - `types/sorted_list`: export `intersect` and `dropTail`; `types/sorted_set`: delegate `intersect` to `sorted_list.intersect`, mirroring how `union` delegates to `sorted_list.merge` (i180-sorted-set-intersect-symmetry) [#1017](https://github.com/functionalscript/functionalscript/pull/1017)
 - `cas`: drop the private 2-char `split` helper and reuse `splitAt(2)` from `fs/types/string` for the CAS shard path computation (i668-cas-reuse-splitat) [#1014](https://github.com/functionalscript/functionalscript/pull/1014)
 - `types/bigint`: add shift-based `divUpE2(e)` / `roundUpE2(e)` helpers for power-of-two round-up; retype `divUp` / `roundUp` from `Reduce` to `(b: bigint) => Unary`; migrate `asn.1` and `crypto/sign` from hand-coded `>> 3n` shifts and `divUp(8n)` / `roundUp(8n)` to the new helpers ([i187](./issues/187-byte-rounding-divup.md))

--- a/fs/asn.1/module.f.ts
+++ b/fs/asn.1/module.f.ts
@@ -4,7 +4,7 @@
  *
  * @module
  */
-import { bitLength, divUpE2 } from "../types/bigint/module.f.ts"
+import { bitLength, divUp8 } from "../types/bigint/module.f.ts"
 import {
     empty,
     isVec,
@@ -64,8 +64,6 @@ const parsedTagDecode = (v: Vec): readonly[ParsedTag, Vec] => {
         : b128decode(rest)
     return [[classPc, number], rest1]
 }
-
-const divUp8 = divUpE2(3n)
 
 const tagEncode = (tag: Tag): Vec =>
     vec(max(divUp8(bitLength(tag)))(1n) << 3n)(tag)

--- a/fs/crypto/sign/module.f.ts
+++ b/fs/crypto/sign/module.f.ts
@@ -4,16 +4,11 @@
  * @module
  */
 import type { Array2 } from '../../types/array/module.f.ts'
-import { bitLength, divUpE2, roundUpE2, type Unary } from '../../types/bigint/module.f.ts'
+import { bitLength, divUp8, roundUp8 } from '../../types/bigint/module.f.ts'
 import { empty, length, msb, repeat, unpack, vec, vec8, type Vec } from '../../types/bit_vec/module.f.ts'
 import { hmac } from '../hmac/module.f.ts'
 import type { Curve } from '../secp/module.f.ts'
 import { computeSync, type Sha2 } from '../sha2/module.f.ts'
-
-// qlen to rlen
-const roundUp8: Unary = roundUpE2(3n)
-
-const divUp8 = divUpE2(3n)
 
 export type All = {
     readonly q: bigint

--- a/fs/types/bigint/module.f.ts
+++ b/fs/types/bigint/module.f.ts
@@ -281,3 +281,13 @@ export const roundUpE2 = (e: bigint): Unary => {
     const d = divUpE2(e)
     return v => d(v) << e
 }
+
+/**
+ * Converts a bit count to a byte count, rounding up — divides by `8` (`2^3` bits per byte).
+ */
+export const divUp8: Unary = divUpE2(3n)
+
+/**
+ * Rounds a bit count up to the nearest whole byte — the nearest multiple of `8` (`2^3` bits per byte).
+ */
+export const roundUp8: Unary = roundUpE2(3n)

--- a/fs/types/bigint/proof.f.ts
+++ b/fs/types/bigint/proof.f.ts
@@ -10,7 +10,9 @@ import {
     divUp,
     roundUp,
     divUpE2,
-    roundUpE2
+    roundUpE2,
+    divUp8,
+    roundUp8
 } from './module.f.ts'
 import { assertEq } from '../../asserts/module.f.ts'
 import { min } from '../function/compare/module.f.ts'
@@ -413,5 +415,17 @@ export const proof = {
         assertEq(roundUpE2(3n)(0n), 0n)
         assertEq(roundUpE2(3n)(8n), 8n)
         assertEq(roundUpE2(3n)(9n), 16n)
+    },
+    divUp8: () => {
+        assertEq(divUp8(0n), 0n)
+        assertEq(divUp8(1n), 1n)
+        assertEq(divUp8(8n), 1n)
+        assertEq(divUp8(9n), 2n)
+    },
+    roundUp8: () => {
+        assertEq(roundUp8(0n), 0n)
+        assertEq(roundUp8(1n), 8n)
+        assertEq(roundUp8(8n), 8n)
+        assertEq(roundUp8(9n), 16n)
     },
 }

--- a/issues/66A-divup8-bits-to-bytes.md
+++ b/issues/66A-divup8-bits-to-bytes.md
@@ -1,7 +1,7 @@
 # 66A-divup8-bits-to-bytes. Share `divUp8` / `roundUp8` bit→byte rounding in `types/bigint`
 
 **Priority:** P4
-**Status:** open
+**Status:** done
 
 ## Problem
 
@@ -76,15 +76,15 @@ byte-identical; only the definition site moves.
 
 ## Tasks
 
-- [ ] Add `divUp8` / `roundUp8` exports (with JSDoc) to
+- [x] Add `divUp8` / `roundUp8` exports (with JSDoc) to
       `fs/types/bigint/module.f.ts`, next to `divUpE2` / `roundUpE2`.
-- [ ] Import them in `fs/crypto/sign/module.f.ts` and delete the two local
+- [x] Import them in `fs/crypto/sign/module.f.ts` and delete the two local
       definitions.
-- [ ] Import `divUp8` in `fs/asn.1/module.f.ts` and delete the local
+- [x] Import `divUp8` in `fs/asn.1/module.f.ts` and delete the local
       definition.
-- [ ] Extend `fs/types/bigint/proof.f.ts` to exercise the new exports
+- [x] Extend `fs/types/bigint/proof.f.ts` to exercise the new exports
       (full line/branch coverage).
-- [ ] Run `npx tsc` and `fjs t`; confirm `sign`, `asn.1`, and `bigint` proofs
+- [x] Run `npx tsc` and `fjs t`; confirm `sign`, `asn.1`, and `bigint` proofs
       still pass.
 
 ## Related


### PR DESCRIPTION
## Summary
Consolidates duplicate `divUp8` and `roundUp8` bit-to-byte rounding utilities into a shared location in the `types/bigint` module, eliminating code duplication across `crypto/sign` and `asn.1` modules.

## Changes
- **fs/types/bigint/module.f.ts**: Added `divUp8` and `roundUp8` exports as specialized versions of `divUpE2(3n)` and `roundUpE2(3n)` with JSDoc documentation
- **fs/crypto/sign/module.f.ts**: Removed local `divUp8` and `roundUp8` definitions; now imports from `types/bigint`
- **fs/asn.1/module.f.ts**: Removed local `divUp8` definition; now imports from `types/bigint`
- **fs/types/bigint/proof.f.ts**: Added comprehensive test coverage for both new exports with multiple assertion cases

## Implementation Details
The new utilities leverage the existing `divUpE2` and `roundUpE2` functions with exponent `3n` (since 2³ = 8 bits per byte), providing a cleaner, more semantic API for bit-to-byte conversions. All existing proofs continue to pass with the refactored imports.

https://claude.ai/code/session_01RFPA7a4LEPzsiobGuDHfER