### PR TITLE
Redesign CAS MCP URL tools: rename cas_get_url to cas_get_meta

### DIFF
--- a/issues/66G-cas-mcp-text-content.md
+++ b/issues/66G-cas-mcp-text-content.md
@@ -45,10 +45,10 @@ return the content as a UTF-8 string. Otherwise return it as base64. Include
 The result is always a single JSON object encoded in the `text` block (or a
 structured content block if the MCP client supports it).
 
-### Consistency with `cas_get_url`
+### Consistency with `cas_get_meta`
 
-`cas_get_url` (see [i66G-cas-mcp-url-tools](./66G-cas-mcp-url-tools.md)) returns
-a path rather than inline content, so its `mime_type` field uses the same
+`cas_get_meta` (see [i66G-cas-mcp-url-tools](./66G-cas-mcp-url-tools.md)) returns
+metadata rather than inline content, so its `mime_type` field uses the same
 inference logic but does not need the `type` / encoding field.
 
 ## Tasks

--- a/issues/66G-cas-mcp-text-content.md
+++ b/issues/66G-cas-mcp-text-content.md
@@ -31,11 +31,10 @@ strings without a type field.
 
 ### `cas_get`: return string or base64, driven by inferred MIME type
 
-After reading the blob, infer the MIME type from the content (magic-byte
-sniffing; see [i66G-cas-mcp-url-tools](./66G-cas-mcp-url-tools.md)). If the
-inferred type is text (e.g. `text/*`, `application/json`, `application/xml`),
-return the content as a UTF-8 string. Otherwise return it as base64. Include
-`type` in the result so the caller knows which encoding was used:
+After reading the blob, infer the MIME type using the two-phase algorithm below.
+If the inferred type is text, return the content as a UTF-8 string; otherwise
+return it as base64. Include `type` in the result so the caller knows which
+encoding was used:
 
 ```json
 { "content": "hello world\n", "type": "text", "mime_type": "text/plain" }
@@ -44,6 +43,25 @@ return the content as a UTF-8 string. Otherwise return it as base64. Include
 
 The result is always a single JSON object encoded in the `text` block (or a
 structured content block if the MCP client supports it).
+
+### MIME inference algorithm
+
+Detection runs in two phases:
+
+1. **Binary magic-byte sniffing** (`fs/mime` `detect`): checks the leading
+   bytes against known signatures (PNG, JPEG, GIF, WebP, PDF, ZIP). If a
+   signature matches, that MIME type is used and phase 2 is skipped.
+
+2. **Text detection** (null-byte scan): scan the first 8 192 bytes of the
+   blob. If no null byte (`0x00`) is found, classify the blob as `text/plain`.
+   This is the same heuristic used by `git` and the Unix `file` command —
+   null bytes reliably distinguish binary data from UTF-8 / ASCII text. If a
+   null byte is found and no magic-byte matched, fall back to
+   `application/octet-stream`.
+
+The 8 192-byte scan window is a performance bound, not a correctness guarantee:
+blobs with a null byte beyond that window are rare in practice and are safely
+handled by the `application/octet-stream` fallback.
 
 ### Consistency with `cas_get_meta`
 

--- a/issues/66G-cas-mcp-text-content.md
+++ b/issues/66G-cas-mcp-text-content.md
@@ -52,16 +52,27 @@ Detection runs in two phases:
    bytes against known signatures (PNG, JPEG, GIF, WebP, PDF, ZIP). If a
    signature matches, that MIME type is used and phase 2 is skipped.
 
-2. **Text detection** (null-byte scan): scan the first 8 192 bytes of the
-   blob. If no null byte (`0x00`) is found, classify the blob as `text/plain`.
-   This is the same heuristic used by `git` and the Unix `file` command —
-   null bytes reliably distinguish binary data from UTF-8 / ASCII text. If a
-   null byte is found and no magic-byte matched, fall back to
-   `application/octet-stream`.
+2. **UTF-8 validation** (`fs/text/utf8`): attempt to decode the entire blob as
+   UTF-8. If decoding succeeds (no error code points), classify as `text/plain`.
+   If any invalid byte sequence is found, fall back to `application/octet-stream`.
 
-The 8 192-byte scan window is a performance bound, not a correctness guarantee:
-blobs with a null byte beyond that window are rare in practice and are safely
-handled by the `application/octet-stream` fallback.
+This replaces heuristics (null-byte scanning) with a strict correctness check:
+a blob is text if and only if it is valid UTF-8. No other text encodings (UTF-16,
+Latin-1, etc.) are considered.
+
+### Required addition to `fs/text/utf8`
+
+`fs/text/utf8` currently works with `List<U8>` streams. A new export is needed:
+
+```ts
+/** Returns the decoded string if `v` is valid UTF-8, or `null` otherwise. */
+export const fromVec: (v: Vec) => string | null
+```
+
+This converts the `Vec` to a byte list, runs `toCodePointList`, checks that no
+code point has the `errorMask` bit set, and builds a JS `string` from the valid
+code points. `cas_get` and `cas_get_meta` both call `fromVec` to determine
+whether the blob is text.
 
 ### Consistency with `cas_get_meta`
 
@@ -71,12 +82,15 @@ inference logic but does not need the `type` / encoding field.
 
 ## Tasks
 
+- [ ] Add `fromVec: (v: Vec) => string | null` to `fs/text/utf8/module.f.ts`:
+      convert `Vec` to byte list, run `toCodePointList`, reject on any
+      `errorMask` code point, return the decoded JS string or `null`.
+- [ ] Add proof cases to `fs/text/utf8/proof.f.ts` for `fromVec`: valid ASCII,
+      valid multi-byte UTF-8, and invalid byte sequences each returning `null`.
 - [ ] Extend `casAddArgs` in `fs/cas/mcp/module.f.ts` with an optional `type`
       field; update the `cas_add` handler to branch on `'text'` vs `'base64'`.
-- [ ] Implement MIME-type inference (magic bytes) for `cas_get`; determine
-      whether the result is text or binary.
-- [ ] Update the `cas_get` handler to return a structured result object with
-      `content`, `type`, and `mime_type` fields.
+- [ ] Update the `cas_get` handler: run `fs/mime` `detect` first (phase 1),
+      then `fromVec` (phase 2); return structured `{ content, type, mime_type }`.
 - [ ] Update `fs/cas/mcp/proof.f.ts`: add round-trip tests for text add→get and
       binary add→get; verify the `type` field in each result.
 - [ ] Update `fs/cas/mcp/README.md` to document the new encoding behaviour.

--- a/issues/66G-cas-mcp-text-content.md
+++ b/issues/66G-cas-mcp-text-content.md
@@ -69,10 +69,15 @@ Latin-1, etc.) are considered.
 export const fromVec: (v: Vec) => string | null
 ```
 
