### PR TITLE
issues/lang: undefined-valued properties don't exist in FS (1010)

### DIFF
--- a/issues/lang/1010-undefined-property.md
+++ b/issues/lang/1010-undefined-property.md
@@ -24,6 +24,9 @@ Object.values(a).filter(v => v !== undefined)
 
 Bare `Object.entries(a)` or `Object.values(a)` without the filter is a compile-time error.
 
+The `in` operator is also prohibited, because `'x' in { x: undefined }` returns `true`
+in JavaScript despite the property being non-existent under the FS model.
+
 ## Motivation
 
 In JavaScript, `{ x: undefined }` and `{}` behave differently under `Object.entries`

--- a/issues/lang/1010-undefined-property.md
+++ b/issues/lang/1010-undefined-property.md
@@ -1,0 +1,39 @@
+# Undefined-Valued Properties
+
+In FunctionalScript, a property whose value is `undefined` is semantically
+equivalent to the property not existing:
+
+```ts
+{ x: undefined }  ≡  {}
+```
+
+This is consistent with JSON (which has no concept of `undefined`) and with
+`JSON.stringify`, which omits `undefined`-valued properties. It also aligns with
+TypeScript's optional-field model, where `field?: T` makes absent and `undefined`
+interchangeable.
+
+## Consequence: `Object.entries` and `Object.values` require a filter
+
+`Object.entries` and `Object.values` are not allowed in isolation. They are only
+permitted as part of the whitelisted patterns that immediately filter out `undefined`:
+
+```ts
+Object.entries(a).filter(([, v]) => v !== undefined)
+Object.values(a).filter(v => v !== undefined)
+```
+
+Bare `Object.entries(a)` or `Object.values(a)` without the filter is a compile-time error.
+
+## Motivation
+
+In JavaScript, `{ x: undefined }` and `{}` behave differently under `Object.entries`
+and `Object.values`, even though the two objects are logically identical under the FS
+object model. This discrepancy is a source of subtle bugs in serializers, equality
+checks, and merge functions. Making undefined properties non-existent by rule eliminates
+the entire class at the language level.
+
+## Related
+
+- [undefined](./2310-undefined.md) — the `undefined` value in DJS
+- [built-in](./2360-built-in.md) — `Object.entries` / `Object.values` side-effect table
+- `fs/types/object/module.f.ts` — `definedEntries` and `definedValues` helpers

--- a/issues/lang/README.md
+++ b/issues/lang/README.md
@@ -21,6 +21,7 @@ File Types:
 ## 1. JSON
 
 - [ ] [JSON](./1000-json.md).
+- [ ] [undefined-property](./1010-undefined-property.md).
 
 **VM**:
 


### PR DESCRIPTION
## Summary

- Adds `issues/lang/1010-undefined-property.md`: a language proposal establishing that a property with an `undefined` value is semantically non-existent in FunctionalScript (`{ x: undefined } ≡ {}`)
- `Object.entries` and `Object.values` are only permitted with an immediate `undefined` filter (whitelisted pattern); bare use is a compile-time error
- The `in` operator is prohibited (would return `true` for `undefined`-valued properties, violating the rule)
- Registers the proposal in `issues/lang/README.md` section 1

## Test plan

- [ ] Proposal is consistent with the FS design principles (whitelisted patterns, not individual operations)
- [ ] Cross-references to `2310-undefined.md` and `2360-built-in.md` are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)