### PR TITLE
test: add coverage for repeat1Plus and setProperty edge cases

### DIFF
--- a/fs/bnf/proof.f.ts
+++ b/fs/bnf/proof.f.ts
@@ -7,6 +7,7 @@ import {
     commaJoin0Plus,
     isEmpty,
     oneEncode,
+    repeat1Plus,
     type Rule,
 } from './module.f.ts'
 
@@ -59,6 +60,20 @@ export const proof = {
         () => {
             const f: Rule = () => ''
             if (!isEmpty(f)) { throw 'function returning empty string should be empty' }
+        },
+    ],
+    repeat1Plus: [
+        () => {
+            const result = repeat1Plus('x')
+            if (result[0] !== 'x') { throw result[0] }
+            if (typeof result[1] !== 'function') { throw 'expected repeat0Plus function' }
+        },
+        () => {
+            const rule: Rule = 'ab'
+            const result = repeat1Plus(rule)
+            if (result[0] !== rule) { throw result[0] }
+            const inner = result[1]()
+            if (!('some' in inner) || !('none' in inner)) { throw 'expected Option shape' }
         },
     ],
 }

--- a/fs/json/proof.f.ts
+++ b/fs/json/proof.f.ts
@@ -3,9 +3,26 @@ import { sort } from '../types/object/module.f.ts'
 import { identity } from '../types/function/module.f.ts'
 
 export const proof = {
-    setProperty: () => {
-        if (setProperty("Hello")([])({}) !== "Hello") { throw 'error' }
-    },
+    setProperty: [
+        () => {
+            if (setProperty("Hello")([])({}) !== "Hello") { throw 'error' }
+        },
+        () => {
+            // src === null: should treat as empty object
+            const x = stringify(sort)(setProperty("Hello")(['a'])(null))
+            if (x !== '{"a":"Hello"}') { throw x }
+        },
+        () => {
+            // typeof src !== 'object': primitive src treated as empty object
+            const x = stringify(sort)(setProperty("Hello")(['a'])(42 as unknown as null))
+            if (x !== '{"a":"Hello"}') { throw x }
+        },
+        () => {
+            // src instanceof Array: array src treated as empty object
+            const x = stringify(sort)(setProperty("Hello")(['a'])([1, 2] as unknown as null))
+            if (x !== '{"a":"Hello"}') { throw x }
+        },
+    ],
     stringify: [
         {
             sort: () => {


### PR DESCRIPTION
- fs/bnf/proof.f.ts: add tests for repeat1Plus, covering the previously
  uncovered line 241 in bnf/module.f.ts (function was exported but never
  called); brings bnf/module.f.ts to 100% line/branch/function coverage
- fs/json/proof.f.ts: extend setProperty tests to cover the three
  branches of `src === null || typeof src !== 'object' || src instanceof
  Array` in json/module.f.ts with null, primitive, and array src values;
  brings json/module.f.ts to 100% branch coverage (was 95.45%)

Overall: line 99.77→99.78, branch 97.17→97.20, funcs 99.37→99.44

https://claude.ai/code/session_01Vfj4nHgF2YBJZ6Lyt6Hxdp