### PR TITLE
Add MIME type detection and typed binary responses to CAS MCP

### DIFF
--- a/fs/cas/mcp/README.md
+++ b/fs/cas/mcp/README.md
@@ -10,11 +10,11 @@ additional front end alongside the CLI `main`, exactly as the issue describes.
 
 ## The three tools
 
-| Tool       | args                  | CAS call         | result text          |
-|------------|-----------------------|------------------|----------------------|
-| `cas_add`  | `{ content: string }` | `c.write(value)` | hash (cBase32)       |
-| `cas_get`  | `{ hash: string }`    | `c.read(key)`    | content (base64)     |
-| `cas_list` | `{}`                  | `c.list()`       | hashes, one per line |
+| Tool       | args                  | CAS call         | result                       |
+|------------|-----------------------|------------------|------------------------------|
+| `cas_add`  | `{ content: string }` | `c.write(value)` | hash (cBase32)               |
+| `cas_get`  | `{ hash: string }`    | `c.read(key)`    | content (base64; see below)  |
+| `cas_list` | `{}`                  | `c.list()`       | hashes, one per line         |
 
 Each tool's argument schema is an rtti struct declared once and used twice:
 [`toJsonSchema`](../../json/schema/module.f.ts) derives the `inputSchema`
@@ -42,9 +42,32 @@ The split was a deliberate revisit of the original "everything in cBase32"
 choice (see [i66E-cas-mcp-base64-content](../../../issues/66E-cas-mcp-base64-content.md)):
 hashes stay cBase32 because that is their canonical identity across the project,
 while content switches to base64 so the MCP surface stays interoperable with the
-broader ecosystem. A follow-up will use base64 again when an `EmbeddedResource`
-`blob` content type lands (see
-[i66E-cas-mcp-file-type](../../../issues/66E-cas-mcp-file-type.md)).
+broader ecosystem.
+
+## File-type detection on `cas_get`
+
+The store keeps raw bytes with no type metadata, so type is recovered on read
+rather than stored on write. `cas_get` sniffs the retrieved bytes with
+[`fs/mime`](../../mime/module.f.ts) `detect` and returns one of two shapes:
+
+- **Recognised** magic-byte signature (PNG, JPEG, GIF, WebP, PDF, ZIP) → an MCP
+  [`EmbeddedResource`](../../mcp/module.f.ts) (`BlobResource`) carrying the
+  detected `mimeType`, the base64 `blob`, and a `cas://sha256/<hash>` URI:
+
+  ```json
+  { "type": "resource",
+    "resource": { "uri": "cas://sha256/<hash>", "mimeType": "image/png", "blob": "<base64>" } }
+  ```
+
+- **Unrecognised** bytes (`detect` → `null`) → the plain `textContent` block, so
+  the tool stays backward compatible:
+
+  ```json
+  { "type": "text", "text": "<base64>" }
+  ```
+
+`cas_add` is unchanged — no type is attached on write; the store stays a pure
+`hash → bytes` map.
 
 ## Protocol errors vs. tool errors
 

--- a/fs/cas/mcp/module.f.ts
+++ b/fs/cas/mcp/module.f.ts
@@ -9,11 +9,11 @@
  *
  * ## The three tools
  *
- * | Tool       | args                  | CAS call         | result text          |
- * |------------|-----------------------|------------------|----------------------|
- * | `cas_add`  | `{ content: string }` | `c.write(value)` | hash (cBase32)       |
- * | `cas_get`  | `{ hash: string }`    | `c.read(key)`    | content (base64)     |
- * | `cas_list` | `{}`                  | `c.list()`       | hashes, one per line |
+ * | Tool       | args                  | CAS call         | result                          |
+ * |------------|-----------------------|------------------|---------------------------------|
+ * | `cas_add`  | `{ content: string }` | `c.write(value)` | hash (cBase32)                  |
+ * | `cas_get`  | `{ hash: string }`    | `c.read(key)`    | content (base64; see below)     |
+ * | `cas_list` | `{}`                  | `c.list()`       | hashes, one per line            |
  *
  * Each tool's argument schema is an rtti struct declared once and used twice:
  * `toJsonSchema` derives the `inputSchema` advertised in `tools/list`, and
@@ -31,6 +31,17 @@
  *   already understand without project-specific knowledge.
  *
  * Both decoders return `null` on malformed input, giving free validation.
+ *
+ * ## File-type detection on `cas_get`
+ *
+ * The store is type-agnostic — it keeps raw bytes only — so type is recovered
+ * on read, not stored. `cas_get` sniffs the retrieved bytes with `fs/mime`
+ * `detect`:
+ * - a recognised magic-byte signature (PNG, JPEG, GIF, WebP, PDF, ZIP) →
+ *   an MCP `EmbeddedResource` (`BlobResource`) with the base64 `blob`, the
+ *   detected `mimeType`, and a `cas://sha256/<hash>` URI;
+ * - unrecognised bytes (`detect` → `null`) → the plain `textContent` block,
+ *   so the tool stays backward compatible.
  *
  * ## Error convention
  *
@@ -52,6 +63,7 @@ import { pure, type Effect, type Operation } from '../../effects/module.f.ts'
 import { create, type MemOp } from '../../effects/memory/module.f.ts'
 import { cBase32ToVec, vecToCBase32 } from '../../cbase32/module.f.ts'
 import { decode as base64Decode, encode as base64Encode } from '../../base64/module.f.ts'
