### PR TITLE
Add refactoring issues for cas_get response shape and HTML escaping

### DIFF
--- a/issues/66N-cas-get-response-shape.md
+++ b/issues/66N-cas-get-response-shape.md
@@ -1,0 +1,165 @@
+# 66N-cas-get-response-shape. Collapse `cas_get`'s three response-building arms into one helper
+
+**Priority:** P3
+**Status:** open
+
+## Problem
+
+The `cas_get` handler in `fs/cas/mcp/module.f.ts` decides the MIME type of a blob in
+three phases — magic-byte sniff, UTF-8 validation, octet-stream fallback — and then,
+in each phase, **rebuilds the same JSON response from scratch**:
+
+```ts
+// fs/cas/mcp/module.f.ts:152-201 (abridged)
+const byteLength = Number(bitVecLength(value) / 8n)
+// Phase 1: magic-byte sniffing
+const detectedMime = detect(value)
+if (detectedMime !== null) {
+    const url = toUrl?.(key)
+    const meta: Record<string, unknown> = {
+        length: byteLength,
+        mime_type: detectedMime,
+        type: 'base64',
+        ...(url !== undefined && { url })
+    }
+    if (r.content === true) {
+        const blob = base64Encode(value)
+        return pure(blob === null
+            ? errorResult(`content is not byte-aligned: ${r.hash}`)
+            : okResult(JSON.stringify({ ...meta, content: blob })))
+    }
+    return pure(okResult(JSON.stringify(meta)))
+}
+// Phase 2: UTF-8 validation
+const str = fromVec(value)
+const url = toUrl?.(key)
+if (str !== null) {
+    const meta: Record<string, unknown> = {
+        length: byteLength,
+        mime_type: 'text/plain',
+        type: 'text',
+        ...(url !== undefined && { url })
+    }
+    return pure(r.content === true
+        ? okResult(JSON.stringify({ ...meta, content: str }))
+        : okResult(JSON.stringify(meta)))
+}
+// Phase 3: octet-stream fallback
+const meta: Record<string, unknown> = {
+    length: byteLength,
+    mime_type: 'application/octet-stream',
+    type: 'base64',
+    ...(url !== undefined && { url })
+}
+if (r.content === true) {
+    const blob = base64Encode(value)
+    return pure(blob === null
+        ? errorResult(`content is not byte-aligned: ${r.hash}`)
+        : okResult(JSON.stringify({ ...meta, content: blob })))
+}
+return pure(okResult(JSON.stringify(meta)))
+```
+
+Two distinct response-shaping concerns are copy-pasted across the three phases:
+
+1. **The `meta` record** — `{ length, mime_type, type, ...(url && { url }) }` — is
+   written out three times (`:157-162`, `:176-181`, `:187-192`), differing only in the
+   `mime_type` and `type` fields.
+2. **The "include content?" envelope** — *if `r.content !== true` emit `meta`, else
+   encode the content and emit `{ ...meta, content }`, erroring when the encoder
+   returns `null`* — is written three times (`:163-170`, `:182-185`, `:193-200`).
+   Phases 1 and 3 are **byte-identical** except for the `mime_type` string: same
+   `base64Encode(value)`, same `content is not byte-aligned` error, same branch shape.
+
+`url` is also recomputed twice (`const url = toUrl?.(key)` at `:156` and again at
+`:174`) when it does not depend on the phase at all.
+
+This is the `AGENTS.md` case verbatim — *"When two code branches share most of their
+structure, refactor so the shared part appears once and only the difference lives in
+the conditional"* — applied across three branches whose only real differences are
+(`mime_type`, `type`, *how the inline content string is produced*). The phase
+selection (sniff → UTF-8 → fallback) is the genuinely varying logic; the response
+construction wrapped around it is not.
+
+## Proposal
+
+Compute `url` once, then name the response-shaping concern in a single local helper
+that takes only what actually varies between phases: the `mime_type`, the `type`
+discriminant, and a thunk that produces the inline content string (or `null` when it
+cannot be encoded). The helper owns the `meta` shape and the `content`-envelope
+branching:
+
+```ts
+const byteLength = Number(bitVecLength(value) / 8n)
+const url = toUrl?.(key)
+
+// the one place the response shape lives
+const respond = (
+    mimeType: string,
+    type: 'text' | 'base64',
+    encode: () => string | null,
+) => {
+    const meta = {
+        length: byteLength,
+        mime_type: mimeType,
+        type,
+        ...(url !== undefined && { url }),
+    }
+    if (r.content !== true) { return pure(okResult(JSON.stringify(meta))) }
+    const content = encode()
+    return pure(content === null
+        ? errorResult(`content is not byte-aligned: ${r.hash}`)
+        : okResult(JSON.stringify({ ...meta, content })))
+}
+
+// the phases now read as just the classification decision:
+const detectedMime = detect(value)
+if (detectedMime !== null) {
+    return respond(detectedMime, 'base64', () => base64Encode(value))
+}
+const str = fromVec(value)
+if (str !== null) {
+    return respond('text/plain', 'text', () => str)
+}
+return respond('application/octet-stream', 'base64', () => base64Encode(value))
+```
+
+The three `meta` literals collapse to one, the `content`-envelope branching is written
+once, `url` is computed once, and the two base64 phases differ only in the `mime_type`
+argument they pass. The `mime_type`/`type` pairing per phase stays visible at the call
+site, so the classification logic is *more* readable, not hidden.
+
+### Notes
+
+- `respond` captures `value`, `key`/`r.hash`, `r.content`, `url`, `byteLength` and
+  `pure`/`okResult`/`errorResult` from the enclosing closure — it is local to the
+  handler body (it cannot be hoisted to module scope because it closes over per-call
+  state), which matches the existing structure of this handler.
+- The text phase passes `() => str` where `str` is already non-`null`, so its
+  `content === null` arm is never taken *for that phase* — but the two base64 phases
+  exercise both arms, so whole-function branch coverage in
+  `fs/cas/mcp/proof.f.ts` is preserved. Confirm the proof still drives: a binary
+  (sniffed) blob, a valid-UTF-8 blob, an octet-stream blob, each with and without
+  `content: true`, plus a non-byte-aligned blob to hit the `null` error arm.
+- The literal `meta` object is built from non-literal values (`byteLength`,
+  `mimeType`, `type`), so it does not need `as const`; but the explicit `Record<string,
+  unknown>` annotation in the current code can be dropped — let inference type `meta`,
+  per the "prefer type inference" guidance.
+
+## Tasks
+
+- [ ] Hoist `url = toUrl?.(key)` above the phase checks and add the local `respond`
+      helper in the `cas_get` handler of `fs/cas/mcp/module.f.ts`.
+- [ ] Rewrite the three phases to call `respond(...)`, removing the duplicated `meta`
+      literals and `content`-envelope branches.
+- [ ] Run `npx tsc` and `fjs t`; confirm `fs/cas/mcp/proof.f.ts` passes with full
+      line/branch coverage (the response is byte-identical for every case).
+
+## Related
+
+- [i66H-cas-mcp-unified-get-add](./66H-cas-mcp-unified-get-add.md),
+  [i66G-cas-mcp-text-content](./66G-cas-mcp-text-content.md),
+  [i66E-cas-mcp-file-type](./66E-cas-mcp-file-type.md) — these designed the *feature*
+  (the get/add tools, the text/base64 split, the MIME metadata). This issue is the
+  internal-readability follow-up on the handler those changes left behind; it changes
+  no behaviour or wire format.