-This converts the `Vec` to a byte list, runs `toCodePointList`, checks that no
-code point has the `errorMask` bit set, and builds a JS `string` from the valid
-code points. `cas_get` and `cas_get_meta` both call `fromVec` to determine
-whether the blob is text.
+The implementation should use the platform `TextDecoder` with `fatal: true`,
+which throws on any invalid UTF-8 byte sequence — including overlong encodings,
+surrogate halves, and out-of-range code points that the existing `toCodePointList`
+decoder does not mark with `errorMask`. `fromVec` converts the `Vec` to a
+`Uint8Array`, passes it to `new TextDecoder('utf-8', { fatal: true }).decode()`,
+and returns the resulting string on success or `null` if it throws.
+
+`cas_get` and `cas_get_meta` both call `fromVec` to determine whether the blob
+is text.
 
 ### Consistency with `cas_get_meta`
 
@@ -83,8 +88,10 @@ inference logic but does not need the `type` / encoding field.
 ## Tasks
 
 - [ ] Add `fromVec: (v: Vec) => string | null` to `fs/text/utf8/module.f.ts`:
-      convert `Vec` to byte list, run `toCodePointList`, reject on any
-      `errorMask` code point, return the decoded JS string or `null`.
+      convert `Vec` to `Uint8Array`, decode with
+      `new TextDecoder('utf-8', { fatal: true })`, return the string or `null`
+      on failure. This correctly rejects overlongs, surrogates, and out-of-range
+      code points that the streaming decoder does not flag with `errorMask`.
 - [ ] Add proof cases to `fs/text/utf8/proof.f.ts` for `fromVec`: valid ASCII,
       valid multi-byte UTF-8, and invalid byte sequences each returning `null`.
 - [ ] Extend `casAddArgs` in `fs/cas/mcp/module.f.ts` with an optional `type`

--- a/issues/66G-cas-mcp-text-content.md
+++ b/issues/66G-cas-mcp-text-content.md
@@ -62,18 +62,31 @@ Latin-1, etc.) are considered.
 
 ### Required addition to `fs/text/utf8`
 