+import { detect } from '../../mime/module.f.ts'
 import { type Read, type Write } from '../../effects/node/module.f.ts'
 import { stdioTransport } from '../../mcp/stdio/module.f.ts'
 import {
@@ -98,6 +110,13 @@ const casListTool: Tool = {
 const okResult = (text: string): ToolsCallResult =>
     ({ content: [{ type: 'text', text }] })
 
+/**
+ * A successful typed-binary result: an `EmbeddedResource` carrying the base64
+ * `blob`, its detected `mimeType`, and a `cas://sha256/<hash>` addressing URI.
+ */
+const resourceResult = (hash: string, mimeType: string, blob: string): ToolsCallResult =>
+    ({ content: [{ type: 'resource', resource: { uri: `cas://sha256/${hash}`, mimeType, blob } }] })
+
 /** A tool-level failure: in-band `isError` result with a text explanation. */
 const errorResult = (text: string): ToolsCallResult =>
     ({ content: [{ type: 'text', text }], isError: true })
@@ -141,9 +160,16 @@ export const casMcpHandlers = <O extends Operation>(c: Cas<O>): McpHandlers<O> =
                     // base64Encode returns null only on a non-octet Vec; the filesystem
                     // store can never produce that, but the contract permits it.
                     const text = base64Encode(value)
-                    return pure(text === null
-                        ? errorResult(`content is not byte-aligned: ${r.hash}`)
-                        : okResult(text))
+                    if (text === null) {
+                        return pure(errorResult(`content is not byte-aligned: ${r.hash}`))
+                    }
+                    // When the bytes carry a recognised magic-byte signature, return a
+                    // typed EmbeddedResource so the mimeType travels with the content;
+                    // otherwise fall back to a plain text block for backward compatibility.
+                    const mimeType = detect(value)
+                    return pure(mimeType === null
+                        ? okResult(text)
+                        : resourceResult(r.hash, mimeType, text))
                 })
             }
             case 'cas_list': {

--- a/fs/cas/mcp/module.f.ts
+++ b/fs/cas/mcp/module.f.ts
@@ -167,9 +167,11 @@ export const casMcpHandlers = <O extends Operation>(c: Cas<O>): McpHandlers<O> =
                     // typed EmbeddedResource so the mimeType travels with the content;
                     // otherwise fall back to a plain text block for backward compatibility.
                     const mimeType = detect(value)
+                    // URI carries the canonical cBase32 (from the decoded key), not the
+                    // caller's spelling, so the same content always gets the same identity.
                     return pure(mimeType === null
                         ? okResult(text)
-                        : resourceResult(r.hash, mimeType, text))
+                        : resourceResult(vecToCBase32(key), mimeType, text))
                 })
             }
             case 'cas_list': {

--- a/fs/cas/mcp/proof.f.ts
+++ b/fs/cas/mcp/proof.f.ts
@@ -4,7 +4,7 @@ import { run, type MemOperationMap } from '../../effects/mock/module.f.ts'
 import { asBase, asNominal, create, read, write, type Key, type MemOp } from '../../effects/memory/module.f.ts'
 import type { Unknown } from '../../json/module.f.ts'
 import type { Response } from '../../json/rpc/module.f.ts'
-import { vec8, type Vec } from '../../types/bit_vec/module.f.ts'
+import { msb, u8ListToVec, vec8, type Vec } from '../../types/bit_vec/module.f.ts'
 import { vecToCBase32 } from '../../cbase32/module.f.ts'
 import { encode as base64Encode } from '../../base64/module.f.ts'
 import { sha256 } from '../../crypto/sha2/module.f.ts'
@@ -96,10 +96,22 @@ const session = (...msgs: readonly unknown[]): readonly unknown[] =>
 const resultOf = (resp: unknown): ToolsCallResult =>
     (resp as { readonly result: ToolsCallResult }).result
 
-const textOf = (resp: unknown): string => resultOf(resp).content[0].text
+const item0 = (resp: unknown): unknown => resultOf(resp).content[0]
+
+const textOf = (resp: unknown): string => (item0(resp) as { readonly text: string }).text
+
+type BlobResource = { readonly uri: string, readonly mimeType?: string, readonly blob: string }
+
+const resourceOf = (resp: unknown): BlobResource =>
+    (item0(resp) as { readonly type: string, readonly resource: BlobResource }).resource
 
 // A valid base64 payload to store and round-trip.
 const sample = base64Encode(vec8(0x2An)) as string
+
+// A base64 blob whose leading bytes are the PNG magic-byte signature, so
+// `cas_get` detects its type and returns an EmbeddedResource.
+const pngSample = base64Encode(
+    u8ListToVec(msb)([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x01])) as string
 
 // ── Tests ───────────────────────────────────────────────────────────────────────
 
@@ -131,6 +143,35 @@ export const proof = {
         )
         assert(!resultOf(getResp).isError)
         assertEq(textOf(getResp), sample)
+    },
+
+    // Opaque bytes (no magic-byte match) come back as a plain text block.
+    getUntypedReturnsText: () => {
+        const [addResp] = session(call(2, 'cas_add', { content: sample }))
+        const hash = textOf(addResp)
+        const [, getResp] = session(
+            call(2, 'cas_add', { content: sample }),
+            call(3, 'cas_get', { hash }),
+        )
+        assertEq(item0(getResp) === null ? null : (item0(getResp) as { type: string }).type, 'text')
+        assertEq(textOf(getResp), sample)
+    },
+
+    // Bytes with a recognised PNG signature come back as an EmbeddedResource
+    // carrying the mimeType, the base64 blob, and a cas:// URI.
+    getTypedReturnsEmbeddedResource: () => {
+        const [addResp] = session(call(2, 'cas_add', { content: pngSample }))
+        const hash = textOf(addResp)
+        const [, getResp] = session(
+            call(2, 'cas_add', { content: pngSample }),
+            call(3, 'cas_get', { hash }),
+        )
+        assert(!resultOf(getResp).isError)
+        assertEq((item0(getResp) as { type: string }).type, 'resource')
+        const resource = resourceOf(getResp)
+        assertEq(resource.mimeType, 'image/png')
+        assertEq(resource.blob, pngSample)
+        assertEq(resource.uri, `cas://sha256/${hash}`)
     },
 
     listEnumeratesStoredHashes: () => {

--- a/fs/mcp/module.f.ts
+++ b/fs/mcp/module.f.ts
@@ -13,7 +13,7 @@
  *
  * @module
  */
-import { boolean, string, option, array, record } from '../types/rtti/module.f.ts'
+import { boolean, string, option, array, record, or } from '../types/rtti/module.f.ts'
 import { unknown, type Unknown } from '../json/module.f.ts'
 import type { Ts } from '../types/rtti/ts/module.f.ts'
 import { pure, type Operation, type Effect } from '../effects/module.f.ts'
@@ -70,6 +70,34 @@ export type InitializeResult = Ts<typeof initializeResult>
 export const textContent = { type: 'text', text: string } as const
 export type TextContent = Ts<typeof textContent>
 
+/**
+ * A binary resource carried inside an {@link embeddedResource}: a base64
+ * `blob`, an addressing `uri`, and an optional `mimeType`. This is MCP's
+ * `BlobResource` shape — the idiomatic way to return typed binary content so a
+ * `mimeType` travels alongside the bytes and clients know how to route them.
+ */
+export const blobResource = {
+    uri: string,
+    mimeType: option(string),
+    blob: string,
+} as const
+export type BlobResource = Ts<typeof blobResource>
+
+/** An `EmbeddedResource` content item wrapping a {@link blobResource}. */
+export const embeddedResource = {
+    type: 'resource',
+    resource: blobResource,
+} as const
+export type EmbeddedResource = Ts<typeof embeddedResource>
+
+/**
+ * A single item in a `tools/call` result's `content` array: either plain
+ * {@link textContent} or an {@link embeddedResource} for typed binary. The
+ * `image` and `audio` variants are not modelled yet.
+ */
+export const contentItem = or(textContent, embeddedResource)
+export type ContentItem = Ts<typeof contentItem>
+
 // ── Tools ──────────────────────────────────────────────────────────────────────
 
 /**
@@ -106,7 +134,7 @@ export const toolsCallParams = {
 export type ToolsCallParams = Ts<typeof toolsCallParams>
 
 export const toolsCallResult = {
-    content: array(textContent),
+    content: array(contentItem),
     isError: option(boolean),
 } as const
 export type ToolsCallResult = Ts<typeof toolsCallResult>

--- a/fs/mcp/proof.f.ts
+++ b/fs/mcp/proof.f.ts
@@ -246,7 +246,7 @@ export const proof = {
             const msg = { jsonrpc: '2.0', method: 'tools/call', id: 6,
                 params: { name: 'greet', arguments: {} } }
             const [resp] = step3(config)(initMsg)(initNotif)(msg)
-            assertEq((resp as { result: ToolsCallResult }).result.content[0].text, 'hello')
+            assertEq(((resp as { result: ToolsCallResult }).result.content[0] as { text: string }).text, 'hello')
         },
 
         toolsCallBadParamsReturnsInvalidParams: () => {
@@ -259,7 +259,7 @@ export const proof = {
             const msg = { jsonrpc: '2.0', method: 'tools/call', id: 13,
                 params: { name: 'greet' } }
             const [resp] = step3(config)(initMsg)(initNotif)(msg)
-            assertEq((resp as { result: ToolsCallResult }).result.content[0].text, 'hello')
+            assertEq(((resp as { result: ToolsCallResult }).result.content[0] as { text: string }).text, 'hello')
         },
 
         toolsCallNullArgumentsReturnsInvalidParams: () => {

--- a/fs/mime/README.md
+++ b/fs/mime/README.md
@@ -1,0 +1,45 @@
+# MIME detection
+
+Magic-byte MIME type detection: a pure table lookup over the leading bytes of a
+`Vec`. No I/O, no dependencies beyond [`fs/types/bit_vec`](../types/bit_vec/).
+
+```ts
+import { detect } from './module.f.ts'
+
+detect(pngBytes)   // 'image/png'
+detect(textBytes)  // null
+```
+
+## Why detect rather than store
+
+The content-addressable store ([`fs/cas`](../cas/)) is type-agnostic by design —
+it keeps raw bytes only, with no room for a per-blob type tag. Type is therefore
+**recovered on read** by sniffing the content, not written on `cas_add`. This
+keeps the store a pure `hash → bytes` map and confines all type knowledge to the
+edge that needs it (the MCP adapter's `cas_get`).
+
+## Recognised signatures
+
+| MIME type         | Leading bytes                          |
+|-------------------|----------------------------------------|
+| `image/png`       | `89 50 4E 47 0D 0A 1A 0A`              |
+| `image/jpeg`      | `FF D8 FF`                             |
+| `image/gif`       | `47 49 46 38` (`"GIF8"`, covers 87a/89a) |
+| `image/webp`      | `52 49 46 46 .. .. .. .. 57 45 42 50` (`"RIFF"…"WEBP"`) |
+| `application/pdf` | `25 50 44 46 2D` (`"%PDF-"`)           |
+| `application/zip` | `50 4B 03 04` (`"PK\x03\x04"`)         |
+
+Anything else — text, unknown binary, or a `Vec` shorter than the signature it
+might match — returns `null`. There is deliberately no text/`charset` fallback:
+distinguishing UTF-8 from arbitrary bytes is not a magic-byte test, and the
+caller's `null` branch already handles "treat as opaque/text".
+
+WebP is the only non-contiguous signature: the four-byte little-endian file size
+sits between the `RIFF` and `WEBP` markers, so it is matched as a prefix plus a
+second marker at byte offset 8.
+
+## Consumers
+
+- [`fs/cas/mcp`](../cas/mcp/) — `cas_get` calls `detect` on the retrieved bytes
+  and returns an MCP `EmbeddedResource` (with `mimeType`) when a type is
+  recognised, falling back to a plain text block on `null`.

--- a/fs/mime/README.md
+++ b/fs/mime/README.md
@@ -24,7 +24,7 @@ edge that needs it (the MCP adapter's `cas_get`).
 |-------------------|----------------------------------------|
 | `image/png`       | `89 50 4E 47 0D 0A 1A 0A`              |
 | `image/jpeg`      | `FF D8 FF`                             |
-| `image/gif`       | `47 49 46 38` (`"GIF8"`, covers 87a/89a) |
+| `image/gif`       | `47 49 46 38 37 61` / `…39 61` (`"GIF87a"` / `"GIF89a"`) |
 | `image/webp`      | `52 49 46 46 .. .. .. .. 57 45 42 50` (`"RIFF"…"WEBP"`) |
 | `application/pdf` | `25 50 44 46 2D` (`"%PDF-"`)           |
 | `application/zip` | `50 4B 03 04` / `05 06` / `07 08` (`"PK"` entry, empty, or spanned) |

--- a/fs/mime/README.md
+++ b/fs/mime/README.md
@@ -27,7 +27,7 @@ edge that needs it (the MCP adapter's `cas_get`).
 | `image/gif`       | `47 49 46 38` (`"GIF8"`, covers 87a/89a) |
 | `image/webp`      | `52 49 46 46 .. .. .. .. 57 45 42 50` (`"RIFF"…"WEBP"`) |
 | `application/pdf` | `25 50 44 46 2D` (`"%PDF-"`)           |
-| `application/zip` | `50 4B 03 04` (`"PK\x03\x04"`)         |
+| `application/zip` | `50 4B 03 04` / `05 06` / `07 08` (`"PK"` entry, empty, or spanned) |
 
 Anything else — text, unknown binary, or a `Vec` shorter than the signature it
 might match — returns `null`. There is deliberately no text/`charset` fallback:

--- a/fs/mime/module.f.ts
+++ b/fs/mime/module.f.ts
@@ -27,30 +27,44 @@
  *
  * @module
  */
-import { msb, u8ListToVec, length, type Vec } from '../types/bit_vec/module.f.ts'
+import { msb, vec, length, type Vec } from '../types/bit_vec/module.f.ts'
+import { bitLength } from '../types/bigint/module.f.ts'
 import type { Nullable } from '../types/nullable/module.f.ts'
 
 const { startsWith, removeFront } = msb
 
-/** Builds a big-endian signature `Vec` from a list of byte values. */
-const sig = (bytes: readonly number[]): Vec => u8ListToVec(msb)(bytes)
+/**
+ * Builds a big-endian signature `Vec` from a hex literal. The leading `1`
+ * nibble is a sentinel: it marks where the byte run starts — so leading zero
+ * bytes are not swallowed — and fixes the length. `bitLength(raw) - 1` is the
+ * signature's bit length, and `vec` masks the sentinel back off.
+ *
+ * ```
+ * sig(0x1_89_50_4e_47n)  // the 4-byte run 89 50 4E 47
+ * ```
+ */
+const sig = (raw: bigint): Vec => vec(bitLength(raw) - 1n)(raw)
 
 /**
  * Contiguous magic-byte signatures, checked in order; the first prefix match
  * wins. Ordering is irrelevant here — no signature is a prefix of another.
  */
 const table: readonly (readonly [Vec, string])[] = [
-    [sig([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), 'image/png'],
-    [sig([0xff, 0xd8, 0xff]), 'image/jpeg'],
-    [sig([0x47, 0x49, 0x46, 0x38]), 'image/gif'],
-    [sig([0x25, 0x50, 0x44, 0x46, 0x2d]), 'application/pdf'],
-    [sig([0x50, 0x4b, 0x03, 0x04]), 'application/zip'],
+    [sig(0x1_89_50_4e_47_0d_0a_1a_0an), 'image/png'],
+    [sig(0x1_ff_d8_ffn), 'image/jpeg'],
+    [sig(0x1_47_49_46_38n), 'image/gif'],
+    [sig(0x1_25_50_44_46_2dn), 'application/pdf'],
+    // ZIP has three "PK" local-header variants: a normal entry, an empty
+    // archive (end-of-central-directory only), and a spanned archive.
+    [sig(0x1_50_4b_03_04n), 'application/zip'],
+    [sig(0x1_50_4b_05_06n), 'application/zip'],
+    [sig(0x1_50_4b_07_08n), 'application/zip'],
 ]
 
 // WebP: "RIFF" at offset 0, "WEBP" at offset 8 (the 4 bytes between are the
 // file size). 12 bytes = 96 bits is the minimum to carry both markers.
-const riff = sig([0x52, 0x49, 0x46, 0x46])
-const webp = sig([0x57, 0x45, 0x42, 0x50])
+const riff = sig(0x1_52_49_46_46n)
+const webp = sig(0x1_57_45_42_50n)
 
 const isWebp = (bytes: Vec): boolean =>
     length(bytes) >= 96n

--- a/fs/mime/module.f.ts
+++ b/fs/mime/module.f.ts
@@ -1,0 +1,73 @@
+/**
+ * Magic-byte MIME type detection.
+ *
+ * A pure table lookup over the leading bytes of a `Vec`: no I/O, no
+ * dependencies beyond `fs/types/bit_vec`. `detect` returns a MIME type string
+ * for the container formats whose signatures it knows, or `null` for anything
+ * else — text, unknown binary, or a `Vec` too short to match.
+ *
+ * The CAS store is type-agnostic and keeps raw bytes only, so type is never
+ * stored; it is recovered on read by sniffing the content. Callers decide what
+ * `null` means: the CAS MCP adapter falls back to a plain text result.
+ *
+ * ## Recognised signatures
+ *
+ * | MIME type         | Leading bytes                          |
+ * |-------------------|----------------------------------------|
+ * | `image/png`       | `89 50 4E 47 0D 0A 1A 0A`              |
+ * | `image/jpeg`      | `FF D8 FF`                             |
+ * | `image/gif`       | `47 49 46 38` (`"GIF8"`)               |
+ * | `image/webp`      | `52 49 46 46 .. .. .. .. 57 45 42 50` (`"RIFF"…"WEBP"`) |
+ * | `application/pdf` | `25 50 44 46 2D` (`"%PDF-"`)           |
+ * | `application/zip` | `50 4B 03 04` (`"PK\x03\x04"`)         |
+ *
+ * WebP is the one signature with a gap: the four-byte little-endian file size
+ * sits between the `RIFF` and `WEBP` markers, so it is matched as a prefix plus
+ * a second marker at byte offset 8 rather than a single contiguous run.
+ *
+ * @module
+ */
+import { msb, u8ListToVec, length, type Vec } from '../types/bit_vec/module.f.ts'
+import type { Nullable } from '../types/nullable/module.f.ts'
+
+const { startsWith, removeFront } = msb
+
+/** Builds a big-endian signature `Vec` from a list of byte values. */
+const sig = (bytes: readonly number[]): Vec => u8ListToVec(msb)(bytes)
+
+/**
+ * Contiguous magic-byte signatures, checked in order; the first prefix match
+ * wins. Ordering is irrelevant here — no signature is a prefix of another.
+ */
+const table: readonly (readonly [Vec, string])[] = [
+    [sig([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), 'image/png'],
+    [sig([0xff, 0xd8, 0xff]), 'image/jpeg'],
+    [sig([0x47, 0x49, 0x46, 0x38]), 'image/gif'],
+    [sig([0x25, 0x50, 0x44, 0x46, 0x2d]), 'application/pdf'],
+    [sig([0x50, 0x4b, 0x03, 0x04]), 'application/zip'],
+]
+
+// WebP: "RIFF" at offset 0, "WEBP" at offset 8 (the 4 bytes between are the
+// file size). 12 bytes = 96 bits is the minimum to carry both markers.
+const riff = sig([0x52, 0x49, 0x46, 0x46])
+const webp = sig([0x57, 0x45, 0x42, 0x50])
+
+const isWebp = (bytes: Vec): boolean =>
+    length(bytes) >= 96n
+        && startsWith(riff)(bytes)
+        && startsWith(webp)(removeFront(64n)(bytes))
+
+/**
+ * Detects the MIME type of `bytes` from its leading magic-byte signature.
+ *
+ * @returns the MIME type string for a recognised format, or `null` when the
+ *   leading bytes match no known signature (including any `Vec` shorter than
+ *   the signature it might otherwise match).
+ */
+export const detect = (bytes: Vec): Nullable<string> => {
+    if (isWebp(bytes)) { return 'image/webp' }
+    for (const [s, m] of table) {
+        if (startsWith(s)(bytes)) { return m }
+    }
+    return null
+}

--- a/fs/mime/module.f.ts
+++ b/fs/mime/module.f.ts
@@ -16,10 +16,10 @@
  * |-------------------|----------------------------------------|
  * | `image/png`       | `89 50 4E 47 0D 0A 1A 0A`              |
  * | `image/jpeg`      | `FF D8 FF`                             |
- * | `image/gif`       | `47 49 46 38` (`"GIF8"`)               |
+ * | `image/gif`       | `47 49 46 38 37 61` / `…39 61` (`"GIF87a"` / `"GIF89a"`) |
  * | `image/webp`      | `52 49 46 46 .. .. .. .. 57 45 42 50` (`"RIFF"…"WEBP"`) |
  * | `application/pdf` | `25 50 44 46 2D` (`"%PDF-"`)           |
- * | `application/zip` | `50 4B 03 04` (`"PK\x03\x04"`)         |
+ * | `application/zip` | `50 4B 03 04` / `05 06` / `07 08` (`"PK"` entry, empty, or spanned) |
  *
  * WebP is the one signature with a gap: the four-byte little-endian file size
  * sits between the `RIFF` and `WEBP` markers, so it is matched as a prefix plus
@@ -27,23 +27,15 @@
  *
  * @module
  */
-import { msb, vec, length, type Vec } from '../types/bit_vec/module.f.ts'
-import { bitLength } from '../types/bigint/module.f.ts'
+import { msb, fromSentinel, length, type Vec } from '../types/bit_vec/module.f.ts'
 import type { Nullable } from '../types/nullable/module.f.ts'
 
 const { startsWith, removeFront } = msb
 
-/**
- * Builds a big-endian signature `Vec` from a hex literal. The leading `1`
- * nibble is a sentinel: it marks where the byte run starts — so leading zero
- * bytes are not swallowed — and fixes the length. `bitLength(raw) - 1` is the
- * signature's bit length, and `vec` masks the sentinel back off.
- *
- * ```
- * sig(0x1_89_50_4e_47n)  // the 4-byte run 89 50 4E 47
- * ```
- */
-const sig = (raw: bigint): Vec => vec(bitLength(raw) - 1n)(raw)
+// Each signature is written as a hex literal whose leading `1` nibble is a
+// sentinel marking the start of the byte run (so leading zero bytes survive)
+// and fixing the length — see `bit_vec` `fromSentinel`.
+const sig = fromSentinel
 
 /**
  * Contiguous magic-byte signatures, checked in order; the first prefix match
@@ -52,7 +44,10 @@ const sig = (raw: bigint): Vec => vec(bitLength(raw) - 1n)(raw)
 const table: readonly (readonly [Vec, string])[] = [
     [sig(0x1_89_50_4e_47_0d_0a_1a_0an), 'image/png'],
     [sig(0x1_ff_d8_ffn), 'image/jpeg'],
-    [sig(0x1_47_49_46_38n), 'image/gif'],
+    // Match the full GIF version headers ("GIF87a" / "GIF89a"), not just "GIF8",
+    // so opaque bytes that merely start with "GIF8" are not mistyped.
+    [sig(0x1_47_49_46_38_37_61n), 'image/gif'],
+    [sig(0x1_47_49_46_38_39_61n), 'image/gif'],
     [sig(0x1_25_50_44_46_2dn), 'application/pdf'],
     // ZIP has three "PK" local-header variants: a normal entry, an empty
     // archive (end-of-central-directory only), and a spanned archive.

--- a/fs/mime/proof.f.ts
+++ b/fs/mime/proof.f.ts
@@ -13,9 +13,15 @@ export const proof = {
     jpeg: () =>
         assertEq(detect(bytes(0xff, 0xd8, 0xff, 0xe0)), 'image/jpeg'),
 
-    gif: () =>
-        // "GIF89a"
+    gif89a: () =>
         assertEq(detect(bytes(0x47, 0x49, 0x46, 0x38, 0x39, 0x61)), 'image/gif'),
+
+    gif87a: () =>
+        assertEq(detect(bytes(0x47, 0x49, 0x46, 0x38, 0x37, 0x61)), 'image/gif'),
+
+    // "GIF8" alone, without a valid version suffix, is not a GIF.
+    gif8NotGif: () =>
+        assertEq(detect(bytes(0x47, 0x49, 0x46, 0x38, 0x30, 0x30)), null),
 
     pdf: () =>
         // "%PDF-1.4"

--- a/fs/mime/proof.f.ts
+++ b/fs/mime/proof.f.ts
@@ -24,6 +24,10 @@ export const proof = {
     zip: () =>
         assertEq(detect(bytes(0x50, 0x4b, 0x03, 0x04, 0x14, 0x00)), 'application/zip'),
 
+    // An empty ZIP archive starts with the end-of-central-directory record.
+    emptyZip: () =>
+        assertEq(detect(bytes(0x50, 0x4b, 0x05, 0x06, 0x00, 0x00)), 'application/zip'),
+
     webp: () =>
         // "RIFF" + 4-byte size + "WEBP"
         assertEq(

--- a/fs/mime/proof.f.ts
+++ b/fs/mime/proof.f.ts
@@ -1,0 +1,51 @@
+import { assertEq } from '../asserts/module.f.ts'
+import { msb, u8ListToVec, empty, type Vec } from '../types/bit_vec/module.f.ts'
+import { detect } from './module.f.ts'
+
+// Builds a big-endian `Vec` from a list of byte values — mirrors how the CAS
+// store would hold the leading bytes of a stored blob.
+const bytes = (...b: readonly number[]): Vec => u8ListToVec(msb)(b)
+
+export const proof = {
+    png: () =>
+        assertEq(detect(bytes(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a)), 'image/png'),
+
+    jpeg: () =>
+        assertEq(detect(bytes(0xff, 0xd8, 0xff, 0xe0)), 'image/jpeg'),
+
+    gif: () =>
+        // "GIF89a"
+        assertEq(detect(bytes(0x47, 0x49, 0x46, 0x38, 0x39, 0x61)), 'image/gif'),
+
+    pdf: () =>
+        // "%PDF-1.4"
+        assertEq(detect(bytes(0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34)), 'application/pdf'),
+
+    zip: () =>
+        assertEq(detect(bytes(0x50, 0x4b, 0x03, 0x04, 0x14, 0x00)), 'application/zip'),
+
+    webp: () =>
+        // "RIFF" + 4-byte size + "WEBP"
+        assertEq(
+            detect(bytes(
+                0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50)),
+            'image/webp'),
+
+    // "RIFF…" without the "WEBP" marker (e.g. a WAV) is not WebP.
+    riffNotWebp: () =>
+        assertEq(
+            detect(bytes(
+                0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45)),
+            null),
+
+    // Plain ASCII text matches no signature.
+    textIsNull: () =>
+        assertEq(detect(bytes(0x68, 0x65, 0x6c, 0x6c, 0x6f)), null),
+
+    // A prefix shorter than any signature falls through to null, not a partial match.
+    shortIsNull: () =>
+        assertEq(detect(bytes(0x89, 0x50)), null),
+
+    emptyIsNull: () =>
+        assertEq(detect(empty), null),
+}

--- a/fs/types/bit_vec/module.f.ts
+++ b/fs/types/bit_vec/module.f.ts
@@ -81,6 +81,25 @@ export const vec = (len: bigint): (ui: bigint) => Vec => {
 export const vec8: (ui: bigint) => Vec = vec(8n)
 
 /**
+ * Builds a vector from a bigint whose most-significant set bit is a sentinel
+ * marking the start of the data.
+ *
+ * The sentinel does double duty: it fixes the length (`bitLength - 1`) and is
+ * stripped from the result. This lets a plain hex literal carry leading zero
+ * bits that would otherwise be lost — write `0x1` ahead of the data and the
+ * `1` both delimits and disappears.
+ *
+ * @example
+ *
+ * ```js
+ * uint(fromSentinel(0x1_89_50n))   // 0x8950n
+ * length(fromSentinel(0x1_89_50n)) // 16n — the two data bytes, sentinel gone
+ * fromSentinel(0x1_00_05n)         // a 16-bit vector holding 0x0005
+ * ```
+ */
+export const fromSentinel = (raw: bigint): Vec => vec(bitLength(raw) - 1n)(raw)
+
+/**
  * Returns the unsigned integer representation of the vector by clearing the stop bit.
  *
  * @example

--- a/fs/types/bit_vec/proof.f.ts
+++ b/fs/types/bit_vec/proof.f.ts
@@ -1,7 +1,7 @@
 import { mask } from '../bigint/module.f.ts'
 import type { Sign } from '../function/compare/module.f.ts'
 import { asBase, asNominal } from '../nominal/module.f.ts'
-import { length, empty, uint, type Vec, vec, lsb, msb, type BitOrder, repeat, vec8, u8ListToVec, u8List, chunkList } from './module.f.ts'
+import { length, empty, uint, type Vec, vec, lsb, msb, type BitOrder, repeat, vec8, u8ListToVec, u8List, chunkList, fromSentinel } from './module.f.ts'
 import { repeat as listRepeat, toArray } from '../list/module.f.ts'
 
 const unsafeVec = (a: bigint): Vec => asNominal(a)
@@ -63,6 +63,18 @@ const concat = (e: BitOrder) => (r: Vec) => () => {
 }
 
 export const proof = {
+    fromSentinel: () => {
+        // Two data bytes; the leading 0x1 nibble is the sentinel, stripped out.
+        const v = fromSentinel(0x1_89_50n)
+        assertEq(length(v), 16n)
+        assertEq(uint(v), 0x8950n)
+        // Leading zero bytes survive because the sentinel pins the length.
+        const z = fromSentinel(0x1_00_05n)
+        assertEq(length(z), 16n)
+        assertEq(uint(z), 0x0005n)
+        // A bare sentinel yields the empty vector.
+        assertEq(fromSentinel(0x1n), empty)
+    },
     examples: {
         vec: () => {
             const vec4 = vec(4n)

--- a/issues/66E-cas-mcp-file-type.md
+++ b/issues/66E-cas-mcp-file-type.md
@@ -1,8 +1,7 @@
 # 66E-cas-mcp-file-type. Include file type (MIME) in CAS MCP content
 
 **Priority:** P2
-**Status:** open
-**Blocked by:** [i66E-cas-mcp-base64-content](./66E-cas-mcp-base64-content.md)
+**Status:** done
 
 ## Problem
 
@@ -120,19 +119,31 @@ embeddedResource` (and `imageContent` / `audioContent` when those land).
 
 ## Tasks
 
-- [ ] Add `fs/mime/module.f.ts`: `detect(bytes: Vec): string | null` with
+- [x] Add `fs/mime/module.f.ts`: `detect(bytes: Vec): Nullable<string>` with
       magic-byte table for common formats; `fs/mime/proof.f.ts` with fixture
       tests per recognised type and the `null` fallback
-- [ ] Add `blobResource` and `embeddedResource` schemas to
+- [x] Add `blobResource` and `embeddedResource` schemas to
       `fs/mcp/module.f.ts`; update `toolsCallResult` content union
-- [ ] In `fs/cas/mcp/module.f.ts`, call `detect` on the retrieved bytes in
+      (`contentItem = or(textContent, embeddedResource)`)
+- [x] In `fs/cas/mcp/module.f.ts`, call `detect` on the retrieved bytes in
       `cas_get`; return `embeddedResource` when MIME is detected, plain
       `textContent` otherwise
-- [ ] Update `fs/cas/mcp/proof.f.ts`: add tests for blobs with recognised
+- [x] Update `fs/cas/mcp/proof.f.ts`: add tests for blobs with recognised
       magic bytes (get → `EmbeddedResource`) and for opaque bytes (get →
       `textContent`)
-- [ ] Update `fs/cas/mcp/README.md` to document MIME detection and the two
-      result shapes
+- [x] Update `fs/cas/mcp/README.md` to document MIME detection and the two
+      result shapes; add `fs/mime/README.md`
+
+## Resolution notes
+
+Scope followed the roadmap (Layer 3): magic-byte detection only (PNG, JPEG,
+GIF, WebP, PDF, ZIP) with `null` for everything else. The UTF-8 text fallback
+floated in the original proposal was **dropped** — distinguishing UTF-8 from
+arbitrary bytes is not a magic-byte test, and the caller's `null` branch
+already routes unrecognised bytes to the plain `textContent` result. The
+rationale lives in `fs/mime/README.md`. WebP is the one non-contiguous
+signature (`RIFF`…`WEBP` with a 4-byte size in between), handled as a prefix
+plus a marker at offset 8.
 
 ## Related
 

--- a/issues/plan/roadmap.md
+++ b/issues/plan/roadmap.md
@@ -34,10 +34,11 @@
 - `fs/base64/module.f.ts` (`encode`/`decode`) already implemented ✓; only MCP wiring remains
 - Tracked: [i66E-cas-mcp-base64-content](../66E-cas-mcp-base64-content.md)
 
-**Layer 3 — Type detection**
-- Detection via magic bytes: PNG, JPEG, GIF, WebP, PDF, ZIP → `null` for unrecognized bytes (per [i66E-cas-mcp-file-type](../66E-cas-mcp-file-type.md))
-- Pure logic in new file `fs/mime/module.f.ts`
-- `cas_get`: when type is detected → return `EmbeddedResource` with `mimeType`; when `null` → fall back to existing `textContent` response for backward compatibility
+**Layer 3 — Type detection (done)**
+- Detection via magic bytes: PNG, JPEG, GIF, WebP, PDF, ZIP → `null` for unrecognized bytes ✓
+- Pure logic in `fs/mime/module.f.ts` ✓
+- `cas_get`: when type is detected → returns `EmbeddedResource` with `mimeType`; when `null` → falls back to existing `textContent` response for backward compatibility ✓
+- `fs/mcp/module.f.ts` gained `blobResource` / `embeddedResource` schemas and a `contentItem` union ✓
 - A separate on-demand `cas_type` tool is a possible extension; needs its own design issue before implementation
 
 ---
@@ -131,7 +132,7 @@ Prerequisite: compiler + CA FunctionalScript complete.
 |---|---|---|
 | 1. Base MCP (add/get/list) | `fs/cas/mcp/`, `fs/mcp/stdio/`, CLI ✓ | `casMcpStep` extraction |
 | 2. Content encoding (base64) | `fs/base64/` ✓ | MCP wiring only |
-| 3. Type detection | — | `fs/mime/` magic-byte detection (PNG/JPEG/GIF/WebP/PDF/ZIP), `cas_get` wiring |
+| 3. Type detection | `fs/mime/` magic-byte detection (PNG/JPEG/GIF/WebP/PDF/ZIP), `cas_get` wiring, `embeddedResource` schema ✓ | — |
 | 4. Signatures | `fs/crypto/sign/` (sign only), `fs/crypto/secp/` ✓ | ECDSA verify + MCP wiring |
 | 5. Trusted timestamps | — | RFC 3161 client + MCP tool |
 | 6. Revision layer | — | Design + implementation |


### PR DESCRIPTION
## Summary

Implements file-type detection for the content-addressable store's MCP interface, allowing `cas_get` to return typed binary content via MCP's `EmbeddedResource` format when a recognized file signature is detected.

## Key Changes

- **New `fs/mime` module** (`module.f.ts`, `proof.f.ts`, `README.md`):
  - Pure magic-byte MIME type detection with no I/O or external dependencies
  - Recognizes PNG, JPEG, GIF, WebP, PDF, and ZIP signatures
  - Returns `null` for unrecognized bytes, text, or undersized inputs
  - Special handling for WebP's non-contiguous signature (RIFF marker at offset 0, WEBP marker at offset 8 with 4-byte size in between)

- **Updated `fs/mcp/module.f.ts`**:
  - Added `blobResource` schema: `{ uri, mimeType?, blob }`
  - Added `embeddedResource` schema wrapping `blobResource`
  - Created `contentItem` union type: `or(textContent, embeddedResource)`
  - Updated `toolsCallResult.content` to use `contentItem` array instead of `textContent` array

- **Updated `fs/cas/mcp/module.f.ts`**:
  - `cas_get` now calls `detect()` on retrieved bytes
  - Returns `EmbeddedResource` with detected `mimeType` when signature matches
  - Falls back to plain `textContent` (base64) when `detect()` returns `null`
  - Maintains backward compatibility through the fallback path

- **Updated `fs/cas/mcp/proof.f.ts`**:
  - Added `getUntypedReturnsText`: verifies opaque bytes return plain text block
  - Added `getTypedReturnsEmbeddedResource`: verifies PNG bytes return typed resource with correct `mimeType`, `blob`, and `cas://sha256/<hash>` URI

- **Documentation**:
  - Updated `fs/cas/mcp/README.md` with file-type detection section and both result shapes
  - Added `fs/mime/README.md` explaining the design rationale (type recovered on read, not stored on write)
  - Updated roadmap to mark Layer 3 complete

## Implementation Details

- Type detection is **read-time only**: the CAS store remains a pure `hash → bytes` map with no type metadata stored
- The `null` fallback deliberately omits UTF-8 text detection—distinguishing UTF-8 from arbitrary bytes is not a magic-byte test; callers already handle the `null` case
- WebP detection uses a two-part check: `startsWith(RIFF)` followed by `startsWith(WEBP)` at byte offset 8 after removing the 4-byte size field
- All changes are backward compatible: untyped blobs continue to work via the `textContent` fallback

https://claude.ai/code/session_01Fxu8Bmqd44K81d553ktjbY