### PR TITLE
Remove dead code: unused type aliases and exports

### DIFF
--- a/fs/djs/parser/module.f.ts
+++ b/fs/djs/parser/module.f.ts
@@ -12,11 +12,6 @@ import { fromMap } from '../../types/object/module.f.ts'
 import type { AstArray, AstConst, AstModule, AstModuleRef } from '../ast/module.f.ts'
 import type { TokenMetadata } from '../../js/tokenizer/module.f.ts'
 
-export type ParseContext = {
-    readonly complete: OrderedMap<Result<AstModule, string>>
-    readonly stack: List<string>
-}
-
 export type ParseError = {
     readonly message: string,
     readonly metadata: TokenMetadata | null

--- a/fs/djs/serializer/module.f.ts
+++ b/fs/djs/serializer/module.f.ts
@@ -20,11 +20,7 @@ export const undefinedSerialize = ['undefined']
 
 type RefCounter = readonly [number, number]
 
-type Entry = ObjectEntry<Unknown>
-
-type Entries = List<Entry>
-
-type MapEntries = (entries: Entries) => Entries
+type MapEntries = (entries: List<ObjectEntry<Unknown>>) => List<ObjectEntry<Unknown>>
 
 type Refs = ReadonlyMap<Unknown, RefCounter>
 

--- a/fs/json/serializer/module.f.ts
+++ b/fs/json/serializer/module.f.ts
@@ -4,24 +4,7 @@
  * @module
  */
 import { flat, reduce, empty, type List } from '../../types/list/module.f.ts'
-import { type Entry as ObjectEntry } from '../../types/object/module.f.ts'
 import { type Reduce } from '../../types/function/operator/module.f.ts'
-
-type Obj<T> = { readonly[k in string]?: Unknown<T> }
-
-type Arr<T> = readonly Unknown<T>[]
-
-type Primitive = |
-    boolean |
-    string |
-    number |
-    null
-
-type Unknown<T> = |
-    Arr<T>|
-    Obj<T>|
-    null|
-    T
 
 const jsonStringify = JSON.stringify
 
@@ -80,9 +63,3 @@ export const objectWrap
 export const arrayWrap
     : (input: List<List<string>>) => List<string>
     = wrap('[')(']')
-
-type Entry<T> = ObjectEntry<Unknown<T>>
-
-type Entries<T> = List<Entry<T>>
-
-type MapEntries<T> = (entries: Entries<T>) => Entries<T>

--- a/fs/types/sorted_set/module.f.ts
+++ b/fs/types/sorted_set/module.f.ts
@@ -32,8 +32,6 @@ import { merge, intersect as listIntersect, find } from '../sorted_list/module.f
 
 export type SortedSet<T> = readonly T[]
 
-type Byte = number
-
 export const union: <T>(cmp: Cmp<T>) => (a: SortedSet<T>) => (b: SortedSet<T>) => SortedSet<T>
     = cmp => a => b => toArray(merge(cmp)(a)(b))
 

--- a/issues/65Y-dead-code-cleanup.md
+++ b/issues/65Y-dead-code-cleanup.md
@@ -1,7 +1,15 @@
 # 65Y-dead-code-cleanup. Remove unused exports and dead local types
 
 **Priority:** P4
-**Status:** open
+**Status:** done
+
+> **Resolution:** items 1, 3, 4, and 6 deleted; items 2 and 5 had already been
+> superseded (PR #886 added an `env` consumer; the `getConstants` eta-wrapper
+> no longer exists — the current `fs/djs/serializer/module.f.ts:getConstants`
+> inlines the walk itself). While removing the dead `Entry`/`Entries`/
+> `MapEntries` aliases from `fs/json/serializer/module.f.ts`, the local
+> `Obj`/`Arr`/`Primitive`/`Unknown` shapes those aliases were parameterized
+> over also became unreferenced and were dropped in the same edit.
 
 > **Update (post-#943):** `fs/io` no longer exists — it was folded into
 > `fs/effects/node/module.ts` and deleted. Item 1's premise (the `Fs` import


### PR DESCRIPTION
## Summary
This PR removes unused type aliases and dead code across multiple modules as part of the ongoing dead code cleanup effort (issue #65Y).

## Key Changes
- **fs/json/serializer/module.f.ts**: Removed unused local type aliases (`Obj`, `Arr`, `Primitive`, `Unknown`) and dead type exports (`Entry`, `Entries`, `MapEntries`)
- **fs/djs/serializer/module.f.ts**: Simplified `MapEntries` type definition by inlining the previously extracted `Entry` and `Entries` type aliases
- **fs/djs/parser/module.f.ts**: Removed unused exported type `ParseContext` that was no longer referenced
- **fs/types/sorted_set/module.f.ts**: Removed unused local type alias `Byte`
- **issues/65Y-dead-code-cleanup.md**: Updated status to "done" and documented the resolution, noting that items 2 and 5 had already been superseded by previous changes (PR #886 and removal of eta-wrapper in current codebase)

## Implementation Details
The cleanup maintains all functional behavior while reducing type definition clutter. The `MapEntries` type in `fs/djs/serializer/module.f.ts` was refactored to inline its dependencies rather than maintaining separate intermediate type aliases, improving clarity without changing semantics.

https://claude.ai/code/session_019Sw7c23cXdZTjMPrTzcDYG