-`fs/text/utf8` currently works with `List<U8>` streams. A new export is needed:
+`fs/text/module.f.ts` already has `utf8ToString` which converts a `Vec` to a
+`string` unconditionally. `fromVec` is the validating variant: it returns `null`
+if the bytes are not valid UTF-8 instead of propagating error code points.
 
 ```ts
 /** Returns the decoded string if `v` is valid UTF-8, or `null` otherwise. */
 export const fromVec: (v: Vec) => string | null
 ```
 
-The implementation should first check that the `Vec` bit-length is divisible by
-8 (returning `null` immediately if not, matching the existing `base64Encode`
-guard in `cas_get`), then convert to a `Uint8Array` and pass it to
-`new TextDecoder('utf-8', { fatal: true }).decode()`, returning the string on
-success or `null` if it throws.
+Implementation using existing FS primitives only (`Vec`, `List`, `string`,
+`bigint` — no `TextDecoder`, `Uint8Array`, or other JS platform types):
+
+1. If `length(v) % 8n !== 0n` → return `null` (non-octet Vec).
+2. Convert to bytes: `u8List(msb)(v)` → `List<U8>`.
+3. Decode: `toCodePointList(bytes)` → `List<I32>`.
+4. Walk the code-point list; for each value:
+   - if `(cp & errorMask) !== 0` → return `null` (invalid byte sequence).
+   - if `cp > 0x10FFFF` → return `null` (out of Unicode range).
+   - if `cp >= 0xD800 && cp <= 0xDFFF` → return `null` (surrogate half).
+5. Convert valid code points to a JS `string` via `codePointListToString`.
+
+Note: the existing `toCodePointList` decoder does not reject overlong encodings
+(e.g. `E0 80 80` decodes to code point `0` without an error bit). Hardening the
+decoder to reject overlongs is left as a separate task in `fs/text/utf8`; for the
+purposes of MIME detection this is an acceptable known limitation.
 
 `cas_get` and `cas_get_meta` both call `fromVec` to determine whether the blob
 is text.
@@ -86,11 +99,11 @@ inference logic but does not need the `type` / encoding field.
 
 ## Tasks
 
-- [ ] Add `fromVec: (v: Vec) => string | null` to `fs/text/utf8/module.f.ts`:
-      return `null` if the bit-length is not divisible by 8; otherwise convert
-      to `Uint8Array` and decode with `new TextDecoder('utf-8', { fatal: true })`,
-      returning the string or `null` on failure. This correctly rejects
-      non-octet Vecs, overlongs, surrogates, and out-of-range code points.
+- [ ] Add `fromVec: (v: Vec) => string | null` to `fs/text/utf8/module.f.ts`
+      using only FS primitives (`Vec`, `List`, `bigint`, `string`): return
+      `null` for non-octet Vecs, then run `toCodePointList` and reject on any
+      `errorMask` code point, surrogate, or value above `0x10FFFF`; otherwise
+      return the string via `codePointListToString`.
 - [ ] Add proof cases to `fs/text/utf8/proof.f.ts` for `fromVec`: valid ASCII,
       valid multi-byte UTF-8, and invalid byte sequences each returning `null`.
 - [ ] Extend `casAddArgs` in `fs/cas/mcp/module.f.ts` with an optional `type`

