### PR TITLE
Refactor UTF-8 byte patterns into named constants and helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `text/utf8`: define the UTF-8 tag/payload-mask constants (`contTag`/`contMask`, `lead2Tag`–`lead4Tag`/`Mask`) and `contByte` / `contPayload` helpers once at module scope and rewrite the encoder/decoder through them — pure refactor, byte-identical behaviour (i666-utf8-continuation-helpers) [#1020](https://github.com/functionalscript/functionalscript/pull/1020)
 - `types/bigint`: export `divUp8` / `roundUp8` (bits → bytes, rounding up) and reuse them in `crypto/sign` and `asn.1` instead of locally re-deriving `divUpE2(3n)` / `roundUpE2(3n)` in each consumer (i66A-divup8-bits-to-bytes) [#1018](https://github.com/functionalscript/functionalscript/pull/1018)
 - `types/sorted_list`: export `intersect` and `dropTail`; `types/sorted_set`: delegate `intersect` to `sorted_list.intersect`, mirroring how `union` delegates to `sorted_list.merge` (i180-sorted-set-intersect-symmetry) [#1017](https://github.com/functionalscript/functionalscript/pull/1017)
 - `cas`: drop the private 2-char `split` helper and reuse `splitAt(2)` from `fs/types/string` for the CAS shard path computation (i668-cas-reuse-splitat) [#1014](https://github.com/functionalscript/functionalscript/pull/1014)

--- a/fs/text/utf8/module.f.ts
+++ b/fs/text/utf8/module.f.ts
@@ -39,6 +39,38 @@ export type Utf8NonEmptyState =
 export type Utf8State = null | Utf8NonEmptyState
 
 /**
+ * UTF-8 byte-format constants. Each byte kind is defined by a tag — the fixed
+ * high bits identifying the kind — and a payload mask selecting the code-point
+ * bits the byte carries. The encoder and the decoder are exact inverses, so
+ * both read their bit patterns from this single set of definitions:
+ *
+ * | byte kind   | pattern      | tag       | payload mask |
+ * |-------------|--------------|-----------|--------------|
+ * | continuation| `10xx_xxxx`  | `contTag` | `contMask`   |
+ * | 2-byte lead | `110x_xxxx`  | `lead2Tag`| `lead2Mask`  |
+ * | 3-byte lead | `1110_xxxx`  | `lead3Tag`| `lead3Mask`  |
+ * | 4-byte lead | `1111_0xxx`  | `lead4Tag`| `lead4Mask`  |
+ */
+const contTag = 0b1000_0000
+const contMask = 0b0011_1111
+const lead2Tag = 0b1100_0000
+const lead2Mask = 0b0001_1111
+const lead3Tag = 0b1110_0000
+const lead3Mask = 0b0000_1111
+const lead4Tag = 0b1111_0000
+const lead4Mask = 0b0000_0111
+
+/**
+ * Encodes the low six bits of `x` as a UTF-8 continuation byte.
+ */
+const contByte = (x: number) => x & contMask | contTag
+
+/**
+ * Reads the six payload bits of a continuation byte.
+ */
+const contPayload = (b: number) => b & contMask
+
+/**
  * Converts a Unicode code point to a sequence of UTF-8 bytes.
  * @param input The Unicode code point to be converted. Valid range:
  *   - 0x0000 to 0x007F for 1-byte sequences.
@@ -53,41 +85,41 @@ const codePointToUtf8 = (input: number): readonly U8[] => {
         return [input & 0b01111_1111]
     }
     if (input >= 0x0080 && input <= 0x07ff) {
-        return [input >> 6 | 0b1100_0000, input & 0b0011_1111 | 0b1000_0000]
+        return [input >> 6 | lead2Tag, contByte(input)]
     }
     if (input >= 0x0800 && input <= 0xffff) {
         return [
-            input >> 12 | 0b1110_0000,
-            input >> 6 & 0b0011_1111 | 0b1000_0000,
-            input & 0b0011_1111 | 0b1000_0000,
+            input >> 12 | lead3Tag,
+            contByte(input >> 6),
+            contByte(input),
         ]
     }
     if (input >= 0x10000 && input <= 0x10ffff) {
         return [
-            input >> 18 | 0b1111_0000,
-            input >> 12 & 0b0011_1111 | 0b1000_0000,
-            input >> 6 & 0b0011_1111 | 0b1000_0000,
-            input & 0b0011_1111 | 0b1000_0000,
+            input >> 18 | lead4Tag,
+            contByte(input >> 12),
+            contByte(input >> 6),
+            contByte(input),
         ]
     }
     if ((input & errorMask) !== 0) {
         if ((input & 0b1000_0000_0000_0000) !== 0) {
             return [
-                input >> 12 & 0b0000_0111 | 0b1111_0000,
-                input >> 6 & 0b0011_1111 | 0b1000_0000,
-                input & 0b0011_1111 | 0b1000_0000,
+                input >> 12 & lead4Mask | lead4Tag,
+                contByte(input >> 6),
+                contByte(input),
             ]
         }
         if ((input & 0b0000_0100_0000_0000) !== 0) {
             return [
-                input >> 6 & 0b0000_1111 | 0b1110_0000,
-                input & 0b0011_1111 | 0b1000_0000,
+                input >> 6 & lead3Mask | lead3Tag,
+                contByte(input),
             ]
         }
         if ((input & 0b0000_0010_0000_0000) !== 0) {
             return [
-                input >> 6 & 0b0000_0111 | 0b1111_0000,
-                input & 0b0011_1111 | 0b1000_0000,
+                input >> 6 & lead4Mask | lead4Tag,
+                contByte(input),
             ]
         }
         if ((input & 0b0000_0000_1000_0000) !== 0) return [input & 0b1111_1111]
@@ -120,16 +152,16 @@ const utf8StateToError = (state: Utf8NonEmptyState): I32 => {
         }
         case 2: {
             const [s0, s1] = state
-            x = s0 < 0b1111_0000
-                ? ((s0 & 0b0000_1111) << 6) + (s1 & 0b0011_1111) + 0b0000_0100_0000_0000
-                : ((s0 & 0b0000_0111) << 6) + (s1 & 0b0011_1111) +
+            x = s0 < lead4Tag
+                ? ((s0 & lead3Mask) << 6) + contPayload(s1) + 0b0000_0100_0000_0000
+                : ((s0 & lead4Mask) << 6) + contPayload(s1) +
                     0b0000_0010_0000_0000
             break
         }
         case 3: {
             const [s0, s1, s2] = state
-            x = ((s0 & 0b0000_0111) << 12) + ((s1 & 0b0011_1111) << 6) +
-                (s2 & 0b0011_1111) + 0b1000_0000_0000_0000
+            x = ((s0 & lead4Mask) << 12) + (contPayload(s1) << 6) +
+                contPayload(s2) + 0b1000_0000_0000_0000
             break
         }
         default:
@@ -152,26 +184,26 @@ const utf8ByteToCodePointOp: StateScan<number, Utf8State, List<I32>> = (byte, st
         return [[errorMask], state]
     }
     if (state === null) {
-        if (byte < 0b1000_0000) return [[byte], null]
+        if (byte < contTag) return [[byte], null]
         if (byte >= 0b1100_0010 && byte <= 0b1111_0100) return [[], [byte]]
         return [[byte | errorMask], null]
     }
-    if (byte >= 0b1000_0000 && byte < 0b1100_0000) {
+    if (byte >= contTag && byte < lead2Tag) {
         switch (state.length) {
             case 1: {
                 const [s0] = state
-                if (s0 < 0b1110_0000) {
-                    return [[((s0 & 0b0001_1111) << 6) + (byte & 0b0011_1111)], null]
+                if (s0 < lead3Tag) {
+                    return [[((s0 & lead2Mask) << 6) + contPayload(byte)], null]
                 }
                 if (s0 < 0b1111_1000) return [[], [s0, byte]]
                 break
             }
             case 2: {
                 const [s0, s1] = state
-                if (s0 < 0b1111_0000) {
+                if (s0 < lead4Tag) {
                     return [[
-                        ((s0 & 0b0000_1111) << 12) + ((s1 & 0b0011_1111) << 6) +
-                        (byte & 0b0011_1111),
+                        ((s0 & lead3Mask) << 12) + (contPayload(s1) << 6) +
+                        contPayload(byte),
                     ], null]
                 }
                 if (s0 < 0b1111_1000) return [[], [s0, s1, byte]]
@@ -180,14 +212,14 @@ const utf8ByteToCodePointOp: StateScan<number, Utf8State, List<I32>> = (byte, st
             case 3: {
                 const [s0, s1, s2] = state
                 return [[
-                    ((s0 & 0b0000_0111) << 18) + ((s1 & 0b0011_1111) << 12) +
-                    ((s2 & 0b0011_1111) << 6) + (byte & 0b0011_1111),
+                    ((s0 & lead4Mask) << 18) + (contPayload(s1) << 12) +
+                    (contPayload(s2) << 6) + contPayload(byte),
                 ], null]
             }
         }
     }
     const error = utf8StateToError(state)
-    if (byte < 0b1000_0000) return [[error, byte], null]
+    if (byte < contTag) return [[error, byte], null]
     if (byte >= 0b1100_0010 && byte <= 0b1111_0100) return [[error], [byte]]
     return [[error, byte | errorMask], null]
 }

--- a/issues/666-utf8-continuation-helpers.md
+++ b/issues/666-utf8-continuation-helpers.md
@@ -1,7 +1,7 @@
 # 666-utf8-continuation-helpers. Name the repeated UTF-8 continuation-byte bit patterns
 
 **Priority:** P5
-**Status:** open
+**Status:** done
 
 ## Problem
 
@@ -58,9 +58,9 @@ proves natural, but keep the change scoped to utf8 first.
 
 ## Tasks
 
-- [ ] add `contByte` / `contPayload` helpers and named lead-byte constants at module scope
-- [ ] rewrite `codePointToUtf8`, `utf8StateToError`, `utf8ByteToCodePointOp` through them
-- [ ] confirm `utf8/proof.f.ts` still passes unchanged (pure refactor)
+- [x] add `contByte` / `contPayload` helpers and named lead-byte constants at module scope
+- [x] rewrite `codePointToUtf8`, `utf8StateToError`, `utf8ByteToCodePointOp` through them
+- [x] confirm `utf8/proof.f.ts` still passes unchanged (pure refactor)
 
 ## Related
 


### PR DESCRIPTION
## Summary
This PR refactors the UTF-8 encoding/decoding implementation to improve code readability and maintainability by extracting repeated bit patterns into named constants and helper functions.

## Key Changes
- **Added UTF-8 byte-format constants** at module scope:
  - `contTag`, `contMask` for continuation bytes (`10xx_xxxx`)
  - `lead2Tag`, `lead2Mask` for 2-byte lead bytes (`110x_xxxx`)
  - `lead3Tag`, `lead3Mask` for 3-byte lead bytes (`1110_xxxx`)
  - `lead4Tag`, `lead4Mask` for 4-byte lead bytes (`1111_0xxx`)

- **Added helper functions**:
  - `contByte(x)`: Encodes the low six bits as a UTF-8 continuation byte
  - `contPayload(b)`: Extracts the six payload bits from a continuation byte

- **Refactored three core functions** to use the new constants and helpers:
  - `codePointToUtf8`: Replaced inline bit patterns with named constants and `contByte()` calls
  - `utf8StateToError`: Replaced inline masks with named constants and `contPayload()` calls
  - `utf8ByteToCodePointOp`: Replaced inline bit patterns with named constants and `contPayload()` calls

- **Updated issue tracking**: Marked issue i666 as complete with all tasks checked off

## Implementation Details
This is a pure refactoring that maintains identical behavior while improving code clarity. The bit patterns are now self-documenting through their constant names and the accompanying documentation table. The helper functions eliminate repeated masking and tagging operations, making the encoding/decoding logic more concise and less error-prone.

https://claude.ai/code/session_01JXNbhukThwhtHVFanYtLzJ