### PR TITLE
Update CI dependencies and Node.js versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,14 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26.3.0"
+            "node-version": "26.3.1"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.31.1"
+          "run": "npm install -g functionalscript@0.32.4"
         },
         {
-          "uses": "actions/checkout@v6"
+          "uses": "actions/checkout@v7"
         },
         {
           "run": "cargo test"
@@ -77,14 +77,14 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26.3.0"
+            "node-version": "26.3.1"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.31.1"
+          "run": "npm install -g functionalscript@0.32.4"
         },
         {
-          "uses": "actions/checkout@v6"
+          "uses": "actions/checkout@v7"
         },
         {
           "run": "cargo test"
@@ -118,14 +118,14 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26.3.0"
+            "node-version": "26.3.1"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.31.1"
+          "run": "npm install -g functionalscript@0.32.4"
         },
         {
-          "uses": "actions/checkout@v6"
+          "uses": "actions/checkout@v7"
         },
         {
           "run": "cargo test"
@@ -159,14 +159,14 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26.3.0"
+            "node-version": "26.3.1"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.31.1"
+          "run": "npm install -g functionalscript@0.32.4"
         },
         {
-          "uses": "actions/checkout@v6"
+          "uses": "actions/checkout@v7"
         },
         {
           "run": "cargo test"
@@ -201,14 +201,14 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26.3.0"
+            "node-version": "26.3.1"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.31.1"
+          "run": "npm install -g functionalscript@0.32.4"
         },
         {
-          "uses": "actions/checkout@v6"
+          "uses": "actions/checkout@v7"
         },
         {
           "run": "cargo test"
@@ -254,14 +254,14 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26.3.0"
+            "node-version": "26.3.1"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.31.1"
+          "run": "npm install -g functionalscript@0.32.4"
         },
         {
-          "uses": "actions/checkout@v6"
+          "uses": "actions/checkout@v7"
         },
         {
           "run": "cargo test"
@@ -306,7 +306,7 @@
           }
         },
         {
-          "uses": "actions/checkout@v6"
+          "uses": "actions/checkout@v7"
         },
         {
           "run": "cargo fmt -- --check"
@@ -395,13 +395,13 @@
           }
         },
         {
-          "run": "deno install -g -A npm:functionalscript@0.31.1"
+          "run": "deno install -g -A npm:functionalscript@0.32.4"
         },
         {
-          "uses": "actions/checkout@v6"
+          "uses": "actions/checkout@v7"
         },
         {
-          "run": "deno run -A npm:functionalscript@0.31.1 t"
+          "run": "deno run -A npm:functionalscript@0.32.4 t"
         },
         {
           "run": "deno install --frozen"
@@ -424,16 +424,16 @@
           }
         },
         {
-          "run": "bun install -g functionalscript@0.31.1"
+          "run": "bun install -g functionalscript@0.32.4"
         },
         {
-          "uses": "actions/checkout@v6"
+          "uses": "actions/checkout@v7"
         },
         {
           "run": "bun install --frozen-lockfile"
         },
         {
-          "run": "bunx functionalscript@0.31.1 t"
+          "run": "bunx functionalscript@0.32.4 t"
         },
         {
           "run": "bun test --coverage"
@@ -449,14 +449,14 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "22.22.3"
+            "node-version": "22.23.0"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.31.1"
+          "run": "npm install -g functionalscript@0.32.4"
         },
         {
-          "uses": "actions/checkout@v6"
+          "uses": "actions/checkout@v7"
         },
         {
           "run": "npm ci"
@@ -475,11 +475,11 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "24.16.0"
+            "node-version": "24.17.0"
           }
         },
         {
-          "uses": "actions/checkout@v6"
+          "uses": "actions/checkout@v7"
         },
         {
           "run": "npm ci"
@@ -498,14 +498,14 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26.3.0"
+            "node-version": "26.3.1"
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260617.2"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260620.1"
         },
         {
-          "uses": "actions/checkout@v6"
+          "uses": "actions/checkout@v7"
         },
         {
           "run": "npm ci"
@@ -533,7 +533,7 @@
         {
           "uses": "actions/setup-node@v6",
           "with": {
-            "node-version": "26.3.0"
+            "node-version": "26.3.1"
           }
         },
         {
@@ -553,7 +553,7 @@
           "run": "playwright install"
         },
         {
-          "uses": "actions/checkout@v6"
+          "uses": "actions/checkout@v7"
         },
         {
           "run": "npm ci"

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -25,7 +25,7 @@ export const images = {
 // published FunctionalScript release; do not tie it to package.json's current
 // in-repo version. A separate maintenance job advances this pin.
 // https://www.npmjs.com/package/functionalscript
-export const functionalscript = '0.31.1' as const
+export const functionalscript = '0.32.4' as const
 
 // https://bun.sh/
 export const bun = '1.3.14'
@@ -38,9 +38,9 @@ export const playwright = '1.61.0'
 
 // https://nodejs.org/en/download
 export const node = {
-    default: '26.3.0',
-    node22: '22.22.3',
-    node24: '24.16.0',
+    default: '26.3.1',
+    node22: '22.23.0',
+    node24: '24.17.0',
 } as const
 
 // https://github.com/bytecodealliance/wasmtime/releases
@@ -50,7 +50,7 @@ export const wasmtime = '45.0.2'
 export const wasmer = '7.1.0'
 
 // https://www.npmjs.com/package/@typescript/native-preview?activeTab=versions
-export const tsgo = '7.0.0-dev.20260617.2'
+export const tsgo = '7.0.0-dev.20260620.1'
 
 // GitHub Action versions used by CI step builders. The key is the action
 // `owner/name`; call sites compose the full ref as
@@ -58,7 +58,7 @@ export const tsgo = '7.0.0-dev.20260617.2'
 // Note: dtolnay/rust-toolchain value is a Rust version, not an action version.
 export const actions = {
     // https://github.com/marketplace/actions/checkout
-    'actions/checkout': 'v6',
+    'actions/checkout': 'v7',
     // https://github.com/marketplace/actions/setup-node-js-environment
     'actions/setup-node': 'v6',
     // https://github.com/marketplace/actions/cache


### PR DESCRIPTION
## Summary
This PR updates various CI dependencies and Node.js versions to their latest releases across all CI workflows.

## Key Changes
- **FunctionalScript**: Updated from `0.31.1` to `0.32.4` across all CI jobs (npm, deno, and bun installations)
- **GitHub Actions**: Upgraded `actions/checkout` from `v6` to `v7` across all workflows
- **Node.js versions**:
  - Default Node.js: `26.3.0` → `26.3.1`
  - Node.js 22: `22.22.3` → `22.23.0`
  - Node.js 24: `24.16.0` → `24.17.0`
- **TypeScript Native Preview**: Updated from `7.0.0-dev.20260617.2` to `7.0.0-dev.20260620.1`

## Implementation Details
All changes were made in the CI configuration source file (`fs/ci/config/module.f.ts`), which is the single source of truth for CI dependencies. The generated GitHub Actions workflow file (`.github/workflows/ci.yml`) was automatically updated to reflect these version changes across multiple job definitions.

https://claude.ai/code/session_01FHSX9X1uurqQ5G6pixCCdb