### PR TITLE
Add proof object for normalizeMantissa zero case coverage

### DIFF
--- a/fs/types/bigfloat/module.f.ts
+++ b/fs/types/bigfloat/module.f.ts
@@ -82,3 +82,10 @@ export const decToBin = (dec: BigFloat): BigFloat => {
     const [m, e] = increaseMantissa(dec)(p * twoPow53)
     return withSign(m, e)(magnitude => round53(divide(magnitude)(p)))
 }
+
+export const proof = {
+    // normalizeMantissa guards against zero mantissa to prevent an infinite loop;
+    // this path is unreachable through decToBin (which returns early for 0n),
+    // so we exercise it here where the private helper is in scope.
+    normalizeMantissaZero: () => { increaseMantissa([0n, 5])(1n) }
+}


### PR DESCRIPTION
## Summary
Added a `proof` export object to the bigfloat module that exercises an edge case in the `normalizeMantissa` helper function that is otherwise unreachable through the public `decToBin` API.

## Key Changes
- Added `proof` object with `normalizeMantissaZero` function that tests the zero mantissa guard in `increaseMantissa`
- This ensures the defensive check against infinite loops in `normalizeMantissa` is exercised, even though `decToBin` returns early for zero values and would never trigger this path in normal usage

## Implementation Details
The `normalizeMantissaZero` proof function directly calls `increaseMantissa([0n, 5])(1n)` to test the private helper's handling of zero mantissa values. This provides explicit coverage for the guard condition that prevents infinite loops, documenting that this edge case is intentionally handled even if unreachable through the public API.

https://claude.ai/code/session_01NXBxJxXHp7Ppd5eenEweZC