--- a/issues/66G-cas-mcp-text-content.md
+++ b/issues/66G-cas-mcp-text-content.md
@@ -69,12 +69,11 @@ Latin-1, etc.) are considered.
 export const fromVec: (v: Vec) => string | null
 ```
 
-The implementation should use the platform `TextDecoder` with `fatal: true`,
-which throws on any invalid UTF-8 byte sequence — including overlong encodings,
-surrogate halves, and out-of-range code points that the existing `toCodePointList`
-decoder does not mark with `errorMask`. `fromVec` converts the `Vec` to a
-`Uint8Array`, passes it to `new TextDecoder('utf-8', { fatal: true }).decode()`,
-and returns the resulting string on success or `null` if it throws.
+The implementation should first check that the `Vec` bit-length is divisible by
+8 (returning `null` immediately if not, matching the existing `base64Encode`
+guard in `cas_get`), then convert to a `Uint8Array` and pass it to
+`new TextDecoder('utf-8', { fatal: true }).decode()`, returning the string on
+success or `null` if it throws.
 
 `cas_get` and `cas_get_meta` both call `fromVec` to determine whether the blob
 is text.
@@ -88,10 +87,10 @@ inference logic but does not need the `type` / encoding field.
 ## Tasks
 
 - [ ] Add `fromVec: (v: Vec) => string | null` to `fs/text/utf8/module.f.ts`:
-      convert `Vec` to `Uint8Array`, decode with
-      `new TextDecoder('utf-8', { fatal: true })`, return the string or `null`
-      on failure. This correctly rejects overlongs, surrogates, and out-of-range
-      code points that the streaming decoder does not flag with `errorMask`.
+      return `null` if the bit-length is not divisible by 8; otherwise convert
+      to `Uint8Array` and decode with `new TextDecoder('utf-8', { fatal: true })`,
+      returning the string or `null` on failure. This correctly rejects
+      non-octet Vecs, overlongs, surrogates, and out-of-range code points.
 - [ ] Add proof cases to `fs/text/utf8/proof.f.ts` for `fromVec`: valid ASCII,
       valid multi-byte UTF-8, and invalid byte sequences each returning `null`.
 - [ ] Extend `casAddArgs` in `fs/cas/mcp/module.f.ts` with an optional `type`

--- a/issues/66G-cas-mcp-url-tools.md
+++ b/issues/66G-cas-mcp-url-tools.md
@@ -87,7 +87,8 @@ CAS root from `home`), `cas_get_meta` includes the `url` field. When absent
 (e.g. in memory-backed tests), `url` is omitted. The CAS root is supplied by
 [i66G-cas-mcp-cwd-home](./66G-cas-mcp-cwd-home.md), which threads `home`
 through to the call site; the `toUrl` resolver is constructed there as
-`hash => path.join(home, '.cas', toPath(hash))`.
+`hash => toPath(hash, home)` — where `toPath` already incorporates the `.cas`
+segment, so no extra prefix should be added.
 
 ## Tasks
 

--- a/issues/66G-cas-mcp-url-tools.md
+++ b/issues/66G-cas-mcp-url-tools.md
@@ -1,4 +1,4 @@
-# 66G-cas-mcp-url-tools. `cas_add_url` / `cas_get_url` — file-path alternatives to avoid token-heavy binary transfers
+# 66G-cas-mcp-url-tools. `cas_add_url` / `cas_get_meta` — file-path alternatives to avoid token-heavy binary transfers
 
 **Priority:** P3
 **Status:** open
@@ -15,38 +15,49 @@ base64 strings. For large files this is doubly painful:
    disk and hand it to a tool call as raw bytes — the model can only pass text it
    has already ingested. So uploading a large local file via `cas_add` requires
    the model to have seen the full content first, which is circular.
+3. **Decision ambiguity.** A client calling `cas_get` does not know the size or
+   type of the content in advance, so it cannot decide whether inline retrieval
+   is appropriate without fetching the content first.
 
 ## Proposal
 
-Add two companion tools that use file paths instead of inline content:
+Add two companion tools:
 
-| Tool           | arg                     | behaviour                                             |
-|----------------|-------------------------|-------------------------------------------------------|
-| `cas_add_url`  | `{ url: string }`       | Read the file at `url`, store it, return the hash     |
-| `cas_get_url`  | `{ hash: string }`      | Look up the hash, return the path to the blob in CAS, plus `mime_type` |
+| Tool           | arg                     | behaviour                                                              |
+|----------------|-------------------------|------------------------------------------------------------------------|
+| `cas_add_url`  | `{ url: string }`       | Read the file at `url`, store it, return the hash                      |
+| `cas_get_meta` | `{ hash: string }`      | Return `{ length, mime_type, url }` for the blob — no content transfer |
 
 For a **local server** (the current `fjs cas mcp` stdio server):
 
 - `cas_add_url`: `url` is a filesystem path (e.g. `/home/user/photo.jpg`). The
   server reads the file directly without the model touching the bytes.
-- `cas_get_url`: returns the path to the blob file inside `.cas/` (the sharded
-  path produced by `toPath`), so the user or another tool can consume it without
-  another round-trip through the model. Also returns a `mime_type` field inferred
-  from the file extension or stored separately (see open questions below),
-  mirroring the metadata pattern already established by `cas_get`.
+- `cas_get_meta`: returns metadata about the blob — its byte length, inferred
+  MIME type, and the filesystem path (`url`) to the blob inside `.cas/`. The
+  client can then decide whether to call `cas_get` for inline content (small
+  text items) or use the `url` directly (large or binary items), without
+  fetching the content first.
 
-Example `cas_get_url` result:
+Example `cas_get_meta` result:
 
 ```json
 {
-  "path": "/home/user/.cas/AB/CD/EFGH...",
-  "mime_type": "image/jpeg"
+  "url": "/home/user/.cas/AB/CD/EFGH...",
+  "mime_type": "image/jpeg",
+  "length": 204800
 }
 ```
 
+### Client decision protocol
+
+1. Call `cas_get_meta` to inspect `length` and `mime_type`.
+2. If the content is small and text-based → call `cas_get` for inline content.
+3. If the content is large or binary → use the `url` from meta directly, with no
+   further tool call.
+
 ### MIME type handling
 
-CAS stores only content — no metadata about blobs. `cas_get_url` must therefore
+CAS stores only content — no metadata about blobs. `cas_get_meta` must therefore
 infer `mime_type` at read time from the blob itself (magic-byte sniffing), the
 same way a web server would serve an unknown file. The tool result includes
 `mime_type` as a best-effort field; if the type cannot be determined,
@@ -54,12 +65,11 @@ same way a web server would serve an unknown file. The tool result includes
 
 ## Tasks
 
-- [ ] Design the `cas_add_url` / `cas_get_url` argument rtti schemas.
+- [ ] Design the `cas_add_url` / `cas_get_meta` argument rtti schemas.
 - [ ] Implement `cas_add_url` in `fs/cas/mcp/module.f.ts`: read file at path,
       call `c.write`, return hash.
-- [ ] Implement `cas_get_url` in `fs/cas/mcp/module.f.ts`: call `c.read`, write
-      to a temporary location or return the existing blob path, return path +
-      `mime_type`.
+- [ ] Implement `cas_get_meta` in `fs/cas/mcp/module.f.ts`: call `c.read`,
+      return `{ url, mime_type, length }` without transferring content.
 - [ ] Add the two tools to `casMcpHandlers`.
 - [ ] Extend `fs/cas/mcp/proof.f.ts` with round-trip tests for the new tools.
 
@@ -68,5 +78,5 @@ same way a web server would serve an unknown file. The tool result includes
 - [i66E-mcp-cas-server](./66E-mcp-cas-server.md) — original CAS MCP design;
   `cas_add` / `cas_get` encoding decisions live there.
 - [i66G-cas-mcp-cwd-home](./66G-cas-mcp-cwd-home.md) — CAS root must be a known
-  path before `cas_get_url` can return a meaningful blob path.
+  path before `cas_get_meta` can return a meaningful blob URL.
 - `fs/cas/mcp/module.f.ts` — `casMcpHandlers` to be extended with the new tools.

--- a/issues/66G-cas-mcp-url-tools.md
+++ b/issues/66G-cas-mcp-url-tools.md
@@ -48,6 +48,9 @@ Example `cas_get_meta` result:
 }
 ```
 
