### PR TITLE
Refactor: Extract common mantissa normalization logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `types/bigfloat`: collapse the private `increaseMantissa` / `decreaseMantissa` mirror into a single `normalizeMantissa` factory parameterized by shift direction, exponent delta, and stop predicate — pure refactor, behavior-identical (i177-bigfloat-normalize-mantissa) [#1021](https://github.com/functionalscript/functionalscript/pull/1021)
 - `text/utf8`: define the UTF-8 tag/payload-mask constants (`contTag`/`contMask`, `lead2Tag`–`lead4Tag`/`Mask`) and `contByte` / `contPayload` helpers once at module scope and rewrite the encoder/decoder through them — pure refactor, byte-identical behaviour (i666-utf8-continuation-helpers) [#1020](https://github.com/functionalscript/functionalscript/pull/1020)
 - `types/bigint`: export `divUp8` / `roundUp8` (bits → bytes, rounding up) and reuse them in `crypto/sign` and `asn.1` instead of locally re-deriving `divUpE2(3n)` / `roundUpE2(3n)` in each consumer (i66A-divup8-bits-to-bytes) [#1018](https://github.com/functionalscript/functionalscript/pull/1018)
 - `types/sorted_list`: export `intersect` and `dropTail`; `types/sorted_set`: delegate `intersect` to `sorted_list.intersect`, mirroring how `union` delegates to `sorted_list.merge` (i180-sorted-set-intersect-symmetry) [#1017](https://github.com/functionalscript/functionalscript/pull/1017)

--- a/fs/types/bigfloat/module.f.ts
+++ b/fs/types/bigfloat/module.f.ts
@@ -12,35 +12,32 @@ type BigFloatWithRemainder = readonly[BigFloat,bigint]
 const twoPow53 = 0b0010_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000n
 const twoPow54 = 0b0100_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000n
 
-const increaseMantissa = ([m, e]: BigFloat) => (min: bigint): BigFloat => {
-    if (m === 0n) {
-        return [m, e]
-    }
-    const s = sign(m)
-    m = abs(m)
-    while (true) {
-        if (m >= min) {
-            return [BigInt(s) * m, e]
+/**
+ * Shifts the mantissa magnitude one bit at a time, compensating the exponent,
+ * until `done(magnitude, bound)` holds; the sign is restored on return.
+ * A zero mantissa is returned unchanged: it can never satisfy a lower bound,
+ * so shifting it would not terminate.
+ */
+const normalizeMantissa =
+    (shift: (m: bigint) => bigint, de: number, done: (m: bigint, bound: bigint) => boolean) =>
+    ([m, e]: BigFloat) => (bound: bigint): BigFloat => {
+        if (m === 0n) {
+            return [m, e]
         }
-        m = m << 1n
-        e--
+        const s = sign(m)
+        m = abs(m)
+        while (true) {
+            if (done(m, bound)) {
+                return [BigInt(s) * m, e]
+            }
+            m = shift(m)
+            e += de
+        }
     }
-}
 
-const decreaseMantissa = ([m, e]: BigFloat) => (max: bigint): BigFloat => {
-    if (m === 0n) {
-        return [m, e]
-    }
-    const s = sign(m)
-    m = abs(m)
-    while (true) {
-        if (m < max) {
-            return [BigInt(s) * m, e]
-        }
-        m = m >> 1n
-        e++
-    }
-}
+const increaseMantissa = normalizeMantissa(m => m << 1n, -1, (m, min) => m >= min)
+
+const decreaseMantissa = normalizeMantissa(m => m >> 1n, +1, (m, max) => m < max)
 
 const pow = (base: bigint) => (exp: number) => base ** BigInt(exp)
 

--- a/issues/177-bigfloat-normalize-mantissa.md
+++ b/issues/177-bigfloat-normalize-mantissa.md
@@ -1,7 +1,7 @@
 # 177. `bigfloat`: collapse `increaseMantissa`/`decreaseMantissa` mirror
 
 **Priority:** P3
-**Status:** open
+**Status:** done
 
 `fs/types/bigfloat/module.f.ts:15` and `:30` are mirror images of one another.
 Both guard the zero mantissa, split off the sign, take the absolute value, then


### PR DESCRIPTION
## Summary
Consolidated the duplicated logic in `increaseMantissa` and `decreaseMantissa` into a single parameterized `normalizeMantissa` function, eliminating code duplication while improving maintainability.

## Key Changes
- **Extracted `normalizeMantissa`**: Created a higher-order function that accepts three parameters:
  - `shift`: A function to transform the mantissa (left shift or right shift)
  - `de`: The exponent delta to apply per iteration (-1 for increase, +1 for decrease)
  - `done`: A predicate function to determine when normalization is complete
  
- **Simplified implementations**: Both `increaseMantissa` and `decreaseMantissa` are now concise one-liners that delegate to `normalizeMantissa` with appropriate parameters

- **Preserved behavior**: The refactored code maintains identical semantics:
  - Zero mantissa handling remains unchanged
  - Sign preservation logic is centralized
  - Bit-shifting operations work as before

## Implementation Details
The new `normalizeMantissa` function uses a closure pattern to capture the shift operation and completion predicate, allowing the same loop logic to serve both increasing and decreasing use cases. This eliminates the mirror-image duplication while making the intent of each operation clearer through their respective predicates (`m >= min` vs `m < max`).

https://claude.ai/code/session_0114D7zg3DCBYqtUU3ervK4c