### PR TITLE
feat(cas/mcp): expose fs/cas as an MCP server (66E)

### DIFF
--- a/fs/cas/mcp/README.md
+++ b/fs/cas/mcp/README.md
@@ -1,0 +1,76 @@
+# CAS MCP server
+
+An [MCP](../../mcp/) front end for the content-addressable store ([`fs/cas`](../)).
+It exposes the three `Cas<O>` operations as MCP tools, so an agent that speaks
+MCP can store a blob and get back its hash, fetch a blob by hash, and enumerate
+what is stored — without shelling out to the `cas` CLI.
+
+The store (`fs/cas/module.f.ts`) stays transport-agnostic; this adapter is an
+additional front end alongside the CLI `main`, exactly as the issue describes.
+
+## The three tools
+
+| Tool       | args                  | CAS call         | result text          |
+|------------|-----------------------|------------------|----------------------|
+| `cas_add`  | `{ content: string }` | `c.write(value)` | hash (cBase32)       |
+| `cas_get`  | `{ hash: string }`    | `c.read(key)`    | content (cBase32)    |
+| `cas_list` | `{}`                  | `c.list()`       | hashes, one per line |
+
+Each tool's argument schema is an rtti struct declared once and used twice:
+[`toJsonSchema`](../../json/schema/module.f.ts) derives the `inputSchema`
+advertised in `tools/list`, and [`validate`](../../types/rtti/validate/module.f.ts)
+decodes the `arguments` object in `tools/call`. There is no drift between what we
+advertise and what we accept.
+
+## Content encoding (cBase32)
+
+`Cas<O>` deals in `Vec` (bit vectors); MCP models only `textContent` (a
+`string`) today. Both hash and content cross the protocol as **cBase32**
+([`fs/cbase32`](../../cbase32/module.f.ts)) — the same encoding the CLI uses for
+hashes:
+
+- `cas_add` takes cBase32 `content` → `Vec` → store → returns the cBase32 hash;
+- `cas_get` takes a cBase32 `hash` → `Vec` key → read → returns cBase32 content.
+
+This keeps a single encoding across the whole CAS surface (the CLI and MCP
+agree), and `cBase32ToVec` already returns `null` on malformed input, giving free
+input validation.
+
+Alternatives considered: base64 (MCP-idiomatic for binary, but a second encoding
+the project does not otherwise use), or adding a `blob`/`resource` content type
+to `fs/mcp` so binary need not be text-shoehorned. Both are follow-ups; cBase32
+is the minimal, consistent start.
+
+## Protocol errors vs. tool errors
+
+MCP draws a line the dispatcher already respects:
+
+- **Protocol failures** — an unknown method, or malformed params at the
+  JSON-RPC layer — are JSON-RPC errors. [`mcpStep`](../../mcp/module.f.ts) handles
+  those; this adapter never produces them.
+- **Tool failures** are *not* JSON-RPC errors. They come back as a normal
+  `tools/call` result with `isError: true` and a text explanation, so the model
+  can read and react. This adapter returns an `isError` result for:
+  - malformed `content` / `hash` (`cBase32ToVec` → `null`);
+  - `cas_get` on an absent hash (`c.read` → `undefined`);
+  - an unknown tool `name`.
+
+This mirrors the CLI's distinction (`errorExit` for bad input vs. a real result)
+but routed through MCP's in-band error channel.
+
+## Running it
+
+`casMcpServer(c)` allocates the session-state slot, builds the `mcpStep` for an
+injected `Cas<O>`, and drives the stdio read → parse → dispatch → write loop
+([`fs/mcp/stdio`](../../mcp/stdio/module.f.ts)) until stdin EOF. The CLI exposes
+it as a subcommand:
+
+```
+cas mcp
+```
+
+which runs the server over a filesystem-backed CAS rooted at the current
+directory (`MemOp | Fs` effects). Because the adapter is generic in `O`, the same
+handlers run over an in-memory `Cas<MemOp>` in `proof.f.ts`, driven through a full
+`initialize` → `notifications/initialized` → `tools/call` sequence with no live
+process.

--- a/fs/cas/mcp/README.md
+++ b/fs/cas/mcp/README.md
@@ -62,11 +62,11 @@ but routed through MCP's in-band error channel.
 
 `casMcpServer(c)` allocates the session-state slot, builds the `mcpStep` for an
 injected `Cas<O>`, and drives the stdio read → parse → dispatch → write loop
-([`fs/mcp/stdio`](../../mcp/stdio/module.f.ts)) until stdin EOF. The CLI exposes
-it as a subcommand:
+([`fs/mcp/stdio`](../../mcp/stdio/module.f.ts)) until stdin EOF. The `cas`
+command (itself a subcommand of the `fjs` binary) exposes it as:
 
 ```
-cas mcp
+fjs cas mcp
 ```
 
 which runs the server over a filesystem-backed CAS rooted at the current

