### PR TITLE
Extract withSign helper for magnitude operations in bigfloat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `types/bigfloat`: factor the abs/sign/`multiply` envelope of `round53` and `decToBin`'s negative-exponent branch into a private `withSign` combinator ("operate on the magnitude, restore the sign") — pure refactor, behavior-identical (i191-bigfloat-with-sign) [#1022](https://github.com/functionalscript/functionalscript/pull/1022)
 - `types/bigfloat`: collapse the private `increaseMantissa` / `decreaseMantissa` mirror into a single `normalizeMantissa` factory parameterized by shift direction, exponent delta, and stop predicate — pure refactor, behavior-identical (i177-bigfloat-normalize-mantissa) [#1021](https://github.com/functionalscript/functionalscript/pull/1021)
 - `text/utf8`: define the UTF-8 tag/payload-mask constants (`contTag`/`contMask`, `lead2Tag`–`lead4Tag`/`Mask`) and `contByte` / `contPayload` helpers once at module scope and rewrite the encoder/decoder through them — pure refactor, byte-identical behaviour (i666-utf8-continuation-helpers) [#1020](https://github.com/functionalscript/functionalscript/pull/1020)
 - `types/bigint`: export `divUp8` / `roundUp8` (bits → bytes, rounding up) and reuse them in `crypto/sign` and `asn.1` instead of locally re-deriving `divUpE2(3n)` / `roundUpE2(3n)` in each consumer (i66A-divup8-bits-to-bytes) [#1018](https://github.com/functionalscript/functionalscript/pull/1018)

--- a/fs/types/bigfloat/module.f.ts
+++ b/fs/types/bigfloat/module.f.ts
@@ -49,19 +49,25 @@ export const multiply = ([m, e]: BigFloat) => (mul: bigint): BigFloat =>
 const divide = ([m, e]: BigFloat) => (div: bigint): BigFloatWithRemainder =>
     [[m / div, e], m % div]
 
-const round53 = ([[m, e], r]: BigFloatWithRemainder): BigFloat => {
-    const mabs = abs(m)
-    const s = BigInt(sign(m))
-    const [m54, e54] = decreaseMantissa([mabs, e])(twoPow54)
-    const o54 = m54 & 1n
-    const m53 = m54 >> 1n
-    const e53 = e54 + 1
-    if (o54 === 1n && r === 0n && mabs === m54 >> BigInt(e - e54)) {
-        const odd = m53 & 1n
-        return multiply([m53 + odd, e53])(s)
-    }
-    return multiply([m53 + o54, e53])(s)
-}
+/**
+ * Runs `f` on the magnitude `[abs(m), e]` and restores the sign of `m` on the
+ * result: operations on signed mantissas factor through the magnitude.
+ */
+const withSign = (m: bigint, e: number) => (f: (magnitude: BigFloat) => BigFloat): BigFloat =>
+    multiply(f([abs(m), e]))(BigInt(sign(m)))
+
+const round53 = ([[m, e], r]: BigFloatWithRemainder): BigFloat =>
+    withSign(m, e)(([mAbs]) => {
+        const [m54, e54] = decreaseMantissa([mAbs, e])(twoPow54)
+        const o54 = m54 & 1n
+        const m53 = m54 >> 1n
+        const e53 = e54 + 1
+        if (o54 === 1n && r === 0n && mAbs === m54 >> BigInt(e - e54)) {
+            const odd = m53 & 1n
+            return [m53 + odd, e53]
+        }
+        return [m53 + o54, e53]
+    })
 
 export const decToBin = (dec: BigFloat): BigFloat => {
     if (dec[0] === 0n) {
@@ -74,9 +80,5 @@ export const decToBin = (dec: BigFloat): BigFloat => {
     }
     const p = pow5(-dec[1])
     const [m, e] = increaseMantissa(dec)(p * twoPow53)
-    const mAbs = abs(m)
-    const s = BigInt(sign(m))
-    const qr = divide([mAbs, e])(p)
-    const r53 = round53(qr)
-    return multiply(r53)(s)
+    return withSign(m, e)(magnitude => round53(divide(magnitude)(p)))
 }

--- a/issues/191-bigfloat-with-sign.md
+++ b/issues/191-bigfloat-with-sign.md
@@ -1,7 +1,7 @@
 # 191. `bigfloat`: a `withSign` helper for "operate on the magnitude, restore the sign"
 
 **Priority:** P3
-**Status:** open
+**Status:** done
 
 Two private `bigfloat` functions strip the sign off a mantissa, do unsigned work,
 then re-apply the sign with `multiply(...)(s)`:


### PR DESCRIPTION
## Summary
Refactored the `bigfloat` module to extract a reusable `withSign` helper function that encapsulates the common pattern of operating on a magnitude and then restoring the original sign.

## Key Changes
- **Added `withSign` helper function**: A new private function that abstracts the pattern of taking the absolute value of a mantissa, applying a function to the magnitude, and then restoring the sign via multiplication
- **Refactored `round53`**: Simplified to use `withSign`, removing manual sign handling and making the logic clearer by focusing on the unsigned rounding operation
- **Refactored `decToBin`**: Simplified the final computation to use `withSign`, eliminating redundant sign extraction and restoration code
- **Improved code clarity**: The helper makes the intent explicit—operations on signed mantissas factor through the magnitude

## Implementation Details
The `withSign` helper takes a mantissa `m` and exponent `e`, applies a function `f` to the magnitude `[abs(m), e]`, and multiplies the result by the sign of `m`. This eliminates the repetitive pattern of:
```
const mAbs = abs(m)
const s = BigInt(sign(m))
// ... operations on mAbs ...
return multiply(result)(s)
```

Both `round53` and `decToBin` now use this helper, making the code more maintainable and reducing duplication.

https://claude.ai/code/session_01M4W7RTphSb4T4a6obgDsG8