### PR TITLE
Add declarative tool definition pattern guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ where `<...Module documentation...>` should be documentation for the module.
 - Before implementing a non-trivial feature, ensure the corresponding issue document in `./issues/` contains a concrete design. If the issue exists but the design is absent, vague, or contradicts the codebase or runtime behaviour, update the issue first and wait for review — do not write code against an incomplete or incorrect design.
 - When a discrepancy is found between an issue's design and reality (a missing API, a wrong environment variable, an incompatible type), correct the design document and surface the problem rather than silently working around it.
 - Before relying on an undocumented or assumed runtime behaviour (environment variable names, API shape, framework detection), verify it with a small test or source check rather than assuming.
+- **Prefer declarative style over imperative.** When defining tools, handlers, dispatchers, or similar abstractions, favor data-driven definitions (metadata + schema + handler together in an array or registry) over imperative switch statements or hardcoded conditionals. Declarative patterns are easier to extend, test, and reason about. For example: define tools as an array of self-descriptive objects (name, description, schema, handler) and dispatch generically over them, rather than hardcoding a switch on tool name. See [i66H-declarative-tool-definitions](./issues/66H-declarative-tool-definitions.md) for an example refactoring from imperative to declarative.
 
 ## Pull Requests
 

--- a/issues/66H-declarative-tool-definitions.md
+++ b/issues/66H-declarative-tool-definitions.md
@@ -1,0 +1,39 @@
+# 66H-declarative-tool-definitions. Refactor MCP tool definitions from imperative to declarative
+
+**Priority:** P3
+**Status:** open
+
+## Problem
+
+The MCP handlers implementation uses an imperative approach: `toolsList` returns a hardcoded array of tool descriptors, and `toolsCall` contains a large switch statement mapping tool names to handlers. This mismatch between the type definition (which expects `toolsList` to take `ToolsListParams`) and the implementation (which takes no parameters) suggests the design is incomplete.
+
+Current issues:
+1. The `toolsList` method signature doesn't match the `McpHandlers<O>` type (takes no params, type says `ToolsListParams`)
+2. Tool definitions (`casAddTool`, `casGetTool`, `casListTool`) are separate from their handlers
+3. The `toolsCall` switch statement couples tool metadata with handler logic
+4. Adding a new tool requires editing the hardcoded array and extending the switch statement
+
+## Proposal
+
+Refactor to a declarative, data-driven approach where:
+- Define an array of tool configurations, each containing:
+  - Tool metadata (name, description)
+  - Input schema (RTTI definition; JSON schema generated via `toJsonSchema`)
+  - Output schema (RTTI definition)
+  - A handler function
+- Replace the switch statement with generic dispatch over this array
+- Similar to how CLI dispatch works
+
+This aligns with:
+- The existing `Tool` type already separates metadata from handlers
+- Other parts of the codebase that use declarative tool/command registration
+- Type correctness (no signature mismatch)
+- Scalability (adding tools becomes additive, not scattered edits)
+
+## Tasks
+
+- [ ] Define a tool registry type capturing metadata + handler + schemas
+- [ ] Convert `cas_add`, `cas_get`, `cas_list` to declarative definitions
+- [ ] Refactor `toolsCall` to generic dispatch over the registry
+- [ ] Update `toolsList` to derive tools from the registry
+- [ ] Verify type correctness with `McpHandlers<O>`


### PR DESCRIPTION
## Summary

Add issue and guidance for preferring declarative over imperative tool definitions.

- Created [i66H-declarative-tool-definitions](./issues/66H-declarative-tool-definitions.md) documenting the design for refactoring MCP tool handlers from imperative (hardcoded array + switch statement) to declarative (data-driven tool registry)
- Updated [AGENTS.md](./AGENTS.md) with architectural guidance to prefer declarative patterns over imperative ones

## Rationale

The current MCP handlers implementation has a type mismatch: `toolsList` takes no parameters but the `McpHandlers<O>` type expects `ToolsListParams`. This suggests the design needs refinement. A declarative approach would:
- Make tool definitions self-descriptive (metadata, schemas, handlers together)
- Enable generic dispatch instead of hardcoded switch statements
- Simplify adding new tools
- Improve type correctness

This pattern aligns with existing codebase practices and provides a template for similar refactoring elsewhere.

🤖 Generated with Claude Code