### PR TITLE
test: increase branch coverage for dev/package_json, dev, and text/sgr modules

### DIFF
--- a/fs/dev/package_json/proof.f.ts
+++ b/fs/dev/package_json/proof.f.ts
@@ -16,6 +16,11 @@ export const proof = {
         const result = validatePackageJsonText('{')
         assert(result[0] === 'error', result)
     },
+    validationError: () => {
+        // valid JSON but `name` is a number, not a string — validation should fail
+        const result = validatePackageJsonText('{"name": 42}')
+        assert(result[0] === 'error', result)
+    },
     validatePreservesOriginalObject: () => {
         const object = { name: 'x', version: '1.0.0', private: true } as const
         const metadata = unwrap(validatePackageJson(object))

--- a/fs/dev/proof.f.ts
+++ b/fs/dev/proof.f.ts
@@ -1,6 +1,17 @@
-import { todo } from '../asserts/module.f.ts'
+import { assert, todo } from '../asserts/module.f.ts'
+import { shouldLoad } from './module.f.ts'
 
 export const proof = {
+    shouldLoad: () => {
+        assert(shouldLoad('foo.f.ts'))
+        assert(shouldLoad('bar.f.js'))
+        assert(shouldLoad('proof.ts'))
+        assert(shouldLoad('proof.js'))
+        assert(shouldLoad('proof.mts'))
+        assert(shouldLoad('proof.mjs'))
+        assert(!shouldLoad('module.ts'))
+        assert(!shouldLoad('readme.md'))
+    },
     shouldPass: () => ({
         then: () => undefined
     }),

--- a/fs/text/sgr/proof.f.ts
+++ b/fs/text/sgr/proof.f.ts
@@ -1,4 +1,16 @@
-import { fgRed, createConsoleText, backspace } from './module.f.ts'
+import { fgRed, reset, createConsoleText, backspace, csiWrite } from './module.f.ts'
+import { virtual, emptyState } from '../../effects/node/virtual/module.f.ts'
+import type { NodeProgramOptions } from '../../effects/node/module.f.ts'
+
+const makeOptions = (isTTY: boolean): NodeProgramOptions => ({
+    args: [],
+    env: {},
+    std: { stdout: { isTTY }, stderr: { isTTY } },
+    testContext: { test: async () => {} },
+    bunTestContext: { test: async () => {} },
+    playwrightTestContext: { test: async () => {} },
+    engine: 'node',
+})
 
 export const proof = [
     () => {
@@ -16,5 +28,11 @@ export const proof = [
         writer2('hi')
         const expected = backspace.repeat(5) + 'hi' + ' '.repeat(3) + backspace.repeat(3)
         if (output[1] !== expected) { throw output[1] }
-    }
+    },
+    () => {
+        // csiWrite with isTTY=false strips ANSI SGR sequences
+        const writeFn = csiWrite(makeOptions(false))('stdout')
+        const [state] = virtual(emptyState)(writeFn(fgRed + 'hello' + reset))
+        if (state.stdout !== 'hello') { throw ['expected ANSI stripped', state.stdout] }
+    },
 ]


### PR DESCRIPTION
- fs/dev/proof.f.ts: add shouldLoad() tests covering all six filename
  patterns (.f.ts, .f.js, proof.ts, proof.js, proof.mts, proof.mjs)
  so their truthy branches are explicitly exercised

- fs/dev/package_json/proof.f.ts: add validationError test — passes
  valid JSON whose name field is a number, covering the error(v2)
  branch in validatePackageJsonText that was previously unreachable

- fs/text/sgr/proof.f.ts: add csiWrite test with isTTY=false, which
  exercises the ANSI-stripping path in str(); uses the virtual effect
  runner to confirm the output has SGR sequences removed

Branch coverage: 96.75% → 96.79% overall;
dev/package_json and text/sgr modules now at 100% branch coverage.

https://claude.ai/code/session_01HzJFY2kysgVvWZXMwJcX74