### PR TITLE
Add three refactoring issues: fsc punctuation, djs serializer, sorted_list

### DIFF
--- a/issues/66B-djs-serializer-shared-ref-predicate.md
+++ b/issues/66B-djs-serializer-shared-ref-predicate.md
@@ -1,0 +1,101 @@
+# 66B-djs-serializer-shared-ref-predicate. `djs/serializer`: name the "shared reference" test
+
+**Priority:** P4
+**Status:** open
+
+## Problem
+
+`fs/djs/serializer/module.f.ts` extracts repeated values into `const`
+declarations so the emitted DJS reuses them. A value is worth extracting when it
+is referenced more than once — that is the central concept of the const-hoisting
+pass — but the test for it is open-coded as a `refs.get(...)` lookup plus a
+`!== undefined && [1] > 1` guard in the two phases that need it:
+
+```ts
+// getConstants — decide which values become consts  (:42-43)
+const refCounter = refs.get(djs)
+if (refCounter !== undefined && refCounter[1] > 1 && !state.added.has(djs)) { … }
+
+// serializeWithConst — emit a reference to an already-hoisted const  (:134-136)
+const refCounter = refs.get(value)
+if (refCounter !== undefined && refCounter[1] > 1) {
+    return [`c${refCounter[0]}`]
+}
+```
+
+where the counter is `type RefCounter = readonly [number, number]` — `[index,
+count]` (`:21`). Both sites:
+
+1. look the value up in `refs`,
+2. ask the same question — "does this value have a counter, and is its `count`
+   (`[1]`) greater than 1?", and
+3. on success read the same `index` field (`[0]`) to form the const name
+   (`serializeWithConst`) or are followed by `getConstants` allocating the const.
+
+The predicate `refCounter !== undefined && refCounter[1] > 1` is the definition
+of "this value is shared / worth a const", and it is spelled out twice. A reader
+has to reconstruct that meaning from the tuple indexing at each site.
+
+## Proposal
+
+Lift the lookup-and-test into one named helper at module scope that returns the
+counter only when the value is shared, so call sites both branch on it and read
+`[0]` from the same result:
+
+```ts
+const sharedRef = (refs: Refs) => (v: Unknown): RefCounter | undefined => {
+    const rc = refs.get(v)
+    return rc !== undefined && rc[1] > 1 ? rc : undefined
+}
+```
+
+Then:
+
+```ts
+// getConstants
+if (sharedRef(refs)(djs) !== undefined && !state.added.has(djs)) { … }
+
+// serializeWithConst
+const rc = sharedRef(refs)(value)
+if (rc !== undefined) { return [`c${rc[0]}`] }
+```
+
+This names the "shared value" concept once, removes the duplicated tuple-index
+guard, and keeps the two serializer phases asking the same question through a
+single definition — so a future change to what "shared" means (e.g. a size
+threshold) lives in one place.
+
+## Why this qualifies
+
+- **DRY.** Two real consumers of the same lookup-and-test, at the second-consumer
+  bar in `AGENTS.md`. The varying part is only which map the caller already holds
+  (it is the same `refs` both times).
+- **Separation of concerns / clarity.** "Is this value referenced more than
+  once?" is the serializer's core decision; today it is expressed as raw tuple
+  indexing inline in two phases. Naming it documents the invariant that drives
+  const hoisting.
+
+## Caveats
+
+- `stringify`'s `constSerialize` (`:187-191`) also does `refs.get(entry)` but
+  there the counter is **known** to exist (the entry came from `getConstants`),
+  so it `throw`s on `undefined` and uses `[0]` unconditionally. That site is a
+  different contract (lookup-or-invariant-violation, not a shared test) and
+  should keep its own `refs.get` — don't fold it into `sharedRef`.
+- The helper returns the counter (not a `boolean`) specifically so
+  `serializeWithConst` can read `rc[0]` without a second lookup; `getConstants`
+  only needs the `!== undefined` check.
+
+## Tasks
+
+- [ ] Add the `sharedRef` helper at module scope in
+      `fs/djs/serializer/module.f.ts`.
+- [ ] Route `getConstants` and `serializeWithConst` through it.
+- [ ] Confirm `fs/djs` proofs still pass (`fjs t`) with full coverage and
+      `npx tsc` is clean.
+
+## Related
+
+- [i157-json-djs-shared-core](./157-json-djs-shared-core.md) — the shared
+  JSON/DJS value layer; this is an internal DJS-serializer cleanup independent
+  of it.

