### PR TITLE
test: improve branch coverage in sgr and json/schema modules

### DIFF
--- a/fs/json/schema/proof.f.ts
+++ b/fs/json/schema/proof.f.ts
@@ -55,6 +55,11 @@ export const proof = {
             type: 'object',
             properties: { x: { anyOf: [{ type: 'string' }, { type: 'number' }] } },
         }),
+        withConst: eq({ x: null, y: string } as const, {
+            type: 'object',
+            properties: { x: { const: null }, y: { type: 'string' } },
+            required: ['x', 'y'],
+        }),
     },
     nested: {
         arrayOfRecords: eq(array(record(boolean)), {

--- a/fs/text/sgr/proof.f.ts
+++ b/fs/text/sgr/proof.f.ts
@@ -35,4 +35,11 @@ export const proof = [
         const [state] = virtual(emptyState)(writeFn(fgRed + 'hello' + reset))
         if (state.stdout !== 'hello') { throw ['expected ANSI stripped', state.stdout] }
     },
+    () => {
+        // csiWrite with isTTY=true preserves ANSI SGR sequences
+        const writeFn = csiWrite(makeOptions(true))('stdout')
+        const [state] = virtual(emptyState)(writeFn(fgRed + 'hello' + reset))
+        const expected = fgRed + 'hello' + reset
+        if (state.stdout !== expected) { throw ['expected ANSI preserved', state.stdout] }
+    },
 ]


### PR DESCRIPTION
- text/sgr: add isTTY=true test for csiWrite, covering the branch
  where ANSI SGR sequences are preserved (was missing the true branch)
- json/schema: add struct-with-const test (null property), covering
  the typeof-not-function branches in stripUndefined and admitsUndefined

Branch coverage: 97.03% → 97.13% overall
sgr/module.f.ts: 92.86% → 100.00% branches
json/schema/module.f.ts: 91.11% → 95.65% branches

https://claude.ai/code/session_01HNaW2k8kK4F3uPRYwQUTF7