### PR TITLE
Add test cases for file rename and read size validation

### DIFF
--- a/fs/effects/node/virtual/proof.f.ts
+++ b/fs/effects/node/virtual/proof.f.ts
@@ -105,6 +105,20 @@ export const proof = {
         const [, result] = virtual({ ...emptyState, root })(rename('src', 'dst'))
         assertEq(result[0], 'error')
     },
+    renameFileOntoDirectory: () => {
+        // rename a file to a path that is already an existing directory should fail
+        const root: Dir = { 'myfile': [vec8(0x42n)], 'mydir': {} }
+        const [, result] = virtual({ ...emptyState, root })(rename('myfile', 'mydir'))
+        assertEq(result[0], 'error')
+    },
+    readFileTooLarge: () => {
+        // a file stored as two max-size chunks exceeds the limit; readFile must return an error
+        const chunk0 = vec(maxLengthBytes * 8n)(0n)
+        const chunk1 = vec(1n)(1n)
+        const root: Dir = { 'big': [chunk0, chunk1] }
+        const [, result] = virtual({ ...emptyState, root })(readFile('big'))
+        assertEq(result[0], 'error')
+    },
     readBytesNegativeSize: () => {
         // readBytes with negative size should fail
         const root: Dir = { 'file': [vec8(0x42n)] }


### PR DESCRIPTION
## Summary
Added two new test cases to the virtual file system proof module to improve test coverage for error handling scenarios.

## Key Changes
- **renameFileOntoDirectory**: New test case that verifies renaming a file onto an existing directory path correctly returns an error
- **readFileTooLarge**: New test case that validates the file size limit enforcement when reading a file composed of multiple chunks that exceed the maximum allowed size

## Implementation Details
Both test cases follow the existing pattern in the proof module:
- They set up a virtual file system state with specific file/directory configurations
- Execute the operation being tested
- Assert that an error result is returned as expected

These tests ensure that the virtual file system properly validates operations and enforces size constraints.

https://claude.ai/code/session_012DjQ14icShemfPpiyPuCZ4