### PR TITLE
Add decode/match accessors for the effect value representation (i661)

### DIFF
--- a/fs/effects/memory/proof.f.ts
+++ b/fs/effects/memory/proof.f.ts
@@ -14,7 +14,7 @@ type MemoryState = {
 const initial: MemoryState = { next: 0, values: {} }
 
 const mock: MemOperationMap<MemOp, MemoryState> = {
-    memCreate: (state, value) => {
+    memCreate: value => state => {
         const id = `k${state.next}`
         const key: Key<unknown> = asNominal(id)
         return [{
@@ -22,9 +22,9 @@ const mock: MemOperationMap<MemOp, MemoryState> = {
             values: { ...state.values, [id]: value },
         }, key]
     },
-    memRead: (state, key) =>
+    memRead: key => state =>
         [state, state.values[asBase(key)]],
-    memWrite: (state, key, value) => {
+    memWrite: (key, value) => state => {
         const id = asBase(key)
         if (!(id in state.values)) { throw id }
         return [{

--- a/fs/effects/mock/module.f.ts
+++ b/fs/effects/mock/module.f.ts
@@ -3,10 +3,15 @@
  *
  * @module
  */
-import type { Effect, Operation, Pr } from "../module.f.ts"
+import { match, type Effect, type Operation, type Pr } from "../module.f.ts"
 
+/**
+ * A synchronous, state-threading operation map. An entry takes the command's
+ * payload (fixed when the command is issued) and returns a state transition —
+ * the curried `state` parameter is data the runner supplies on each step.
+ */
 export type MemOperationMap<O extends Operation, S> = {
-    readonly [K in O[0]]: (state: S, ...payload: Pr<O, K>[0]) => readonly[S, Pr<O, K>[1]]
+    readonly [K in O[0]]: (...payload: Pr<O, K>[0]) => (state: S) => readonly[S, Pr<O, K>[1]]
 }
 
 export type RunInstance<O extends Operation, S> =
@@ -19,18 +24,16 @@ export const run =
     state =>
     effect =>
 {
+    const next = match(o)
     let s = state
     let e = effect
     while (true) {
-        const { value } = e
-        if (value.length === 1) {
-            const [v] = value
-            return [s, v]
+        const r = next(e)
+        if (r[0] === 'done') {
+            return [s, r[1]]
         }
-        const [cmd, payload, cont] = value
-        const operation = o[cmd]
-        const [ns, m] = operation(s, ...payload)
+        const [ns, m] = r[1](s)
         s = ns
-        e = cont(m)
+        e = r[2](m)
     }
 }

--- a/fs/effects/module.f.ts
+++ b/fs/effects/module.f.ts
@@ -81,6 +81,63 @@ export const forEachStep =
     (items: List<T>): Effect<O, void> =>
     foldStep((item: T) => () => f(item))(undefined)(items)
 
+/**
+ * The decoded form of an effect's next step: either a final `result`, or a
+ * `command` to perform with its `payload` and the `continuation` to resume
+ * with the command's output.
+ */
+export type Decoded<O extends Operation, T> =
+    | { readonly done: true, readonly result: T }
+    | {
+        readonly done: false,
+        readonly command: Do<O, T>[0],
+        readonly payload: Do<O, T>[1],
+        readonly continuation: Do<O, T>[2],
+    }
+
+/**
+ * Decodes an effect's next step: a pure result, or a command to perform.
+ *
+ * This is the only function that knows how `Value` is laid out (a length-1
+ * tuple for `Pure`, a `[command, payload, continuation]` tuple for `Do`).
+ * Interpreters and proofs must go through `decode` (or `match`) instead of
+ * inspecting the tuple, so the representation can change without touching
+ * them.
+ */
+export const decode = <O extends Operation, T>({ value }: Effect<O, T>): Decoded<O, T> =>
+    value.length === 1
+        ? { done: true, result: value[0] }
+        : { done: false, command: value[0], payload: value[1], continuation: value[2] }
+
+/**
+ * An operation map whose entries take a command's payload and return some
+ * output `R`. Generalizes `ToAsyncOperationMap` (`R = Promise<…>`) and the
+ * curried `MemOperationMap` (`R = (state) => [state, …]`).
+ */
+export type OperationMap<O extends Operation, R> = {
+    readonly [K in O[0]]: (...payload: Pr<O, K>[0]) => R
+}
+
+export type MatchResult<O extends Operation, T, R> =
+    | readonly['done', T]
+    | readonly['cont', R, Do<O, T>[2]]
+
+/**
+ * Decodes an effect's next step and dispatches its command to `map`,
+ * returning either the final result or the operation's output `R` paired
+ * with the continuation. The one world-specific step — `await` for async
+ * runners, state threading for sync ones — is left to the caller, so every
+ * interpreter loop is this skeleton plus a single eliminator line.
+ */
+export const match =
+    <O extends Operation, R>(map: OperationMap<O, R>) =>
+    <O1 extends O, T>(effect: Effect<O1, T>): MatchResult<O1, T, R> => {
+        const d = decode(effect)
+        return d.done
+            ? ['done', d.result]
+            : ['cont', map[d.command](...d.payload), d.continuation]
+    }
+
 export type ToAsyncOperationMap<O extends Operation> = {
     readonly [K in O[0]]: (...payload: Pr<O, K>[0]) => Promise<Pr<O, K>[1]>
 }

--- a/fs/effects/module.ts
+++ b/fs/effects/module.ts
@@ -1,17 +1,15 @@
-import type { Effect, Operation, ToAsyncOperationMap } from "./module.f.ts"
+import { match, type Effect, type Operation, type ToAsyncOperationMap } from "./module.f.ts"
 
 export const asyncRun =
     <O extends Operation>(map: ToAsyncOperationMap<O>) =>
     async<T, E extends Effect<O, T>>(effect: Effect<O, T>): Promise<T> =>
 {
+    const next = match(map)
     while (true) {
-        const {value} = effect
-        if (value.length === 1) {
-            return value[0]
+        const r = next(effect)
+        if (r[0] === 'done') {
+            return r[1]
         }
-        const [command, payload, continuation] = value
-        const operation = map[command]
-        const result = await operation(...payload)
-        effect = continuation(result)
+        effect = r[2](await r[1])
     }
 }

--- a/fs/effects/node/proof.f.ts
+++ b/fs/effects/node/proof.f.ts
@@ -1,29 +1,24 @@
 import { empty, isVec, uint, vec8 } from "../../types/bit_vec/module.f.ts"
 import { utf8, utf8ToString } from "../../text/module.f.ts"
-import { pure } from "../module.f.ts"
+import { decode, pure } from "../module.f.ts"
 import { both, fetch, mkdir, now, readdir, readFile, readUtf8File, rm, sandbox, writeFile, writeUtf8File } from "./module.f.ts"
 import { create as memCreate, read as memRead, write as memWrite } from "../memory/module.f.ts"
 import { emptyState, virtual } from "./virtual/module.f.ts"
 
 export const proof = {
     map: () => {
-        let e = readFile('hello').step(([k, v]) => {
+        const e = readFile('hello').step(([k, v]) => {
             if (k === 'error') { throw v }
             return pure(uint(v) * 2n)
         })
         //
-        while (true) {
-            const { value } = e
-            if (value.length === 1) {
-                const [result] = value
-                if (result !== 0x2An) { throw result }
-                return
-            }
-            const [cmd, p, cont] = value
-            if (cmd !== 'readFile') { throw cmd }
-            if (p[0] !== 'hello') { throw p }
-            e = cont(['ok', vec8(0x15n)])
+        let d = decode(e)
+        while (!d.done) {
+            if (d.command !== 'readFile') { throw d.command }
+            if (d.payload[0] !== 'hello') { throw d.payload }
+            d = decode(d.continuation(['ok', vec8(0x15n)]))
         }
+        if (d.result !== 0x2An) { throw d.result }
     },
     fetch: () => {
         const [_, [t, result]] = virtual({

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -66,7 +66,7 @@ const operation =
         const [newSubDir, r] = f(subDir, rest)
         return [{ ...dir, [first]: newSubDir }, r]
     }
-    return (state: State, path: string) => {
+    return (path: string) => (state: State) => {
         const [root, result] = f(state.root, parse(path))
         return [{ ...state, root }, result] as const
     }
@@ -159,7 +159,7 @@ const rm = operation((dir, path): readonly[Dir, IoResult<void>] => {
 })
 
 const map: MemOperationMap<NodeOp, State> = {
-    all: (state, ...a) => {
+    all: (...a) => state => {
         let e: readonly unknown[] = []
         for (const i of a) {
             const [ns, ei] = virtual(state)(i)
@@ -168,7 +168,7 @@ const map: MemOperationMap<NodeOp, State> = {
         }
         return [state, e]
     },
-    memCreate: (state, value) => {
+    memCreate: value => state => {
         const id = `mem${state.memoryNext}`
         const key: Key<unknown> = asNominal(id)
         return [{
@@ -177,23 +177,23 @@ const map: MemOperationMap<NodeOp, State> = {
             memoryValues: { ...state.memoryValues, [id]: value },
         }, key]
     },
-    memRead: (state, key) =>
+    memRead: key => state =>
         [state, state.memoryValues[asBase(key)]],
-    memWrite: (state, key, value) => {
+    memWrite: (key, value) => state => {
         const id = asBase(key)
         return [{
             ...state,
             memoryValues: { ...state.memoryValues, [id]: value },
         }, undefined]
     },
-    fetch: (state, url) => {
+    fetch: url => state => {
         const result = state.internet[url]
         return result === undefined ? [state, error('not found')] : [state, ok(result)]
     },
-    mkdir: (state, path, p) => mkdir(p !== undefined)(state, path),
+    mkdir: (path, p) => mkdir(p !== undefined)(path),
     readFile,
-    readdir: (state, path, { recursive }) => readdir(path, recursive === true)(state, path),
-    writeFile: (state, path, payload) => writeFile(payload)(state, path),
+    readdir: (path, { recursive }) => readdir(path, recursive === true)(path),
+    writeFile: (path, payload) => writeFile(payload)(path),
     access,
     import: import_,
     rm,
@@ -201,7 +201,7 @@ const map: MemOperationMap<NodeOp, State> = {
     createServer: todo,
     listen: todo,
     forever: todo,
-    now: (state) => [state, state.epochNs],
+    now: () => state => [state, state.epochNs],
     // Virtual sandbox is a pass-through: the fixture's test function is
     // expected to return a `SandboxResult` directly (encoding pass/fail and a
     // chosen duration), so the handler invokes it without try/catch or clock
@@ -209,10 +209,10 @@ const map: MemOperationMap<NodeOp, State> = {
     // result instead of the runner measuring real execution. A genuine
     // exception in a fixture propagates loudly as a bug in the fixture.
     // See: issues/156-tf-virtual-tests.md
-    sandbox: (state, f) => [state, f() as SandboxResult<unknown>],
-    await: (state, p) => [state, [p]],
+    sandbox: f => state => [state, f() as SandboxResult<unknown>],
+    await: p => state => [state, [p]],
     test: todo,
-    write: (state, stream, data) => {
+    write: (stream, data) => state => {
         const s = utf8ToString(data)
         return [{ ...state, [stream]: `${state[stream]}${s}` }, undefined] as const
     },

--- a/fs/effects/proof.f.ts
+++ b/fs/effects/proof.f.ts
@@ -1,4 +1,14 @@
-import { foldStep, forEachStep, pure } from './module.f.ts'
+import { decode, do_, foldStep, forEachStep, match, pure, type Effect, type Operation } from './module.f.ts'
+
+const assertPure = <O extends Operation, T>(e: Effect<O, T>, expected: T) => {
+    const d = decode(e)
+    if (!d.done) { throw e.value }
+    if (d.result !== expected) { throw d.result }
+}
+
+type AddOp = readonly['add', (a: number, b: number) => number]
+
+const next = match<AddOp, number>({ add: (a, b) => a + b })
 
 export const proof = {
     foldStep: {
@@ -7,41 +17,53 @@ export const proof = {
                 ((x: number) => (s: number) => pure(s + x))
                 (10)
                 ([])
-            const { value } = e
-            if (value.length !== 1) { throw value }
-            if (value[0] !== 10) { throw value[0] }
+            assertPure(e, 10)
         },
         threadsState: () => {
             const e = foldStep
                 ((x: number) => (s: number) => pure(s + x))
                 (0)
                 ([1, 2, 3, 4])
-            const { value } = e
-            if (value.length !== 1) { throw value }
-            if (value[0] !== 10) { throw value[0] }
+            assertPure(e, 10)
         },
         order: () => {
             const e = foldStep
                 ((x: string) => (s: string) => pure(s + x))
                 ('')
                 (['a', 'b', 'c'])
-            const { value } = e
-            if (value.length !== 1) { throw value }
-            if (value[0] !== 'abc') { throw value[0] }
+            assertPure(e, 'abc')
         },
     },
     forEachStep: {
         empty: () => {
             const e = forEachStep<never, number>(() => pure(undefined))([])
-            const { value } = e
-            if (value.length !== 1) { throw value }
-            if (value[0] !== undefined) { throw value[0] }
+            assertPure(e, undefined)
         },
         runs: () => {
             const e = forEachStep<never, number>(() => pure(undefined))([1, 2, 3])
-            const { value } = e
-            if (value.length !== 1) { throw value }
-            if (value[0] !== undefined) { throw value[0] }
+            assertPure(e, undefined)
+        },
+    },
+    decode: () => {
+        const d = decode(do_<AddOp>('add')(2, 3))
+        if (d.done) { throw d }
+        if (d.command !== 'add') { throw d.command }
+        if (d.payload[0] !== 2 || d.payload[1] !== 3) { throw d.payload }
+        assertPure(d.continuation(5), 5)
+    },
+    match: {
+        done: () => {
+            const r = next(pure(7))
+            if (r[0] !== 'done') { throw r }
+            if (r[1] !== 7) { throw r[1] }
+        },
+        cont: () => {
+            const r = next(do_<AddOp>('add')(2, 3))
+            if (r[0] !== 'cont') { throw r }
+            if (r[1] !== 5) { throw r[1] }
+            const r2 = next(r[2](r[1]))
+            if (r2[0] !== 'done') { throw r2 }
+            if (r2[1] !== 5) { throw r2[1] }
         },
     },
 }

--- a/fs/emergent_testing/proof.f.ts
+++ b/fs/emergent_testing/proof.f.ts
@@ -281,8 +281,8 @@ export const registerSuffixes = () => {
     const noopCtx: TestContext = { test: (_n, _o, _f) => Promise.resolve() }
 
     const makeRunner = () => mockRun<Ops, S>({
-        test: (s, _ctx, name, _xf, _fn) => [[...s, name], undefined],
-        all: (s, ...effects: readonly Effect<Ops, unknown>[]) => {
+        test: (_ctx, name, _xf, _fn) => (s: S) => [[...s, name], undefined],
+        all: (...effects: readonly Effect<Ops, unknown>[]) => (s: S) => {
             let st = s
             const rs: unknown[] = []
             for (const e of effects) {
@@ -292,7 +292,7 @@ export const registerSuffixes = () => {
             }
             return [st, rs]
         },
-        await: (s, p) => [s, [p]],
+        await: p => (s: S) => [s, [p]],
     } as Parameters<typeof mockRun<Ops, S>>[0])
 
     runner = makeRunner()

--- a/fs/mcp/proof.f.ts
+++ b/fs/mcp/proof.f.ts
@@ -20,13 +20,13 @@ type MemoryState = {
 const initial: MemoryState = { next: 0, values: {} }
 
 const mock: MemOperationMap<MemOp, MemoryState> = {
-    memCreate: (state, value) => {
+    memCreate: value => state => {
         const id = `k${state.next}`
         const key: Key<unknown> = asNominal(id)
         return [{ next: state.next + 1, values: { ...state.values, [id]: value } }, key]
     },
-    memRead: (state, key) => [state, state.values[asBase(key)]],
-    memWrite: (state, key, value) => {
+    memRead: key => state => [state, state.values[asBase(key)]],
+    memWrite: (key, value) => state => {
         const id = asBase(key)
         return [{ ...state, values: { ...state.values, [id]: value } }, undefined]
     },

--- a/issues/661-effect-value-decoder.md
+++ b/issues/661-effect-value-decoder.md
@@ -1,7 +1,31 @@
 # 661. `effects`: a single decoder for the `Pure | Do` value representation
 
 **Priority:** P3
-**Status:** open
+**Status:** done
+
+## Resolution
+
+Implemented as proposed: `decode` + `match` in `fs/effects/module.f.ts`, the
+`MemOperationMap` currying landed in the same change (not as a follow-up), and
+both production runners plus the proofs now go through the shared accessor.
+Notes on how reality diverged from the proposal below:
+
+- **`match` is generic in the effect's operation set.** The sketch typed the
+  effect parameter as `Effect<O, T>`, but `Effect` is *not* covariant in `O`
+  (the continuation consumes the operation's result, an input position), so
+  `RunInstance`'s `<O1 extends O>` effects would not be assignable. `match`
+  takes `<O1 extends O, T>(effect: Effect<O1, T>)` instead, mirroring
+  `RunInstance`.
+- **Curried-map consumers.** Besides the virtual filesystem, two proof-local
+  mocks (`fs/effects/memory/proof.f.ts`, `fs/mcp/proof.f.ts`) and the partial
+  map in `fs/emergent_testing/proof.f.ts` (which keeps its pre-existing
+  `as Parameters<…>` cast) were migrated mechanically.
+- `ToAsyncOperationMap` is unchanged — it is a per-key-precise refinement of
+  `OperationMap<O, Promise<…>>` and inference handles the widening at the
+  `match(map)` call.
+- The new exports carry their own proofs (`decode`, `match.done`,
+  `match.cont` in `fs/effects/proof.f.ts`) against a minimal `AddOp`, in
+  addition to the runner proofs that exercise them end to end.
 
 The `Effect` ADT encodes a node as a tuple: a **pure** value is a length-1
 tuple `readonly[T]`, a **do** node is a length-3 tuple


### PR DESCRIPTION
Implements [i661](issues/661-effect-value-decoder.md): the `Pure | Do` tuple layout (`value.length === 1` discriminant, `[command, payload, continuation]` indexing) was re-derived by hand in the async runner, the mock runner, an inline proof runner, and five proof assertions — 8+ sites, none of them the module that owns the type.

## What changed

- **`fs/effects/module.f.ts`** now owns the representation:
  - `decode` turns an effect's next step into a named, discriminated form (`{ done: true, result } | { done: false, command, payload, continuation }`). It is the only place that knows the tuple layout.
  - `match(map)(effect)` decodes *and* dispatches the command to an `OperationMap<O, R>`, returning `['done', T] | ['cont', R, continuation]` — only the world-specific eliminator (`await` for async, state threading for sync) stays in each runner.
- **Runners** (`fs/effects/module.ts`, `fs/effects/mock/module.f.ts`) become the shared `match` skeleton plus one eliminator line.
- **`MemOperationMap` is curried**: `(state, ...payload) => [state, r]` → `(...payload) => (state) => [state, r]`, separating a command's arguments (fixed at issue time) from the state the runner threads. Migrated mechanically: `fs/effects/node/virtual`, `fs/effects/memory/proof.f.ts`, `fs/mcp/proof.f.ts`, `fs/emergent_testing/proof.f.ts`.
- **Proofs** (`fs/effects/proof.f.ts`, `fs/effects/node/proof.f.ts`) use `decode` instead of poking at the tuple; new `decode` / `match.done` / `match.cont` proofs cover both branches of each new export against a minimal `AddOp`.

## Divergence from the issue sketch

`match`'s effect parameter is `<O1 extends O, T>(effect: Effect<O1, T>)` rather than `Effect<O, T>`: `Effect` is not covariant in `O` (the continuation consumes the operation result, an input position), so `RunInstance`'s `<O1 extends O>` effects would not be assignable otherwise. Recorded in the issue's resolution section, which is now marked **done**.

## Testing

- `npx tsc` — clean, no casts introduced.
- `node ./fs/fjs/module.ts t` — 1764 pass, 0 fail (includes the mock/virtual runner proofs that exercise both runners end to end).

https://claude.ai/code/session_01CRQ5Etje6SzgEYFhYKEcPL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRQ5Etje6SzgEYFhYKEcPL)_