### PR TITLE
Add ObjectIdentifier encoding/decoding proof tests

### DIFF
--- a/fs/asn.1/proof.f.ts
+++ b/fs/asn.1/proof.f.ts
@@ -12,8 +12,12 @@ import {
     constructedSequence,
     octetString,
     boolean,
-    constructedSet
+    constructedSet,
+    encodeObjectIdentifier,
+    decodeObjectIdentifier,
+    type ObjectIdentifier,
 } from "./module.f.ts"
+import { assertEq } from "../asserts/module.f.ts"
 
 const { concat, popFront: pop, listToVec } = msb
 const pop8 = pop(8n)
@@ -226,6 +230,26 @@ export const proof = {
                     encode([integer, 2n])
                 ])
             )
+        },
+    },
+    objectIdentifier: {
+        simple: () => {
+            const oid: ObjectIdentifier = [1n, 2n]
+            const encoded = encodeObjectIdentifier(oid)
+            const decoded = decodeObjectIdentifier(encoded)
+            assertEq(decoded.length, 2)
+            assertEq(decoded[0], 1n)
+            assertEq(decoded[1], 2n)
+        },
+        withArc: () => {
+            // OID 1.2.840.113549 (RSA)
+            const oid: ObjectIdentifier = [1n, 2n, 840n, 113549n]
+            const decoded = decodeObjectIdentifier(encodeObjectIdentifier(oid))
+            assertEq(decoded.length, 4)
+            assertEq(decoded[0], 1n)
+            assertEq(decoded[1], 2n)
+            assertEq(decoded[2], 840n)
+            assertEq(decoded[3], 113549n)
         },
     },
     raw: [


### PR DESCRIPTION
## Summary
Added comprehensive proof tests for ObjectIdentifier (OID) encoding and decoding functionality to verify correct round-trip serialization.

## Key Changes
- Imported `encodeObjectIdentifier`, `decodeObjectIdentifier`, and `ObjectIdentifier` type from the module
- Imported `assertEq` test assertion utility
- Added `objectIdentifier` test suite with two test cases:
  - `simple`: Tests basic OID encoding/decoding with a minimal 2-arc identifier `[1, 2]`
  - `withArc`: Tests OID encoding/decoding with a real-world example (RSA OID `1.2.840.113549`) containing 4 arcs

## Implementation Details
Both test cases follow the same pattern: encode an OID, decode the result, and verify all arcs match the original values using assertions. This ensures the encode/decode functions are inverses of each other and handle both simple and complex OID structures correctly.

https://claude.ai/code/session_01B8WYFBMDchYGe9jU3mKrLx