### PR TITLE
Add readUtf8File/writeUtf8File helpers to fs/effects/node (i198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `effects/node`: add `readUtf8File`/`writeUtf8File` helpers next to the `readFile`/`writeFile` effects — `readUtf8File` decodes a file as UTF-8 text while preserving the `IoResult` for caller-side error handling, `writeUtf8File` encodes a string and writes it; migrate the open-coded UTF-8 sandwiches in `djs/transpiler` (read), `djs` compile output and `ci` (write) to the helpers (i198-utf8-file-effects) [#1052](https://github.com/functionalscript/functionalscript/pull/1052)
 - `effects/node`: drop the private `Io` indirection from the node effect runner — inline the single handler table into a module-level `asyncRun({ … })` wired straight to the Node globals, delete the dead `Io`/`App`/`Run` types and the `io` members the interpreter never read (`console`, `tryCatch`, `asyncTryCatch`, `performance`); pure refactor, `run`/`runEffect` unchanged (i664-drop-io-interface) [#1051](https://github.com/functionalscript/functionalscript/pull/1051)
 - `fjs`: add a `proof.f.ts` covering the CLI command handlers (help output, the `compile` missing-argument error path, and the `run` handler's import-and-invoke and import-failure paths) via the virtual Node-effect interpreter [#1047](https://github.com/functionalscript/functionalscript/pull/1047)
 - `effects/node/virtual`: add proofs covering the virtual `await` handler, the `fetch` not-found branch, and the `import_` invalid-path branch [#1046](https://github.com/functionalscript/functionalscript/pull/1046)

--- a/fs/ci/module.f.ts
+++ b/fs/ci/module.f.ts
@@ -3,9 +3,8 @@
  *
  * @module
  */
-import { utf8 } from '../text/module.f.ts'
 import { pure, type Effect } from '../effects/module.f.ts'
-import { access, writeFile, type NodeOp } from '../effects/node/module.f.ts'
+import { access, writeUtf8File, type NodeOp } from '../effects/node/module.f.ts'
 import { functionalscript, images } from './config/module.f.ts'
 import { type Architecture, type GitHubAction, type Job, type Jobs, type MetaStep, type Os, architecture, os, toSteps, ubuntuArm } from './common/module.f.ts'
 import { rustPlatformSteps, rustWasmSteps } from './rust/module.f.ts'
@@ -58,7 +57,7 @@ export const ci = ({ nodeExtra }: Setup): Effect<NodeOp, number> =>
             },
             jobs,
         }
-        return writeFile('.github/workflows/ci.yml', utf8(JSON.stringify(gha, null, '  ')))
+        return writeUtf8File('.github/workflows/ci.yml', JSON.stringify(gha, null, '  '))
             .step(() => pure(0))
     })
 

--- a/fs/djs/module.f.ts
+++ b/fs/djs/module.f.ts
@@ -9,12 +9,11 @@ import { stringify, stringifyAsTree } from './serializer/module.f.ts'
 import { sort } from '../types/object/module.f.ts'
 import { type Effect, pure } from '../effects/module.f.ts'
 import {
-    writeFile,
+    writeUtf8File,
     type WriteFile, type ReadFile,
     type Write,
     error,
 } from '../effects/node/module.f.ts'
-import { utf8 } from '../text/module.f.ts'
 
 export type Object = {
    readonly [k in string]: Unknown
@@ -45,7 +44,7 @@ export const compile: (args: readonly string[]) => Effect<CompileOp, number>
             const content = outputFileName.endsWith('.json')
                 ? stringifyAsTree(sort)(result[1])
                 : stringify(sort)(result[1])
-            return writeFile(outputFileName, utf8(content))
+            return writeUtf8File(outputFileName, content)
                 .step(() => pure(0))
         })
     }

--- a/fs/djs/transpiler/module.f.ts
+++ b/fs/djs/transpiler/module.f.ts
@@ -13,8 +13,7 @@ import { concat as pathConcat } from '../../path/module.f.ts'
 import { type ParseError, parseFromTokens } from '../parser/module.f.ts'
 import { run, type AstModule } from '../ast/module.f.ts'
 import { type Effect, foldStep, pure } from '../../effects/module.f.ts'