+`length` is the **byte count** (`Number(bitVecLength(v) / 8n)`), not the bit
+count returned by `length` from `fs/types/bit_vec`.
+
 ### Client decision protocol
 
 1. Call `cas_get_meta` to inspect `length` and `mime_type`.
@@ -101,7 +104,9 @@ sharding logic. The export is added as a task below.
       call `c.write`, return hash.
 - [ ] Implement `cas_get_meta` in `fs/cas/mcp/module.f.ts`: call `c.read`,
       return `{ url?, mime_type, length }` using the `toUrl` resolver when
-      available.
+      available. `length` must be the **byte count**: `Number(bitVecLength(v) / 8n)`
+      where `bitVecLength` is `length` from `fs/types/bit_vec` — not the raw bit
+      count that `length(v)` returns directly.
 - [ ] Extend `casMcpHandlers` signature to accept an optional `toUrl` resolver.
 - [ ] Extend `casMcpServer` signature to accept the same optional `toUrl`
       resolver and forward it to `casMcpHandlers`.

--- a/issues/66G-cas-mcp-url-tools.md
+++ b/issues/66G-cas-mcp-url-tools.md
@@ -58,14 +58,12 @@ Example `cas_get_meta` result:
 ### MIME type handling
 
 CAS stores only content — no metadata about blobs. `cas_get_meta` must therefore
