### PR TITLE
Add test coverage for large duration formatting and tokenizer edge cases

### DIFF
--- a/fs/emergent_testing/proof.f.ts
+++ b/fs/emergent_testing/proof.f.ts
@@ -235,6 +235,20 @@ export const defaultReporterOutput = () => {
     )
 }
 
+// timeFormat with duration >= 1ms covers the `yl <= 0` branch (no leading zeros needed)
+export const defaultReporterOutputLargeDuration = () => {
+    const [stdout, , exit] = runMain({
+        'a.proof.f.ts': () => ({ proof: { x: ok1 } }),
+    })
+    assertEq(exit, 0)
+    assertEq(
+        stdout,
+        'import("./a.proof.f.ts").proof.x(): ok, 1.0000 ms\n'
+        + 'Number of tests: pass: 1, fail: 0, total: 1\n'
+        + 'Time: 1.0000 ms\n',
+    )
+}
+
 // a failure on the non-GitHub reporter writes the error to stderr, not stdout
 export const defaultReporterFailOutput = () => {
     const [, stderr, exit] = runMain({
@@ -394,6 +408,7 @@ export const proof = {
     throwByFunctionName,
     namedExports,
     defaultReporterOutput,
+    defaultReporterOutputLargeDuration,
     defaultReporterFailOutput,
     githubReporterOutput,
     registerSuffixes,

--- a/fs/js/tokenizer/proof.f.ts
+++ b/fs/js/tokenizer/proof.f.ts
@@ -133,6 +133,11 @@ export const proof = {
             if (result !== '[{"kind":"error","message":"invalid number"},{"kind":"eof"}]') { throw result }
         },
         () => {
+            // terminal char after invalidNumber state (covers invalidNumberStateOp terminal branch)
+            const result = stringify(tokenizeString('00,'))
+            if (result !== '[{"kind":"error","message":"invalid number"},{"kind":","},{"kind":"eof"}]') { throw result }
+        },
+        () => {
             const result = stringify(tokenizeString('0abc,'))
             if (result !== '[{"kind":"error","message":"invalid number"},{"kind":"id","value":"abc"},{"kind":","},{"kind":"eof"}]') { throw result }
         },


### PR DESCRIPTION
## Summary
This PR adds additional test cases to improve code coverage for the proof testing framework, specifically targeting duration formatting with larger values and tokenizer edge cases.

## Key Changes
- **Reporter output test**: Added `defaultReporterOutputLargeDuration` test to cover the `timeFormat` function with durations >= 1ms, which exercises the branch where no leading zeros are needed
- **Tokenizer test**: Added a test case for the `invalidNumberStateOp` terminal branch in the tokenizer, specifically testing the scenario where a terminal character (comma) immediately follows an invalid number token

## Implementation Details
- The new reporter test verifies that the output formatting correctly displays durations in milliseconds without unnecessary leading zeros
- The tokenizer test ensures proper error handling and token generation when invalid numbers are followed by terminal characters, improving branch coverage in the tokenization logic

https://claude.ai/code/session_017aLo96PHwdVEdc4vfZ7cCm