### PR TITLE
issues: add Strategy 1 effects and implementation issues (66N)

### DIFF
--- a/issues/66N-strategy-1-effects.md
+++ b/issues/66N-strategy-1-effects.md
@@ -59,7 +59,9 @@ effects, and add them to `NodeOp`.
 - [ ] Add `TryLockExclusive`, `Stat` effect types and `do_` constructors
 - [ ] Extend `Fs` union and `NodeOp` to include all six new effects
 - [ ] Implement all six effects in the Node runner (`fs/effects/node/module.ts`)
-- [ ] Add `FileHandle` map to the runner's interpreter state (alongside the `Server` map)
+- [ ] In the Node runner, represent `FileHandle` using `asNominal`/`asBase` to wrap a Node.js
+  `fs.promises.FileHandle` directly — the same pattern `Server` uses to wrap `node:http`'s server
+  object; there is no separate handle-ID map in the runner's state
 - [ ] Implement the virtual/mock runner stubs in `fs/effects/node/virtual/module.f.ts` for test use
 - [ ] Unit tests covering the happy path and error cases for each effect
 
@@ -67,4 +69,4 @@ effects, and add them to `NodeOp`.
 
 - [cas/strategy-1.md](./cas/strategy-1.md) — full design including Windows asymmetries and cleaning protocol
 - [cas/staging.md](./cas/staging.md) — mtime grace period rationale and POSIX `flock`/`unlink` asymmetry
-- [66N-strategy-1-impl](./66N-strategy-1-impl.md) — the CAS-layer implementation that depends on these effects
+- [i66N-strategy-1-impl](./66N-strategy-1-impl.md) — the CAS-layer implementation that depends on these effects

--- a/issues/66N-strategy-1-effects.md
+++ b/issues/66N-strategy-1-effects.md
@@ -6,7 +6,7 @@
 ## Problem
 
 Strategy 1 (Staging + Rename, see [cas/strategy-1.md](./cas/strategy-1.md)) cannot be
-implemented with the current effect set in `fs/effects/node/module.f.ts`. Six new
+implemented with the current effect set in `fs/effects/node/module.f.ts`. Seven new
 effects and one new nominal type are required before any CAS-layer code can be
 written.
 
@@ -35,30 +35,31 @@ Nothing outside the runner can inspect or forge a `FileHandle`.
 
 | Effect | Signature | Notes |
 |---|---|---|
-| `openExclusive` | `(path: string) => IoResult<FileHandle>` | Creates the file if absent; acquires an exclusive lock (`flock(LOCK_EX)` on POSIX, inherent on Windows via open handle). |
+| `openExclusive` | `(path: string) => IoResult<FileHandle>` | Creates the file with exclusive-create semantics (`O_CREAT \| O_EXCL` on POSIX, `CREATE_NEW` on Windows) — returns an error if the path already exists; the caller must retry with a new name. Acquires an exclusive lock (`flock(LOCK_EX)` on POSIX, inherent on Windows). Using O_EXCL closes the race where a second writer opens an existing staging path, then acquires the flock after the first writer's `commitHandle` renames the file to its shard destination, letting `appendHandle` mutate committed CAS content. |
 | `appendHandle` | `(handle: FileHandle, data: Vec) => IoResult<void>` | Writes `data` through the held file descriptor. Bounded to ≤128 KiB per call. |
 | `commitHandle` | `(handle: FileHandle, destPath: string) => IoResult<void>` | Renames the staging file to `destPath`, marks it read-only (`chmod 444`), closes the fd, and releases the lock. On Windows: if `destPath` already exists with ReadOnly attribute, delete the staging file and return success (CAS invariant: same hash ⇒ same bytes). |
-| `abortHandle` | `(handle: FileHandle) => IoResult<void>` | Closes the fd and releases the lock, then deletes the staging file. |
+| `abortHandle` | `(handle: FileHandle) => IoResult<void>` | Deletes the staging file, then closes the fd and releases the lock. **Delete before close** keeps the flock held through the unlink, so no other writer can reuse the staging path between unlink and close. (Writer abort path only — for the cleaner path use `deleteHandle`.) |
 
-### Read/stat-side effects
+### Read/stat/clean-side effects
 
 | Effect | Signature | Notes |
 |---|---|---|