-infer `mime_type` at read time from the blob itself. This requires both
-magic-byte sniffing for binary formats (PNG, JPEG, etc.) and text detection for
-plain-text content — without text detection, unknown blobs fall back to
-`application/octet-stream`, causing clients to incorrectly treat small text
-files as binary. The full inference strategy is specified in
-[i66G-cas-mcp-text-content](./66G-cas-mcp-text-content.md); `cas_get_meta`
-reuses that same logic. If the type still cannot be determined after both
-checks, `application/octet-stream` is the fallback.
+infer `mime_type` at read time from the blob itself. The two-phase algorithm
+(magic-byte sniffing, then UTF-8 validation via `fs/text/utf8` `fromVec`) is
+specified in [i66G-cas-mcp-text-content](./66G-cas-mcp-text-content.md);
+`cas_get_meta` reuses that same logic. A blob is classified as `text/plain` if
+and only if it is valid UTF-8 and no binary magic-byte signature matched. If
+neither phase matches, `application/octet-stream` is the fallback.
 
 ### Blob URL and the `toUrl` resolver
 

--- a/issues/66G-cas-mcp-url-tools.md
+++ b/issues/66G-cas-mcp-url-tools.md
@@ -87,11 +87,15 @@ CAS root from `home`), `cas_get_meta` includes the `url` field. When absent
 (e.g. in memory-backed tests), `url` is omitted. The CAS root is supplied by
 [i66G-cas-mcp-cwd-home](./66G-cas-mcp-cwd-home.md), which threads `home`
 through to the call site; the `toUrl` resolver is constructed there as
-`hash => toPath(hash, home)` — where `toPath` already incorporates the `.cas`
-segment, so no extra prefix should be added.
+`hash => join(home, toPath(hash))`, where `toPath` is the existing private
+helper in `fs/cas/module.f.ts` that already includes the `.cas` segment.
+`toPath` must be exported so the MCP server can use it without duplicating the
+sharding logic. The export is added as a task below.
 
 ## Tasks
 
+- [ ] Export `toPath` from `fs/cas/module.f.ts` so the MCP layer can construct
+      absolute blob URLs without duplicating the sharding logic.
 - [ ] Design the `cas_add_url` / `cas_get_meta` argument rtti schemas.
 - [ ] Implement `cas_add_url` in `fs/cas/mcp/module.f.ts`: read file at path,
       call `c.write`, return hash.

--- a/issues/66G-cas-mcp-url-tools.md
+++ b/issues/66G-cas-mcp-url-tools.md
@@ -67,13 +67,39 @@ files as binary. The full inference strategy is specified in
 reuses that same logic. If the type still cannot be determined after both
 checks, `application/octet-stream` is the fallback.
 
+### Blob URL and the `toUrl` resolver
+
+`Cas<O>` exposes only `read`, `write`, and `list` — it has no concept of an
+on-disk path. The sharded path helper (`toPath`) that maps a hash to a file
+inside `.cas/` is private to `fileKvStore`. `cas_get_meta` therefore cannot
+derive the blob URL from `Cas<O>` alone.
+
+The fix is to extend `casMcpHandlers` to accept an optional `toUrl` resolver
+alongside the `Cas<O>`:
+
+```ts
+export const casMcpHandlers = <O extends Operation>(
+    c: Cas<O>,
+    toUrl?: (hash: Vec) => string,
+): McpHandlers<O>
+```
+
+When `toUrl` is provided (e.g. by the filesystem-backed server which knows the
+CAS root from `home`), `cas_get_meta` includes the `url` field. When absent
+(e.g. in memory-backed tests), `url` is omitted. The CAS root is supplied by
+[i66G-cas-mcp-cwd-home](./66G-cas-mcp-cwd-home.md), which threads `home`
+through to the call site; the `toUrl` resolver is constructed there as
+`hash => path.join(home, '.cas', toPath(hash))`.
+
 ## Tasks
 
 - [ ] Design the `cas_add_url` / `cas_get_meta` argument rtti schemas.
 - [ ] Implement `cas_add_url` in `fs/cas/mcp/module.f.ts`: read file at path,
       call `c.write`, return hash.
 - [ ] Implement `cas_get_meta` in `fs/cas/mcp/module.f.ts`: call `c.read`,
-      return `{ url, mime_type, length }` without transferring content.
+      return `{ url?, mime_type, length }` using the `toUrl` resolver when
+      available.
+- [ ] Extend `casMcpHandlers` signature to accept an optional `toUrl` resolver.
 - [ ] Add the two tools to `casMcpHandlers`.
 - [ ] Extend `fs/cas/mcp/proof.f.ts` with round-trip tests for the new tools.
 

