### PR TITLE
Add test for missing hash argument in cas_get

### DIFF
--- a/fs/cas/mcp/proof.f.ts
+++ b/fs/cas/mcp/proof.f.ts
@@ -205,6 +205,11 @@ export const proof = {
         assertEq(resultOf(resp).isError, true)
     },
 
+    getMissingHashArgumentIsError: () => {
+        const [resp] = session(call(2, 'cas_get', {}))
+        assertEq(resultOf(resp).isError, true)
+    },
+
     getInvalidHashIsError: () => {
         const [resp] = session(call(2, 'cas_get', { hash: 'not valid!' }))
         assertEq(resultOf(resp).isError, true)


### PR DESCRIPTION
## Summary
Added a new test case to verify that the `cas_get` RPC method properly returns an error when called without the required `hash` argument.

## Changes
- Added `getMissingHashArgumentIsError` test function that validates error handling when `cas_get` is invoked with an empty arguments object
- Test follows the existing pattern of other error validation tests in the proof suite

## Details
The new test ensures that the CAS (Content Addressable Storage) `get` operation correctly rejects requests missing the mandatory `hash` parameter, maintaining API contract validation and preventing invalid operations.

https://claude.ai/code/session_015HJzUe4uN6jtPojgZPEQk5