### PR TITLE
Update dependencies: FunctionalScript, wasmtime, tsgo, and @types/node

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "functionalscript",
       "devDependencies": {
         "@playwright/test": "1.60.0",
-        "@types/node": "25.9.2",
+        "@types/node": "25.9.3",
         "typescript": "6.0.3",
       },
     },
@@ -14,7 +14,7 @@
   "packages": {
     "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
 
-    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+    "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 

--- a/deno.lock
+++ b/deno.lock
@@ -2,7 +2,7 @@
   "version": "5",
   "specifiers": {
     "npm:@playwright/test@1.60.0": "1.60.0",
-    "npm:@types/node@25.9.2": "25.9.2",
+    "npm:@types/node@25.9.3": "25.9.3",
     "npm:typescript@6.0.3": "6.0.3"
   },
   "npm": {
@@ -13,8 +13,8 @@
       ],
       "bin": true
     },
-    "@types/node@25.9.2": {
-      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+    "@types/node@25.9.3": {
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "dependencies": [
         "undici-types"
       ]
@@ -50,7 +50,7 @@
     "packageJson": {
       "dependencies": [
         "npm:@playwright/test@1.60.0",
-        "npm:@types/node@25.9.2",
+        "npm:@types/node@25.9.3",
         "npm:typescript@6.0.3"
       ]
     }

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -25,7 +25,7 @@ export const images = {
 // published FunctionalScript release; do not tie it to package.json's current
 // in-repo version. A separate maintenance job advances this pin.
 // https://www.npmjs.com/package/functionalscript
-export const functionalscript = '0.29.1' as const
+export const functionalscript = '0.30.0' as const
 
 // https://bun.sh/
 export const bun = '1.3.14'
@@ -44,13 +44,13 @@ export const node = {
 } as const
 
 // https://github.com/bytecodealliance/wasmtime/releases
-export const wasmtime = '45.0.0'
+export const wasmtime = '45.0.1'
 
 // https://github.com/wasmerio/wasmer/releases
 export const wasmer = '7.1.0'
 
 // https://www.npmjs.com/package/@typescript/native-preview?activeTab=versions
-export const tsgo = '7.0.0-dev.20260609.1'
+export const tsgo = '7.0.0-dev.20260611.2'
 
 // GitHub Action versions used by CI step builders. The key is the action
 // `owner/name`; call sites compose the full ref as

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@playwright/test": "1.60.0",
-        "@types/node": "25.9.2",
+        "@types/node": "25.9.3",
         "typescript": "6.0.3"
       },
       "engines": {
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.9.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
-      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "homepage": "https://github.com/functionalscript/functionalscript#readme",
   "devDependencies": {
     "@playwright/test": "1.60.0",
-    "@types/node": "25.9.2",
+    "@types/node": "25.9.3",
     "typescript": "6.0.3"
   }
 }


### PR DESCRIPTION
## Summary
This PR updates several development and runtime dependencies to their latest versions.

## Key Changes
- **FunctionalScript**: Updated from `0.29.1` to `0.30.0`
- **wasmtime**: Updated from `45.0.0` to `45.0.1`
- **tsgo**: Updated from `7.0.0-dev.20260609.1` to `7.0.0-dev.20260611.2`
- **@types/node**: Updated from `25.9.2` to `25.9.3`

## Details
All updates are patch or pre-release version bumps that include bug fixes and improvements from upstream projects. The FunctionalScript update is a minor version bump that may include new features or enhancements.

https://claude.ai/code/session_01Rtoj9Dra7hiCv9Lw2xgGTp