### PR TITLE
Refactor punctuation token rules into data-driven table

### DIFF
--- a/fs/fsc/module.f.ts
+++ b/fs/fsc/module.f.ts
@@ -77,36 +77,15 @@ export const terminal = -1
 const toInit: () => ToResult
     = () => () => [[], init]
 
+const single = (c: string): State<undefined> =>
+    range(c)(() => () => [[c], unexpectedSymbol])
+
+const punctuation = "!\"%&'()*+,-./:;<=>?[]^`{|}~"
+
 export const init: ToResult = create([
     codePointRange(one(terminal))(toInit),
     rangeSet(['\t', ' ', '\n', '\r'])(toInit),
-    range('!')(() => () => [['!'], unexpectedSymbol]),
-    range('"')(() => () => [['"'], unexpectedSymbol]),
     rangeSet(['$', '_', 'AZ', 'az'])(() => c => [[fromCharCode(c)], unexpectedSymbol]),
-    range('%')(() => () => [['%'], unexpectedSymbol]),
-    range('&')(() => () => [['&'], unexpectedSymbol]),
-    range("'")(() => () => [["'"], unexpectedSymbol]),
-    range('(')(() => () => [['('], unexpectedSymbol]),
-    range(')')(() => () => [[')'], unexpectedSymbol]),
-    range('*')(() => () => [['*'], unexpectedSymbol]),
-    range('+')(() => () => [['+'], unexpectedSymbol]),
-    range(',')(() => () => [[','], unexpectedSymbol]),
-    range('-')(() => () => [['-'], unexpectedSymbol]),
-    range('.')(() => () => [['.'], unexpectedSymbol]),
-    range('/')(() => () => [['/'], unexpectedSymbol]),
     range('09')(() => a => [[fromCharCode(a)], unexpectedSymbol]),
-    range(':')(() => () => [[':'], unexpectedSymbol]),
-    range(';')(() => () => [[';'], unexpectedSymbol]),
-    range('<')(() => () => [['<'], unexpectedSymbol]),
-    range('=')(() => () => [['='], unexpectedSymbol]),
-    range('>')(() => () => [['>'], unexpectedSymbol]),
-    range('?')(() => () => [['?'], unexpectedSymbol]),
-    range('[')(() => () => [['['], unexpectedSymbol]),
-    range(']')(() => () => [[']'], unexpectedSymbol]),
-    range('^')(() => () => [['^'], unexpectedSymbol]),
-    range('`')(() => () => [['`'], unexpectedSymbol]),
-    range('{')(() => () => [['{'], unexpectedSymbol]),
-    range('|')(() => () => [['|'], unexpectedSymbol]),
-    range('}')(() => () => [['}'], unexpectedSymbol]),
-    range('~')(() => () => [['~'], unexpectedSymbol]),
+    ...[...punctuation].map(single),
 ])(undefined)

--- a/fs/fsc/module.f.ts
+++ b/fs/fsc/module.f.ts
@@ -80,7 +80,7 @@ const toInit: () => ToResult
 const single = (c: string): State<undefined> =>
     range(c)(() => () => [[c], unexpectedSymbol])
 
-const punctuation = "!\"%&'()*+,-./:;<=>?[]^`{|}~"
+const punctuation = "!\"%&'()*+,-./:;<=>?[]^`{|}~" as const
 
 export const init: ToResult = create([
     codePointRange(one(terminal))(toInit),

--- a/issues/66B-fsc-punctuation-token-table.md
+++ b/issues/66B-fsc-punctuation-token-table.md
@@ -1,7 +1,7 @@
 # 66B-fsc-punctuation-token-table. `fsc`: collapse 27 single-char punctuation rules into one table
 
 **Priority:** P3
-**Status:** open
+**Status:** done
 
 ## Problem
 
@@ -101,9 +101,9 @@ character still maps to its own one-character self-emitting rule.
 
 ## Tasks
 
-- [ ] Add the `single` helper and `punctuation` string at module scope.
-- [ ] Replace the 27 punctuation rows in `init` with `...[...punctuation].map(single)`.
-- [ ] Confirm `fs/fsc/proof.f.ts` still passes (`fjs t`) with full branch
+- [x] Add the `single` helper and `punctuation` string at module scope.
+- [x] Replace the 27 punctuation rows in `init` with `...[...punctuation].map(single)`.
+- [x] Confirm `fs/fsc/proof.f.ts` still passes (`fjs t`) with full branch
       coverage and `npx tsc` is clean — the `fsc` tokenizer is exercised by
       `fjs compile`.
 


### PR DESCRIPTION
## Summary
Refactored 27 individual punctuation character rules in the FSC tokenizer into a single data-driven approach, improving code maintainability and reducing duplication.

## Changes
- **Added helper function `single`**: A reusable function that creates a state rule for a single character, returning the character and an `unexpectedSymbol` error
- **Added `punctuation` constant**: A string containing all 27 punctuation characters that need tokenization rules
- **Replaced 27 individual rules**: Consolidated 27 separate `range()` calls (one per punctuation character) into a single spread expression that maps over the punctuation string: `...[...punctuation].map(single)`

## Implementation Details
The refactoring maintains identical behavior while significantly reducing code volume:
- Each punctuation character still maps to its own one-character self-emitting rule
- The `single` helper abstracts the common pattern: `range(c)(() => () => [[c], unexpectedSymbol])`
- The punctuation string is defined as: `"!\"%&'()*+,-./:;<=>?[]^`{|}~"`
- All tests pass with full branch coverage and clean TypeScript compilation

This change addresses issue #66B by collapsing the token table from 27 explicit rules into a maintainable, data-driven structure.

https://claude.ai/code/session_0179RaNrFEyLTkarz2kV6bVF