### PR TITLE
test: add coverage for html raw element children and json schema unknown thunk

### DIFF
--- a/fs/html/proof.f.ts
+++ b/fs/html/proof.f.ts
@@ -60,5 +60,10 @@ export const proof = {
             const s = htmlToString(x)
             if (s !== '<!DOCTYPE html><div id="a&lt;">const a = a&lt;b&gt;c</div>') { throw s }
         },
+        elemChild: () => {
+            const x: Element = ['script', ['span', 'ignored'], 'visible']
+            const s = htmlToString(x)
+            if (s !== '<!DOCTYPE html><script>visible</script>') { throw s }
+        },
     }
 }

--- a/fs/json/schema/proof.f.ts
+++ b/fs/json/schema/proof.f.ts
@@ -1,6 +1,6 @@
 import { boolean, number, string, bigint, unknown, array, record, or, option } from '../../types/rtti/module.f.ts'
 import { stringify, type Unknown as JsonValue } from '../module.f.ts'
-import { toJsonSchema, type Unknown } from './module.f.ts'
+import { toJsonSchema, type Unknown, unknown as schemaUnknown } from './module.f.ts'
 
 const serialize = (v: Unknown) => stringify(e => e)(v as unknown as JsonValue)
 
@@ -60,6 +60,10 @@ export const proof = {
             properties: { x: { const: null }, y: { type: 'string' } },
             required: ['x', 'y'],
         }),
+    },
+    schemaUnknownTag: () => {
+        const r = schemaUnknown()
+        if (r[0] !== 'const') { throw r[0] }
     },
     nested: {
         arrayOfRecords: eq(array(record(boolean)), {


### PR DESCRIPTION
- html: covers the raw(element)→'' branch when an Element is nested inside
  a script/style tag (previously untested path in rawMap)
- json/schema: covers unknownThunk by calling schemaUnknown() directly;
  importing it as a separate binding avoids the infinite-recursion risk of
  passing it through toJsonSchema

Branch coverage: 97.34% → 97.38% (+0.04)
Function coverage: 99.51% → 99.58% (+0.07)

https://claude.ai/code/session_01B4hqcUiRgXiJnpQmymXbjS