--- a/fs/cas/mcp/module.f.ts
+++ b/fs/cas/mcp/module.f.ts
@@ -1,0 +1,166 @@
+/**
+ * MCP adapter for the content-addressable store.
+ *
+ * Maps the three `Cas<O>` operations onto three MCP tools, so an agent that
+ * speaks MCP can store a blob and get back its hash, fetch a blob by hash, and
+ * enumerate what is stored — without shelling out to the `cas` CLI. The store
+ * itself (`fs/cas/module.f.ts`) stays transport-agnostic; this is an additional
+ * front end alongside the CLI `main`.
+ *
+ * ## The three tools
+ *
+ * | Tool       | args                  | CAS call         | result text          |
+ * |------------|-----------------------|------------------|----------------------|
+ * | `cas_add`  | `{ content: string }` | `c.write(value)` | hash (cBase32)       |
+ * | `cas_get`  | `{ hash: string }`    | `c.read(key)`    | content (cBase32)    |
+ * | `cas_list` | `{}`                  | `c.list()`       | hashes, one per line |
+ *
+ * Each tool's argument schema is an rtti struct declared once and used twice:
+ * `toJsonSchema` derives the `inputSchema` advertised in `tools/list`, and
+ * `validate` decodes the `arguments` object in `tools/call`. No drift between
+ * what we advertise and what we accept.
+ *
+ * ## Content encoding
+ *
+ * `Cas<O>` deals in `Vec` (bit vectors); MCP models only `textContent` today.
+ * Both hash and content cross the protocol as cBase32 (`fs/cbase32`), the same
+ * encoding the CLI uses for hashes — one encoding across the whole CAS surface.
+ * `cBase32ToVec` returns `null` on malformed input, giving free validation.
+ *
+ * ## Error convention
+ *
+ * MCP draws a line the dispatcher already respects: *protocol* failures
+ * (unknown method, malformed JSON-RPC params) are JSON-RPC errors handled by
+ * `mcpStep`. *Tool* failures come back as a normal `tools/call` result with
+ * `isError: true` and a text explanation, so the model can read and react:
+ * - malformed `content` / `hash` (`cBase32ToVec` → `null`) → `isError` result
+ * - `cas_get` on an absent hash (`c.read` → `undefined`) → `isError` result
+ * - unknown tool `name` → `isError` result
+ *
+ * @module
+ */
+import { string } from '../../types/rtti/module.f.ts'
+import { validate } from '../../types/rtti/validate/module.f.ts'
+import { toJsonSchema } from '../../json/schema/module.f.ts'
+import { pure, type Effect, type Operation } from '../../effects/module.f.ts'
+import { create, type MemOp } from '../../effects/memory/module.f.ts'
+import { cBase32ToVec, vecToCBase32 } from '../../cbase32/module.f.ts'
+import { type Read, type Write } from '../../effects/node/module.f.ts'
+import { stdioTransport } from '../../mcp/stdio/module.f.ts'
+import {
+    mcpStep, uninitializedState,
+    type McpConfig, type McpHandlers, type Tool,
+    type ToolsCallParams, type ToolsCallResult, type ToolsListResult,
+} from '../../mcp/module.f.ts'
+import type { Cas } from '../module.f.ts'
+
+// ── Argument schemas (declared once, used for both inputSchema and validate) ─────
+
+/** Arguments for `cas_add`: cBase32-encoded content to store. */
+export const casAddArgs = { content: string } as const
+
+/** Arguments for `cas_get`: the cBase32 hash to look up. */
+export const casGetArgs = { hash: string } as const
+
+/** Arguments for `cas_list`: none. */
+export const casListArgs = {} as const
+
+// ── Tool descriptors ────────────────────────────────────────────────────────────
+
+const casAddTool: Tool = {
+    name: 'cas_add',
+    description: 'Store content (cBase32) and return its hash (cBase32).',
+    inputSchema: toJsonSchema(casAddArgs),
+}
+
+const casGetTool: Tool = {
+    name: 'cas_get',
+    description: 'Fetch content (cBase32) by its hash (cBase32).',
+    inputSchema: toJsonSchema(casGetArgs),
+}
+
+const casListTool: Tool = {
+    name: 'cas_list',
+    description: 'List all stored content hashes (cBase32), one per line.',
+    inputSchema: toJsonSchema(casListArgs),
+}
+
+// ── Result helpers ──────────────────────────────────────────────────────────────
+
+/** A successful single-text-block tool result. */
+const okResult = (text: string): ToolsCallResult =>
+    ({ content: [{ type: 'text', text }] })
+
+/** A tool-level failure: in-band `isError` result with a text explanation. */
+const errorResult = (text: string): ToolsCallResult =>
+    ({ content: [{ type: 'text', text }], isError: true })
+
+// ── Handlers ────────────────────────────────────────────────────────────────────
+
+/**
+ * MCP handlers for an injected `Cas<O>` — generic in `O` exactly like `Cas`
+ * itself, so the same handlers run over `Fs` (production) or memory (tests).
+ */
+export const casMcpHandlers = <O extends Operation>(c: Cas<O>): McpHandlers<O> => ({
+    toolsList: (): Effect<O, ToolsListResult> =>
+        pure({ tools: [casAddTool, casGetTool, casListTool] }),
+    toolsCall: ({ name, arguments: args }: ToolsCallParams): Effect<O, ToolsCallResult> => {
+        const a = args === undefined ? {} : args
+        switch (name) {
+            case 'cas_add': {
+                const [t, r] = validate(casAddArgs)(a)
+                if (t === 'error') {
+                    return pure(errorResult(`invalid arguments: ${r.message}`))
+                }
+                const value = cBase32ToVec(r.content)
+                if (value === null) {
+                    return pure(errorResult(`invalid cBase32 content: ${r.content}`))
+                }
+                return c.write(value).step(hash => pure(okResult(vecToCBase32(hash))))
+            }
+            case 'cas_get': {
+                const [t, r] = validate(casGetArgs)(a)
+                if (t === 'error') {
+                    return pure(errorResult(`invalid arguments: ${r.message}`))
+                }
+                const key = cBase32ToVec(r.hash)
+                if (key === null) {
+                    return pure(errorResult(`invalid cBase32 hash: ${r.hash}`))
+                }
+                return c.read(key).step(value => pure(value === undefined
+                    ? errorResult(`no such hash: ${r.hash}`)
+                    : okResult(vecToCBase32(value))))
+            }
+            case 'cas_list': {
+                return c.list().step(hashes =>
+                    pure(okResult(hashes.map(vecToCBase32).join('\n'))))
+            }
+            default: {
+                return pure(errorResult(`unknown tool: ${name}`))
+            }
+        }
+    },
+})
+
+// ── Session configuration ───────────────────────────────────────────────────────
+
+/**
+ * Static MCP configuration for the CAS server: advertises the `tools`
+ * capability, identifies the server, and pins the protocol version.
+ */
+export const casConfig: McpConfig = {
+    serverInfo: { name: 'functionalscript-cas', version: '0.30.0' },
+    capabilities: { tools: {} },
+    protocolVersion: '2024-11-05',
+}
+
+// ── Server ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Runs the CAS MCP server over stdio: allocates the session-state slot, builds
+ * the `mcpStep` for `c`, and drives the read → parse → dispatch → write loop
+ * until stdin EOF. Generic in `O` so it composes with any `Cas<O>` backing.
+ */
+export const casMcpServer = <O extends Operation>(c: Cas<O>): Effect<Read | Write | MemOp | O, void> =>
+    create(uninitializedState).step(key =>
+        stdioTransport(mcpStep<O>(casConfig)(casMcpHandlers(c))(key)))