--- a/issues/66N-html-escape-table.md
+++ b/issues/66N-html-escape-table.md
@@ -1,0 +1,100 @@
+# 66N-html-escape-table. Make HTML character escaping a declarative table
+
+**Priority:** P4
+**Status:** open
+
+## Problem
+
+`fs/html/module.f.ts` escapes the four HTML-significant characters with a hand-written
+`switch` whose arms map a code point to its entity, falling back to the literal
+character:
+
+```ts
+// fs/html/module.f.ts:71-79
+const escapeCharCode = (code: number) => {
+    switch (code) {
+        case quotationMark: return '&quot;'
+        case ampersand: return '&amp;'
+        case lessThanSign: return '&lt;'
+        case greaterThanSign: return '&gt;'
+        default: return fromCharCode(code)
+    }
+}
+```
+
+This is precisely the imperative-dispatch shape that `AGENTS.md` asks us to prefer
+*against*:
+
+> **Prefer declarative style over imperative.** … favor data-driven definitions
+> (metadata + … together in an array or registry) over imperative switch
+> statements or hardcoded conditionals.
+
+The mapping `code point → entity` is plain data — a four-row lookup table — but here
+it is expressed as control flow. The `default` arm additionally mixes the *fallback
+policy* ("anything not in the table passes through unescaped") into the same `switch`
+as the table itself, so the two concerns (what the escape set is, and what to do with
+characters outside it) are not separable.
+
+The codebase already treats this exact pattern as worth converting elsewhere:
+
+- [i65Z-asn1-tag-codec-table](./65Z-asn1-tag-codec-table.md) — replace a tag/codec
+  `switch` with a data table.
+- [i667-js-tokenizer-handler-literals](./667-js-tokenizer-handler-literals.md) — the
+  five `\b \f \n \r \t` escape handlers "differ only in emitted char" and should
+  become an `escapeTo` table.
+
+The HTML escaper is the same shape and is currently the odd one out.
+
+## Proposal
+
+Lift the escape set into a data table keyed by code point, and reduce
+`escapeCharCode` to a single table lookup with the pass-through fallback expressed
+once:
+
+```ts
+// the escape set as data — one row per escaped character
+const escapeTable = {
+    [quotationMark]: '&quot;',
+    [ampersand]: '&amp;',
+    [lessThanSign]: '&lt;',
+    [greaterThanSign]: '&gt;',
+} as const
+
+const escapeCharCode = (code: number): string =>
+    escapeTable[code] ?? fromCharCode(code)
+```
+
+Now the escape set is a value that can be read, extended, or shared without touching
+control flow: adding (say) `&#x27;` for `'` is a new row, not a new `case`. The
+fallback policy ("not in the table ⇒ emit the raw character") appears exactly once, in
+`escapeCharCode`, separated from the table that defines *what* is escaped. `escape`
+(`:81`), `attribute` (`:96-97`) and every downstream consumer are unchanged because
+`escapeCharCode`'s signature is identical.
+
+### Notes / things to confirm during implementation
+
+- The `escapeTable` keys come from the `ascii` module constants
+  (`quotationMark`, `ampersand`, `lessThanSign`, `greaterThanSign`), which are typed
+  `number` (not literal). A computed-key object literal over `number` keys yields a
+  numeric index signature, so `escapeTable[code]` type-checks for an arbitrary `code`.
+  The object literal needs its type pinned per `AGENTS.md` (the literal-`const` rule):
+  `as const` as shown, or an explicit annotation if `as const` interacts badly with the
+  numeric-index inference — pick whichever `npx tsc` accepts without an `as` cast.
+- The behaviour is byte-for-byte identical; `fs/html/proof.f.ts` should pass unchanged
+  and must still cover both the "escaped" and "pass-through" outcomes (the `??` arms).
+
+## Tasks
+
+- [ ] Replace the `escapeCharCode` `switch` in `fs/html/module.f.ts` with an
+      `escapeTable` lookup plus the `?? fromCharCode(code)` fallback.
+- [ ] Confirm the table-literal type pins correctly without an `as` cast; run
+      `npx tsc`.
+- [ ] Run `fjs t`; confirm `fs/html/proof.f.ts` still passes with full line/branch
+      coverage (both the escaped and pass-through branches exercised).
+
+## Related
+
+- [i65Z-asn1-tag-codec-table](./65Z-asn1-tag-codec-table.md) — same switch→table move
+  in `fs/asn.1`.
+- [i667-js-tokenizer-handler-literals](./667-js-tokenizer-handler-literals.md) — the
+  tokenizer's escape handlers, same "table of char→string" shape.


