### PR TITLE
Add test cases for awaitIfPromise, fetch, and import_ handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `effects/node/virtual`: add proofs covering the virtual `await` handler, the `fetch` not-found branch, and the `import_` invalid-path branch [#1046](https://github.com/functionalscript/functionalscript/pull/1046)
 - `asn.1`: extract a private generic `decodeAll<T>(step)` helper that drains a `Vec` by repeatedly applying a `(Vec) => [T, Vec]` step until empty; rewrite `decodeObjectIdentifier` and `decodeSequence` through it instead of two near-identical `let`/`while` accumulators — pure refactor, behavior-identical (i189-asn1-decode-all-unfold) [#1041](https://github.com/functionalscript/functionalscript/pull/1041)
 - `types/bigfloat`: factor the abs/sign/`multiply` envelope of `round53` and `decToBin`'s negative-exponent branch into a private `withSign` combinator ("operate on the magnitude, restore the sign") — pure refactor, behavior-identical (i191-bigfloat-with-sign) [#1022](https://github.com/functionalscript/functionalscript/pull/1022)
 - `types/bigfloat`: collapse the private `increaseMantissa` / `decreaseMantissa` mirror into a single `normalizeMantissa` factory parameterized by shift direction, exponent delta, and stop predicate — pure refactor, behavior-identical (i177-bigfloat-normalize-mantissa) [#1021](https://github.com/functionalscript/functionalscript/pull/1021)

--- a/fs/effects/node/virtual/proof.f.ts
+++ b/fs/effects/node/virtual/proof.f.ts
@@ -1,5 +1,5 @@
 import { assertEq } from '../../../asserts/module.f.ts'
-import { rm, writeFile, readFile, readdir, import_ } from '../module.f.ts'
+import { awaitIfPromise, fetch, rm, writeFile, readFile, readdir, import_ } from '../module.f.ts'
 import { vec8 } from '../../../types/bit_vec/module.f.ts'
 import { emptyState, virtual, type Dir, type JsModule } from './module.f.ts'
 
@@ -44,6 +44,22 @@ export const proof = {
         const outer: Dir = { 'b': inner }
         const root: Dir = { 'a': outer }
         const [, result] = virtual({ ...emptyState, root })(readFile('a/b'))
+        assertEq(result[0], 'error')
+    },
+    awaitNonPromise: () => {
+        // a non-promise value passes through the virtual `await` handler as-is
+        const [, result] = virtual(emptyState)(awaitIfPromise(42))
+        assertEq(result, 42)
+    },
+    fetchNotFound: () => {
+        // covers the `result === undefined` branch of the `fetch` handler
+        const [, result] = virtual(emptyState)(fetch('https://example.com/missing'))
+        assertEq(result[0], 'error')
+    },
+    importNestedPath: () => {
+        // import_ on a path whose parent does not exist covers the
+        // path.length !== 1 branch of the import_ op
+        const [, result] = virtual(emptyState)(import_('a/b'))
         assertEq(result[0], 'error')
     },
     importNonModule: () => {


### PR DESCRIPTION
## Summary
This PR adds three new test cases to the proof module to improve code coverage of virtual effect handlers.

## Key Changes
- **awaitNonPromise test**: Verifies that non-promise values pass through the virtual `await` handler unchanged
- **fetchNotFound test**: Tests the error handling path when a fetch request returns undefined (covers the `result === undefined` branch)
- **importNestedPath test**: Tests import_ behavior on nested paths where parent directories don't exist (covers the `path.length !== 1` branch)
- Updated imports to include `awaitIfPromise` and `fetch` functions needed by the new tests

## Implementation Details
All three tests follow the existing pattern of using the `virtual` function with `emptyState` to verify handler behavior and assert expected results. The tests are positioned before the existing `importNonModule` test to maintain logical grouping of import-related tests.

https://claude.ai/code/session_01DWHbxYxAtRgXuLSSnrJ6HL