-| `tryLockExclusive` | `(path: string) => IoResult<FileHandle \| undefined>` | Non-blocking attempt: returns a `FileHandle` if the lock was acquired (file is orphaned, safe to delete), or `undefined` if another process holds it (writer is active, skip). Maps to `flock(LOCK_EX \| LOCK_NB)` on POSIX; attempted open on Windows. |
+| `tryLockExclusive` | `(path: string) => IoResult<FileHandle \| undefined>` | Non-blocking attempt: returns a `FileHandle` if the lock was acquired (file is orphaned, safe to delete via `deleteHandle`), or `undefined` if another process holds it (writer is active, skip). Maps to `flock(LOCK_EX \| LOCK_NB)` on POSIX; attempted open on Windows. The caller **must** follow up with `deleteHandle`, not a plain `rm` + close, to avoid the POSIX race described under `deleteHandle`. |
+| `deleteHandle` | `(handle: FileHandle) => IoResult<void>` | Deletes (unlinks) the staging file, then closes the fd and releases the lock. Intended for the **cleaner path** after `tryLockExclusive` succeeds. **Delete before close** keeps the flock held through the unlink; closing first would release the flock before the file is gone, creating a window where a new writer could reuse the same staging path and acquire the lock before the cleaner's unlink runs. |
 | `stat` | `(path: string) => IoResult<{ readonly size: number, readonly mtimeMs: number }>` | Returns file metadata without reading content. `mtimeMs` is required by the POSIX cleaner's mandatory mtime grace check (see [cas/staging.md](./cas/staging.md)). Currently `fs.promises.stat` is used internally by the Node runner's `readFile` but is not exported as an effect. |
 
 ### `Fs` union update
 
-Add all six new effects to the `Fs` union alongside the existing filesystem
+Add all seven new effects to the `Fs` union alongside the existing filesystem
 effects, and add them to `NodeOp`.
 
 ## Tasks
 
 - [ ] Add `FileHandle` nominal type to `fs/effects/node/module.f.ts`
 - [ ] Add `OpenExclusive`, `AppendHandle`, `CommitHandle`, `AbortHandle` effect types and `do_` constructors
-- [ ] Add `TryLockExclusive`, `Stat` effect types and `do_` constructors
-- [ ] Extend `Fs` union and `NodeOp` to include all six new effects
-- [ ] Implement all six effects in the Node runner (`fs/effects/node/module.ts`)
+- [ ] Add `TryLockExclusive`, `DeleteHandle`, `Stat` effect types and `do_` constructors
+- [ ] Extend `Fs` union and `NodeOp` to include all seven new effects
+- [ ] Implement all seven effects in the Node runner (`fs/effects/node/module.ts`)
 - [ ] In the Node runner, represent `FileHandle` using `asNominal`/`asBase` to wrap a
   struct `{ fd: fs.promises.FileHandle, stagingPath: string }` — a bare `fs.promises.FileHandle`
   does not retain the path, but `commitHandle` (rename) and `abortHandle` (delete) both need it;