--- a/fs/cas/mcp/proof.f.ts
+++ b/fs/cas/mcp/proof.f.ts
@@ -1,0 +1,178 @@
+import { assert, assertEq } from '../../asserts/module.f.ts'
+import { pure, type Effect } from '../../effects/module.f.ts'
+import { run, type MemOperationMap } from '../../effects/mock/module.f.ts'
+import { asBase, asNominal, create, read, write, type Key, type MemOp } from '../../effects/memory/module.f.ts'
+import type { Unknown } from '../../json/module.f.ts'
+import type { Response } from '../../json/rpc/module.f.ts'
+import { vec8, type Vec } from '../../types/bit_vec/module.f.ts'
+import { vecToCBase32 } from '../../cbase32/module.f.ts'
+import { sha256 } from '../../crypto/sha2/module.f.ts'
+import { cas, type KvStore } from '../module.f.ts'
+import {
+    mcpStep, uninitializedState, type McpSessionState, type ToolsCallResult,
+} from '../../mcp/module.f.ts'
+import { casConfig, casMcpHandlers } from './module.f.ts'
+
+// ── Memory mock (mirrors fs/mcp/proof.f.ts) ─────────────────────────────────────
+
+type MemoryState = {
+    readonly next: number
+    readonly values: { readonly [key: string]: unknown }
+}
+
+const initial: MemoryState = { next: 0, values: {} }
+
+const mock: MemOperationMap<MemOp, MemoryState> = {
+    memCreate: value => state => {
+        const id = `k${state.next}`
+        const key: Key<unknown> = asNominal(id)
+        return [{ next: state.next + 1, values: { ...state.values, [id]: value } }, key]
+    },
+    memRead: key => state => [state, state.values[asBase(key)]],
+    memWrite: (key, value) => state => {
+        const id = asBase(key)
+        return [{ ...state, values: { ...state.values, [id]: value } }, undefined]
+    },
+}
+
+const runMem = <T>(effect: Effect<MemOp, T>): T => run(mock)(initial)(effect)[1]
+
+// ── In-memory KvStore backed by a single memory slot ────────────────────────────
+// Persists writes across steps so add → get round-trips, keyed by cBase32 hash.
+
+// Maps cBase32(key) → [key, value]; storing the key Vec lets `list` return keys
+// (hashes), matching the `KvStore` contract that the filesystem backing fulfils.
+type VecMap = { readonly [k: string]: readonly [Vec, Vec] }
+
+const memKvStore = (mapKey: Key<VecMap>): KvStore<MemOp> => ({
+    read: (key: Vec): Effect<MemOp, Vec | undefined> =>
+        read(mapKey).step(m => pure(m[vecToCBase32(key)]?.[1])),
+    write: (key: Vec, value: Vec): Effect<MemOp, void> =>
+        read(mapKey).step(m => write(mapKey, { ...m, [vecToCBase32(key)]: [key, value] })),
+    list: (): Effect<MemOp, readonly Vec[]> =>
+        read(mapKey).step(m => pure(Object.values(m).map(([k]) => k))),
+})
+
+// ── Session driver ──────────────────────────────────────────────────────────────
+
+// Feeds each message to `step` in order, collecting every response.
+const feed =
+    (step: (v: Unknown) => Effect<MemOp, Response | null>) =>
+    (msgs: readonly unknown[]): Effect<MemOp, readonly unknown[]> => {
+        const go = (i: number, acc: readonly unknown[]): Effect<MemOp, readonly unknown[]> =>
+            i === msgs.length
+                ? pure(acc)
+                : step(msgs[i] as Unknown).step(r => go(i + 1, [...acc, r]))
+        return go(0, [])
+    }
+
+// Runs a full session over a fresh in-memory CAS, returning all responses.
+const runSession = (msgs: readonly unknown[]): readonly unknown[] =>
+    runMem(
+        create({} as VecMap).step(mapKey =>
+            create(uninitializedState as McpSessionState).step(sessionKey => {
+                const c = cas(sha256)(memKvStore(mapKey))
+                const step = mcpStep<MemOp>(casConfig)(casMcpHandlers(c))(sessionKey)
+                return feed(step)(msgs)
+            })))
+
+// ── Messages ────────────────────────────────────────────────────────────────────
+
+const init = { jsonrpc: '2.0', method: 'initialize', id: 1,
+    params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'c', version: '0' } } }
+
+const initialized = { jsonrpc: '2.0', method: 'notifications/initialized' }
+
+const call = (id: number, name: string, args: unknown) =>
+    ({ jsonrpc: '2.0', method: 'tools/call', id, params: { name, arguments: args } })
+
+const list = (id: number) => ({ jsonrpc: '2.0', method: 'tools/list', id })
+
+// Runs `init`, `notifications/initialized`, then `msgs`; returns the tool responses.
+const session = (...msgs: readonly unknown[]): readonly unknown[] =>
+    runSession([init, initialized, ...msgs]).slice(2)
+
+const resultOf = (resp: unknown): ToolsCallResult =>
+    (resp as { readonly result: ToolsCallResult }).result
+
+const textOf = (resp: unknown): string => resultOf(resp).content[0].text
+
+// A valid cBase32 payload to store and round-trip.
+const sample = vecToCBase32(vec8(0x2An))
+
+// ── Tests ───────────────────────────────────────────────────────────────────────
+
+export const proof = {
+    toolsListAdvertisesThreeTools: () => {
+        const [resp] = runSession([init, initialized, list(2)]).slice(2)
+        const tools = (resp as { result: { tools: readonly { name: string }[] } }).result.tools
+        assertEq(tools.length, 3)
+        assertEq(tools.map(t => t.name).join(','), 'cas_add,cas_get,cas_list')
+        // Each tool advertises an object inputSchema derived from its rtti args.
+        const add = (resp as { result: { tools: readonly { inputSchema: { type?: string } }[] } }).result.tools[0]
+        assertEq(add.inputSchema.type, 'object')
+    },
+
+    addReturnsHash: () => {
+        const [resp] = session(call(2, 'cas_add', { content: sample }))
+        assert(!resultOf(resp).isError)
+        assert(textOf(resp).length > 0)
+    },
+
+    addGetRoundTrips: () => {
+        // First learn the hash from a standalone add...
+        const [addResp] = session(call(2, 'cas_add', { content: sample }))
+        const hash = textOf(addResp)
+        // ...then add + get in one session so the store is shared.
+        const [, getResp] = session(
+            call(2, 'cas_add', { content: sample }),
+            call(3, 'cas_get', { hash }),
+        )
+        assert(!resultOf(getResp).isError)
+        assertEq(textOf(getResp), sample)
+    },
+
+    listEnumeratesStoredHashes: () => {
+        const [addResp, listResp] = session(
+            call(2, 'cas_add', { content: sample }),
+            call(3, 'cas_list', {}),
+        )
+        const hash = textOf(addResp)
+        assert(!resultOf(listResp).isError)
+        assertEq(textOf(listResp), hash)
+    },
+
+    addInvalidContentIsError: () => {
+        const [resp] = session(call(2, 'cas_add', { content: 'not valid!' }))
+        assertEq(resultOf(resp).isError, true)
+    },
+
+    addMissingContentIsError: () => {
+        const [resp] = session(call(2, 'cas_add', {}))
+        assertEq(resultOf(resp).isError, true)
+    },
+
+    getInvalidHashIsError: () => {
+        const [resp] = session(call(2, 'cas_get', { hash: 'not valid!' }))
+        assertEq(resultOf(resp).isError, true)
+    },
+
+    getMissingHashIsError: () => {
+        // valid cBase32 that was never stored
+        const absent = vecToCBase32(vec8(0x99n))
+        const [resp] = session(call(2, 'cas_get', { hash: absent }))
+        assertEq(resultOf(resp).isError, true)
+    },
+
+    unknownToolIsError: () => {
+        const [resp] = session(call(2, 'cas_remove', { hash: sample }))
+        assertEq(resultOf(resp).isError, true)
+    },
+
+    // Tool failures are in-band results, never JSON-RPC errors.
+    toolErrorIsNotJsonRpcError: () => {
+        const [resp] = session(call(2, 'cas_add', { content: 'not valid!' }))
+        assert(!('error' in (resp as object)))
+        assert('result' in (resp as object))
+    },
+}