--- a/issues/66B-fsc-punctuation-token-table.md
+++ b/issues/66B-fsc-punctuation-token-table.md
@@ -1,0 +1,115 @@
+# 66B-fsc-punctuation-token-table. `fsc`: collapse 27 single-char punctuation rules into one table
+
+**Priority:** P3
+**Status:** open
+
+## Problem
+
+`fs/fsc/module.f.ts` builds the tokenizer's initial state (`init`) from a
+literal array of range rules. Most of that array is 27 single-character
+punctuation rules that are byte-identical except for the one character they
+match and emit:
+
+```ts
+// fs/fsc/module.f.ts:83-111 (excerpt)
+range('!')(() => () => [['!'], unexpectedSymbol]),
+range('"')(() => () => [['"'], unexpectedSymbol]),
+range('%')(() => () => [['%'], unexpectedSymbol]),
+range('&')(() => () => [['&'], unexpectedSymbol]),
+range("'")(() => () => [["'"], unexpectedSymbol]),
+range('(')(() => () => [['('], unexpectedSymbol]),
+// … 21 more identical rows …
+range('}')(() => () => [['}'], unexpectedSymbol]),
+range('~')(() => () => [['~'], unexpectedSymbol]),
+```
+
+Every one of these rows has the exact shape
+
+```ts
+range(C)(() => () => [[C], unexpectedSymbol])
+```
+
+— match the single ASCII character `C`, emit `C` as a one-character token, and
+fall back to `unexpectedSymbol` for whatever follows. The character `C` is the
+*only* thing that varies across all 27 rows. This is the textbook "same
+algorithm, one varying constant" shape that DRY targets, and it is the bulk of
+the file: 27 of the ~31 rules in `init` are this single pattern, so the rule
+that a character is a self-emitting punctuation token is buried under 27 copies
+of identical boilerplate.
+
+The remaining rules in the array are genuinely distinct and should stay as they
+are:
+
+- `codePointRange(one(terminal))(toInit)` — the end-of-input rule (`:81`).
+- `rangeSet(['\t', ' ', '\n', '\r'])(toInit)` — whitespace (`:82`).
+- `rangeSet(['$', '_', 'AZ', 'az'])(() => c => [[fromCharCode(c)], …])` —
+  identifier characters, which emit the *matched* code point, not a fixed
+  literal (`:85`).
+- `range('09')(() => a => [[fromCharCode(a)], …])` — digits, same (`:97`).
+
+## Proposal
+
+Name the repeated shape once as a module-scope helper (it captures no local
+state, so it belongs at module scope per `AGENTS.md`) and drive the 27 rows
+from a single string of the punctuation characters:
+
+```ts
+const single = (c: string): State<undefined> =>
+    range(c)(() => () => [[c], unexpectedSymbol])
+
+// "!\"%&'()*+,-./:;<=>?[]^`{|}~" — all 27 single-char punctuation tokens.
+// (Double-quoted so the apostrophe is literal; the backtick is fine unescaped.)
+const punctuation = "!\"%&'()*+,-./:;<=>?[]^`{|}~"
+```
+
+Then `init` becomes:
+
+```ts
+export const init: ToResult = create([
+    codePointRange(one(terminal))(toInit),
+    rangeSet(['\t', ' ', '\n', '\r'])(toInit),
+    ...[...punctuation].map(single),
+    rangeSet(['$', '_', 'AZ', 'az'])(() => c => [[fromCharCode(c)], unexpectedSymbol]),
+    range('09')(() => a => [[fromCharCode(a)], unexpectedSymbol]),
+])(undefined)
+```
+
+This collapses ~27 lines to two declarations plus one spread, with no behavioral
+change: `reduce`/`rangeMapMerge` is order-independent and each punctuation
+character still maps to its own one-character self-emitting rule.
+
+## Why this qualifies
+
+- **DRY.** 27 copies of one rule shape, far past the second-consumer bar. The
+  varying part (the character) is data; the structure is constant.
+- **Readability.** The reader sees one helper and one alphabet string instead of
+  scanning 27 near-identical rows to confirm they really are all the same. If a
+  punctuation token ever needs different handling, it stands out the moment it
+  leaves the `single`/`punctuation` set.
+- **Maintainability.** Adding or removing a punctuation token becomes a
+  one-character edit to `punctuation`, not a new hand-spelled row.
+
+## Caveats
+
+- The emitter ignores its `state` argument, so `single` is parametric in the
+  state type; annotate its result as `State<undefined>` (the type `init`'s
+  `create(...)(undefined)` fixes) so the `map` produces the array element type
+  the surrounding literal expects, rather than relying on widening.
+- `single` is intentionally limited to the *fixed-literal* punctuation rows.
+  The identifier and digit rules emit the matched code point and must keep their
+  own `rangeSet` / `range('09')` form — do not fold them into `single`.
+
+## Tasks
+
+- [ ] Add the `single` helper and `punctuation` string at module scope.
+- [ ] Replace the 27 punctuation rows in `init` with `...[...punctuation].map(single)`.
+- [ ] Confirm `fs/fsc/proof.f.ts` still passes (`fjs t`) with full branch
+      coverage and `npx tsc` is clean — the `fsc` tokenizer is exercised by
+      `fjs compile`.
+
+## Related
+
+- [i024-fsc-ts](./024-fsc-ts.md) — broader `fsc` direction; this is a localized
+  cleanup independent of it.
+- [i174-range-map-lexer](./174-range-map-lexer.md) — the range-map lexer
+  machinery (`range`, `rangeSet`, `rangeMapMerge`) these rules plug into.

--- a/issues/66B-sorted-list-cmp-reduce-factory.md
+++ b/issues/66B-sorted-list-cmp-reduce-factory.md
@@ -1,0 +1,73 @@
+# 66B-sorted-list-cmp-reduce-factory. `sorted_list`: share the compare-and-select reduce shape
+
+**Priority:** P5
+**Status:** open
+
+## Problem
+
+`fs/types/sorted_list/module.f.ts` defines two `ReduceOp<T, null>` constructors
+for `genericMerge` that are identical except for the value they place in the
+first tuple slot:
+
+```ts
+// :48-51
+const cmpReduce = <T>(cmp: Cmp<T>): CmpReduceOp<T> => () => a => b => {
+    const sign = cmp(a)(b)
+    return [sign === 1 ? b : a, sign, null]
+}
+
+// :57-60
+const intersectReduce = <T>(cmp: Cmp<T>): ReduceOp<T, null> => () => a => b => {
+    const sign = cmp(a)(b)
+    return [sign === 0 ? a : null, sign, null]
+}
+```
+
+Both share the entire skeleton — the `() => a => b =>` shape, the
+`const sign = cmp(a)(b)` comparison, and the `[…, sign, null]` return envelope.
+They differ only in how the first element is selected from `sign`/`a`/`b`:
+`merge` keeps the larger (`sign === 1 ? b : a`), `intersect` keeps the equal one
+or drops it (`sign === 0 ? a : null`).
+
+## Proposal
+
+Factor the shared skeleton into one factory parameterized by the selector,
+deriving both reducers point-free:
+
+```ts
+const cmpReduceBy = <T>(select: (sign: Sign, a: T, b: T) => Nullable<T>) =>
+    (cmp: Cmp<T>): ReduceOp<T, null> => () => a => b => {
+        const sign = cmp(a)(b)
+        return [select(sign, a, b), sign, null]
+    }
+
+const cmpReduce = cmpReduceBy<unknown>((sign, a, b) => sign === 1 ? b : a)
+const intersectReduce = cmpReduceBy<unknown>((sign, a, b) => sign === 0 ? a : null)
+```
+
+The compare-and-thread-`sign` mechanics live once; only the per-operation
+selection rule remains at each derivation, which is the genuine difference
+between "merge" and "intersect".
+
+## Why this is filed at P5
+
+This is borderline against the `AGENTS.md` "readability over DRY for short, clear
+functions" guidance — the originals are three lines each and already readable,
+and the `select` callback adds an indirection a reader must follow. It is the
+same caliber as [i66A-emergent-add-result](./66A-emergent-add-result.md) (two
+near-identical updaters differing in one slot), filed at the same low priority:
+worth doing if the file is being touched anyway, or as a prerequisite if a third
+sign-driven merge reducer is added (e.g. set difference), but not on its own.
+
+## Tasks
+
+- [ ] Add `cmpReduceBy` and derive `cmpReduce` / `intersectReduce` from it.
+- [ ] Confirm `fs/types/sorted_list/proof.f.ts` still passes (`fjs t`) with full
+      branch coverage and `npx tsc` is clean.
+
+## Related
+
+- [i180-sorted-set-intersect-symmetry](./180-sorted-set-intersect-symmetry.md) —
+  adjacent sorted-collection merge/intersect cleanup.
+- [i66A-emergent-add-result](./66A-emergent-add-result.md) — the same
+  "two updaters differing in one slot" pattern, filed at the same priority.


### PR DESCRIPTION
This PR adds three new refactoring issues to the backlog, each targeting localized code cleanup opportunities in different modules.

## Summary

Three new issues have been filed documenting refactoring opportunities that apply the DRY principle to reduce boilerplate and improve maintainability:

## Issues Added

- **66B-fsc-punctuation-token-table**: Collapse 27 nearly-identical single-character punctuation tokenizer rules in `fs/fsc/module.f.ts` into a data-driven approach using a helper function and a punctuation character string. This reduces ~27 lines of boilerplate to two declarations plus a spread operator with no behavioral change.

- **66B-djs-serializer-shared-ref-predicate**: Extract the repeated "is this value shared?" test in `fs/djs/serializer/module.f.ts` into a named `sharedRef` helper. The same lookup-and-guard pattern appears twice across `getConstants` and `serializeWithConst`; naming it documents the core const-hoisting invariant and eliminates duplicated tuple indexing.

- **66B-sorted-list-cmp-reduce-factory**: Factor the shared skeleton of two nearly-identical `ReduceOp` constructors in `fs/types/sorted_list/module.f.ts` into a parameterized factory `cmpReduceBy`. Both `cmpReduce` and `intersectReduce` share the compare-and-thread mechanics; only the selection rule differs.

## Priority Levels

- **66B-fsc-punctuation-token-table**: P3 (high-value DRY opportunity, bulk of a small file)
- **66B-djs-serializer-shared-ref-predicate**: P4 (clear concept naming, two consumers)
- **66B-sorted-list-cmp-reduce-factory**: P5 (borderline readability trade-off; worth doing if file is touched or a third reducer is added)

All three are independent, localized cleanups with no behavioral changes and clear task lists for implementation and verification.

https://claude.ai/code/session_01UJBepMY7GVWbA2bnr3EeZq