### PR TITLE
Add rename, readBytes, and randomInt file system operations

### DIFF
--- a/fs/effects/node/module.f.ts
+++ b/fs/effects/node/module.f.ts
@@ -140,19 +140,19 @@ export type Rename = readonly['rename', (src: string, dst: string) => IoResult<v
 export const rename: Func<Rename> =
     do_('rename')
 
-// readChunk
+// readBytes
 
-export type ReadChunk = readonly['readChunk', (path: string, offset: number, size: number) => IoResult<Vec>]
+export type ReadBytes = readonly['readBytes', (path: string, offset: number, size: number) => IoResult<Vec>]
 
-export const readChunk: Func<ReadChunk> =
-    do_('readChunk')
+export const readBytes: Func<ReadBytes> =
+    do_('readBytes')
 
-// randomBytes
+// randomInt
 
-export type RandomBytes = readonly['randomBytes', (size: number) => Vec]
+export type RandomInt = readonly['randomInt', () => number]
 
-export const randomBytes: Func<RandomBytes> =
-    do_('randomBytes')
+export const randomInt: Func<RandomInt> =
+    do_('randomInt')
 
 // exec
 
@@ -175,7 +175,7 @@ export const access: Func<Access> =
 
 // Fs
 
-export type Fs = Mkdir | ReadFile | ReadChunk | Readdir | WriteFile | Rm | Rename | Exec | Access
+export type Fs = Mkdir | ReadFile | ReadBytes | Readdir | WriteFile | Rm | Rename | Exec | Access
 
 // Server
 
@@ -414,7 +414,7 @@ export type NodeOp =
     | Import
     | MemOp
     | Now
-    | RandomBytes
+    | RandomInt
     | Read
     | Sandbox
     | Write

--- a/fs/effects/node/module.f.ts
+++ b/fs/effects/node/module.f.ts
@@ -133,6 +133,27 @@ export type Rm = readonly['rm', (path: string) => IoResult<void>]
 export const rm: Func<Rm> =
     do_('rm')
 
+// rename
+
+export type Rename = readonly['rename', (src: string, dst: string) => IoResult<void>]
+
+export const rename: Func<Rename> =
+    do_('rename')
+
+// readChunk
+
+export type ReadChunk = readonly['readChunk', (path: string, offset: number, size: number) => IoResult<Vec>]
+
+export const readChunk: Func<ReadChunk> =
+    do_('readChunk')
+
+// randomBytes
+
+export type RandomBytes = readonly['randomBytes', (size: number) => Vec]
+
+export const randomBytes: Func<RandomBytes> =
+    do_('randomBytes')
+
 // exec
 
 export type ExecResult = {
@@ -154,7 +175,7 @@ export const access: Func<Access> =
 
 // Fs
 
-export type Fs = Mkdir | ReadFile | Readdir | WriteFile | Rm | Exec | Access
+export type Fs = Mkdir | ReadFile | ReadChunk | Readdir | WriteFile | Rm | Rename | Exec | Access
 
 // Server
 
@@ -393,6 +414,7 @@ export type NodeOp =
     | Import
     | MemOp
     | Now
+    | RandomBytes
     | Read
     | Sandbox
     | Write

--- a/fs/effects/node/module.ts
+++ b/fs/effects/node/module.ts
@@ -227,6 +227,9 @@ const runNodeEffect: EffectToPromise = asyncRun({
     rm: path => tc(() => rm(path)),
     rename: (src, dst) => tc(() => rename(src, dst)),
     readBytes: (path, offset, size) => tc(async () => {
+        if (size > maxFileSizeBytes) {
+            throw new Error(`Chunk size ${size} exceeds maximum allowed size of ${maxFileSizeBytes} bytes`)
+        }
         const fh = await open(path, 'r')
         try {
             const buffer = Buffer.alloc(size)

--- a/fs/effects/node/module.ts
+++ b/fs/effects/node/module.ts
@@ -14,6 +14,7 @@
  */
 import http from 'node:http'
 import childProcess from 'node:child_process'
+import crypto from 'node:crypto'
 import fs from 'node:fs'
 import os from 'node:os'
 import process from 'node:process'
@@ -88,7 +89,7 @@ const collect = async <T>(v: AsyncIterable<T>): Promise<readonly T[]> => {
     return result
 }
 
-const { mkdir, readFile, readdir, writeFile, rm, access, stat } = fs.promises
+const { mkdir, open, readFile, readdir, rename, writeFile, rm, access, stat } = fs.promises
 
 const { exec } = childProcess
 
@@ -224,6 +225,18 @@ const runNodeEffect: EffectToPromise = asyncRun({
     ),
     writeFile: (path, data) => tc(() => writeFile(path, fromVec(data))),
     rm: path => tc(() => rm(path)),
+    rename: (src, dst) => tc(() => rename(src, dst)),
+    readChunk: (path, offset, size) => tc(async () => {
+        const fh = await open(path, 'r')
+        try {
+            const buffer = Buffer.alloc(size)
+            const { bytesRead } = await fh.read(buffer, 0, size, offset)
+            return toVec(buffer.subarray(0, bytesRead))
+        } finally {
+            await fh.close()
+        }
+    }),
+    randomBytes: async size => toVec(crypto.randomBytes(size)),
     access: path => tc(() => access(path)),
     import: path => tc(() => asyncImport(path)),
     exec: (command, stdin) => new Promise(resolve => {

--- a/fs/effects/node/module.ts
+++ b/fs/effects/node/module.ts
@@ -226,7 +226,7 @@ const runNodeEffect: EffectToPromise = asyncRun({
     writeFile: (path, data) => tc(() => writeFile(path, fromVec(data))),
     rm: path => tc(() => rm(path)),
     rename: (src, dst) => tc(() => rename(src, dst)),
-    readChunk: (path, offset, size) => tc(async () => {
+    readBytes: (path, offset, size) => tc(async () => {
         const fh = await open(path, 'r')
         try {
             const buffer = Buffer.alloc(size)
@@ -236,7 +236,7 @@ const runNodeEffect: EffectToPromise = asyncRun({
             await fh.close()
         }
     }),
-    randomBytes: async size => toVec(crypto.randomBytes(size)),
+    randomInt: async () => crypto.randomInt(2 ** 32),
     access: path => tc(() => access(path)),
     import: path => tc(() => asyncImport(path)),
     exec: (command, stdin) => new Promise(resolve => {

--- a/fs/effects/node/module.ts
+++ b/fs/effects/node/module.ts
@@ -227,6 +227,9 @@ const runNodeEffect: EffectToPromise = asyncRun({
     rm: path => tc(() => rm(path)),
     rename: (src, dst) => tc(() => rename(src, dst)),
     readBytes: (path, offset, size) => tc(async () => {
+        if (offset < 0) {
+            throw new Error(`Offset ${offset} is negative`)
+        }
         if (size > maxFileSizeBytes) {
             throw new Error(`Chunk size ${size} exceeds maximum allowed size of ${maxFileSizeBytes} bytes`)
         }

--- a/fs/effects/node/proof.f.ts
+++ b/fs/effects/node/proof.f.ts
@@ -322,7 +322,9 @@ export const proof = {
                 root: { tmp: { src: vec8(0x2An) } },
             })(rename('tmp/src', 'tmp/dst'))
             if (t !== 'ok') { throw result }
-            if (state.root.tmp?.src !== undefined) { throw state.root }
+            const tmp = state.root.tmp
+            if (typeof tmp !== 'object') { throw state.root }
+            if (tmp.src !== undefined) { throw tmp }
         },
         dirOverFile: () => {
             const [state, [t, result]] = virtual({

--- a/fs/effects/node/proof.f.ts
+++ b/fs/effects/node/proof.f.ts
@@ -1,7 +1,7 @@
 import { empty, isVec, uint, vec8 } from "../../types/bit_vec/module.f.ts"
 import { utf8, utf8ToString } from "../../text/module.f.ts"
 import { decode, pure } from "../module.f.ts"
-import { both, fetch, mkdir, now, readdir, readFile, readUtf8File, rm, sandbox, writeFile, writeUtf8File } from "./module.f.ts"
+import { both, fetch, mkdir, now, readdir, readFile, readUtf8File, rm, sandbox, writeFile, writeUtf8File, rename, readBytes, randomInt } from "./module.f.ts"
 import { create as memCreate, read as memRead, write as memWrite } from "../memory/module.f.ts"
 import { emptyState, virtual } from "./virtual/module.f.ts"
 
@@ -303,6 +303,77 @@ export const proof = {
             )
             const [_, value] = virtual(emptyState)(effect)
             if (value !== 99) { throw value }
+        },
+    },
+    rename: {
+        fileOverFile: () => {
+            const [state, [t, result]] = virtual({
+                ...emptyState,
+                root: { src: vec8(0x2An), dst: vec8(0x15n) },
+            })(rename('src', 'dst'))
+            if (t !== 'ok') { throw result }
+            if (state.root.src !== undefined) { throw state.root }
+            if (!isVec(state.root.dst)) { throw state.root }
+            if (uint(state.root.dst) !== 0x2An) { throw state.root }
+        },
+        nestedRename: () => {
+            const [state, [t, result]] = virtual({
+                ...emptyState,
+                root: { tmp: { src: vec8(0x2An) } },
+            })(rename('tmp/src', 'tmp/dst'))
+            if (t !== 'ok') { throw result }
+            if (state.root.tmp?.src !== undefined) { throw state.root }
+        },
+        dirOverFile: () => {
+            const [state, [t, result]] = virtual({
+                ...emptyState,
+                root: { src: {}, dst: vec8(0x15n) },
+            })(rename('src', 'dst'))
+            if (t !== 'error') { throw result }
+            if (state.root.dst === undefined || isVec(state.root.dst)) { throw state.root }
+        },
+        missingSource: () => {
+            const [_, [t, result]] = virtual(emptyState)(rename('missing', 'dst'))
+            if (t !== 'error') { throw result }
+        },
+    },
+    readBytes: {
+        simple: () => {
+            const [_, [t, result]] = virtual({
+                ...emptyState,
+                root: { file: vec8(0xABCDn) },
+            })(readBytes('file', 0, 2))
+            if (t !== 'ok') { throw result }
+            if (!isVec(result)) { throw result }
+        },
+        withOffset: () => {
+            const [_, [t, result]] = virtual({
+                ...emptyState,
+                root: { file: vec8(0xABCDn) },
+            })(readBytes('file', 1, 1))
+            if (t !== 'ok') { throw result }
+            if (!isVec(result)) { throw result }
+        },
+        oversizeChunk: () => {
+            const [_, [t, result]] = virtual({
+                ...emptyState,
+                root: { file: vec8(0x2An) },
+            })(readBytes('file', 0, Number(2n ** 32n)))
+            if (t !== 'error') { throw result }
+        },
+        missingFile: () => {
+            const [_, [t, result]] = virtual(emptyState)(readBytes('missing', 0, 4))
+            if (t !== 'error') { throw result }
+        },
+    },
+    randomInt: {
+        increments: () => {
+            const [state1, r1] = virtual(emptyState)(randomInt())
+            if (r1 !== 0) { throw r1 }
+            const [state2, r2] = virtual(state1)(randomInt())
+            if (r2 !== 1) { throw r2 }
+            const [state3, r3] = virtual(state2)(randomInt())
+            if (r3 !== 2) { throw r3 }
         },
     },
 }

--- a/fs/effects/node/proof.f.ts
+++ b/fs/effects/node/proof.f.ts
@@ -372,7 +372,7 @@ export const proof = {
             if (r1 !== 0) { throw r1 }
             const [state2, r2] = virtual(state1)(randomInt())
             if (r2 !== 1) { throw r2 }
-            const [state3, r3] = virtual(state2)(randomInt())
+            const [_, r3] = virtual(state2)(randomInt())
             if (r3 !== 2) { throw r3 }
         },
     },

--- a/fs/effects/node/proof.f.ts
+++ b/fs/effects/node/proof.f.ts
@@ -330,7 +330,7 @@ export const proof = {
                 root: { src: {}, dst: vec8(0x15n) },
             })(rename('src', 'dst'))
             if (t !== 'error') { throw result }
-            if (state.root.dst === undefined || isVec(state.root.dst)) { throw state.root }
+            if (!isVec(state.root.dst)) { throw state.root }
         },
         missingSource: () => {
             const [_, [t, result]] = virtual(emptyState)(rename('missing', 'dst'))

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -242,6 +242,7 @@ const readBytesOp = (path: string, offset: number, size: number) => readOperatio
     if (typeof file === 'function') { throw new Error(`'${p[0]}' is a JsModule; readBytes not supported`) }
     if (file === undefined) { return enoent }
     if (!isVec(file)) { return error(`'${p[0]}' is not a file`) }
+    if (size < 0) { return error(`Chunk size ${size} is negative`) }
     if (BigInt(size) > maxLengthBytes) { return error(`Chunk size ${size} exceeds maximum allowed size of ${maxLengthBytes} bytes`) }
     const offsetBits = BigInt(offset) * 8n
     const sizeBits = BigInt(size) * 8n

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -242,6 +242,7 @@ const readBytesOp = (path: string, offset: number, size: number) => readOperatio
     if (typeof file === 'function') { throw new Error(`'${p[0]}' is a JsModule; readBytes not supported`) }
     if (file === undefined) { return enoent }
     if (!isVec(file)) { return error(`'${p[0]}' is not a file`) }
+    if (offset < 0) { return error(`Offset ${offset} is negative`) }
     if (size < 0) { return error(`Chunk size ${size} is negative`) }
     if (BigInt(size) > maxLengthBytes) { return error(`Chunk size ${size} exceeds maximum allowed size of ${maxLengthBytes} bytes`) }
     const offsetBits = BigInt(offset) * 8n

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -189,8 +189,8 @@ const insertEntityAt = (dir: Dir, path: readonly string[], entity: Entity): read
     if (path.length === 1) {
         const [name] = path
         const existing = dir[name]
-        if (existing !== undefined) {
-            return [dir, error(`'${name}' already exists`)]
+        if (existing !== undefined && !isVec(existing)) {
+            return [dir, error(`'${name}' is a directory`)]
         }
         return [{ ...dir, [name]: entity }, okVoid]
     }

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -41,6 +41,8 @@ export type State = {
     epochNs: number
     memoryNext: number
     memoryValues: { readonly [key: string]: unknown }
+    /** Monotonically increasing counter returned by `randomInt`; starts at 0. */
+    randomNext: number
 }
 
 export const emptyState: State = {
@@ -52,6 +54,7 @@ export const emptyState: State = {
     epochNs: 0,
     memoryNext: 0,
     memoryValues: {},
+    randomNext: 0,
 }
 
 const operation =
@@ -204,10 +207,10 @@ const rename = (src: string, dst: string) => (state: State): readonly[State, IoR
     return [{ ...state, root: dstRoot }, okVoid]
 }
 
-const readChunkOp = (path: string, offset: number, size: number) => readOperation((dir, p): IoResult<Vec> => {
+const readBytesOp = (path: string, offset: number, size: number) => readOperation((dir, p): IoResult<Vec> => {
     if (p.length !== 1) { return enoent }
     const file = dir[p[0]]
-    if (typeof file === 'function') { throw new Error(`'${p[0]}' is a JsModule; readChunk not supported`) }
+    if (typeof file === 'function') { throw new Error(`'${p[0]}' is a JsModule; readBytes not supported`) }
     if (file === undefined) { return enoent }
     if (!isVec(file)) { return error(`'${p[0]}' is not a file`) }
     const chunk = fromVec(file).subarray(offset, offset + size)
@@ -254,8 +257,8 @@ const map: MemOperationMap<NodeOp, State> = {
     import: import_,
     rm,
     rename,
-    readChunk: readChunkOp,
-    randomBytes: size => state => [state, toVec(new Uint8Array(size))],
+    readBytes: readBytesOp,
+    randomInt: () => state => [{ ...state, randomNext: state.randomNext + 1 }, state.randomNext],
     exec: todo,
     createServer: todo,
     listen: todo,

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -6,8 +6,7 @@
 import { todo } from '../../../asserts/module.f.ts'
 import { join, parse } from '../../../path/module.f.ts'
 import { utf8ToString } from '../../../text/module.f.ts'
-import { isVec, type Vec } from '../../../types/bit_vec/module.f.ts'
-import { fromVec, toVec } from '../../../types/uint8array/module.f.ts'
+import { isVec, length, msb, vec, type Vec } from '../../../types/bit_vec/module.f.ts'
 import { error, ok } from '../../../types/result/module.f.ts'
 import { run, type MemOperationMap, type RunInstance } from '../../mock/module.f.ts'
 import { asBase, asNominal, type Key } from '../../memory/module.f.ts'
@@ -218,8 +217,11 @@ const readBytesOp = (path: string, offset: number, size: number) => readOperatio
     if (typeof file === 'function') { throw new Error(`'${p[0]}' is a JsModule; readBytes not supported`) }
     if (file === undefined) { return enoent }
     if (!isVec(file)) { return error(`'${p[0]}' is not a file`) }
-    const chunk = fromVec(file).subarray(offset, offset + size)
-    return ok(toVec(chunk))
+    const offsetBits = BigInt(offset) * 8n
+    const sizeBits = BigInt(size) * 8n
+    const remaining = msb.removeFront(offsetBits)(file)
+    const actualSizeBits = sizeBits < length(remaining) ? sizeBits : length(remaining)
+    return ok(vec(actualSizeBits)(msb.front(actualSizeBits)(remaining)))
 })(path)
 
 const map: MemOperationMap<NodeOp, State> = {

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -6,7 +6,7 @@
 import { todo } from '../../../asserts/module.f.ts'
 import { join, parse } from '../../../path/module.f.ts'
 import { utf8ToString } from '../../../text/module.f.ts'
-import { isVec, length, msb, vec, type Vec } from '../../../types/bit_vec/module.f.ts'
+import { isVec, length, maxLengthBytes, msb, vec, type Vec } from '../../../types/bit_vec/module.f.ts'
 import { error, ok } from '../../../types/result/module.f.ts'
 import { run, type MemOperationMap, type RunInstance } from '../../mock/module.f.ts'
 import { asBase, asNominal, type Key } from '../../memory/module.f.ts'
@@ -189,8 +189,15 @@ const insertEntityAt = (dir: Dir, path: readonly string[], entity: Entity): read
     if (path.length === 1) {
         const [name] = path
         const existing = dir[name]
-        if (existing !== undefined && !isVec(existing)) {
-            return [dir, error(`'${name}' is a directory`)]
+        if (existing !== undefined) {
+            const entityIsDir = typeof entity === 'object'
+            const existingIsDir = typeof existing === 'object'
+            if (entityIsDir && !existingIsDir) {
+                return [dir, error(`cannot overwrite file '${name}' with a directory`)]
+            }
+            if (!entityIsDir && existingIsDir) {
+                return [dir, error(`'${name}' is a directory`)]
+            }
         }
         return [{ ...dir, [name]: entity }, okVoid]
     }
@@ -206,19 +213,7 @@ const insertEntityAt = (dir: Dir, path: readonly string[], entity: Entity): read
 const rename = (src: string, dst: string) => (state: State): readonly[State, IoResult<void>] => {
     const [srcRoot, srcResult] = extractEntity(state.root, parse(src))
     if (srcResult[0] === 'error') { return [state, srcResult] }
-    const srcEntity = srcResult[1]
-    const isSourceDir = typeof srcEntity === 'object'
-
-    const dstParsed = parse(dst)
-    if (dstParsed.length === 1) {
-        const [name] = dstParsed
-        const existing = srcRoot[name]
-        if (existing !== undefined && isSourceDir && isVec(existing)) {
-            return [state, error(`cannot rename directory onto file '${name}'`)]
-        }
-    }
-
-    const [dstRoot, dstResult] = insertEntityAt(srcRoot, dstParsed, srcEntity)
+    const [dstRoot, dstResult] = insertEntityAt(srcRoot, parse(dst), srcResult[1])
     if (dstResult[0] === 'error') { return [state, dstResult] }
     return [{ ...state, root: dstRoot }, okVoid]
 }
@@ -229,6 +224,7 @@ const readBytesOp = (path: string, offset: number, size: number) => readOperatio
     if (typeof file === 'function') { throw new Error(`'${p[0]}' is a JsModule; readBytes not supported`) }
     if (file === undefined) { return enoent }
     if (!isVec(file)) { return error(`'${p[0]}' is not a file`) }
+    if (BigInt(size) > maxLengthBytes) { return error(`Chunk size ${size} exceeds maximum allowed size of ${maxLengthBytes} bytes`) }
     const offsetBits = BigInt(offset) * 8n
     const sizeBits = BigInt(size) * 8n
     const remaining = msb.removeFront(offsetBits)(file)

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -206,7 +206,19 @@ const insertEntityAt = (dir: Dir, path: readonly string[], entity: Entity): read
 const rename = (src: string, dst: string) => (state: State): readonly[State, IoResult<void>] => {
     const [srcRoot, srcResult] = extractEntity(state.root, parse(src))
     if (srcResult[0] === 'error') { return [state, srcResult] }
-    const [dstRoot, dstResult] = insertEntityAt(srcRoot, parse(dst), srcResult[1])
+    const srcEntity = srcResult[1]
+    const isSourceDir = typeof srcEntity === 'object'
+
+    const dstParsed = parse(dst)
+    if (dstParsed.length === 1) {
+        const [name] = dstParsed
+        const existing = srcRoot[name]
+        if (existing !== undefined && isSourceDir && isVec(existing)) {
+            return [state, error(`cannot rename directory onto file '${name}'`)]
+        }
+    }
+
+    const [dstRoot, dstResult] = insertEntityAt(srcRoot, dstParsed, srcEntity)
     if (dstResult[0] === 'error') { return [state, dstResult] }
     return [{ ...state, root: dstRoot }, okVoid]
 }

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -242,6 +242,8 @@ const readBytesOp = (path: string, offset: number, size: number) => readOperatio
     if (typeof file === 'function') { throw new Error(`'${p[0]}' is a JsModule; readBytes not supported`) }
     if (file === undefined) { return enoent }
     if (!isVec(file)) { return error(`'${p[0]}' is not a file`) }
+    if (!Number.isInteger(offset)) { return error(`Offset ${offset} is not an integer`) }
+    if (!Number.isInteger(size)) { return error(`Chunk size ${size} is not an integer`) }
     if (offset < 0) { return error(`Offset ${offset} is negative`) }
     if (size < 0) { return error(`Chunk size ${size} is negative`) }
     if (BigInt(size) > maxLengthBytes) { return error(`Chunk size ${size} exceeds maximum allowed size of ${maxLengthBytes} bytes`) }

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -7,6 +7,7 @@ import { todo } from '../../../asserts/module.f.ts'
 import { join, parse } from '../../../path/module.f.ts'
 import { utf8ToString } from '../../../text/module.f.ts'
 import { isVec, type Vec } from '../../../types/bit_vec/module.f.ts'
+import { fromVec, toVec } from '../../../types/uint8array/module.f.ts'
 import { error, ok } from '../../../types/result/module.f.ts'
 import { run, type MemOperationMap, type RunInstance } from '../../mock/module.f.ts'
 import { asBase, asNominal, type Key } from '../../memory/module.f.ts'
@@ -164,6 +165,55 @@ const rm = operation((dir, path): readonly[Dir, IoResult<void>] => {
     return [rest as Dir, okVoid]
 })
 
+const extractEntity = (dir: Dir, path: readonly string[]): readonly[Dir, IoResult<Entity>] => {
+    if (path.length === 0) { return [dir, error('cannot extract root')] }
+    if (path.length === 1) {
+        const [name] = path
+        const entry = dir[name]
+        if (entry === undefined) { return [dir, enoent] }
+        const { [name]: _, ...rest } = dir
+        return [rest as Dir, ok(entry)]
+    }
+    const [first, ...rest] = path
+    const sub = dir[first]
+    if (sub === undefined || isVec(sub) || typeof sub === 'function') { return [dir, enoent] }
+    const [newSub, result] = extractEntity(sub, rest)
+    if (result[0] === 'error') { return [dir, result] }
+    return [{ ...dir, [first]: newSub }, result]
+}
+
+const insertEntityAt = (dir: Dir, path: readonly string[], entity: Entity): readonly[Dir, IoResult<void>] => {
+    if (path.length === 0) { return [dir, error('cannot insert at root')] }
+    if (path.length === 1) {
+        const [name] = path
+        return [{ ...dir, [name]: entity }, okVoid]
+    }
+    const [first, ...rest] = path
+    const sub = dir[first] ?? {}
+    if (isVec(sub) || typeof sub === 'function') { return [dir, error('not a directory')] }
+    const [newSub, result] = insertEntityAt(sub as Dir, rest, entity)
+    if (result[0] === 'error') { return [dir, result] }
+    return [{ ...dir, [first]: newSub }, result]
+}
+
+const rename = (src: string, dst: string) => (state: State): readonly[State, IoResult<void>] => {
+    const [srcRoot, srcResult] = extractEntity(state.root, parse(src))
+    if (srcResult[0] === 'error') { return [state, srcResult] }
+    const [dstRoot, dstResult] = insertEntityAt(srcRoot, parse(dst), srcResult[1])
+    if (dstResult[0] === 'error') { return [state, dstResult] }
+    return [{ ...state, root: dstRoot }, okVoid]
+}
+
+const readChunkOp = (path: string, offset: number, size: number) => readOperation((dir, p): IoResult<Vec> => {
+    if (p.length !== 1) { return enoent }
+    const file = dir[p[0]]
+    if (typeof file === 'function') { throw new Error(`'${p[0]}' is a JsModule; readChunk not supported`) }
+    if (file === undefined) { return enoent }
+    if (!isVec(file)) { return error(`'${p[0]}' is not a file`) }
+    const chunk = fromVec(file).subarray(offset, offset + size)
+    return ok(toVec(chunk))
+})(path)
+
 const map: MemOperationMap<NodeOp, State> = {
     all: (...a) => state => {
         let e: readonly unknown[] = []
@@ -203,6 +253,9 @@ const map: MemOperationMap<NodeOp, State> = {
     access,
     import: import_,
     rm,
+    rename,
+    readChunk: readChunkOp,
+    randomBytes: size => state => [state, toVec(new Uint8Array(size))],
     exec: todo,
     createServer: todo,
     listen: todo,

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -223,14 +223,14 @@ const isProperPrefix = (prefix: readonly string[], path: readonly string[]): boo
 const rename = (src: string, dst: string) => (state: State): readonly[State, IoResult<void>] => {
     const srcParsed = parse(src)
     const dstParsed = parse(dst)
-    // reject if dst is strictly inside src's subtree (rename into own descendant)
-    // or if src is strictly inside dst's subtree (rename onto own ancestor, which
-    // would appear empty after extractEntity strips the child)
+    // extract source first to report ENOENT if it's missing, before checking subtree guards
+    const [srcRoot, srcResult] = extractEntity(state.root, srcParsed)
+    if (srcResult[0] === 'error') { return [state, srcResult] }
+    // now that source exists, reject if dst is strictly inside src's subtree (rename into own descendant)
+    // or if src is strictly inside dst's subtree (rename onto own ancestor)
     if (isProperPrefix(srcParsed, dstParsed) || isProperPrefix(dstParsed, srcParsed)) {
         return [state, error('cannot rename a directory into its own subtree or onto an ancestor')]
     }
-    const [srcRoot, srcResult] = extractEntity(state.root, srcParsed)
-    if (srcResult[0] === 'error') { return [state, srcResult] }
     const [dstRoot, dstResult] = insertEntityAt(srcRoot, dstParsed, srcResult[1])
     if (dstResult[0] === 'error') { return [state, dstResult] }
     return [{ ...state, root: dstRoot }, okVoid]

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -217,13 +217,17 @@ const insertEntityAt = (dir: Dir, path: readonly string[], entity: Entity): read
     return [{ ...dir, [first]: newSub }, result]
 }
 
+const isProperPrefix = (prefix: readonly string[], path: readonly string[]): boolean =>
+    prefix.length < path.length && prefix.every((seg, i) => seg === path[i])
+
 const rename = (src: string, dst: string) => (state: State): readonly[State, IoResult<void>] => {
     const srcParsed = parse(src)
     const dstParsed = parse(dst)
-    // reject if dst is an ancestor of src (src is nested inside dst)
-    if (dstParsed.length <= srcParsed.length &&
-        dstParsed.every((seg, i) => seg === srcParsed[i])) {
-        return [state, error('cannot rename a directory onto itself or an ancestor')]
+    // reject if dst is strictly inside src's subtree (rename into own descendant)
+    // or if src is strictly inside dst's subtree (rename onto own ancestor, which
+    // would appear empty after extractEntity strips the child)
+    if (isProperPrefix(srcParsed, dstParsed) || isProperPrefix(dstParsed, srcParsed)) {
+        return [state, error('cannot rename a directory into its own subtree or onto an ancestor')]
     }
     const [srcRoot, srcResult] = extractEntity(state.root, srcParsed)
     if (srcResult[0] === 'error') { return [state, srcResult] }

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -198,6 +198,13 @@ const insertEntityAt = (dir: Dir, path: readonly string[], entity: Entity): read
             if (!entityIsDir && existingIsDir) {
                 return [dir, error(`'${name}' is a directory`)]
             }
+            if (entityIsDir && existingIsDir) {
+                const existingDir = existing as Dir
+                const hasContent = Object.values(existingDir).some(v => v !== undefined)
+                if (hasContent) {
+                    return [dir, error(`cannot overwrite non-empty directory '${name}'`)]
+                }
+            }
         }
         return [{ ...dir, [name]: entity }, okVoid]
     }

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -218,9 +218,16 @@ const insertEntityAt = (dir: Dir, path: readonly string[], entity: Entity): read
 }
 
 const rename = (src: string, dst: string) => (state: State): readonly[State, IoResult<void>] => {
-    const [srcRoot, srcResult] = extractEntity(state.root, parse(src))
+    const srcParsed = parse(src)
+    const dstParsed = parse(dst)
+    // reject if dst is an ancestor of src (src is nested inside dst)
+    if (dstParsed.length <= srcParsed.length &&
+        dstParsed.every((seg, i) => seg === srcParsed[i])) {
+        return [state, error('cannot rename a directory onto itself or an ancestor')]
+    }
+    const [srcRoot, srcResult] = extractEntity(state.root, srcParsed)
     if (srcResult[0] === 'error') { return [state, srcResult] }
-    const [dstRoot, dstResult] = insertEntityAt(srcRoot, parse(dst), srcResult[1])
+    const [dstRoot, dstResult] = insertEntityAt(srcRoot, dstParsed, srcResult[1])
     if (dstResult[0] === 'error') { return [state, dstResult] }
     return [{ ...state, root: dstRoot }, okVoid]
 }

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -189,10 +189,15 @@ const insertEntityAt = (dir: Dir, path: readonly string[], entity: Entity): read
     if (path.length === 0) { return [dir, error('cannot insert at root')] }
     if (path.length === 1) {
         const [name] = path
+        const existing = dir[name]
+        if (existing !== undefined) {
+            return [dir, error(`'${name}' already exists`)]
+        }
         return [{ ...dir, [name]: entity }, okVoid]
     }
     const [first, ...rest] = path
-    const sub = dir[first] ?? {}
+    const sub = dir[first]
+    if (sub === undefined) { return [dir, enoent] }
     if (isVec(sub) || typeof sub === 'function') { return [dir, error('not a directory')] }
     const [newSub, result] = insertEntityAt(sub as Dir, rest, entity)
     if (result[0] === 'error') { return [dir, result] }

--- a/fs/effects/node/virtual/proof.f.ts
+++ b/fs/effects/node/virtual/proof.f.ts
@@ -117,4 +117,10 @@ export const proof = {
         const [, result] = virtual({ ...emptyState, root })(readBytes('file', 0, 0))
         assertEq(result[0], 'ok')
     },
+    readBytesNegativeOffset: () => {
+        // readBytes with negative offset should fail
+        const root: Dir = { 'file': vec8(0x42n) }
+        const [, result] = virtual({ ...emptyState, root })(readBytes('file', -1, 1))
+        assertEq(result[0], 'error')
+    },
 }

--- a/fs/effects/node/virtual/proof.f.ts
+++ b/fs/effects/node/virtual/proof.f.ts
@@ -123,4 +123,16 @@ export const proof = {
         const [, result] = virtual({ ...emptyState, root })(readBytes('file', -1, 1))
         assertEq(result[0], 'error')
     },
+    readBytesFractionalSize: () => {
+        // readBytes with fractional size should fail rather than throw RangeError
+        const root: Dir = { 'file': vec8(0x42n) }
+        const [, result] = virtual({ ...emptyState, root })(readBytes('file', 0, 1.5))
+        assertEq(result[0], 'error')
+    },
+    readBytesFractionalOffset: () => {
+        // readBytes with fractional offset should fail rather than throw RangeError
+        const root: Dir = { 'file': vec8(0x42n) }
+        const [, result] = virtual({ ...emptyState, root })(readBytes('file', 0.5, 1))
+        assertEq(result[0], 'error')
+    },
 }

--- a/fs/effects/node/virtual/proof.f.ts
+++ b/fs/effects/node/virtual/proof.f.ts
@@ -1,5 +1,5 @@
 import { assertEq } from '../../../asserts/module.f.ts'
-import { awaitIfPromise, fetch, rm, writeFile, readFile, readdir, import_ } from '../module.f.ts'
+import { awaitIfPromise, fetch, rm, writeFile, readFile, readdir, import_, rename, readBytes } from '../module.f.ts'
 import { vec8 } from '../../../types/bit_vec/module.f.ts'
 import { emptyState, virtual, type Dir, type JsModule } from './module.f.ts'
 
@@ -74,5 +74,47 @@ export const proof = {
             const root: Dir = { 'a.f.ts': (() => ({})) as JsModule }
             virtual({ ...emptyState, root })(readFile('a.f.ts'))
         },
+    },
+    renameSamePath: () => {
+        // rename('a', 'a') should succeed as a no-op, not reject
+        const root: Dir = { 'a': vec8(0x42n) }
+        const [, result] = virtual({ ...emptyState, root })(rename('a', 'a'))
+        assertEq(result[0], 'ok')
+    },
+    renameIntoOwnSubtree: () => {
+        // rename('a', 'a/b') should fail (dst inside src's subtree)
+        const root: Dir = { 'a': { 'b': vec8(0x42n) } }
+        const [, result] = virtual({ ...emptyState, root })(rename('a', 'a/b'))
+        assertEq(result[0], 'error')
+    },
+    renameOntoOwnAncestor: () => {
+        // rename('a/b', 'a') should fail (src inside dst's subtree)
+        const root: Dir = { 'a': { 'b': vec8(0x42n) } }
+        const [, result] = virtual({ ...emptyState, root })(rename('a/b', 'a'))
+        assertEq(result[0], 'error')
+    },
+    renameNonEmptyDirOverEmptyDir: () => {
+        // rename a directory onto an empty directory should succeed
+        const root: Dir = { 'src': { 'file': vec8(0x42n) }, 'dst': {} }
+        const [, result] = virtual({ ...emptyState, root })(rename('src', 'dst'))
+        assertEq(result[0], 'ok')
+    },
+    renameEmptyDirOverNonEmptyDir: () => {
+        // rename an empty directory onto a non-empty directory should fail
+        const root: Dir = { 'src': {}, 'dst': { 'file': vec8(0x42n) } }
+        const [, result] = virtual({ ...emptyState, root })(rename('src', 'dst'))
+        assertEq(result[0], 'error')
+    },
+    readBytesNegativeSize: () => {
+        // readBytes with negative size should fail
+        const root: Dir = { 'file': vec8(0x42n) }
+        const [, result] = virtual({ ...emptyState, root })(readBytes('file', 0, -1))
+        assertEq(result[0], 'error')
+    },
+    readBytesZeroSize: () => {
+        // readBytes with zero size should succeed and return empty vec
+        const root: Dir = { 'file': vec8(0x42n) }
+        const [, result] = virtual({ ...emptyState, root })(readBytes('file', 0, 0))
+        assertEq(result[0], 'ok')
     },
 }


### PR DESCRIPTION
## Summary
This PR adds three new file system operations to the Node.js effects module: `rename` for moving/renaming files, `readBytes` for reading file chunks at specific offsets, and `randomInt` for generating random integers.

## Key Changes
- **New FS Operations**: Added `rename`, `readBytes`, and `randomInt` to the Fs type union and implemented them in both the virtual and real Node.js effect handlers
- **Virtual Implementation**: 
  - Implemented `extractEntity` and `insertEntityAt` helper functions to support the rename operation by extracting and reinserting entities in the virtual file system
  - Added `readBytesOp` to read file chunks using offset and size parameters
  - Added `randomInt` operation that returns a monotonically increasing counter from the state
- **Real Implementation**: 
  - `rename` delegates to `fs.promises.rename`
  - `readBytes` uses `fs.promises.open` with file handle read operations to support offset-based reading
  - `randomInt` uses `crypto.randomInt(2 ** 32)` for cryptographically secure random integers
- **State Management**: Added `randomNext` counter field to the virtual State type to track randomInt calls
- **Type Definitions**: Added corresponding type definitions (`Rename`, `ReadBytes`, `RandomInt`) in the module.f.ts file
- **Imports**: Added necessary imports for `uint8array` conversion utilities and `crypto` module

## Notable Implementation Details
- The `extractEntity` and `insertEntityAt` functions recursively traverse the virtual directory structure to support nested paths
- `readBytes` properly handles file handles with try/finally to ensure cleanup
- The virtual `randomInt` implementation uses a simple counter for deterministic testing, while the real implementation uses cryptographically secure randomness

https://claude.ai/code/session_01UgfFEn7s7LCLqVZzWCn7Xb