--- a/fs/cas/mcp/proof.f.ts
+++ b/fs/cas/mcp/proof.f.ts
@@ -147,6 +147,18 @@ export const proof = {
         assertEq(resultOf(resp).isError, true)
     },
 
+    // An unterminated cBase32 string (all zero symbols) must decode to null and
+    // return an isError result, not spin the single stdio loop forever.
+    addUnterminatedContentIsError: () => {
+        const [resp] = session(call(2, 'cas_add', { content: '0' }))
+        assertEq(resultOf(resp).isError, true)
+    },
+
+    getUnterminatedHashIsError: () => {
+        const [resp] = session(call(2, 'cas_get', { hash: '0' }))
+        assertEq(resultOf(resp).isError, true)
+    },
+
     addMissingContentIsError: () => {
         const [resp] = session(call(2, 'cas_add', {}))
         assertEq(resultOf(resp).isError, true)

--- a/fs/cas/module.f.ts
+++ b/fs/cas/module.f.ts
@@ -10,6 +10,7 @@ import { cBase32ToVec, vecToCBase32 } from '../cbase32/module.f.ts'
 import { forEachStep, pure, type Effect, type Operation } from '../effects/module.f.ts'
 import { errorExit, log, mkdir, readdir, readFile, writeFile, type Fs, type NodeEffect, type NodeOp, type NodeProgramOptions } from '../effects/node/module.f.ts'
 import { dispatch, type Commands } from '../cli/module.f.ts'
+import { casMcpServer } from './mcp/module.f.ts'
 import { toOption } from '../types/nullable/module.f.ts'
 import { unwrap } from '../types/result/module.f.ts'
 import { splitAt } from '../types/string/module.f.ts'
@@ -134,6 +135,12 @@ export const main = (options: NodeProgramOptions): Effect<NodeOp, number> => {
                 c.list()
                     .step(forEachStep<NodeOp, Vec>(j => log(vecToCBase32(j))))
                     .step(() => pure(0)),
+        },
+        {
+            names: ['mcp'],
+            description: 'Run an MCP server over stdio exposing the CAS as tools',
+            handler: () =>
+                casMcpServer(c).step(() => pure(0)),
         },
     ]
     return dispatch(commands)(options)

