### PR TITLE
Add cas_add_url and cas_get_meta MCP tools with file I/O support

### DIFF
--- a/fs/cas/mcp/module.f.ts
+++ b/fs/cas/mcp/module.f.ts
@@ -64,7 +64,8 @@ import { create, type MemOp } from '../../effects/memory/module.f.ts'
 import { cBase32ToVec, vecToCBase32 } from '../../cbase32/module.f.ts'
 import { decode as base64Decode, encode as base64Encode } from '../../base64/module.f.ts'
 import { detect } from '../../mime/module.f.ts'
-import { type Read, type Write } from '../../effects/node/module.f.ts'
+import { length as bitVecLength, type Vec } from '../../types/bit_vec/module.f.ts'
+import { readFile, type Read, type ReadFile, type Write } from '../../effects/node/module.f.ts'
 import { stdioTransport } from '../../mcp/stdio/module.f.ts'
 import {
     mcpStep, uninitializedState,
@@ -72,6 +73,7 @@ import {
     type ToolsCallParams, type ToolsCallResult, type ToolsListResult,
 } from '../../mcp/module.f.ts'
 import type { Cas } from '../module.f.ts'
+import { fromVec } from '../../text/utf8/module.f.ts'
 
 // ── Argument schemas (declared once, used for both inputSchema and validate) ─────
 
@@ -83,6 +85,12 @@ export const casGetArgs = { hash: string } as const
 
 /** Arguments for `cas_list`: none. */
 export const casListArgs = {} as const
+
+/** Arguments for `cas_add_url`: filesystem path to read and store. */
+export const casAddUrlArgs = { url: string } as const
+
+/** Arguments for `cas_get_meta`: the cBase32 hash to inspect. */
+export const casGetMetaArgs = { hash: string } as const
 
 // ── Tool descriptors ────────────────────────────────────────────────────────────
 
@@ -102,6 +110,18 @@ const casListTool: Tool = {
     name: 'cas_list',
     description: 'List all stored content hashes (cBase32), one per line.',
     inputSchema: toJsonSchema(casListArgs),
+}
+
+const casAddUrlTool: Tool = {
+    name: 'cas_add_url',
+    description: 'Read the file at the given path (url), store it, and return its hash (cBase32).',
+    inputSchema: toJsonSchema(casAddUrlArgs),
+}
+
+const casGetMetaTool: Tool = {
+    name: 'cas_get_meta',
+    description: 'Return metadata (length, mime_type, url) for a blob by hash — no content transfer.',
+    inputSchema: toJsonSchema(casGetMetaArgs),
 }
 
 // ── Result helpers ──────────────────────────────────────────────────────────────
@@ -126,11 +146,18 @@ const errorResult = (text: string): ToolsCallResult =>
 /**
  * MCP handlers for an injected `Cas<O>` — generic in `O` exactly like `Cas`
  * itself, so the same handlers run over `Fs` (production) or memory (tests).
+ *
+ * When `toUrl` is provided, `cas_get_meta` includes the `url` field pointing to
+ * the blob on the local filesystem. When absent (e.g. memory-backed tests),
+ * `url` is omitted.
  */
-export const casMcpHandlers = <O extends Operation>(c: Cas<O>): McpHandlers<O> => ({
-    toolsList: (): Effect<O, ToolsListResult> =>
-        pure({ tools: [casAddTool, casGetTool, casListTool] }),
-    toolsCall: ({ name, arguments: args }: ToolsCallParams): Effect<O, ToolsCallResult> => {
+export const casMcpHandlers = <O extends Operation>(
+    c: Cas<O>,
+    toUrl?: (hash: Vec) => string,
+): McpHandlers<ReadFile | O> => ({
+    toolsList: (): Effect<ReadFile | O, ToolsListResult> =>
+        pure({ tools: [casAddTool, casGetTool, casListTool, casAddUrlTool, casGetMetaTool] }),
+    toolsCall: ({ name, arguments: args }: ToolsCallParams): Effect<ReadFile | O, ToolsCallResult> => {
         const a = args === undefined ? {} : args
         switch (name) {
             case 'cas_add': {
@@ -178,6 +205,40 @@ export const casMcpHandlers = <O extends Operation>(c: Cas<O>): McpHandlers<O> =
                 return c.list().step(hashes =>
                     pure(okResult(hashes.map(vecToCBase32).join('\n'))))
             }
+            case 'cas_add_url': {
+                const [t, r] = validate(casAddUrlArgs)(a)
+                if (t === 'error') {
+                    return pure(errorResult(`invalid arguments: ${r.message}`))
+                }
+                return readFile(r.url).step(result => {
+                    if (result[0] === 'error') {
+                        return pure(errorResult(`cannot read file: ${r.url}: ${result[1]}`))
+                    }
+                    return c.write(result[1]).step(hash => pure(okResult(vecToCBase32(hash))))
+                })
+            }
+            case 'cas_get_meta': {
+                const [t, r] = validate(casGetMetaArgs)(a)
+                if (t === 'error') {
+                    return pure(errorResult(`invalid arguments: ${r.message}`))
+                }
+                const key = cBase32ToVec(r.hash)
+                if (key === null) {
+                    return pure(errorResult(`invalid cBase32 hash: ${r.hash}`))
+                }
+                return c.read(key).step(value => {
+                    if (value === undefined) {
+                        return pure(errorResult(`no such hash: ${r.hash}`))
+                    }
+                    const byteLength = Number(bitVecLength(value) / 8n)
+                    const mimeType = detect(value) ?? (fromVec(value) !== null ? 'text/plain' : 'application/octet-stream')
+                    const url = toUrl?.(key)
+                    const meta = url !== undefined
+                        ? { length: byteLength, mime_type: mimeType, url }
+                        : { length: byteLength, mime_type: mimeType }
+                    return pure(okResult(JSON.stringify(meta)))
+                })
+            }
             default: {
                 return pure(errorResult(`unknown tool: ${name}`))
             }
@@ -203,7 +264,12 @@ export const casConfig: McpConfig = {
  * Runs the CAS MCP server over stdio: allocates the session-state slot, builds
  * the `mcpStep` for `c`, and drives the read → parse → dispatch → write loop
  * until stdin EOF. Generic in `O` so it composes with any `Cas<O>` backing.
+ *
+ * When `toUrl` is provided, `cas_get_meta` includes the blob's filesystem URL.
  */
-export const casMcpServer = <O extends Operation>(c: Cas<O>): Effect<Read | Write | MemOp | O, void> =>
+export const casMcpServer = <O extends Operation>(
+    c: Cas<O>,
+    toUrl?: (hash: Vec) => string,
+): Effect<Read | Write | MemOp | ReadFile | O, void> =>
     create(uninitializedState).step(key =>
-        stdioTransport(mcpStep<O>(casConfig)(casMcpHandlers(c))(key)))
+        stdioTransport(mcpStep<ReadFile | O>(casConfig)(casMcpHandlers(c, toUrl))(key)))

--- a/fs/cas/mcp/proof.f.ts
+++ b/fs/cas/mcp/proof.f.ts
@@ -102,7 +102,7 @@ const runSession = (msgs: readonly unknown[]): readonly unknown[] =>
 const runSessionWithFiles =
     (files: { readonly [path: string]: Vec }) =>
     (msgs: readonly unknown[]): readonly unknown[] =>
-        runMemWithFiles(files)(
+        runMemWithFiles(files)<readonly unknown[]>(
             create({} as VecMap).step(mapKey =>
                 create(uninitializedState as McpSessionState).step(sessionKey => {
                     const c = cas(sha256)(memKvStore(mapKey))

--- a/fs/cas/mcp/proof.f.ts
+++ b/fs/cas/mcp/proof.f.ts
@@ -102,7 +102,7 @@ const runSession = (msgs: readonly unknown[]): readonly unknown[] =>
 const runSessionWithFiles =
     (files: { readonly [path: string]: Vec }) =>
     (msgs: readonly unknown[]): readonly unknown[] =>
-        runMemWithFiles(files)<readonly unknown[]>(
+        runMemWithFiles<readonly unknown[]>(files)(
             create({} as VecMap).step(mapKey =>
                 create(uninitializedState as McpSessionState).step(sessionKey => {
                     const c = cas(sha256)(memKvStore(mapKey))
@@ -276,10 +276,9 @@ export const proof = {
 
     addUrlStoresFileAndReturnsHash: () => {
         const fileContent = utf8('hello from file')
-        const [addUrlResp, getMetaResp] = runSessionWithFiles({ '/tmp/hello.txt': fileContent })([
+        const [addUrlResp] = runSessionWithFiles({ '/tmp/hello.txt': fileContent })([
             init, initialized,
             call(2, 'cas_add_url', { url: '/tmp/hello.txt' }),
-            call(3, 'cas_get', { hash: '' }), // placeholder; we use the hash from addUrl
         ]).slice(2) as readonly unknown[]
         assert(!resultOf(addUrlResp).isError)
         assert(textOf(addUrlResp).length > 0)
@@ -316,10 +315,9 @@ export const proof = {
 
     getMetaReturnsLengthAndMimeType: () => {
         const fileContent = utf8('text content')
-        const [addResp, metaResp] = runSessionWithFiles({ '/f': fileContent })([
+        const [addResp] = runSessionWithFiles({ '/f': fileContent })([
             init, initialized,
             call(2, 'cas_add_url', { url: '/f' }),
-            call(3, 'cas_get_meta', { hash: '' }), // placeholder
         ]).slice(2) as readonly unknown[]
         const hash = textOf(addResp)
         // Re-run with correct hash.
@@ -335,7 +333,6 @@ export const proof = {
     },
 
     getMetaBinaryBlob: () => {
-        const pngVec = u8ListToVec(msb)([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x01])
         const [addResp] = session(call(2, 'cas_add', { content: pngSample }))
         const hash = textOf(addResp)
         const [, metaResp] = session(

--- a/fs/cas/mcp/proof.f.ts
+++ b/fs/cas/mcp/proof.f.ts
@@ -8,10 +8,12 @@ import { msb, u8ListToVec, vec8, type Vec } from '../../types/bit_vec/module.f.t
 import { vecToCBase32 } from '../../cbase32/module.f.ts'
 import { encode as base64Encode } from '../../base64/module.f.ts'
 import { sha256 } from '../../crypto/sha2/module.f.ts'
+import { utf8 } from '../../text/module.f.ts'
 import { cas, type KvStore } from '../module.f.ts'
 import {
     mcpStep, uninitializedState, type McpSessionState, type ToolsCallResult,
 } from '../../mcp/module.f.ts'
+import { type ReadFile } from '../../effects/node/module.f.ts'
 import { casConfig, casMcpHandlers } from './module.f.ts'
 
 // ── Memory mock (mirrors fs/mcp/proof.f.ts) ─────────────────────────────────────
@@ -21,22 +23,41 @@ type MemoryState = {
     readonly values: { readonly [key: string]: unknown }
 }
 
-const initial: MemoryState = { next: 0, values: {} }
+type TestState = {
+    readonly memory: MemoryState
+    readonly files: { readonly [path: string]: Vec }
+}
 
-const mock: MemOperationMap<MemOp, MemoryState> = {
+const initialTestState: TestState = { memory: { next: 0, values: {} }, files: {} }
+
+const mock: MemOperationMap<MemOp | ReadFile, TestState> = {
     memCreate: value => state => {
-        const id = `k${state.next}`
+        const id = `k${state.memory.next}`
         const key: Key<unknown> = asNominal(id)
-        return [{ next: state.next + 1, values: { ...state.values, [id]: value } }, key]
+        return [
+            { ...state, memory: { next: state.memory.next + 1, values: { ...state.memory.values, [id]: value } } },
+            key,
+        ]
     },
-    memRead: key => state => [state, state.values[asBase(key)]],
+    memRead: key => state => [state, state.memory.values[asBase(key)]],
     memWrite: (key, value) => state => {
         const id = asBase(key)
-        return [{ ...state, values: { ...state.values, [id]: value } }, undefined]
+        return [{ ...state, memory: { ...state.memory, values: { ...state.memory.values, [id]: value } } }, undefined]
+    },
+    readFile: path => state => {
+        const v = state.files[path]
+        return v !== undefined
+            ? [state, ['ok', v] as const]
+            : [state, ['error', new Error(`ENOENT: ${path}`)] as readonly ['error', unknown]]
     },
 }
 
-const runMem = <T>(effect: Effect<MemOp, T>): T => run(mock)(initial)(effect)[1]
+const runMem = <T>(effect: Effect<MemOp | ReadFile, T>): T =>
+    run(mock)(initialTestState)(effect)[1]
+
+const runMemWithFiles = <T>(files: { readonly [path: string]: Vec }) =>
+    (effect: Effect<MemOp | ReadFile, T>): T =>
+        run(mock)({ memory: { next: 0, values: {} }, files })(effect)[1]
 
 // ── In-memory KvStore backed by a single memory slot ────────────────────────────
 // Persists writes across steps so add → get round-trips, keyed by cBase32 hash.
@@ -58,9 +79,9 @@ const memKvStore = (mapKey: Key<VecMap>): KvStore<MemOp> => ({
 
 // Feeds each message to `step` in order, collecting every response.
 const feed =
-    (step: (v: Unknown) => Effect<MemOp, Response | null>) =>
-    (msgs: readonly unknown[]): Effect<MemOp, readonly unknown[]> => {
-        const go = (i: number, acc: readonly unknown[]): Effect<MemOp, readonly unknown[]> =>
+    (step: (v: Unknown) => Effect<MemOp | ReadFile, Response | null>) =>
+    (msgs: readonly unknown[]): Effect<MemOp | ReadFile, readonly unknown[]> => {
+        const go = (i: number, acc: readonly unknown[]): Effect<MemOp | ReadFile, readonly unknown[]> =>
             i === msgs.length
                 ? pure(acc)
                 : step(msgs[i] as Unknown).step(r => go(i + 1, [...acc, r]))
@@ -73,9 +94,21 @@ const runSession = (msgs: readonly unknown[]): readonly unknown[] =>
         create({} as VecMap).step(mapKey =>
             create(uninitializedState as McpSessionState).step(sessionKey => {
                 const c = cas(sha256)(memKvStore(mapKey))
-                const step = mcpStep<MemOp>(casConfig)(casMcpHandlers(c))(sessionKey)
+                const step = mcpStep<MemOp | ReadFile>(casConfig)(casMcpHandlers(c))(sessionKey)
                 return feed(step)(msgs)
             })))
+
+// Runs a session with a mocked filesystem (for cas_add_url tests).
+const runSessionWithFiles =
+    (files: { readonly [path: string]: Vec }) =>
+    (msgs: readonly unknown[]): readonly unknown[] =>
+        runMemWithFiles(files)(
+            create({} as VecMap).step(mapKey =>
+                create(uninitializedState as McpSessionState).step(sessionKey => {
+                    const c = cas(sha256)(memKvStore(mapKey))
+                    const step = mcpStep<MemOp | ReadFile>(casConfig)(casMcpHandlers(c))(sessionKey)
+                    return feed(step)(msgs)
+                })))
 
 // ── Messages ────────────────────────────────────────────────────────────────────
 
@@ -119,8 +152,8 @@ export const proof = {
     toolsListAdvertisesThreeTools: () => {
         const [resp] = runSession([init, initialized, list(2)]).slice(2)
         const tools = (resp as { result: { tools: readonly { name: string }[] } }).result.tools
-        assertEq(tools.length, 3)
-        assertEq(tools.map(t => t.name).join(','), 'cas_add,cas_get,cas_list')
+        assertEq(tools.length, 5)
+        assertEq(tools.map(t => t.name).join(','), 'cas_add,cas_get,cas_list,cas_add_url,cas_get_meta')
         // Each tool advertises an object inputSchema derived from its rtti args.
         const add = (resp as { result: { tools: readonly { inputSchema: { type?: string } }[] } }).result.tools[0]
         assertEq(add.inputSchema.type, 'object')
@@ -232,5 +265,126 @@ export const proof = {
         const [resp] = session(call(2, 'cas_add', { content: 'not valid!' }))
         assert(!('error' in (resp as object)))
         assert('result' in (resp as object))
+    },
+
+    toolsListAdvertisesFiveTools: () => {
+        const [resp] = runSession([init, initialized, list(2)]).slice(2)
+        const tools = (resp as { result: { tools: readonly { name: string }[] } }).result.tools
+        assertEq(tools.length, 5)
+        assertEq(tools.map(t => t.name).join(','), 'cas_add,cas_get,cas_list,cas_add_url,cas_get_meta')
+    },
+
+    addUrlStoresFileAndReturnsHash: () => {
+        const fileContent = utf8('hello from file')
+        const [addUrlResp, getMetaResp] = runSessionWithFiles({ '/tmp/hello.txt': fileContent })([
+            init, initialized,
+            call(2, 'cas_add_url', { url: '/tmp/hello.txt' }),
+            call(3, 'cas_get', { hash: '' }), // placeholder; we use the hash from addUrl
+        ]).slice(2) as readonly unknown[]
+        assert(!resultOf(addUrlResp).isError)
+        assert(textOf(addUrlResp).length > 0)
+    },
+
+    addUrlRoundTrips: () => {
+        const fileContent = utf8('round-trip content')
+        const msgs = runSessionWithFiles({ '/tmp/rt.txt': fileContent })([
+            init, initialized,
+            call(2, 'cas_add_url', { url: '/tmp/rt.txt' }),
+        ]).slice(2) as readonly unknown[]
+        const hash = textOf(msgs[0])
+        // Now add_url then get in one session to verify the stored content.
+        const msgs2 = runSessionWithFiles({ '/tmp/rt.txt': fileContent })([
+            init, initialized,
+            call(2, 'cas_add_url', { url: '/tmp/rt.txt' }),
+            call(3, 'cas_get', { hash }),
+        ]).slice(2) as readonly unknown[]
+        assert(!resultOf(msgs2[1]).isError)
+    },
+
+    addUrlMissingFileIsError: () => {
+        const [resp] = runSessionWithFiles({})([
+            init, initialized,
+            call(2, 'cas_add_url', { url: '/nonexistent/path.txt' }),
+        ]).slice(2) as readonly unknown[]
+        assertEq(resultOf(resp).isError, true)
+    },
+
+    addUrlMissingUrlArgumentIsError: () => {
+        const [resp] = session(call(2, 'cas_add_url', {}))
+        assertEq(resultOf(resp).isError, true)
+    },
+
+    getMetaReturnsLengthAndMimeType: () => {
+        const fileContent = utf8('text content')
+        const [addResp, metaResp] = runSessionWithFiles({ '/f': fileContent })([
+            init, initialized,
+            call(2, 'cas_add_url', { url: '/f' }),
+            call(3, 'cas_get_meta', { hash: '' }), // placeholder
+        ]).slice(2) as readonly unknown[]
+        const hash = textOf(addResp)
+        // Re-run with correct hash.
+        const [, metaResp2] = runSessionWithFiles({ '/f': fileContent })([
+            init, initialized,
+            call(2, 'cas_add_url', { url: '/f' }),
+            call(3, 'cas_get_meta', { hash }),
+        ]).slice(2) as readonly unknown[]
+        assert(!resultOf(metaResp2).isError)
+        const meta = JSON.parse(textOf(metaResp2)) as { length: number, mime_type: string }
+        assertEq(meta.mime_type, 'text/plain')
+        assertEq(meta.length, Number(BigInt(/* 'text content'.length */ 12)))
+    },
+
+    getMetaBinaryBlob: () => {
+        const pngVec = u8ListToVec(msb)([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x01])
+        const [addResp] = session(call(2, 'cas_add', { content: pngSample }))
+        const hash = textOf(addResp)
+        const [, metaResp] = session(
+            call(2, 'cas_add', { content: pngSample }),
+            call(3, 'cas_get_meta', { hash }),
+        )
+        assert(!resultOf(metaResp).isError)
+        const meta = JSON.parse(textOf(metaResp)) as { length: number, mime_type: string }
+        assertEq(meta.mime_type, 'image/png')
+        assertEq(meta.length, 10)
+    },
+
+    getMetaOctetStreamForUnknownBinary: () => {
+        // A Vec with high bytes that aren't valid UTF-8 and no magic signature.
+        const binaryContent = u8ListToVec(msb)([0xFF, 0xFE, 0x00, 0x01])
+        const binaryB64 = base64Encode(binaryContent) as string
+        const [addResp] = session(call(2, 'cas_add', { content: binaryB64 }))
+        const hash = textOf(addResp)
+        const [, metaResp] = session(
+            call(2, 'cas_add', { content: binaryB64 }),
+            call(3, 'cas_get_meta', { hash }),
+        )
+        assert(!resultOf(metaResp).isError)
+        const meta = JSON.parse(textOf(metaResp)) as { length: number, mime_type: string }
+        assertEq(meta.mime_type, 'application/octet-stream')
+    },
+
+    getMetaNoUrlWhenToUrlAbsent: () => {
+        const content = utf8('no url')
+        const binaryB64 = base64Encode(content) as string
+        const [addResp] = session(call(2, 'cas_add', { content: binaryB64 }))
+        const hash = textOf(addResp)
+        const [, metaResp] = session(
+            call(2, 'cas_add', { content: binaryB64 }),
+            call(3, 'cas_get_meta', { hash }),
+        )
+        assert(!resultOf(metaResp).isError)
+        const meta = JSON.parse(textOf(metaResp)) as { url?: string }
+        assertEq(meta.url, undefined)
+    },
+
+    getMetaMissingHashIsError: () => {
+        const absent = vecToCBase32(vec8(0x77n))
+        const [resp] = session(call(2, 'cas_get_meta', { hash: absent }))
+        assertEq(resultOf(resp).isError, true)
+    },
+
+    getMetaInvalidHashIsError: () => {
+        const [resp] = session(call(2, 'cas_get_meta', { hash: 'bad!' }))
+        assertEq(resultOf(resp).isError, true)
     },
 }

--- a/fs/cas/module.f.ts
+++ b/fs/cas/module.f.ts
@@ -35,7 +35,7 @@ const split2 = splitAt(2)
 const prefix = '.cas'
 
 /** Converts a content key to its sharded relative CAS file path. */
-const toPath = (key: Vec): string => {
+export const toPath = (key: Vec): string => {
     const s = vecToCBase32(key)
     const [a, bc] = split2(s)
     const [b, c] = split2(bc)
@@ -163,7 +163,7 @@ export const commands: Commands<FileKvStoreOperation | Write | All | MemOp | Rea
         description: 'Run an MCP server over stdio exposing the CAS as tools',
         handler: ({ home }) => {
             const c = cas(sha256)(fileKvStore(home))
-            return casMcpServer(c).step(() => pure(0))
+            return casMcpServer(c, hash => join(home, toPath(hash))).step(() => pure(0))
         },
     },
 ]

--- a/fs/text/utf8/module.f.ts
+++ b/fs/text/utf8/module.f.ts
@@ -3,10 +3,12 @@
  *
  * @module
  */
-import { flatMap, type List, type Thunk } from '../../types/list/module.f.ts'
+import { flatMap, toArray, type List, type Thunk } from '../../types/list/module.f.ts'
 import type { StateScan } from '../../types/function/operator/module.f.ts'
 import type { Array1, Array2, Array3 } from '../../types/array/module.f.ts'
 import { decoder, errorMask } from '../code_point/module.f.ts'
+import { msb, u8List, length, type Vec } from '../../types/bit_vec/module.f.ts'
+import { codePointListToString } from '../utf16/module.f.ts'
 
 /**
  * An unsigned 8-bit integer, represents a single byte.
@@ -247,3 +249,19 @@ const utf8EofToCodePointOp = (
  */
 export const toCodePointList: (input: List<U8>) => List<I32> =
     decoder(utf8ByteToCodePointOp, utf8EofToCodePointOp)
+
+/**
+ * Returns the decoded string if `v` is valid UTF-8, or `null` otherwise.
+ * Rejects non-octet Vecs, invalid byte sequences, surrogates, and out-of-range
+ * code points.
+ */
+export const fromVec = (v: Vec): string | null => {
+    if (length(v) % 8n !== 0n) { return null }
+    const arr = toArray(toCodePointList(u8List(msb)(v)))
+    for (const cp of arr) {
+        if (cp < 0) { return null }
+        if (cp > 0x10FFFF) { return null }
+        if (cp >= 0xD800 && cp <= 0xDFFF) { return null }
+    }
+    return codePointListToString(arr)
+}

--- a/fs/text/utf8/proof.f.ts
+++ b/fs/text/utf8/proof.f.ts
@@ -1,7 +1,8 @@
-import { toCodePointList, fromCodePointList } from './module.f.ts'
+import { toCodePointList, fromCodePointList, fromVec } from './module.f.ts'
 import { stringify as jsonStringify } from '../../json/module.f.ts'
 import { sort } from '../../types/object/module.f.ts'
 import { toArray } from '../../types/list/module.f.ts'
+import { msb, u8ListToVec } from '../../types/bit_vec/module.f.ts'
 
 const stringify = jsonStringify(sort)
 
@@ -120,5 +121,47 @@ export const proof = {
             const result = stringify(toArray(fromCodePointList(codePointList)))
             if (result !== '[240,160,160,244,160,160]') { throw result }
         }
+    ],
+    fromVec: [
+        // Valid ASCII → decoded string
+        () => {
+            const v = u8ListToVec(msb)([0x68, 0x65, 0x6c, 0x6c, 0x6f]) // "hello"
+            if (fromVec(v) !== 'hello') { throw 'expected "hello"' }
+        },
+        // Valid multi-byte UTF-8 → decoded string (U+00A9 COPYRIGHT SIGN, 2-byte)
+        () => {
+            const v = u8ListToVec(msb)([0xc2, 0xa9]) // "©"
+            if (fromVec(v) !== '©') { throw 'expected copyright sign' }
+        },
+        // Valid 3-byte UTF-8 (U+4E2D CJK)
+        () => {
+            const v = u8ListToVec(msb)([0xe4, 0xb8, 0xad]) // "中"
+            if (fromVec(v) !== '中') { throw 'expected CJK character' }
+        },
+        // Valid 4-byte UTF-8 (U+1F600 GRINNING FACE)
+        () => {
+            const v = u8ListToVec(msb)([0xf0, 0x9f, 0x98, 0x80])
+            if (fromVec(v) !== '\u{1f600}') { throw 'expected emoji' }
+        },
+        // Invalid byte sequence → null
+        () => {
+            const v = u8ListToVec(msb)([0xff, 0xfe]) // not valid UTF-8
+            if (fromVec(v) !== null) { throw 'expected null for invalid UTF-8' }
+        },
+        // Lone continuation byte → null
+        () => {
+            const v = u8ListToVec(msb)([0x80])
+            if (fromVec(v) !== null) { throw 'expected null for lone continuation byte' }
+        },
+        // Surrogate half (U+D800, encoded as CESU-8 0xED 0xA0 0x80) → null
+        () => {
+            const v = u8ListToVec(msb)([0xed, 0xa0, 0x80])
+            if (fromVec(v) !== null) { throw 'expected null for surrogate' }
+        },
+        // Empty Vec → empty string
+        () => {
+            const v = u8ListToVec(msb)([])
+            if (fromVec(v) !== '') { throw 'expected empty string' }
+        },
     ]
 }


### PR DESCRIPTION
## Summary
This PR extends the CAS MCP server with two new tools for managing content-addressed storage via filesystem URLs and metadata inspection. It adds support for reading files from the filesystem and returning their content hashes, plus retrieving metadata (length, MIME type, optional URL) for stored blobs.

## Key Changes

- **New MCP Tools**: Added `cas_add_url` and `cas_get_meta` tools to the CAS MCP handlers
  - `cas_add_url`: Reads a file from a given filesystem path, stores its content, and returns the cBase32 hash
  - `cas_get_meta`: Returns metadata (byte length, MIME type, optional URL) for a blob by its hash without transferring content

- **File I/O Integration**: 
  - Imported `readFile` and `ReadFile` effect type from the node effects module
  - Updated `casMcpHandlers` to accept an optional `toUrl` callback for mapping hashes back to filesystem paths
  - Updated `casMcpServer` to thread `ReadFile` effects through the MCP pipeline

- **Test Infrastructure**:
  - Extended test state to include a mocked filesystem (`TestState` with `files` field)
  - Added `runMemWithFiles` helper to run sessions with pre-populated file mocks
  - Added `runSessionWithFiles` to test the new URL-based tools
  - Implemented `readFile` mock operation in the memory operation map

- **UTF-8 Utilities**:
  - Added `fromVec` function to safely decode UTF-8 from bit vectors, returning `null` for invalid sequences
  - Validates octet alignment, byte sequences, surrogates, and code point ranges

- **MIME Type Detection**:
  - Integrated `detect` function for automatic MIME type detection from binary content
  - Falls back to `text/plain` for valid UTF-8 or `application/octet-stream` for binary

- **Comprehensive Test Coverage**:
  - Tests for successful file reading and hash storage
  - Round-trip tests verifying stored content can be retrieved
  - Error cases: missing files, missing arguments, invalid hashes
  - Metadata tests for text, PNG images, unknown binary, and missing content
  - Updated tool count assertions from 3 to 5 tools

## Notable Implementation Details

- The `toUrl` callback is optional, allowing the handlers to work in both production (with filesystem paths) and test (without URL mapping) contexts
- MIME type detection uses magic signatures (via `detect`) with UTF-8 validation as a fallback for text
- The `cas_get_meta` response conditionally includes the `url` field only when `toUrl` is provided
- File reading errors are gracefully handled and returned as MCP error results

https://claude.ai/code/session_01X4N3in8CVFYizCywrmSpmV