### PR TITLE
Add issue #209: Simplify fjs command syntax from `fjs cas mcp` to `fjs mcp`

### DIFF
--- a/issues/209-simplify-fjs-command-syntax.md
+++ b/issues/209-simplify-fjs-command-syntax.md
@@ -1,0 +1,27 @@
+# 209. Simplify fjs command line syntax: change from `fjs cas mcp` to `fjs mcp`.
+
+**Priority:** P2
+**Status:** open
+
+## Description
+
+Currently, the fjs CLI requires calling `fjs cas mcp` to invoke the MCP server via the CAS (content-addressable storage) layer. This proposal is to simplify the command syntax to `fjs mcp` by removing the intermediate `cas` command.
+
+## Rationale
+
+The MCP server will have more functionality than CAS in the future, and the CAS layer will become an internal implementation detail rather than a primary user-facing interface. Removing the `cas` command level will:
+
+1. Simplify the user-facing API
+2. Allow direct access to MCP functionality
+3. Prepare for expanded MCP capabilities beyond CAS
+
+## Changes Required
+
+- Update CLI argument parsing to accept `fjs mcp` directly
+- Maintain backwards compatibility during transition if needed
+- Update documentation and examples
+- Update test cases to use new syntax
+
+## Related Issues
+
+None


### PR DESCRIPTION
## Summary
This PR documents issue #209, which proposes simplifying the fjs CLI command syntax by removing the intermediate `cas` command level, allowing users to invoke the MCP server directly via `fjs mcp` instead of `fjs cas mcp`.

## Changes
- Added issue specification document outlining the motivation and requirements for simplifying the CLI syntax
- Documented the rationale for treating CAS as an internal implementation detail rather than a user-facing command
- Specified required changes including CLI argument parsing updates, backwards compatibility considerations, and documentation updates

## Details
The issue identifies that as the MCP server gains more functionality beyond CAS, the current nested command structure becomes unnecessarily complex. This change will streamline the user experience while preparing the codebase for expanded MCP capabilities.

https://claude.ai/code/session_01KqqZA9jpcCRgSFvGBechdW