### PR TITLE
Add tests to improve branch coverage in map and emergent_testing modules

### DIFF
--- a/fs/emergent_testing/proof.f.ts
+++ b/fs/emergent_testing/proof.f.ts
@@ -395,6 +395,17 @@ export const helpers = {
     },
 }
 
+// a passing throw-test emits '# EXPECTED TO THROW' in its output line
+const defaultReporterExpectedToThrow = () => {
+    // fail0 returns a SandboxResult indicating an error; in a throw context
+    // defaultTest inverts it to ok, so defaultReporter.result sees s==='ok' and throws===true
+    const [stdout, , exit] = runMain({
+        'a.proof.f.ts': () => ({ proof: { throw: { x: fail0 } } }),
+    })
+    assertEq(exit, 0)
+    assert(stdout.includes('# EXPECTED TO THROW'), stdout)
+}
+
 export const proof = {
     flat,
     nested,
@@ -412,5 +423,6 @@ export const proof = {
     defaultReporterFailOutput,
     githubReporterOutput,
     registerSuffixes,
+    defaultReporterExpectedToThrow,
     helpers
 }

--- a/fs/types/map/proof.f.ts
+++ b/fs/types/map/proof.f.ts
@@ -1,4 +1,5 @@
 import { mapSet, mapDelete } from './module.f.ts'
+import { assertEq } from '../../asserts/module.f.ts'
 
 export const proof = {
     set: () => {
@@ -10,5 +11,13 @@ export const proof = {
         const map = mapDelete(mapSet(new Map(), 'a', 'b'), 'a')
         if (map.get('a') !== undefined) { throw 'error' }
         if (map.size !== 0) { throw 'error' }
-    }
+    },
+    deleteOneOfMany: () => {
+        const m0 = mapSet(new Map<string, number>(), 'a', 1)
+        const m1 = mapSet(m0, 'b', 2)
+        const result = mapDelete(m1, 'a')
+        assertEq(result.get('b'), 2)
+        assertEq(result.get('a'), undefined)
+        assertEq(result.size, 1)
+    },
 }


### PR DESCRIPTION
- types/map/proof.f.ts: add deleteOneOfMany test to cover the `yield x`
  branch in filter() when an entry survives deletion from a multi-key map;
  bumps map module branch coverage from 88.89% to 100%

- emergent_testing/proof.f.ts: add defaultReporterExpectedToThrow test to
  cover the `throws ? ' # EXPECTED TO THROW' : ''` branch in
  defaultReporter.result when a throw-test passes (error result inverted to
  ok); improves emergent_testing branch coverage from 93.85% to 94.66%

Overall branch coverage: 96.61% → 96.68%

https://claude.ai/code/session_01CugWqtzYb7mDidUznCge3Q