--- a/fs/cas/module.f.ts
+++ b/fs/cas/module.f.ts
@@ -8,7 +8,7 @@ import { join, parse } from '../path/module.f.ts'
 import type { Vec } from '../types/bit_vec/module.f.ts'
 import { cBase32ToVec, vecToCBase32 } from '../cbase32/module.f.ts'
 import { forEachStep, pure, type Effect, type Operation } from '../effects/module.f.ts'
-import { access, errorExit, log, mkdir, readdir, readFile, writeFile, type Fs, type NodeEffect, type NodeOp, type NodeProgramOptions } from '../effects/node/module.f.ts'
+import { access, errorExit, isNotFound, log, mkdir, readdir, readFile, writeFile, type Fs, type NodeEffect, type NodeOp, type NodeProgramOptions } from '../effects/node/module.f.ts'
 import { dispatch, type Commands } from '../cli/module.f.ts'
 import { casMcpServer } from './mcp/module.f.ts'
 import { toOption } from '../types/nullable/module.f.ts'
@@ -46,8 +46,12 @@ const toPath = (key: Vec): string => {
  */
 export const fileKvStore = (path: string): KvStore<Fs> => ({
     read: (key: Vec): Effect<Fs, Vec|undefined> =>
-        readFile(toPath(key))
-            .step(([status, data]) => pure(status === 'error' ? undefined : data)),
+        readFile(toPath(key)).step(r => {
+            if (r[0] === 'ok') { return pure(r[1]) }
+            // A missing file means "no such content"; surface anything else.
+            if (isNotFound(r[1])) { return pure(undefined) }
+            throw r[1]
+        }),
     write: (key: Vec, value: Vec): Effect<Fs, void> => {
         const p = toPath(key)
         const parts = parse(p)
@@ -59,16 +63,20 @@ export const fileKvStore = (path: string): KvStore<Fs> => ({
     },
     list: (): Effect<Fs, readonly Vec[]> =>
         // A fresh store has no `.cas` directory yet. Treat *only* that case as an
-        // empty store (via `access`), mirroring how `read` maps a missing file to
-        // `undefined`. A `.cas` that exists but cannot be read is a genuine
-        // storage error and is surfaced (`unwrap`), not masked as "no hashes".
-        access('.cas').step(a => a[0] === 'error'
-            ? pure([] as readonly Vec[])
-            : readdir('.cas', { recursive: true })
+        // empty store, mirroring how `read` maps a missing file to `undefined`.
+        // A `.cas` that exists but cannot be read (permissions, corruption) is a
+        // genuine storage error and is surfaced, not masked as "no hashes".
+        access('.cas').step(a => {
+            if (a[0] === 'error') {
+                if (isNotFound(a[1])) { return pure([] as readonly Vec[]) }
+                throw a[1]
+            }
+            return readdir('.cas', { recursive: true })
                 .step(r => pure(unwrap(r).flatMap(({ name, parentPath, isFile }) =>
                     toOption(isFile
                         ? cBase32ToVec(parentPath.substring(prefix.length).replaceAll('/', '') + name)
-                        : null))))),
+                        : null))))
+        }),
 })
 
 export type Cas<O extends Operation> = {

--- a/fs/cas/module.f.ts
+++ b/fs/cas/module.f.ts
@@ -58,9 +58,11 @@ export const fileKvStore = (path: string): KvStore<Fs> => ({
             .step(() => pure(undefined))
     },
     list: (): Effect<Fs, readonly Vec[]> =>
-        // TODO: remove unwrap
+        // A fresh store has no `.cas` directory yet; `readdir` then errors with
+        // ENOENT. Treat that as an empty store rather than crashing, mirroring
+        // how `read` maps a missing file to `undefined`.
         readdir('.cas', { recursive: true })
-            .step(r => pure(unwrap(r).flatMap(({ name, parentPath, isFile }) =>
+            .step(r => pure(r[0] === 'error' ? [] : r[1].flatMap(({ name, parentPath, isFile }) =>
                 toOption(isFile
                     ? cBase32ToVec(parentPath.substring(prefix.length).replaceAll('/', '') + name)
                     : null)))),

--- a/fs/cas/module.f.ts
+++ b/fs/cas/module.f.ts
@@ -8,7 +8,7 @@ import { join, parse } from '../path/module.f.ts'
 import type { Vec } from '../types/bit_vec/module.f.ts'
 import { cBase32ToVec, vecToCBase32 } from '../cbase32/module.f.ts'
 import { forEachStep, pure, type Effect, type Operation } from '../effects/module.f.ts'
-import { errorExit, log, mkdir, readdir, readFile, writeFile, type Fs, type NodeEffect, type NodeOp, type NodeProgramOptions } from '../effects/node/module.f.ts'
+import { access, errorExit, log, mkdir, readdir, readFile, writeFile, type Fs, type NodeEffect, type NodeOp, type NodeProgramOptions } from '../effects/node/module.f.ts'
 import { dispatch, type Commands } from '../cli/module.f.ts'
 import { casMcpServer } from './mcp/module.f.ts'
 import { toOption } from '../types/nullable/module.f.ts'
@@ -58,14 +58,17 @@ export const fileKvStore = (path: string): KvStore<Fs> => ({
             .step(() => pure(undefined))
     },
     list: (): Effect<Fs, readonly Vec[]> =>
-        // A fresh store has no `.cas` directory yet; `readdir` then errors with
-        // ENOENT. Treat that as an empty store rather than crashing, mirroring
-        // how `read` maps a missing file to `undefined`.
-        readdir('.cas', { recursive: true })
-            .step(r => pure(r[0] === 'error' ? [] : r[1].flatMap(({ name, parentPath, isFile }) =>
-                toOption(isFile
-                    ? cBase32ToVec(parentPath.substring(prefix.length).replaceAll('/', '') + name)
-                    : null)))),
+        // A fresh store has no `.cas` directory yet. Treat *only* that case as an
+        // empty store (via `access`), mirroring how `read` maps a missing file to
+        // `undefined`. A `.cas` that exists but cannot be read is a genuine
+        // storage error and is surfaced (`unwrap`), not masked as "no hashes".
+        access('.cas').step(a => a[0] === 'error'
+            ? pure([] as readonly Vec[])
+            : readdir('.cas', { recursive: true })
+                .step(r => pure(unwrap(r).flatMap(({ name, parentPath, isFile }) =>
+                    toOption(isFile
+                        ? cBase32ToVec(parentPath.substring(prefix.length).replaceAll('/', '') + name)
+                        : null))))),
 })
 
 export type Cas<O extends Operation> = {

--- a/fs/cas/proof.f.ts
+++ b/fs/cas/proof.f.ts
@@ -74,6 +74,14 @@ export const proof = {
         if (exitCode !== 0) { throw ['expected exit 0', exitCode] }
         if (finalState.stdout !== '') { throw ['expected empty stdout', finalState.stdout] }
     },
+    mainListCorruptStore: () => {
+        // `.cas` exists but is a file, not a directory: a real storage error
+        // that must surface, not be masked as an empty list.
+        const state = { ...emptyState, root: { '.cas': vec8(0x2An) } }
+        let threw = false
+        try { virtual(state)(main(makeOptions(['list']))) } catch { threw = true }
+        if (!threw) { throw 'expected list to surface the storage error' }
+    },
     mainNoCmd: () => {
         const [finalState, exitCode] = virtual(emptyState)(main(makeOptions([])))
         if (exitCode !== 1) { throw ['expected exit 1', exitCode] }

--- a/fs/cas/proof.f.ts
+++ b/fs/cas/proof.f.ts
@@ -67,6 +67,13 @@ export const proof = {
         const [, exitCode] = virtual(state1)(main(makeOptions(['list'])))
         if (exitCode !== 0) { throw ['expected exit 0', exitCode] }
     },
+    mainListEmptyStore: () => {
+        // A fresh directory has no `.cas` yet; listing must succeed (empty),
+        // not crash unwrapping a readdir ENOENT.
+        const [finalState, exitCode] = virtual(emptyState)(main(makeOptions(['list'])))
+        if (exitCode !== 0) { throw ['expected exit 0', exitCode] }
+        if (finalState.stdout !== '') { throw ['expected empty stdout', finalState.stdout] }
+    },
     mainNoCmd: () => {
         const [finalState, exitCode] = virtual(emptyState)(main(makeOptions([])))
         if (exitCode !== 1) { throw ['expected exit 1', exitCode] }

--- a/fs/cbase32/module.f.ts
+++ b/fs/cbase32/module.f.ts
@@ -62,11 +62,14 @@ export const cBase32ToVec5x = (s: string): Nullable<Vec> => {
 
 export const cBase32ToVec = (s: string): Nullable<Vec> => {
     let v = cBase32ToVec5x(s)
-    if (v === null || v === empty) { return null }
-    // TODO: replace with a function that computes trailing zeros.
-    while (true) {
-        const [last, v0] = popBack1(v)
-        v = v0
+    if (v === null) { return null }
+    // Strip the padding: trailing zeros up to and including the sentinel `1` bit.
+    // A string with no sentinel — only zero symbols (`0`/`o`), or empty — exhausts
+    // to `empty` and is rejected as `null` rather than looping forever.
+    while (v !== empty) {
+        const [last, rest] = popBack1(v)
+        v = rest
         if (last === 1n) { return v }
     }
+    return null
 }

--- a/fs/cbase32/proof.f.ts
+++ b/fs/cbase32/proof.f.ts
@@ -53,5 +53,12 @@ export const proof = {
         if (cBase32ToVec5x("l") !== cBase32ToVec5x("1")) { throw 'l maps to 1' }
         if (cBase32ToVec5x("o") !== cBase32ToVec5x("0")) { throw 'o maps to 0' }
         if (cBase32ToVec5x("u") !== null) { throw 'should error on invalid character' }
+    },
+    unterminated: () => {
+        // No sentinel `1` bit → invalid; must return null, not loop forever.
+        if (cBase32ToVec("") !== null) { throw 'empty must be null' }
+        if (cBase32ToVec("0") !== null) { throw 'single zero symbol must be null' }
+        if (cBase32ToVec("00") !== null) { throw 'all-zero symbols must be null' }
+        if (cBase32ToVec("o") !== null) { throw 'o (maps to 0) must be null' }
     }
 }

--- a/fs/effects/node/module.f.ts
+++ b/fs/effects/node/module.f.ts
@@ -24,6 +24,17 @@ import {
 
 export type IoResult<T> = Result<T, unknown>
 
+/**
+ * True if `e` is a "file or directory does not exist" (`ENOENT`) error.
+ *
+ * Node's filesystem rejections are `Error`s carrying `code: 'ENOENT'`; the
+ * virtual interpreter mirrors that shape for absent paths. Lets callers swallow
+ * only the missing-path case (e.g. a fresh store) while propagating genuine
+ * failures (permissions, corruption) rather than masking them.
+ */
+export const isNotFound = (e: unknown): boolean =>
+    typeof e === 'object' && e !== null && (e as { readonly code?: unknown }).code === 'ENOENT'
+
 // all
 
 export type All = ['all', <T>(...effects: Effect<never, T>[]) => readonly T[]]

--- a/fs/effects/node/proof.f.ts
+++ b/fs/effects/node/proof.f.ts
@@ -85,7 +85,7 @@ export const proof = {
         nestedPath: () => {
             const [_, [t, result]] = virtual(emptyState)(readFile('tmp/cache'))
             if (t !== 'error') { throw result }
-            if (result !== 'no such file') { throw result }
+            if ((result as { code?: unknown }).code !== 'ENOENT') { throw result }
         }
     },
     readUtf8File: {

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -95,12 +95,15 @@ const mkdir = (recursive: boolean) => operation((dir, path): readonly[Dir, IoRes
     return [dir, okVoid]
 })
 
-const readFileError = error('no such file')
+/** Absent-path error mirroring Node's `ENOENT`, so `isNotFound` recognizes it. */
+const enoent = error({ code: 'ENOENT' })
 
 const readFile = readOperation((dir, path): IoResult<Vec> => {
-    if (path.length !== 1) { return readFileError }
+    if (path.length !== 1) { return enoent }
     const file = dir[path[0]]
     if (typeof file === 'function') { throw new Error(`'${path[0]}' is a JsModule; readFile not supported`) }
+    if (file === undefined) { return enoent }
+    // exists but is a directory — a real error, not a missing path
     if (!isVec(file)) { return error(`'${path[0]}' is not a file`) }
     return ok(file)
 })
@@ -147,8 +150,8 @@ const readdir = (base: string, recursive: boolean) => readOperation((dir, path):
 
 const access = readOperation((dir, path): IoResult<void> => {
     if (path.length === 0) { return okVoid }
-    if (path.length !== 1) { return error('no such file or directory') }
-    return dir[path[0]] !== undefined ? okVoid : error('no such file or directory')
+    if (path.length !== 1) { return enoent }
+    return dir[path[0]] !== undefined ? okVoid : enoent
 })
 
 const rm = operation((dir, path): readonly[Dir, IoResult<void>] => {

--- a/issues/66E-mcp-cas-server.md
+++ b/issues/66E-mcp-cas-server.md
@@ -1,8 +1,10 @@
 # 66E-mcp-cas-server. Design: an MCP server that exposes `fs/cas` as tools
 
 **Priority:** P3
-**Status:** open
-**Blocked by:** [i66E-mcp-stdio-transport](./66E-mcp-stdio-transport.md) — stdio transport not yet built
+**Status:** done
+**Blocked by:** ~~[i66E-mcp-stdio-transport](./66E-mcp-stdio-transport.md)~~ — stdio transport
+has since landed (`fs/mcp/stdio`, byte-level stdin read effect in `fs/effects/node`),
+unblocking this issue including the `cas mcp` CLI subcommand.
 
 ## Problem
 
@@ -145,22 +147,23 @@ before the live loop exists (the proof drives `step` directly, exactly as
 
 ## Tasks
 
-- [ ] Add `fs/cas/mcp/module.f.ts`: `casAddArgs` / `casGetArgs` / `casListArgs`
+- [x] Add `fs/cas/mcp/module.f.ts`: `casAddArgs` / `casGetArgs` / `casListArgs`
       rtti schemas, the three `Tool` descriptors (`inputSchema` via
       `toJsonSchema`), and `casMcpHandlers(c: Cas<O>): McpHandlers<O>`.
-- [ ] Implement `tools/call` dispatch with per-tool `validate`, cBase32
+- [x] Implement `tools/call` dispatch with per-tool `validate`, cBase32
       decode/encode, and the `isError` result convention for bad input / missing
       hash / unknown tool.
-- [ ] Add `casConfig: McpConfig` (capabilities `{ tools: {} }`, `serverInfo`,
+- [x] Add `casConfig: McpConfig` (capabilities `{ tools: {} }`, `serverInfo`,
       pinned `protocolVersion`).
-- [ ] `fs/cas/mcp/proof.f.ts`: drive `mcpStep(casConfig)(casMcpHandlers(c))` over
+- [x] `fs/cas/mcp/proof.f.ts`: drive `mcpStep(casConfig)(casMcpHandlers(c))` over
       an in-memory `Cas<MemOp>` through a full `initialize` →
       `notifications/initialized` → `tools/call` sequence; assert add→get
       round-trips, `cas_list` enumerates, and each error path returns `isError`.
-- [ ] Document the cBase32 content-encoding decision and the protocol-error vs.
-      tool-error split in `fs/cas/README.md` (or a new `fs/cas/mcp/README.md`).
-- [ ] **(blocked)** stdio transport loop once a stdin read effect lands in
-      `fs/effects/node`; add a `cas mcp` CLI subcommand that runs it.
+- [x] Document the cBase32 content-encoding decision and the protocol-error vs.
+      tool-error split in a new `fs/cas/mcp/README.md`.
+- [x] stdio transport loop (now landed in `fs/mcp/stdio`, over the stdin read
+      effect in `fs/effects/node`); added a `cas mcp` CLI subcommand
+      (`casMcpServer`) that runs it.
 
 ## Open questions
 


### PR DESCRIPTION
Add fs/cas/mcp adapter mapping the three Cas<O> operations onto MCP tools
(cas_add / cas_get / cas_list), with cBase32 content encoding and an
isError result convention for tool-level failures. Wire a `cas mcp` CLI
subcommand that runs the server over stdio now that the stdin read effect
and fs/mcp/stdio transport have landed.

https://claude.ai/code/session_01E11yeeHS1e2am2T7XEgxyS