### PR TITLE
test: improve branch coverage in asn.1 and virtual modules

### DIFF
--- a/fs/asn.1/proof.f.ts
+++ b/fs/asn.1/proof.f.ts
@@ -1,4 +1,4 @@
-import { empty, length, msb, uint, unpack, vec, vec8, type Vec } from "../types/bit_vec/module.f.ts"
+import { empty, isVec, length, msb, uint, unpack, vec, vec8, type Vec } from "../types/bit_vec/module.f.ts"
 import { asBase } from "../types/nominal/module.f.ts"
 import {
     decodeRaw,
@@ -251,6 +251,15 @@ export const proof = {
             assertEq(decoded[2], 840n)
             assertEq(decoded[3], 113549n)
         },
+    },
+    unknownTag: () => {
+        // bitString (0x03) is not in SupportedRecord, exercises the default case in rawToRecord
+        const raw = encodeRaw([0x03n, vec8(0x42n)])
+        const [decoded, rest] = decode(raw)
+        if (!isVec(decoded)) { throw 'expected UnsupportedRecord (Vec)' }
+        if (rest !== empty) { throw 'expected empty rest' }
+        // Re-encoding an UnsupportedRecord returns it unchanged (it is already the TLV bytes)
+        if (encode(decoded) !== raw) { throw 'encode should round-trip UnsupportedRecord' }
     },
     raw: [
         () => {

--- a/fs/effects/node/virtual/proof.f.ts
+++ b/fs/effects/node/virtual/proof.f.ts
@@ -1,0 +1,62 @@
+import { assertEq } from '../../../asserts/module.f.ts'
+import { rm, writeFile, readFile, readdir, import_ } from '../module.f.ts'
+import { vec8 } from '../../../types/bit_vec/module.f.ts'
+import { emptyState, virtual, type Dir, type JsModule } from './module.f.ts'
+
+export const proof = {
+    rm: {
+        success: () => {
+            const root: Dir = { 'a.txt': vec8(0x42n) }
+            const [, result] = virtual({ ...emptyState, root })(rm('a.txt'))
+            assertEq(result[0], 'ok')
+        },
+        notFound: () => {
+            const [, result] = virtual(emptyState)(rm('notexist.txt'))
+            assertEq(result[0], 'error')
+        },
+        isDirectory: () => {
+            const inner: Dir = {}
+            const root: Dir = { 'mydir': inner }
+            const [, result] = virtual({ ...emptyState, root })(rm('mydir'))
+            assertEq(result[0], 'error')
+        },
+    },
+    writeFileOnDirectory: () => {
+        const inner: Dir = {}
+        const root: Dir = { 'mydir': inner }
+        const [, result] = virtual({ ...emptyState, root })(writeFile('mydir', vec8(0x42n)))
+        assertEq(result[0], 'error')
+    },
+    readdirRecursive: () => {
+        const file = vec8(0x42n)
+        const sub: Dir = { 'file.txt': file }
+        const outer: Dir = { 'sub': sub }
+        const root: Dir = { 'mydir': outer }
+        const [, result] = virtual({ ...emptyState, root })(readdir('mydir', { recursive: true }))
+        assertEq(result[0], 'ok')
+        if (result[0] !== 'ok') { throw result }
+        assertEq(result[1].length, 2)
+    },
+    readFileIntoDir: () => {
+        // 'a/b' where both 'a' and 'b' are directories
+        // hits path.length === 0 in operation's f and path.length !== 1 in readFile op
+        const inner: Dir = {}
+        const outer: Dir = { 'b': inner }
+        const root: Dir = { 'a': outer }
+        const [, result] = virtual({ ...emptyState, root })(readFile('a/b'))
+        assertEq(result[0], 'error')
+    },
+    importNonModule: () => {
+        // import_ on a Vec (not a JsModule) covers typeof entry !== 'function' branch
+        const root: Dir = { 'module.f.ts': vec8(0x42n) }
+        const [, result] = virtual({ ...emptyState, root })(import_('module.f.ts'))
+        assertEq(result[0], 'error')
+    },
+    throw: {
+        readFileOnJsModule: () => {
+            // readFile on a JsModule path covers typeof file === 'function' branch
+            const root: Dir = { 'a.f.ts': (() => ({})) as JsModule }
+            virtual({ ...emptyState, root })(readFile('a.f.ts'))
+        },
+    },
+}


### PR DESCRIPTION
- fs/asn.1/proof.f.ts: add unknownTag test covering the default case in
  rawToRecord (unknown ASN.1 tags returned as UnsupportedRecord/Vec)
- fs/effects/node/virtual/proof.f.ts: new proof file with tests for:
  - rm success/notFound/isDirectory operations
  - writeFile on a directory (error path)
  - readdir with recursive option
  - readFile into a directory path
  - import_ on a non-JsModule Vec (typeof entry !== 'function' branch)
  - readFile on a JsModule path (typeof file === 'function' throw branch)

Coverage improvements:
  fs/asn.1/module.f.ts: branch 92.86% → 96.49%
  fs/effects/node/virtual/module.f.ts: branch 86.76% → 89.86%
  all files: branch 97.20% → 97.34%

https://claude.ai/code/session_015SUy7Qtv6heWrmkdc4cGPw