### PR TITLE
Add tests for both() and parseObjectNextOp error branch to increase coverage

### DIFF
--- a/fs/effects/node/proof.f.ts
+++ b/fs/effects/node/proof.f.ts
@@ -1,6 +1,6 @@
 import { empty, isVec, uint, vec8 } from "../../types/bit_vec/module.f.ts"
 import { pure } from "../module.f.ts"
-import { fetch, mkdir, now, readdir, readFile, rm, sandbox, writeFile } from "./module.f.ts"
+import { both, fetch, mkdir, now, readdir, readFile, rm, sandbox, writeFile } from "./module.f.ts"
 import { create as memCreate, read as memRead, write as memWrite } from "../memory/module.f.ts"
 import { emptyState, virtual } from "./virtual/module.f.ts"
 
@@ -223,6 +223,19 @@ export const proof = {
             if (result !== 'invalid path') { throw result }
             if (state.root.tmp === undefined) { throw state.root }
         },
+    },
+    both: () => {
+        const [_, results] = virtual({
+            ...emptyState,
+            root: {
+                a: vec8(0x2An),
+                b: vec8(0x15n),
+            },
+        })(both(readFile('a'))(readFile('b')))
+        if (results[0][0] !== 'ok') { throw results[0] }
+        if (results[1][0] !== 'ok') { throw results[1] }
+        if (uint(results[0][1]) !== 0x2An) { throw results[0][1] }
+        if (uint(results[1][1]) !== 0x15n) { throw results[1][1] }
     },
     now: () => {
         const [_, result] = virtual({ ...emptyState, epochNs: 1_000_000 })(now())

--- a/fs/json/parser/proof.f.ts
+++ b/fs/json/parser/proof.f.ts
@@ -226,6 +226,12 @@ export const proof = {
             if (result !== '["error","unexpected token"]') { throw result }
         },
         () => {
+            const tokenList = tokenizeString('{"a":1 "b":2}')
+            const obj = parse(tokenList)
+            const result = stringify(obj)
+            if (result !== '["error","unexpected token"]') { throw result }
+        },
+        () => {
             const tokenList = tokenizeString('[{]}')
             const obj = parse(tokenList)
             const result = stringify(obj)


### PR DESCRIPTION
- fs/effects/node/proof.f.ts: add test for the `both` function which
  combines two effects into a result tuple via `all`; this covers
  lines 38-39 (previously 0% function coverage on `both`)
- fs/json/parser/proof.f.ts: add invalid test for {"a":1 "b":2} which
  reaches parseObjectNextOp with a non-separator token after an object
  value, covering line 192 (previously uncovered branch)

Overall coverage: line 99.75→99.77, branch 97.13→97.20, funcs 99.29→99.37

https://claude.ai/code/session_01HeaWwAfddTXBGRVhzyNrra