### PR TITLE
Add memory effect proofs and improve CI/website test coverage

### DIFF
--- a/fs/ci/proof.f.ts
+++ b/fs/ci/proof.f.ts
@@ -2,7 +2,7 @@ import { ci, main } from './module.f.ts'
 import { functionalscript } from './config/module.f.ts'
 import { utf8, utf8ToString } from '../text/module.f.ts'
 import { empty as emptyVec, isVec } from '../types/bit_vec/module.f.ts'
-import { type MetaStep, type Os, test, type GitHubAction, parseGitHubAction } from './common/module.f.ts'
+import { type MetaStep, type Os, test, ubuntu, type GitHubAction, parseGitHubAction } from './common/module.f.ts'
 import { assert } from '../asserts/module.f.ts'
 import type { State } from '../effects/node/virtual/module.f.ts'
 import { emptyState, virtual } from '../effects/node/virtual/module.f.ts'
@@ -134,5 +134,10 @@ export const proof = {
             const gha = runDefault()
             assert(hasRun(`npm install -g functionalscript@${functionalscript}`)(gha), 'expected configured-version install')
         },
+    },
+    ubuntu: () => {
+        const job = ubuntu([test({ run: 'echo hi' })])
+        assert(job['runs-on'] !== undefined, 'expected runs-on')
+        assert(job.steps.length > 0, 'expected steps')
     },
 }

--- a/fs/effects/node/proof.f.ts
+++ b/fs/effects/node/proof.f.ts
@@ -1,6 +1,7 @@
 import { empty, isVec, uint, vec8 } from "../../types/bit_vec/module.f.ts"
 import { pure } from "../module.f.ts"
 import { fetch, mkdir, now, readdir, readFile, rm, sandbox, writeFile } from "./module.f.ts"
+import { create as memCreate, read as memRead, write as memWrite } from "../memory/module.f.ts"
 import { emptyState, virtual } from "./virtual/module.f.ts"
 
 export const proof = {
@@ -244,6 +245,20 @@ export const proof = {
                 sandbox(() => ({ result: ['error', err], duration: 0 }) as never))
             if (result[0] !== 'error') { throw result }
             if (result[1] !== err) { throw result[1] }
+        },
+    },
+    memory: {
+        createAndRead: () => {
+            const effect = memCreate(42).step(key => memRead(key))
+            const [_, value] = virtual(emptyState)(effect)
+            if (value !== 42) { throw value }
+        },
+        createAndWrite: () => {
+            const effect = memCreate(1).step(key =>
+                memWrite(key, 99).step(() => memRead(key))
+            )
+            const [_, value] = virtual(emptyState)(effect)
+            if (value !== 99) { throw value }
         },
     },
 }

--- a/fs/website/proof.f.ts
+++ b/fs/website/proof.f.ts
@@ -1,8 +1,16 @@
 import { main } from './module.f.ts'
+import { emptyState, virtual } from '../effects/node/virtual/module.f.ts'
+import { assert } from '../asserts/module.f.ts'
+import { isVec } from '../types/bit_vec/module.f.ts'
 
 export const proof = {
     main: () => {
         const program = main()
         if (program === undefined) { throw 'expected a program effect' }
-    }
+    },
+    run: () => {
+        const state = { ...emptyState, root: { '.github': { workflows: {} } } }
+        const [_, result] = virtual(state)(main())
+        assert(result === 0, result)
+    },
 }

--- a/fs/website/proof.f.ts
+++ b/fs/website/proof.f.ts
@@ -1,7 +1,6 @@
 import { main } from './module.f.ts'
 import { emptyState, virtual } from '../effects/node/virtual/module.f.ts'
 import { assert } from '../asserts/module.f.ts'
-import { isVec } from '../types/bit_vec/module.f.ts'
 
 export const proof = {
     main: () => {


### PR DESCRIPTION
This PR adds comprehensive test coverage for memory effects and improves the test suite for CI and website modules.

**Key changes:**

- **Memory effects testing**: Added proof tests for `memCreate`, `memRead`, and `memWrite` operations in `fs/effects/node/proof.f.ts`, including:
  - `createAndRead`: Verifies creating a memory location and reading its value
  - `createAndWrite`: Verifies writing to and reading from a memory location

- **Website module testing**: Enhanced `fs/website/proof.f.ts` with a new `run` proof that executes the main program effect against a virtual filesystem state and validates the result

- **CI module improvements**: 
  - Added `ubuntu` import to `fs/ci/proof.f.ts` from the common module
  - Added `ubuntu` proof test that validates the job configuration includes required fields (`runs-on` and `steps`)

These additions improve test coverage for core functionality and ensure memory operations, website execution, and CI job configuration work as expected.

https://claude.ai/code/session_0197WSedoAAn9Wr2yNk77a1U