### PR TITLE
Consolidate path imports and normalize home directory path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `effects/node`: normalize the home directory path on Windows using `toPosix` so `home` always uses forward slashes (`C:/Users/x/` instead of `C:\Users\x\`) [#1108](https://github.com/functionalscript/functionalscript/pull/1108)
+
 ## 0.31.0
 
 - `cas/mcp`: unify `cas_add`/`cas_add_url` and `cas_get`/`cas_get_meta` into three tools — `cas_add` gains `type:'url'` so passing a filesystem path as `content` stores the file directly (replaces `cas_add_url`); `cas_get` gains `content?: boolean` and always returns `{ length, mime_type, type, url? }` (metadata + encoding type) so the agent can decide whether to fetch inline content without paying the token cost; pass `content: true` to also get the inline payload; `cas_add_url` and `cas_get_meta` removed (i66H-cas-mcp-unified-get-add) [#1106](https://github.com/functionalscript/functionalscript/pull/1106)

--- a/fs/effects/node/module.ts
+++ b/fs/effects/node/module.ts
@@ -20,8 +20,7 @@ import process from 'node:process'
 import { once } from 'node:events'
 import * as testContext from 'node:test'
 
-import { concat } from '../../path/module.f.ts'
-import { normalize } from '../../path/module.f.ts'
+import { concat, normalize, toPosix } from '../../path/module.f.ts'
 import { type Effect } from '../module.f.ts'
 import { asyncRun } from '../module.ts'
 import { memoryOperationMap } from './memory/module.ts'
@@ -284,7 +283,7 @@ const playwrightTestContext = wrapInlineTest(pwTest!)
 const options: NodeProgramOptions = {
     args: process.argv.slice(2),
     env: process.env,
-    home: os.homedir().replaceAll('\\', '/'),
+    home: toPosix(os.homedir()),
     std: { stdout: process.stdout, stderr: process.stderr },
     testContext,
     bunTestContext,

--- a/fs/effects/node/module.ts
+++ b/fs/effects/node/module.ts
@@ -284,7 +284,7 @@ const playwrightTestContext = wrapInlineTest(pwTest!)
 const options: NodeProgramOptions = {
     args: process.argv.slice(2),
     env: process.env,
-    home: os.homedir(),
+    home: os.homedir().replaceAll('\\', '/'),
     std: { stdout: process.stdout, stderr: process.stderr },
     testContext,
     bunTestContext,


### PR DESCRIPTION
## Summary
This PR improves path handling in the Node.js effects module by consolidating related imports and ensuring the home directory path is normalized to POSIX format.

## Key Changes
- **Consolidated imports**: Combined two separate import statements from `../../path/module.f.ts` into a single import statement, adding `toPosix` to the imports
- **Normalized home directory**: Applied `toPosix()` transformation to `os.homedir()` to ensure consistent POSIX-style path formatting in the `NodeProgramOptions` configuration

## Implementation Details
The `toPosix()` function is now used to convert the home directory path returned by `os.homedir()` to a standardized POSIX format. This ensures consistent path handling across different operating systems and prevents potential issues with path operations that may expect forward slashes instead of backslashes (particularly relevant on Windows systems).

https://claude.ai/code/session_01UtmtXVzpMCmMDdXNgodQBH