### PR DESCRIPTION
## Summary

This PR adds two internal refactoring issues to the codebase, documenting opportunities to improve code quality and maintainability without changing behavior or wire format.

## Changes

- **66N-cas-get-response-shape.md**: Documents a refactoring to collapse three duplicated response-building arms in the `cas_get` handler into a single helper function. The handler currently rebuilds the same JSON response shape three times across different MIME type detection phases (magic-byte sniffing, UTF-8 validation, octet-stream fallback). The proposal extracts the shared response construction logic into a local `respond` helper that takes only the varying parameters (mime_type, type discriminant, and content encoder), eliminating ~50 lines of copy-pasted code while improving readability.

- **66N-html-escape-table.md**: Documents a refactoring to convert the HTML character escaping logic from an imperative `switch` statement into a declarative data table. The current implementation mixes the escape mapping (code point → entity) with control flow, making it harder to extend or reason about. The proposal lifts the escape set into a `const` object keyed by code point, reducing `escapeCharCode` to a single table lookup with a fallback policy.

Both issues follow the guidance in `AGENTS.md` to prefer declarative, data-driven definitions over imperative control flow, and to eliminate duplicated code structure by extracting shared concerns into reusable helpers. Both changes preserve existing behavior, wire format, and test coverage.

https://claude.ai/code/session_01MtdymPCjK9qFtf76HCnrsq