### PR TITLE
Add proof tests for CLI commands and module execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `fjs`: add a `proof.f.ts` covering the CLI command handlers (help output, the `compile` missing-argument error path, and the `run` handler's import-and-invoke and import-failure paths) via the virtual Node-effect interpreter [#1047](https://github.com/functionalscript/functionalscript/pull/1047)
 - `effects/node/virtual`: add proofs covering the virtual `await` handler, the `fetch` not-found branch, and the `import_` invalid-path branch [#1046](https://github.com/functionalscript/functionalscript/pull/1046)
 - `asn.1`: extract a private generic `decodeAll<T>(step)` helper that drains a `Vec` by repeatedly applying a `(Vec) => [T, Vec]` step until empty; rewrite `decodeObjectIdentifier` and `decodeSequence` through it instead of two near-identical `let`/`while` accumulators — pure refactor, behavior-identical (i189-asn1-decode-all-unfold) [#1041](https://github.com/functionalscript/functionalscript/pull/1041)
 - `types/bigfloat`: factor the abs/sign/`multiply` envelope of `round53` and `decToBin`'s negative-exponent branch into a private `withSign` combinator ("operate on the magnitude, restore the sign") — pure refactor, behavior-identical (i191-bigfloat-with-sign) [#1022](https://github.com/functionalscript/functionalscript/pull/1022)

--- a/fs/fjs/proof.f.ts
+++ b/fs/fjs/proof.f.ts
@@ -1,0 +1,44 @@
+import { assert, assertEq } from '../asserts/module.f.ts'
+import { pure } from '../effects/module.f.ts'
+import type { NodeProgram, NodeProgramOptions } from '../effects/node/module.f.ts'
+import { emptyState, virtual, type Dir } from '../effects/node/virtual/module.f.ts'
+import { main } from './module.f.ts'
+
+const makeOptions = (args: readonly string[]): NodeProgramOptions => ({
+    args,
+    env: {},
+    std: { stdout: { isTTY: false }, stderr: { isTTY: false } },
+    testContext: { test: async () => {} },
+    bunTestContext: { test: async () => {} },
+    playwrightTestContext: { test: async () => {} },
+    engine: 'node' as const,
+})
+
+const run = (root: Dir) => (args: readonly string[]) =>
+    virtual({ ...emptyState, root })(main(makeOptions(args)))
+
+const appMain: NodeProgram = ({ args }) => pure(args.length)
+
+export const proof = {
+    help: () => {
+        const [state, code] = run({})(['help'])
+        assertEq(code, 0)
+        assert(state.stdout.includes('compile'), 'expected command list in stdout')
+    },
+    compileRequiresArgs: () => {
+        const [state, code] = run({})(['compile'])
+        assertEq(code, 1)
+        assert(state.stderr.length !== 0, 'expected error in stderr')
+    },
+    runModule: () => {
+        const root: Dir = { 'app.f.ts': () => ({ main: appMain }) }
+        const [, code] = run(root)(['run', 'app.f.ts', 'x', 'y'])
+        // `run` strips the command and file name, so `main` sees two arguments
+        assertEq(code, 2)
+    },
+    throw: {
+        runImportError: () => {
+            run({})(['run', 'missing.f.ts'])
+        },
+    },
+}


### PR DESCRIPTION
## Summary
Added a new proof test module (`proof.f.ts`) that validates the core functionality of the CLI application, including help output, command argument validation, and module execution.

## Key Changes
- Created `fs/fjs/proof.f.ts` with a comprehensive test suite covering:
  - **Help command**: Verifies that the help command returns exit code 0 and includes command documentation in stdout
  - **Argument validation**: Ensures the compile command fails with exit code 1 when required arguments are missing
  - **Module execution**: Tests the `run` command's ability to load and execute modules, verifying argument passing behavior
  - **Error handling**: Validates that missing module imports are properly caught and reported

## Implementation Details
- Leverages the virtual file system (`virtual` module) to test CLI behavior without actual file I/O
- Uses helper functions (`makeOptions`, `run`) to reduce boilerplate in test cases
- Tests verify both exit codes and output streams (stdout/stderr) to ensure proper error reporting
- The `runModule` test demonstrates that the CLI correctly strips command and filename arguments before passing remaining args to the module's main function

https://claude.ai/code/session_01DuHJgGXuosJugCiQtzQgNL