-import { readFile, type ReadFile } from '../../effects/node/module.f.ts'
-import { utf8ToString } from '../../text/module.f.ts'
+import { readUtf8File, type ReadFile } from '../../effects/node/module.f.ts'
 
 /**
  * State threaded through the recursive transpilation of a DJS module graph.
@@ -47,11 +46,11 @@ const mapDjs
 
 const parseModule
     : (path: string) => Effect<ReadFile, Result<AstModule, ParseError>>
-    = path => readFile(path).step(result => {
+    = path => readUtf8File(path).step(result => {
         if (result[0] === 'error') {
             return pure(error({ message: 'file not found', metadata: null }))
         }
-        const tokens = tokenize(stringToList(utf8ToString(result[1])))(path)
+        const tokens = tokenize(stringToList(result[1]))(path)
         return pure(parseFromTokens(tokens))
     })
 

--- a/fs/effects/node/module.f.ts
+++ b/fs/effects/node/module.f.ts
@@ -1,17 +1,18 @@
 /**
  * Node.js effect operations: filesystem (`mkdir`, `readFile`, `readdir`,
- * `writeFile`, `rm`, `access`), networking (`fetch`, `createServer`, `listen`),
+ * `writeFile`, `rm`, `access`, plus the `readUtf8File`/`writeUtf8File` text
+ * helpers), networking (`fetch`, `createServer`, `listen`),
  * subprocess `exec`, `log`/`error` (wrappers over `write`), `import_`, `now`,
  * `sandbox`, `forever`, and `all`/`both` parallelism; defines the
  * `NodeOp`/`NodeProgram` types used by the Node runner.
  *
  * @module
  */
-import { utf8 } from '../../text/module.f.ts'
+import { utf8, utf8ToString } from '../../text/module.f.ts'
 import type { Vec } from '../../types/bit_vec/module.f.ts'
 import type { MemOp } from '../memory/module.f.ts'
 import type { Nominal } from '../../types/nominal/module.f.ts'
