### PR TITLE
asn.1: extract decodeAll unfold for "drain Vec until empty"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `asn.1`: extract a private generic `decodeAll<T>(step)` helper that drains a `Vec` by repeatedly applying a `(Vec) => [T, Vec]` step until empty; rewrite `decodeObjectIdentifier` and `decodeSequence` through it instead of two near-identical `let`/`while` accumulators — pure refactor, behavior-identical (i189-asn1-decode-all-unfold) [#1041](https://github.com/functionalscript/functionalscript/pull/1041)
 - `types/bigfloat`: factor the abs/sign/`multiply` envelope of `round53` and `decToBin`'s negative-exponent branch into a private `withSign` combinator ("operate on the magnitude, restore the sign") — pure refactor, behavior-identical (i191-bigfloat-with-sign) [#1022](https://github.com/functionalscript/functionalscript/pull/1022)
 - `types/bigfloat`: collapse the private `increaseMantissa` / `decreaseMantissa` mirror into a single `normalizeMantissa` factory parameterized by shift direction, exponent delta, and stop predicate — pure refactor, behavior-identical (i177-bigfloat-normalize-mantissa) [#1021](https://github.com/functionalscript/functionalscript/pull/1021)
 - `text/utf8`: define the UTF-8 tag/payload-mask constants (`contTag`/`contMask`, `lead2Tag`–`lead4Tag`/`Mask`) and `contByte` / `contPayload` helpers once at module scope and rewrite the encoder/decoder through them — pure refactor, byte-identical behaviour (i666-utf8-continuation-helpers) [#1020](https://github.com/functionalscript/functionalscript/pull/1020)

--- a/fs/asn.1/module.f.ts
+++ b/fs/asn.1/module.f.ts
@@ -217,19 +217,24 @@ export const encodeObjectIdentifier = (oid: ObjectIdentifier): Vec => {
     return listToVec([vec8(firstByte), ...rest.map(b128encode)])
 }
 
+/**
+ * Drains a bit vector by repeatedly applying a step until the vector is empty,
+ * collecting every decoded item into an array.
+ */
+const decodeAll = <T>(step: (v: Vec) => readonly [T, Vec]) => (v: Vec): readonly T[] => {
+    let result: readonly T[] = []
+    while (length(v) !== 0n) {
+        const [item, rest] = step(v)
+        result = [...result, item]
+        v = rest
+    }
+    return result
+}
+
 /** Decodes an OBJECT IDENTIFIER value. */
 export const decodeObjectIdentifier = (v: Vec): ObjectIdentifier => {
     const [firstByte, rest] = pop8(v)
-    const first = firstByte / 40n
-    const second = firstByte % 40n
-    let result: ObjectIdentifier = [first, second]
-    let tail = rest
-    while (length(tail) > 0n) {
-        const [value, next] = b128decode(tail)
-        result = [...result, value]
-        tail = next
-    }
-    return result
+    return [firstByte / 40n, firstByte % 40n, ...decodeAll(b128decode)(rest)]
 }
 
 // sequence
@@ -245,15 +250,7 @@ export const encodeSequence: (...records: Sequence) => Vec =
     genericEncodeSequence(identity)
 
 /** Decodes a SEQUENCE payload into records. */
-export const decodeSequence = (v: Vec): Sequence => {
-    let result: readonly Record[] = []
-    while (length(v) !== 0n) {
-        const [record, rest] = decode(v)
-        result = [...result, record]
-        v = rest
-    }
-    return result
-}
+export const decodeSequence = (v: Vec): Sequence => decodeAll(decode)(v)
 
 // set
 

--- a/issues/189-asn1-decode-all-unfold.md
+++ b/issues/189-asn1-decode-all-unfold.md
@@ -1,7 +1,7 @@
 # 189. `asn.1`: a `decodeAll` unfold for "consume a `Vec` until empty"
 
 **Priority:** P3
-**Status:** open
+**Status:** done
 
 Two `asn.1` decoders grow an array by applying a `(Vec) => [item, Vec]` step until
 the input vector is exhausted — the same imperative unfold, written twice:


### PR DESCRIPTION
## Summary

- `fs/asn.1`: `decodeObjectIdentifier` and `decodeSequence` shared an imperative `while (length(v) !== 0n)` loop that applies a step `(Vec) => [item, Vec]` and accumulates items. Hoist the loop into a private generic helper `decodeAll<T>(step)` and rewrite both decoders through it.
- Resolves [i189-asn1-decode-all-unfold](../blob/main/issues/189-asn1-decode-all-unfold.md). Pure refactor: behavior-identical, full proof coverage remains in `fs/asn.1/proof.f.ts` (`encodeDecode.sequence`, `encodeDecode.set`, `objectIdentifier.simple`, `objectIdentifier.withArc`).

## Test plan

- [x] `npx tsc` clean.
- [x] `node ./fs/fjs/module.ts t fs/asn.1` — 1719 / 1719 passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_0183Fg63i7qPMbFKtJHyduGp)_