--- a/issues/66N-strategy-1-effects.md
+++ b/issues/66N-strategy-1-effects.md
@@ -1,0 +1,70 @@
+# 66N-strategy-1-effects. Strategy 1 effects: `FileHandle`, `openExclusive`, `appendHandle`, `commitHandle`, `abortHandle`, `tryLockExclusive`, `stat`
+
+**Priority:** P2
+**Status:** open
+
+## Problem
+
+Strategy 1 (Staging + Rename, see [cas/strategy-1.md](./cas/strategy-1.md)) cannot be
+implemented with the current effect set in `fs/effects/node/module.f.ts`. Six new
+effects and one new nominal type are required before any CAS-layer code can be
+written.
+
+The current `Fs` union (`Mkdir | ReadFile | ReadBytes | Readdir | WriteFile | Rm | Rename | Exec | Access`)
+covers stateless filesystem operations. Strategy 1's write pipeline requires a
+stateful file handle — an opaque token that carries a live OS resource (open file
+descriptor + lock) through `openExclusive → appendHandle → commitHandle/abortHandle`
+— which has no equivalent in the current effect set.
+
+## Proposal
+
+Add the following to `fs/effects/node/module.f.ts`:
+
+### `FileHandle` nominal type
+
+```ts
+export type FileHandle =
+    Nominal<'fileHandle', `<sha-of-definition>`, unknown>
+```
+
+Opaque black-box value, analogous to `Server`. The Node runner stores the live OS
+resource (fd + flock) in its interpreter state and maps the nominal token to it.
+Nothing outside the runner can inspect or forge a `FileHandle`.
+
+### Write-side effects
+
+| Effect | Signature | Notes |
+|---|---|---|
+| `openExclusive` | `(path: string) => IoResult<FileHandle>` | Creates the file if absent; acquires an exclusive lock (`flock(LOCK_EX)` on POSIX, inherent on Windows via open handle). |
+| `appendHandle` | `(handle: FileHandle, data: Vec) => IoResult<void>` | Writes `data` through the held file descriptor. Bounded to ≤128 KiB per call. |
+| `commitHandle` | `(handle: FileHandle, destPath: string) => IoResult<void>` | Renames the staging file to `destPath`, marks it read-only (`chmod 444`), closes the fd, and releases the lock. On Windows: if `destPath` already exists with ReadOnly attribute, delete the staging file and return success (CAS invariant: same hash ⇒ same bytes). |
+| `abortHandle` | `(handle: FileHandle) => IoResult<void>` | Closes the fd and releases the lock, then deletes the staging file. |
+
+### Read/stat-side effects
+
+| Effect | Signature | Notes |
+|---|---|---|
+| `tryLockExclusive` | `(path: string) => IoResult<FileHandle \| undefined>` | Non-blocking attempt: returns a `FileHandle` if the lock was acquired (file is orphaned, safe to delete), or `undefined` if another process holds it (writer is active, skip). Maps to `flock(LOCK_EX \| LOCK_NB)` on POSIX; attempted open on Windows. |
+| `stat` | `(path: string) => IoResult<{ readonly size: number, readonly mtimeMs: number }>` | Returns file metadata without reading content. `mtimeMs` is required by the POSIX cleaner's mandatory mtime grace check (see [cas/staging.md](./cas/staging.md)). Currently `fs.promises.stat` is used internally by the Node runner's `readFile` but is not exported as an effect. |
+
+### `Fs` union update
+
+Add all six new effects to the `Fs` union alongside the existing filesystem
+effects, and add them to `NodeOp`.
+
+## Tasks
+
+- [ ] Add `FileHandle` nominal type to `fs/effects/node/module.f.ts`
+- [ ] Add `OpenExclusive`, `AppendHandle`, `CommitHandle`, `AbortHandle` effect types and `do_` constructors
+- [ ] Add `TryLockExclusive`, `Stat` effect types and `do_` constructors
+- [ ] Extend `Fs` union and `NodeOp` to include all six new effects
+- [ ] Implement all six effects in the Node runner (`fs/effects/node/module.ts`)
+- [ ] Add `FileHandle` map to the runner's interpreter state (alongside the `Server` map)
+- [ ] Implement the virtual/mock runner stubs in `fs/effects/node/virtual/module.f.ts` for test use
+- [ ] Unit tests covering the happy path and error cases for each effect
+
+## Related
+
+- [cas/strategy-1.md](./cas/strategy-1.md) — full design including Windows asymmetries and cleaning protocol
+- [cas/staging.md](./cas/staging.md) — mtime grace period rationale and POSIX `flock`/`unlink` asymmetry
+- [66N-strategy-1-impl](./66N-strategy-1-impl.md) — the CAS-layer implementation that depends on these effects

--- a/issues/66N-strategy-1-effects.md
+++ b/issues/66N-strategy-1-effects.md
@@ -59,9 +59,10 @@ effects, and add them to `NodeOp`.
 - [ ] Add `TryLockExclusive`, `Stat` effect types and `do_` constructors
 - [ ] Extend `Fs` union and `NodeOp` to include all six new effects
 - [ ] Implement all six effects in the Node runner (`fs/effects/node/module.ts`)
-- [ ] In the Node runner, represent `FileHandle` using `asNominal`/`asBase` to wrap a Node.js
-  `fs.promises.FileHandle` directly — the same pattern `Server` uses to wrap `node:http`'s server
-  object; there is no separate handle-ID map in the runner's state
+- [ ] In the Node runner, represent `FileHandle` using `asNominal`/`asBase` to wrap a
+  struct `{ fd: fs.promises.FileHandle, stagingPath: string }` — a bare `fs.promises.FileHandle`
+  does not retain the path, but `commitHandle` (rename) and `abortHandle` (delete) both need it;
+  this follows the same `asNominal`/`asBase` pattern `Server` uses, with no separate handle-ID map
 - [ ] Implement the virtual/mock runner stubs in `fs/effects/node/virtual/module.f.ts` for test use
 - [ ] Unit tests covering the happy path and error cases for each effect
 