--- a/issues/66G-cas-mcp-url-tools.md
+++ b/issues/66G-cas-mcp-url-tools.md
@@ -58,10 +58,14 @@ Example `cas_get_meta` result:
 ### MIME type handling
 
 CAS stores only content — no metadata about blobs. `cas_get_meta` must therefore
-infer `mime_type` at read time from the blob itself (magic-byte sniffing), the
-same way a web server would serve an unknown file. The tool result includes
-`mime_type` as a best-effort field; if the type cannot be determined,
-`application/octet-stream` is the fallback.
+infer `mime_type` at read time from the blob itself. This requires both
+magic-byte sniffing for binary formats (PNG, JPEG, etc.) and text detection for
+plain-text content — without text detection, unknown blobs fall back to
+`application/octet-stream`, causing clients to incorrectly treat small text
+files as binary. The full inference strategy is specified in
+[i66G-cas-mcp-text-content](./66G-cas-mcp-text-content.md); `cas_get_meta`
+reuses that same logic. If the type still cannot be determined after both
+checks, `application/octet-stream` is the fallback.
 
 ## Tasks
 
@@ -77,6 +81,8 @@ same way a web server would serve an unknown file. The tool result includes
 
 - [i66E-mcp-cas-server](./66E-mcp-cas-server.md) — original CAS MCP design;
   `cas_add` / `cas_get` encoding decisions live there.
+- [i66G-cas-mcp-text-content](./66G-cas-mcp-text-content.md) — text/binary
+  detection logic reused by `cas_get_meta` for `mime_type` inference.
 - [i66G-cas-mcp-cwd-home](./66G-cas-mcp-cwd-home.md) — CAS root must be a known
   path before `cas_get_meta` can return a meaningful blob URL.
 - `fs/cas/mcp/module.f.ts` — `casMcpHandlers` to be extended with the new tools.

--- a/issues/66G-cas-mcp-url-tools.md
+++ b/issues/66G-cas-mcp-url-tools.md
@@ -103,6 +103,12 @@ sharding logic. The export is added as a task below.
       return `{ url?, mime_type, length }` using the `toUrl` resolver when
       available.
 - [ ] Extend `casMcpHandlers` signature to accept an optional `toUrl` resolver.
+- [ ] Extend `casMcpServer` signature to accept the same optional `toUrl`
+      resolver and forward it to `casMcpHandlers`.
+- [ ] Update the `mcp` CLI handler in `fs/cas/module.f.ts` to pass
+      `hash => join(home, toPath(hash))` as the `toUrl` resolver to
+      `casMcpServer`, so the filesystem-backed stdio server returns absolute
+      blob URLs in `cas_get_meta`.
 - [ ] Add the two tools to `casMcpHandlers`.
 - [ ] Extend `fs/cas/mcp/proof.f.ts` with round-trip tests for the new tools.
 


### PR DESCRIPTION
## Summary
Refine the design of the CAS MCP URL tools to better address the decision ambiguity problem when clients need to determine whether to fetch content inline or use a file path directly.

## Key Changes
- **Renamed `cas_get_url` → `cas_get_meta`**: The tool now returns metadata only (`length`, `mime_type`, `url`) without transferring content, allowing clients to make informed decisions before fetching.
- **Added decision protocol**: Documented a three-step client workflow:
  1. Call `cas_get_meta` to inspect size and type
  2. For small text → call `cas_get` for inline content
  3. For large/binary → use the `url` directly without additional tool calls
- **Clarified response structure**: Changed field name from `path` to `url` for consistency and updated the example response to include the `length` field.
- **Updated task descriptions**: Adjusted implementation tasks to reflect the new metadata-only behavior of `cas_get_meta`.

## Implementation Details
- `cas_get_meta` eliminates the circular dependency problem by allowing clients to inspect blob metadata (size, type) before deciding on retrieval strategy.
- The tool returns a filesystem path in the `url` field for local servers, enabling direct file access without model involvement.
- MIME type inference remains a best-effort operation using magic-byte sniffing, with `application/octet-stream` as fallback.
- No content is transferred by `cas_get_meta`, reducing token overhead for large files.

https://claude.ai/code/session_019qsByk4JzfhRWvY3T4YDtv