-import type { Result } from '../../types/result/module.f.ts'
+import { ok, type Result } from '../../types/result/module.f.ts'
 import {
     type Effect, type Func, type Operation, type ToAsyncOperationMap,
     do_, pure
@@ -61,6 +62,17 @@ export type ReadFile = readonly['readFile', (path: string) => IoResult<Vec>]
 export const readFile: Func<ReadFile> =
     do_('readFile')
 
+/**
+ * Reads a file as UTF-8 text.
+ *
+ * Preserves the `IoResult` instead of unwrapping so callers can pattern-match
+ * on errors (e.g. convert them into domain-specific errors) or `unwrap` at the
+ * call site.
+ */
+export const readUtf8File = (path: string): Effect<ReadFile, IoResult<string>> =>
+    readFile(path).step(r =>
+        pure(r[0] === 'ok' ? ok(utf8ToString(r[1])) : r))
+
 // readdir
 
 /**
@@ -88,6 +100,10 @@ export type WriteFile = readonly['writeFile', (path: string, data: Vec) => IoRes
 
 export const writeFile: Func<WriteFile> =
     do_('writeFile')
+
+/** Writes a string to `path` as UTF-8 bytes. */
+export const writeUtf8File = (path: string, content: string): Effect<WriteFile, IoResult<void>> =>
+    writeFile(path, utf8(content))
 
 // rm
 

--- a/fs/effects/node/proof.f.ts
+++ b/fs/effects/node/proof.f.ts
@@ -1,6 +1,7 @@
 import { empty, isVec, uint, vec8 } from "../../types/bit_vec/module.f.ts"
+import { utf8, utf8ToString } from "../../text/module.f.ts"
 import { pure } from "../module.f.ts"
-import { both, fetch, mkdir, now, readdir, readFile, rm, sandbox, writeFile } from "./module.f.ts"
+import { both, fetch, mkdir, now, readdir, readFile, readUtf8File, rm, sandbox, writeFile, writeUtf8File } from "./module.f.ts"
 import { create as memCreate, read as memRead, write as memWrite } from "../memory/module.f.ts"
 import { emptyState, virtual } from "./virtual/module.f.ts"
 
@@ -91,6 +92,20 @@ export const proof = {
             if (t !== 'error') { throw result }
             if (result !== 'no such file') { throw result }
         }
+    },
+    readUtf8File: {
+        ok: () => {
+            const [_, [t, result]] = virtual({
+                ...emptyState,
+                root: { hello: utf8('Hello, world!') },
+            })(readUtf8File('hello'))
+            if (t !== 'ok') { throw result }
+            if (result !== 'Hello, world!') { throw result }
+        },
+        noSuchFile: () => {
+            const [_, [t, result]] = virtual(emptyState)(readUtf8File('hello'))
+            if (t !== 'error') { throw result }
+        },
     },
     readdir: {
         one: () => {
@@ -189,6 +204,15 @@ export const proof = {
             const tmp = state.root.tmp
             if (tmp === undefined || isVec(tmp)) { throw tmp }
         },
+    },
+    writeUtf8File: () => {
+        const [state, [t, result]] = virtual(emptyState)(
+            writeUtf8File('hello', 'Hello, world!')
+        )
+        if (t !== 'ok') { throw result }
+        const file = state.root.hello
+        if (!isVec(file)) { throw file }
+        if (utf8ToString(file) !== 'Hello, world!') { throw file }
     },
     rm: {
         one: () => {

--- a/issues/176-json-file-effects.md
+++ b/issues/176-json-file-effects.md
@@ -1,8 +1,17 @@
 # 176. `read`/`write` JSON file effect helpers
 
 **Priority:** P3
-**Status:** open
-**Blocked by:** [i198](./198-utf8-file-effects.md)
+**Status:** on-hold
+
+> **Drift note (2026-06-12).** [i198](./198-utf8-file-effects.md) is done, so
+> this is no longer blocked — but the consumer inventory below is stale. The
+> `dev/version` module is gone and `fs/dev/module.f.ts` no longer reads or
+> writes `deno.json`. The only remaining JSON-file call site is the `ci` write
+> (`writeUtf8File('.github/workflows/ci.yml', JSON.stringify(gha, null, '  '))`),
+> which is below the second-consumer bar for extracting `writeJsonFile`, and
+> there are no production JSON-file reads at all. On hold until a second real
+> consumer appears; the design below (now a one-line composition over
+> `readUtf8File`/`writeUtf8File`) remains valid when it does.
 
 Three modules independently open-code "read a file, UTF-8 decode it, JSON-parse
 it" and "JSON-stringify a value (pretty, 2-space), UTF-8 encode it, write the

--- a/issues/198-utf8-file-effects.md
+++ b/issues/198-utf8-file-effects.md
@@ -1,7 +1,28 @@
 # 198. `effects/node`: `readUtf8File` / `writeUtf8File` helpers
 
 **Priority:** P3
-**Status:** open
+**Status:** done
+
+## Resolution
+
+Implemented `readUtf8File` and `writeUtf8File` in
+`fs/effects/node/module.f.ts`, next to `readFile`/`writeFile`.
+Notes on how reality diverged from the proposal below:
+
+- **Consumer drift.** The `dev` and `dev/version` consumers listed below
+  were refactored away before this landed. Remaining call sites migrated:
+  `djs/transpiler` (read), `djs` compile output and `ci` (write).
+- **Return shape.** `readUtf8File` returns `Effect<ReadFile, IoResult<string>>`
+  as proposed — `djs/transpiler` pattern-matches the error to build a
+  domain-specific `ParseError`. `writeUtf8File` returns
+  `Effect<WriteFile, IoResult<void>>`, not `Effect<WriteFile, void>` as
+  sketched: `writeFile` itself yields `IoResult<void>`, and the helper is a
+  transparent wrapper.
+- **No dependency cycle.** `fs/effects/node` already imported `utf8` from
+  `fs/text` (for `log`/`error`), so adding `utf8ToString` introduced no new
+  dependency edge.
+- [i176](./176-json-file-effects.md) is now unblocked, but its own consumer
+  base has eroded — see the note added there.
 
 ## Problem
 


### PR DESCRIPTION
Implements [i198-utf8-file-effects](./issues/198-utf8-file-effects.md): lifts the recurring UTF-8 ↔ file conversion sandwich into two helpers next to the `readFile`/`writeFile` effects in `fs/effects/node/module.f.ts`.

## Changes

- **`readUtf8File(path): Effect<ReadFile, IoResult<string>>`** — reads a file and decodes it as UTF-8 text. Preserves the `IoResult` (per the issue's return-shape decision) so callers can pattern-match errors or `unwrap` at the call site.
- **`writeUtf8File(path, content): Effect<WriteFile, IoResult<void>>`** — encodes a string as UTF-8 and writes it. Yields `IoResult<void>` rather than the `void` sketched in the issue, because `writeFile` itself yields `IoResult<void>` and the helper stays a transparent wrapper.
- Migrated the remaining consumers:
  - `fs/djs/transpiler/module.f.ts` — read sandwich; keeps converting the I/O error into a domain-specific `ParseError`.
  - `fs/djs/module.f.ts` — compile output write.
  - `fs/ci/module.f.ts` — `ci.yml` write.
- Proofs for both helpers in `fs/effects/node/proof.f.ts` (ok + error branches of `readUtf8File`, round-trip for `writeUtf8File`) via the virtual runner.

## Issue updates

- **i198** marked **done**, recording how reality diverged from the proposal: the `dev`/`dev/version` consumers listed in the issue were refactored away before this landed, and the write helper's actual return type is `IoResult<void>`.
- **i176** (JSON file helpers, blocked by i198) moved to **on-hold** with a drift note: it is now unblocked, but only one JSON-file call site remains in the codebase (the `ci` write) — below the second-consumer bar for extracting `writeJsonFile`.

No dependency-cycle risk: `fs/effects/node` already imported `utf8` from `fs/text` for `log`/`error`.

## Testing

- `npx tsc` — clean.
- `npm test` — 1733 pass, 0 fail, including the three new proofs.

https://claude.ai/code/session_01WBQLzq5ZmfQMSjiaRbmvw9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBQLzq5ZmfQMSjiaRbmvw9)_