### PR TITLE
Add tests for primitive AstConst values in djs/ast to improve branch coverage

### DIFF
--- a/fs/djs/ast/proof.f.ts
+++ b/fs/djs/ast/proof.f.ts
@@ -1,6 +1,7 @@
 import { sort } from '../../types/object/module.f.ts'
 import { run } from './module.f.ts'
 import { stringifyAsTree } from '../serializer/module.f.ts'
+import { assertEq } from '../../asserts/module.f.ts'
 
 export const proof = {
     test: () => {
@@ -27,5 +28,21 @@ export const proof = {
         const djs = run([1, 2, 3, 4, 5, {"key": { "key2": ['array', [['aref', 3], ['cref', 3]]]}}])([11, 12, 13, 14, 15])
         const result = stringifyAsTree(sort)(djs)
         if (result !== '{"key":{"key2":[14,4]}}') { throw result }
+    },
+    testBool: () => {
+        assertEq(stringifyAsTree(sort)(run([true])([])), 'true')
+        assertEq(stringifyAsTree(sort)(run([false])([])), 'false')
+    },
+    testStr: () => {
+        assertEq(stringifyAsTree(sort)(run(['hello'])([])), '"hello"')
+    },
+    testNull: () => {
+        assertEq(stringifyAsTree(sort)(run([null])([])), 'null')
+    },
+    testBigint: () => {
+        assertEq(stringifyAsTree(sort)(run([42n])([])), '42n')
+    },
+    testUndefined: () => {
+        assertEq(stringifyAsTree(sort)(run([undefined])([])), 'undefined')
     },
 }


### PR DESCRIPTION
Adds testBool, testStr, testNull, testBigint, and testUndefined to cover
the previously untested boolean, string, bigint, null, and undefined
branches in toDjs's switch statement, bringing djs/ast/module.f.ts to
100% branch coverage.

https://claude.ai/code/session_01Fobe1YfMBTLVgHHCj4cRsU