### PR TITLE
test: increase branch coverage for hmac and secp modules

### DIFF
--- a/fs/crypto/hmac/proof.f.ts
+++ b/fs/crypto/hmac/proof.f.ts
@@ -26,5 +26,12 @@ export const proof = {
         if (r !== vec(512n)(0xb42af09057bac1e2d41708e48a902e09b5ff7f12ab428a4fe86653c73dd248fb82f948a549f7b791a5b41915ee4d1ec3935357e4e2317250d0372afa2ebeeb3an)) {
             throw r
         }
+    },
+    // RFC 4231 Test Case 6: key (131 bytes of 0xaa = 1048 bits) exceeds SHA-256 block size (512 bits),
+    // so the key is first compressed via the hash function before use.
+    longKey: () => {
+        const key = vec(1048n)(BigInt('0x' + 'aa'.repeat(131)))
+        const r = hmac(sha256)(key)(utf8('Test Using Larger Than Block-Size Key - Hash Key First'))
+        if (uint(r) !== 0x60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54n) { throw uint(r).toString(16) }
     }
 }

--- a/fs/crypto/hmac/proof.f.ts
+++ b/fs/crypto/hmac/proof.f.ts
@@ -1,3 +1,4 @@
+import { assertEq } from '../../asserts/module.f.ts'
 import { utf8 } from '../../text/module.f.ts'
 import { uint, vec } from '../../types/bit_vec/module.f.ts'
 import { sha256, sha384, sha512 } from '../sha2/module.f.ts'
@@ -32,6 +33,6 @@ export const proof = {
     longKey: () => {
         const key = vec(1048n)(BigInt('0x' + 'aa'.repeat(131)))
         const r = hmac(sha256)(key)(utf8('Test Using Larger Than Block-Size Key - Hash Key First'))
-        if (uint(r) !== 0x60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54n) { throw uint(r).toString(16) }
+        assertEq(uint(r), 0x60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54n)
     }
 }

--- a/fs/crypto/secp/proof.f.ts
+++ b/fs/crypto/secp/proof.f.ts
@@ -1,3 +1,4 @@
+import { assert } from '../../asserts/module.f.ts'
 import { prime_field } from '../../types/prime_field/module.f.ts'
 import { curve, secp256k1, secp192r1, secp256r1, eq, type Point, secp384r1, secp521r1, type Curve, type Init } from './module.f.ts'
 
@@ -123,13 +124,10 @@ export const proof = {
     // Cover null (point at infinity) branches in neg, add, and eq.
     nullPointOps: () => {
         const c = secp256k1
-        // neg(null) → null  [covers secp:114-115]
-        if (c.neg(null) !== null) { throw 'neg(null) should be null' }
-        // eq null branches  [covers secp:126-127]
-        if (!eq(null)(null)) { throw 'eq(null)(null) should be true' }
-        if (eq(null)(c.g)) { throw 'eq(null)(g) should be false' }
-        if (eq(c.g)(null)) { throw 'eq(g)(null) should be false' }
-        // add with null second argument  [covers secp:86-87]
-        if (!eq(c.add(c.g)(null))(c.g)) { throw 'g + null should equal g' }
+        assert(c.neg(null) === null)
+        assert(eq(null)(null))
+        assert(!eq(null)(c.g))
+        assert(!eq(c.g)(null))
+        assert(eq(c.add(c.g)(null))(c.g))
     }
 }

--- a/fs/crypto/secp/proof.f.ts
+++ b/fs/crypto/secp/proof.f.ts
@@ -119,5 +119,17 @@ export const proof = {
             //secp256r1,
         }
         return Object.fromEntries(Object.entries(c).map(([k, v]) => [k, poker(v)]))
+    },
+    // Cover null (point at infinity) branches in neg, add, and eq.
+    nullPointOps: () => {
+        const c = secp256k1
+        // neg(null) → null  [covers secp:114-115]
+        if (c.neg(null) !== null) { throw 'neg(null) should be null' }
+        // eq null branches  [covers secp:126-127]
+        if (!eq(null)(null)) { throw 'eq(null)(null) should be true' }
+        if (eq(null)(c.g)) { throw 'eq(null)(g) should be false' }
+        if (eq(c.g)(null)) { throw 'eq(g)(null) should be false' }
+        // add with null second argument  [covers secp:86-87]
+        if (!eq(c.add(c.g)(null))(c.g)) { throw 'g + null should equal g' }
     }
 }


### PR DESCRIPTION
- hmac: add RFC 4231 test case 6 (131-byte key > SHA-256 block size),
  covering the key-hashing branch in hmac/module.f.ts:50
- secp: add nullPointOps test covering the three null (point at infinity)
  branches in neg (114-115), add (86-87), and eq (126-127)

Both modules now report 100% line/branch/function coverage.

https://claude.ai/code/session_014vgH2iSuwDgKQSc5RKv7ce