--- a/issues/66N-strategy-1-impl.md
+++ b/issues/66N-strategy-1-impl.md
@@ -1,0 +1,95 @@
+# 66N-strategy-1-impl. Implement Strategy 1 (Staging + Rename) in CAS
+
+**Priority:** P2
+**Status:** blocked
+**Blocked by:** [66N-strategy-1-effects](./66N-strategy-1-effects.md)
+
+## Problem
+
+The current CAS upload path in `fs/cas/module.f.ts` uses an ad-hoc `.cas/.stage/`
+directory with per-upload temp files but no persistent OS-level lock. This means:
+
+- A cleaner cannot distinguish an active upload from an orphaned staging file —
+  there is no dead-man's switch to release on process crash.
+- The `.stage/` directory predates the formal Strategy 1 design and does not follow
+  the `tryLockExclusive` cleaning protocol (see [cas/staging.md](./cas/staging.md)).
+- The mtime of a staged file can be arbitrarily old immediately after `casUpload`'s
+  internal rename from `cas_upload/` into `.stage/<uuid>`, making a mtime-based
+  grace check classify an active upload as stale.
+
+Strategy 1 (see [cas/strategy-1.md](./cas/strategy-1.md)) fixes all of these by:
+1. Holding an OS lock for the entire lifetime of each staging file (dead-man's switch).
+2. Writing to `.cas/_staging/` (excluded from `list` via `cBase32ToVec`).
+3. Atomically renaming to the final shard path once the hash is known.
+4. Marking the committed file read-only (`chmod 444`) to signal immutability.
+
+## Proposal
+
+### Write pipeline
+
+```
+openExclusive(.cas/_staging/<uuid>)  →  FileHandle
+appendHandle(handle, chunk)          →  ok | error   (repeat)
+commitHandle(handle, .cas/<prefix>/<hash>)  →  ok | error
+abortHandle(handle)                  →  ok | error   (on any error)
+```
+
+The `key` (`<prefix>/<hash>`) is passed to `commitHandle`, not `openExclusive`,
+because it is only known after the full stream has been consumed.
+
+### Cleaner
+
+Runs lazily, piggy-backed on `openExclusive`. Scans `.cas/_staging/`:
+
+1. For each file: call `stat` to get `mtimeMs`.
+2. If `mtimeMs` is newer than the grace threshold (60 s recommended), skip.
+3. Call `tryLockExclusive`. If it returns `undefined`, a writer is active — skip.
+4. If a `FileHandle` is returned, the file is orphaned — delete it and close the handle.
+
+### Migration from `casUpload`
+
+The existing `casUpload` writes to `.cas/.stage/` and is **not** safe to scan with
+the new cleaner (mtime race — see [cas/staging.md](./cas/staging.md)). Migration path:
+
+- Replace `casUpload` with the new `openExclusive / appendHandle / commitHandle / abortHandle`
+  pipeline writing into `.cas/_staging/`.
+- Remove the old `.stage/` staging path once no callers remain.
+- Do **not** teach the new cleaner to scan `.stage/` (unsafe — see staging.md).
+
+### Key-value interface exposed by Strategy 1
+
+```ts
+openWrite()                → WriteHandle   // = FileHandle at OS level
+append(handle, chunk)      → ok | error
+commit(handle, key)        → ok | error
+abort(handle)              → ok | error
+
+get(key)                   → [Meta, ChunkStream] | not_found | error
+list()                     → Vec[] | error
+```
+
+`WriteHandle` at the CAS/KV layer IS the `FileHandle` at the effect layer — the
+same opaque nominal token, passed through without inspection.
+
+## Tasks
+
+- [ ] Add `openWrite` / `append` / `commit` / `abort` to the CAS KV layer using
+  `openExclusive` / `appendHandle` / `commitHandle` / `abortHandle` effects
+- [ ] Write to `.cas/_staging/<uuid>` (generate UUID via `randomInt`)
+- [ ] On `commit`: call `commitHandle(handle, .cas/<prefix>/<hash>)`; create
+  the shard subdirectory with `mkdir` if it does not exist
+- [ ] On `abort` (or any error in the pipeline): call `abortHandle`
+- [ ] Implement lazy cleaner in `openWrite`: scan `.cas/_staging/`, apply
+  mtime grace check + `tryLockExclusive` protocol
+- [ ] Replace `casUpload` with the new pipeline; delete the `.stage/` staging path
+- [ ] Integration test: write a large file in chunks, verify committed shard is
+  read-only and retrievable; simulate crash by calling `abortHandle` mid-write and
+  verify the cleaner reclaims the orphan
+- [ ] Update `fs/cas/module.f.ts` JSDoc and `cas/README.md` to reflect Strategy 1
+
+## Related
+
+- [cas/strategy-1.md](./cas/strategy-1.md) — full design: Windows asymmetries, read-only semantics, cleaning protocol
+- [cas/staging.md](./cas/staging.md) — staging directory behavior, POSIX `flock`/`unlink` asymmetry, mtime grace period
+- [cas/README.md](./cas/README.md) — strategy comparison and recommended 1→3 progression
+- [66N-strategy-1-effects](./66N-strategy-1-effects.md) — prerequisite: new effects this implementation depends on

--- a/issues/66N-strategy-1-impl.md
+++ b/issues/66N-strategy-1-impl.md
@@ -44,7 +44,7 @@ Runs lazily, piggy-backed on `openWrite` (CAS layer). Scans `.cas/_staging/`:
 1. For each file: call `stat` to get `mtimeMs`.
 2. If `mtimeMs` is newer than the grace threshold (60 s recommended), skip.
 3. Call `tryLockExclusive`. If it returns `undefined`, a writer is active — skip.
-4. If a `FileHandle` is returned, the file is orphaned — delete it and close the handle.
+4. If a `FileHandle` is returned, the file is orphaned — call `deleteHandle` (delete-then-close, not close-then-delete).
 
 ### Migration from `casUpload`
 

--- a/issues/66N-strategy-1-impl.md
+++ b/issues/66N-strategy-1-impl.md
@@ -2,7 +2,7 @@
 
 **Priority:** P2
 **Status:** blocked
-**Blocked by:** [66N-strategy-1-effects](./66N-strategy-1-effects.md)
+**Blocked by:** [i66N-strategy-1-effects](./66N-strategy-1-effects.md)
 
 ## Problem
 
@@ -39,7 +39,7 @@ because it is only known after the full stream has been consumed.
 
 ### Cleaner
 
-Runs lazily, piggy-backed on `openExclusive`. Scans `.cas/_staging/`:
+Runs lazily, piggy-backed on `openWrite` (CAS layer). Scans `.cas/_staging/`:
 
 1. For each file: call `stat` to get `mtimeMs`.
 2. If `mtimeMs` is newer than the grace threshold (60 s recommended), skip.
@@ -95,4 +95,4 @@ same opaque nominal token, passed through without inspection.
 - [cas/strategy-1.md](./cas/strategy-1.md) — full design: Windows asymmetries, read-only semantics, cleaning protocol
 - [cas/staging.md](./cas/staging.md) — staging directory behavior, POSIX `flock`/`unlink` asymmetry, mtime grace period
 - [cas/README.md](./cas/README.md) — strategy comparison and recommended 1→3 progression
-- [66N-strategy-1-effects](./66N-strategy-1-effects.md) — prerequisite: new effects this implementation depends on
+- [i66N-strategy-1-effects](./66N-strategy-1-effects.md) — prerequisite: new effects this implementation depends on

--- a/issues/66N-strategy-1-impl.md
+++ b/issues/66N-strategy-1-impl.md
@@ -75,6 +75,8 @@ same opaque nominal token, passed through without inspection.
 
 - [ ] Add `openWrite` / `append` / `commit` / `abort` to the CAS KV layer using
   `openExclusive` / `appendHandle` / `commitHandle` / `abortHandle` effects
+- [ ] `openWrite`: ensure `.cas/_staging/` exists with `mkdir({ recursive: true })`
+  before calling `openExclusive` — the directory is absent on a fresh store
 - [ ] Write to `.cas/_staging/<uuid>` (generate UUID via `randomInt`)
 - [ ] On `commit`: call `commitHandle(handle, .cas/<prefix>/<hash>)`; create
   the shard subdirectory with `mkdir` if it does not exist
@@ -82,9 +84,10 @@ same opaque nominal token, passed through without inspection.
 - [ ] Implement lazy cleaner in `openWrite`: scan `.cas/_staging/`, apply
   mtime grace check + `tryLockExclusive` protocol
 - [ ] Replace `casUpload` with the new pipeline; delete the `.stage/` staging path
-- [ ] Integration test: write a large file in chunks, verify committed shard is
-  read-only and retrievable; simulate crash by calling `abortHandle` mid-write and
-  verify the cleaner reclaims the orphan
+- [ ] Integration test: write a large file in chunks; verify committed shard is
+  read-only and retrievable; simulate a process crash by dropping the virtual
+  runner's live `FileHandle` state (do **not** call `abortHandle` — that is
+  graceful cleanup, not a crash) and verify the cleaner reclaims the orphan
 - [ ] Update `fs/cas/module.f.ts` JSDoc and `cas/README.md` to reflect Strategy 1
 
 ## Related


### PR DESCRIPTION
- 66N-strategy-1-effects: tracks the six new effect types needed
  (FileHandle, openExclusive, appendHandle, commitHandle, abortHandle,
  tryLockExclusive, stat) before Strategy 1 can be coded
- 66N-strategy-1-impl: tracks the CAS-layer implementation of the
  Staging + Rename pipeline, blocked on the effects issue

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BTAgvPpqYeSAt6Cue4C8XB