### PR TITLE
Add lock-free staging design via deadline leases

### DIFF
--- a/issues/cas/README.md
+++ b/issues/cas/README.md
@@ -4,9 +4,17 @@ Three strategies for storing files of arbitrary size in a content-addressable st
 each with different trade-offs between memory use, streaming, atomicity, and
 deduplication.
 
-- [Strategy 1: Staging + Rename](strategy-1.md) — stream data through a staging file
-  held by an OS lock; rename to the final hash-addressed path on commit. Constant
-  memory, safe for arbitrarily large files on a real filesystem.
+- [Strategy 1: Staging + Rename](strategy-1.md) — stream data through a staging file;
+  rename to the final hash-addressed path on commit. Constant memory, safe for
+  arbitrarily large files on a real filesystem. The staging mechanism is described by two
+  alternatives:
+  - [Staging file behavior](staging.md) — the original OS-lock (`flock` / open-handle)
+    dead-man's switch.
+  - [Lock-free staging via deadline leases](staging-lease.md) — **the chosen design.** A
+    deadline encoded in the staging file name replaces the lock. It is lock-free,
+    platform-symmetric, survives reboots, works across machines, and fails safe (worst case
+    is a restarted upload, never a corrupted shard). See that doc's comparison table for why
+    it wins over the lock-based approach.
 
 - [Strategy 2: Array of Bit Vectors](strategy-2.md) — read and write the whole file
   as a `readonly Vec[]`; retire `readBytes`. Hash is known before the write, so no

--- a/issues/cas/README.md
+++ b/issues/cas/README.md
@@ -26,6 +26,15 @@ deduplication.
   SUL. Requires garbage collection (`_roots/` + `_parts/` directory split) and uses
   cached multi-hash maps (SHA-256 / SHA3-512 → Strategy 3 Merkle root) for external addressing.
 
+## Integrity: scrubbing and repair
+
+Independent of the write strategy, a committed block can later become invalid (bit rot,
+torn writes, durability gaps). [Block scrubbing and repair](scrub.md) is the committed-store
+counterpart to the staging GC: it scans `.cas/<prefix>/` shards, verifies each against its
+hash (the address *is* the checksum), quarantines corruption, and — in the future — repairs
+it by re-fetching the block by hash from a friendly CAS. Staging minimises bad writes; scrub
+is the always-on backstop for everything that slips through afterward.
+
 ## Recommended progression: 1 → 3
 
 Strategies 1 and 3 compose naturally; Strategy 2 is an alternative in-memory path

--- a/issues/cas/plan.md
+++ b/issues/cas/plan.md
@@ -64,9 +64,9 @@ existing `streamHash` helper folds into `write`.
 
 Implement `write` as the `upload` algorithm from [staging-lease.md](staging-lease.md):
 
-1. `rand = random256()`; staging file `.cas/_staging/<deadline>-<rand>` (the `_` prefix
+1. `rand = random256()`; staging file `.cas/_stage/<deadline>-<rand>` (the `_` prefix
    excludes it from `list` via `cBase32ToVec`).
-2. `mkdir(_staging, {recursive})`; `createExclusive` the file.
+2. `mkdir(_stage, {recursive})`; `createExclusive` the file.
 3. Fold the payload stream: `writeBytes(path, offset, chunk)`, advance `offset`, update the
    hash, and renew the lease each chunk by renaming to a fresh `now()+delta` deadline. Any
    error ⇒ `rm(path)` and return an upload error.
@@ -90,13 +90,13 @@ corruption is caught by scrub — see staging-lease.md *Future optimizations*).
 
 ### Garbage collection
 
-Lazy, piggy-backed on `write`: `readdir(_staging/)`, delete entries whose `<deadline>` is in
+Lazy, piggy-backed on `write`: `readdir(_stage/)`, delete entries whose `<deadline>` is in
 the past (sorted lexically = chronologically, so expired names are a prefix).
 
 ### Migrate `casUpload`
 
 Replace the existing `casUpload` (`.cas/.stage/` move-hash-move) with the new pipeline writing
-into `_staging/`; remove the `.stage/` path once no callers remain.
+into `_stage/`; remove the `.stage/` path once no callers remain.
 
 ### Tests
 

--- a/issues/cas/plan.md
+++ b/issues/cas/plan.md
@@ -25,7 +25,7 @@ type Cas<O extends Operation> = {
 `fs/effects/module.f.ts`) — a lazy, effectful cons-stream: each pull yields `[item, rest]`
 or `undefined` at end. Wrapping `T = IoResult<Vec>` gives every pull an explicit ok/error, so
 a missing shard or read error is distinguishable from end-of-stream (`undefined`), and the
-payload type matches the `EffectList<IoResult<Vec>>` shape already used elsewhere. This is
+payload type matches the `ListEffect<O, IoResult<Vec>>` shape used by the CAS interface. This is
 what keeps memory constant for arbitrarily large files.
 
 ## Step 1 — Remove the key-value interface

--- a/issues/cas/plan.md
+++ b/issues/cas/plan.md
@@ -48,9 +48,9 @@ system already provides the mockability the KV layer was giving.
 
 Replace whole-`Vec` in/out with chunk streams:
 
-- `write(payload: ListEffect<O, Vec>)` — fold the stream, feeding each chunk to both the
-  staging file and the running SHA-2 state; return the computed hash. Never holds the whole
-  payload in memory.
+- `write(payload: ListEffect<O, IoResult<Vec>>)` — fold the stream; for each item, propagate
+  an error item as an upload failure, otherwise feed the chunk to both the staging file and
+  the running SHA-2 state. Return the computed hash. Never holds the whole payload in memory.
 - `read(hash)` — produce a `ListEffect<O, IoResult<Vec>>` that pulls `readBytes(toPath(hash),
   offset, CHUNK_BYTES)` lazily, `CHUNK_BYTES = maxLengthBytes`. The final short/empty chunk
   ends the stream (`undefined`); a missing shard or read error is an `error` *item*, never
@@ -70,7 +70,8 @@ Implement `write` as the `upload` algorithm from [staging-lease.md](staging-leas
 3. Fold the payload stream: `writeBytes(path, offset, chunk)`, advance `offset`, update the
    hash, and renew the lease each chunk by renaming to a fresh `now()+delta` deadline. Any
    error ⇒ `rm(path)` and return an upload error.
-4. `hash = shaFinal(...)`; `dst = .cas/${toPath(hash)}`.
+4. `hash = shaFinal(...)`; `dst = toPath(hash)` (already `.cas`-rooted — do **not** prepend
+   `.cas` again).
 5. `mkdir(dirOf(dst), {recursive})`, `rename(path, dst)`, `rm(path)` — results ignored.
 6. Success iff `stat(dst).size === offset`; else upload error.
 

--- a/issues/cas/plan.md
+++ b/issues/cas/plan.md
@@ -11,18 +11,22 @@ Design references: [staging-lease.md](staging-lease.md) (the upload algorithm), 
 
 ```ts
 type Cas<O extends Operation> = {
-    // stream the content out in <=128 KiB chunks; not-found surfaces on the first pull
-    readonly read:  (hash: Vec) => ListEffect<O, Vec>
-    // consume a chunk stream, compute the hash incrementally, return the address
-    readonly write: (payload: ListEffect<O, Vec>) => Effect<O, IoResult<Vec>>
+    // stream the content out in <=128 KiB chunks; a missing shard or I/O error is an
+    // explicit error *item* in the stream, never collapsed into EOF
+    readonly read:  (hash: Vec) => ListEffect<O, IoResult<Vec>>
+    // consume a chunk stream (each item ok(chunk) or error), hash incrementally, return the address
+    readonly write: (payload: ListEffect<O, IoResult<Vec>>) => Effect<O, IoResult<Vec>>
     // all stored content hashes
     readonly list:  () => Effect<O, readonly Vec[]>
 }
 ```
 
 `ListEffect<O, T> = Effect<O, readonly[T, ListEffect<O, T>] | undefined>` (from
-`fs/effects/module.f.ts`) — a lazy, effectful cons-stream: each pull yields `[chunk, rest]`
-or `undefined` at end. This is what keeps memory constant for arbitrarily large files.
+`fs/effects/module.f.ts`) — a lazy, effectful cons-stream: each pull yields `[item, rest]`
+or `undefined` at end. Wrapping `T = IoResult<Vec>` gives every pull an explicit ok/error, so
+a missing shard or read error is distinguishable from end-of-stream (`undefined`), and the
+payload type matches the `EffectList<IoResult<Vec>>` shape already used elsewhere. This is
+what keeps memory constant for arbitrarily large files.
 
 ## Step 1 — Remove the key-value interface
 
@@ -47,9 +51,10 @@ Replace whole-`Vec` in/out with chunk streams:
 - `write(payload: ListEffect<O, Vec>)` — fold the stream, feeding each chunk to both the
   staging file and the running SHA-2 state; return the computed hash. Never holds the whole
   payload in memory.
-- `read(hash)` — produce a `ListEffect<O, Vec>` that pulls `readBytes(toPath(hash), offset,
-  CHUNK_BYTES)` lazily, `CHUNK_BYTES = maxLengthBytes`. The final short/empty chunk ends the
-  stream; a missing shard surfaces as an error on the first pull.
+- `read(hash)` — produce a `ListEffect<O, IoResult<Vec>>` that pulls `readBytes(toPath(hash),
+  offset, CHUNK_BYTES)` lazily, `CHUNK_BYTES = maxLengthBytes`. The final short/empty chunk
+  ends the stream (`undefined`); a missing shard or read error is an `error` *item*, never
+  folded into EOF.
 - `list()` stays `readonly Vec[]` (or a `ListEffect` of hashes if we want it lazy too).
 
 This is the interface the lock-free algorithm consumes (`write`) and produces (`read`); the
@@ -75,7 +80,9 @@ Implement `write` as the `upload` algorithm from [staging-lease.md](staging-leas
 
 - `createExclusive(path) => IoResult<void>` — `O_CREAT|O_EXCL`.
 - `writeBytes(path, offset, data: Vec) => IoResult<void>` — open existing (no create),
-  pwrite at `offset`; the mirror of `readBytes`.
+  pwrite at `offset`; the mirror of `readBytes`. Contract: writes the **entire** `Vec` or
+  returns an error — no partial writes (the runner loops over short writes); otherwise the
+  size check could pass over a hole.
 - `stat(path) => IoResult<{ size }>` — used by the publish size check (and future resume).
 
 No `fsync`, `FileHandle`, or read-only effects in the baseline (durability is best-effort;

--- a/issues/cas/plan.md
+++ b/issues/cas/plan.md
@@ -52,9 +52,10 @@ Replace whole-`Vec` in/out with chunk streams:
   an error item as an upload failure, otherwise feed the chunk to both the staging file and
   the running SHA-2 state. Return the computed hash. Never holds the whole payload in memory.
 - `read(hash)` — produce a `ListEffect<O, IoResult<Vec>>` that pulls `readBytes(toPath(hash),
-  offset, CHUNK_BYTES)` lazily, `CHUNK_BYTES = maxLengthBytes`. The final short/empty chunk
-  ends the stream (`undefined`); a missing shard or read error is an `error` *item*, never
-  folded into EOF.
+  offset, CHUNK_BYTES)` lazily (`CHUNK_BYTES = maxLengthBytes`). Emit **every non-empty** read
+  as an `ok(chunk)` item — including a final short (`< CHUNK_BYTES`) chunk — and end the stream
+  (`undefined`) only on an **empty** read. A missing shard or read error is an `error` *item*,
+  never folded into EOF.
 - `list()` stays `readonly Vec[]` (or a `ListEffect` of hashes if we want it lazy too).
 
 This is the interface the lock-free algorithm consumes (`write`) and produces (`read`); the

--- a/issues/cas/plan.md
+++ b/issues/cas/plan.md
@@ -1,0 +1,105 @@
+# CAS Implementation Plan
+
+Make the content-addressable store stream-native and build it on the lock-free staging
+algorithm, removing the key-value layer it is currently (awkwardly) built on.
+
+Design references: [staging-lease.md](staging-lease.md) (the upload algorithm), [scrub.md](scrub.md)
+(corruption detection/repair), [README.md](README.md) (strategy layering). Current code:
+`fs/cas/module.f.ts`.
+
+## Goal interface
+
+```ts
+type Cas<O extends Operation> = {
+    // stream the content out in <=128 KiB chunks; not-found surfaces on the first pull
+    readonly read:  (hash: Vec) => ListEffect<O, Vec>
+    // consume a chunk stream, compute the hash incrementally, return the address
+    readonly write: (payload: ListEffect<O, Vec>) => Effect<O, IoResult<Vec>>
+    // all stored content hashes
+    readonly list:  () => Effect<O, readonly Vec[]>
+}
+```
+
+`ListEffect<O, T> = Effect<O, readonly[T, ListEffect<O, T>] | undefined>` (from
+`fs/effects/module.f.ts`) — a lazy, effectful cons-stream: each pull yields `[chunk, rest]`
+or `undefined` at end. This is what keeps memory constant for arbitrarily large files.
+
+## Step 1 — Remove the key-value interface
+
+The CAS is currently `cas = (sha2) => (kvStore) => Cas`, layered on a generic
+`KvStore.read/write(key,value)/list`. That doesn't fit content addressing: the key is
+*derived* from the value (never supplied), streaming has no shape in `write(key, value)`,
+and `fileKvStore.write` is truncate-in-place where CAS needs no-clobber publish. The effect
+system already provides the mockability the KV layer was giving.
+
+- Delete `KvStore<O>`, `Kv`, `fileKvStore`, and the `cas(sha2)(kvStore)` wrapper from
+  `fs/cas/module.f.ts`.
+- Define `Cas` directly over filesystem effects (no intermediate store).
+- Keep `toPath` (sharding) and `random256`.
+- Update the `add` / `get` / `list` CLI commands to the new direct CAS.
+- `readFile` / `writeFile` stay as the ≤128 KiB small-object effect primitive (Strategy 3
+  nodes use them directly) — only the *KV facade over CAS* is removed, not these effects.
+
+## Step 2 — Stream payloads with `ListEffect`
+
+Replace whole-`Vec` in/out with chunk streams:
+
+- `write(payload: ListEffect<O, Vec>)` — fold the stream, feeding each chunk to both the
+  staging file and the running SHA-2 state; return the computed hash. Never holds the whole
+  payload in memory.
+- `read(hash)` — produce a `ListEffect<O, Vec>` that pulls `readBytes(toPath(hash), offset,
+  CHUNK_BYTES)` lazily, `CHUNK_BYTES = maxLengthBytes`. The final short/empty chunk ends the
+  stream; a missing shard surfaces as an error on the first pull.
+- `list()` stays `readonly Vec[]` (or a `ListEffect` of hashes if we want it lazy too).
+
+This is the interface the lock-free algorithm consumes (`write`) and produces (`read`); the
+existing `streamHash` helper folds into `write`.
+
+## Step 3 — Implement the lock-free staging algorithm
+
+Implement `write` as the `upload` algorithm from [staging-lease.md](staging-lease.md):
+
+1. `rand = random256()`; staging file `.cas/_staging/<deadline>-<rand>` (the `_` prefix
+   excludes it from `list` via `cBase32ToVec`).
+2. `mkdir(_staging, {recursive})`; `createExclusive` the file.
+3. Fold the payload stream: `writeBytes(path, offset, chunk)`, advance `offset`, update the
+   hash, and renew the lease each chunk by renaming to a fresh `now()+delta` deadline. Any
+   error ⇒ `rm(path)` and return an upload error.
+4. `hash = shaFinal(...)`; `dst = .cas/${toPath(hash)}`.
+5. `mkdir(dirOf(dst), {recursive})`, `rename(path, dst)`, `rm(path)` — results ignored.
+6. Success iff `stat(dst).size === offset`; else upload error.
+
+### New effects (`fs/effects/node/module.f.ts`)
+
+`rename`, `rm`, `mkdir`, `readBytes`, `readdir` already exist. Add:
+
+- `createExclusive(path) => IoResult<void>` — `O_CREAT|O_EXCL`.
+- `writeBytes(path, offset, data: Vec) => IoResult<void>` — open existing (no create),
+  pwrite at `offset`; the mirror of `readBytes`.
+- `stat(path) => IoResult<{ size }>` — used by the publish size check (and future resume).
+
+No `fsync`, `FileHandle`, or read-only effects in the baseline (durability is best-effort;
+corruption is caught by scrub — see staging-lease.md *Future optimizations*).
+
+### Garbage collection
+
+Lazy, piggy-backed on `write`: `readdir(_staging/)`, delete entries whose `<deadline>` is in
+the past (sorted lexically = chronologically, so expired names are a prefix).
+
+### Migrate `casUpload`
+
+Replace the existing `casUpload` (`.cas/.stage/` move-hash-move) with the new pipeline writing
+into `_staging/`; remove the `.stage/` path once no callers remain.
+
+### Tests
+
+Virtual-runner coverage in `fs/effects/node/virtual/`: streaming write of a multi-chunk
+payload, read-back streaming, dedup (same content ⇒ same hash, second upload is a no-op
+publish), a simulated mid-stream error (staging file deleted, error returned), and GC
+reclaiming an expired staging file.
+
+## Dependency order
+
+Step 1 and Step 2 reshape the interface (`Cas` direct + streaming); Step 3 implements `write`
+behind it and adds the three effects. Land them in order: remove KV → stream interface →
+staging algorithm + effects + GC + `casUpload` migration.

--- a/issues/cas/scrub.md
+++ b/issues/cas/scrub.md
@@ -1,0 +1,140 @@
+# CAS Block Scrubbing and Repair
+
+## Purpose
+
+No matter which write strategy a CAS uses, a committed block can later become **invalid** —
+its stored bytes no longer match the hash that addresses it. The staging design
+([staging-lease.md](staging-lease.md)) works hard to *minimise* the probability of a bad
+write, but it cannot drive it to zero, and it only governs the write path up to commit.
+Everything after commit needs a separate, always-on backstop: a mechanism — parallel to the
+staging GC — that scans committed shards, verifies each against its hash, detects
+corruption, and (in the future) repairs it from a friendly peer.
+
+This is the active form of the principle in *staging-lease.md*: hash verification is the
+only near-deterministic layer, so the store's integrity guarantee comes from *continuously
+re-verifying* the committed bytes, not from trusting that a write once succeeded.
+
+## Why corruption is inevitable
+
+Staging governs the write path up to commit; the committed store is exposed to sources no
+staging strategy can touch:
+
+- **Media decay** — bit rot, latent sector errors, degrading flash cells.
+- **Hardware/firmware faults** — torn writes, misdirected writes, controller bugs, RAID
+  write holes.
+- **Durability gaps** — an `fsync` that was acknowledged but not truly persisted, followed
+  by power loss.
+- **Read-path errors** — memory bit-flips while a shard is read back.
+- **Out-of-band mutation** — software or operator accidents that bypass the read-only bit
+  (`chmod 444` does not stop a directory-writer from `rename`/`unlink`, as noted in
+  strategy-1.md).
+- **Write-path residue** — even at commit, the base staging design trusts the incrementally
+  accumulated hash and does not re-read, so a torn or misdirected write the OS acknowledged
+  but did not persist can commit a shard whose bytes already differ from its hash.
+
+The last point is the important honesty: lock-free staging *reduces* the probability of an
+incorrect write, but — exactly as with everything else in this design — it cannot guarantee
+one never happens. Scrubbing is the layer that assumes it eventually will.
+
+## Scope: scrubbing is GC's dual
+
+Scrubbing and the staging GC partition the store cleanly and never overlap:
+
+| | Staging GC | Scrub |
+|---|---|---|
+| Domain | `.cas/_staging/` (in-progress uploads) | `.cas/<prefix>/` (committed shards) |
+| Question | "is this upload still alive?" | "do these bytes still match their hash?" |
+| Signal | deadline in the file name | re-hash vs. the address |
+| Action | `rm` expired/orphaned files | quarantine + repair corrupt shards |
+| Failure mode | over-eager delete ⇒ restarted upload | undetected corruption ⇒ bad read |
+
+GC guards the write-in-progress space; scrub guards the committed space. Together they cover
+the whole store, with no shard in both domains at once.
+
+## Detection: the address is the checksum
+
+In a content-addressed store the shard's path *is* its expected hash, so detection needs no
+side metadata:
+
+```
+scrub_block(path):
+  expected = hashFromPath(path)            // the address itself
+  actual   = hash(readAll(path))           // re-read and re-hash the bytes
+  if actual != expected:
+      report/quarantine(path)              // the block is corrupt
+```
+
+Because the expected value is the name, there is nothing to keep in sync, nothing to
+corrupt separately, and no question of which copy is authoritative.
+
+## Repair: re-fetch by hash, verify by hash
+
+Repair is where content addressing pays off most. Mutable-replication systems face version
+skew and quorum ambiguity; a CAS does not. The hash is a *global* content address, so **any
+source that has that hash has byte-identical content by definition**. Repairing a corrupt
+block is therefore unambiguous and cannot go wrong:
+
+```
+repair_block(key):
+  bytes = fetchFromPeer(key)               // future: ask a friendly CAS for this hash
+  if hash(bytes) == key:                   // verify by the same address
+      recommit(key, bytes)                 // staging + rename over the corrupt shard
+  // else try another peer; a peer that fails verification is simply skipped
+```
+
+`recommit` reuses the ordinary staging+rename machinery: write the re-fetched bytes to a
+staging file, verify, and atomically rename over the corrupt shard (clearing/replacing the
+read-only bit as `commit` already does). A repaired block is verified by the same hash that
+named it, so a corrupt block can never be "repaired wrong."
+
+In a single store with no redundancy, detection is all that is possible — the scrubber can
+quarantine a corrupt shard but not rebuild it. Repair requires either local redundancy
+(out of scope here) or the peer-reupload path above. The peer mechanism is future work; the
+detection half stands alone and is useful immediately.
+
+## Two intensities, like GC's lazy/sweep split
+
+- **Verify-on-read.** Re-hash a shard as it is read for normal use and compare to its
+  address. This catches corruption at the point of use for nearly free and covers *hot*
+  blocks continuously. It can be sampled (verify a fraction of reads) to bound CPU.
+- **Background sweep.** A throttled scan of all committed shards, prioritised by
+  least-recently-scrubbed. This covers *cold* blocks that nobody reads — precisely where
+  bit rot accumulates undetected. Like the staging GC it is not urgent and can run lazily or
+  on a schedule; like a ZFS/Ceph scrub it is I/O-heavy and must be rate-limited.
+
+Verify-on-read and the sweep are complementary: the first bounds the damage of corruption in
+active data, the second bounds how long corruption can hide in dormant data.
+
+## Relationship to Strategy 3 (Merkle tree)
+
+Scrubbing composes naturally with [strategy-3.md](strategy-3.md): a Merkle tree's internal
+nodes are themselves CAS blocks, so scrubbing every leaf and internal node verifies the
+whole tree. A corrupt leaf can be repaired from a peer while its parent hashes continue to
+validate the rest, so repair is localised to the damaged block rather than the whole file.
+
+## Defense in depth and the probabilistic contract
+
+Scrubbing is one layer in a stack, none of which is 100% and all of which compose:
+
+1. **Probabilistic prevention** — lock-free staging minimises incorrect writes.
+2. **Probabilistic detection** — scrubbing (verify-on-read + sweep) bounds how long an
+   invalid block survives.
+3. **Near-deterministic verification** — the hash check is certain up to the
+   astronomically small probability of a collision.
+4. **Repair** — re-fetch by hash from a friendly peer, verified by the same hash.
+
+No single layer guarantees integrity, and the design does not pretend otherwise. Composed,
+they push the probability of an *undetected and unrepaired* corrupt block down toward the
+hash-collision floor — which is the strongest guarantee a content-addressed store can
+honestly offer.
+
+## Caveats
+
+- **A full sweep is O(total bytes).** It must be throttled and scheduled; it is not free.
+- **Detection without redundancy cannot repair.** Until the peer-reupload mechanism exists,
+  a single store can only quarantine and report corrupt shards.
+- **Collision-masked corruption is undetectable** — if corrupted bytes happened to hash to
+  the same address, the check passes. This is the same ~collision-probability floor the rest
+  of the design accepts as "certain enough."
+- **Verify-on-read costs CPU per read** and should be sampled rather than applied to every
+  read on hot paths.

--- a/issues/cas/scrub.md
+++ b/issues/cas/scrub.md
@@ -42,7 +42,7 @@ Scrubbing and the staging GC partition the store cleanly and never overlap:
 
 | | Staging GC | Scrub |
 |---|---|---|
-| Domain | `.cas/_staging/` (in-progress uploads) | `.cas/<prefix>/` (committed shards) |
+| Domain | `.cas/_stage/` (in-progress uploads) | `.cas/<prefix>/` (committed shards) |
 | Question | "is this upload still alive?" | "do these bytes still match their hash?" |
 | Signal | deadline in the file name | re-hash vs. the address |
 | Action | `rm` expired/orphaned files | quarantine + repair corrupt shards |

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -120,7 +120,7 @@ runner-held token. Every effect is stateless and path-based, exactly like the ex
 | `rename` | `(src, dst) => IoResult<void>` | Already exists. Used both for **renew** (`<oldDeadline>-<rand>` → `<newDeadline>-<rand>`) and for **commit** (`_staging/...` → `.cas/<prefix>/<hash>`). |
 | `rm` | `(path) => IoResult<void>` | Already exists. Used for **abort** and by the GC. |
 | `stat` | `(path) => IoResult<{size, mtimeMs}>` | **New.** Used for **resume** (`offset = size`) and optional bookkeeping. `mtimeMs` is **not** required for correctness here — unlike `staging.md`, there is no open→lock gap to cover. |
-| `fsync` | `(path) => IoResult<void>` | **New.** Flushes the staging file's data to disk. Required by `commit` *before* the final rename, so the bytes are durable before the shard becomes visible. There is no such effect in the current node set. |
+| `fsync` | `(path) => IoResult<void>` | **New.** Flushes a path to disk. On a **file** path it persists the data; on a **directory** path it persists that directory's entries (creations/renames) — the same `fsync(fd)` syscall on a directory fd. `commit` needs both: file data before the rename, and the destination directory after it (so the new shard entry survives a power loss). There is no such effect in the current node set. On Windows, a directory fsync has no exact equivalent; use a write-through rename (`MOVEFILE_WRITE_THROUGH`) to make the commit durable instead. |
 | `setReadonly` | `(path) => IoResult<void>` | **New.** Marks the committed shard read-only (`chmod 444` on POSIX; ReadOnly attribute on Windows). Required by `commit` *after* the rename. There is no such effect in the current node set. |
 
 `createExclusive`, `writeBytes`, `stat`, `fsync`, and `setReadonly` are **new** effects to
@@ -162,19 +162,30 @@ renew(handle):
   return { ...handle, path: newPath }
 
 commit(handle, key):
-  fsync(handle.path)                        // bytes durable before the shard is visible
+  fsync(handle.path)                        // 1. file data durable before the shard is visible
   dst = `.cas/${shard(key)}`
-  rename(handle.path, dst)                   // ENOENT ⇒ lease lost ⇒ error, restart upload
-  setReadonly(dst)                           // chmod 444 / ReadOnly attribute
+  rename(handle.path, dst)                   // 2. ENOENT ⇒ lease lost ⇒ error, restart upload
+  fsync(dirOf(dst))                          // 3. make the new directory entry durable, BEFORE
+                                             //    reporting success — else a power loss after
+                                             //    commit returns can lose the rename and the
+                                             //    shard reverts/vanishes on reboot (POSIX).
+  setReadonly(dst)                           // 4. chmod 444 / ReadOnly attribute (durability of
+                                             //    the read-only bit itself is not critical:
+                                             //    strategy-1.md — content is correct without it)
   // Windows: if dst already exists with the ReadOnly attribute, MoveFileEx fails with
   // access-denied. By the CAS invariant (same hash ⇒ same bytes) the existing shard is
   // already correct, so the right response is rm(handle.path) and return success — or
-  // clear ReadOnly on dst, then rename over it. (POSIX rename replaces silently.)
-  // Same case as commitHandle in strategy-1.md.
+  // clear ReadOnly on dst, then rename over it. (POSIX rename replaces silently.) Windows
+  // can also make the rename itself durable with a write-through move instead of a dir fsync.
 
 abort(handle):
   rm(handle.path)                           // ENOENT is fine — already reclaimed
 ```
+
+The staging directory itself is **not** fsynced on `createExclusive`/`renew`: a staging
+file lost to a crash before commit just restarts the upload (fail-safe), so only `commit` —
+the point where success is acknowledged — needs durability, and it needs *both* the file
+data (step 1) and the destination directory entry (step 3).
 
 `append` writes at an **explicit offset** rather than `O_APPEND`. This makes every write
 idempotent: a transient failure can be retried with the same bytes at the same offset

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -116,11 +116,12 @@ existing `readBytes` / `writeFile` / `rename` effects in `fs/effects/node/module
 |---|---|---|
 | `createExclusive` | `(path) => IoResult<void>` | `O_CREAT\|O_EXCL`. Creates the staging file. With 256 random bits in the name `EEXIST` never happens in practice; it is just a sanity guard. |
 | `writeBytes` | `(path, offset, data: Vec) => IoResult<void>` | Mirror of `readBytes`. Opens the **existing** file (no create) and writes at `offset`. `ENOENT` ⇒ the GC already reclaimed this file ⇒ the upload failed; delete and restart. Bounded to ≤128 KiB per call. |
-| `rename` | `(src, dst) => IoResult<void>` | Already exists. Renews the lease (`…-<rand>` → a newer deadline) and publishes the shard (`_staging/…` → `.cas/<prefix>/<hash>`). |
+| `renameNoReplace` | `(src, dst) => IoResult<void>` | **No-clobber rename**: fails with `EEXIST` if `dst` exists (rather than POSIX `rename`'s silent replace). Publishing analyzes the result — `ok` = published, `EEXIST` = dedup. Implement via `renameat2(RENAME_NOREPLACE)` (Linux), `MoveFile` without `REPLACE_EXISTING` (Windows), or `link`+`rm` (portable). Also used for lease renewal, where `dst` never pre-exists. |
 | `rm` | `(path) => IoResult<void>` | Already exists. Deletes a partial/aborted upload; also the GC's reclaim. |
 | `stat` | `(path) => IoResult<{size}>` | **New.** Used by resume to recover `offset = size`. |
 
-`createExclusive`, `writeBytes`, and `stat` are **new**; `rename`, `rm`, and `mkdir` already
+`createExclusive`, `writeBytes`, `stat`, and `renameNoReplace` are **new** (the existing node
+`rename` replaces silently, which the publish step must not do); `rm` and `mkdir` already
 exist. Marking a committed shard read-only (`chmod 444`) for immutability is an optional
 extra, not part of the core upload. The set is far smaller than the lock design's (no
 `FileHandle`, `openExclusive`, `appendHandle`, `commitHandle`, `abortHandle`, or
@@ -155,11 +156,11 @@ upload(stream, ttl):                          // returns the content hash (the C
   key = shaFinal(hash)                          // the address IS the hash of the bytes written
   dst = `.cas/${shard(key)}`
   mkdir(dirOf(dst), {recursive})                // create the hash-prefix directories
-  if exists(dst):                               // already present ⇒ dedup. Do NOT validate its hash.
-      rm(path)                                  //   delete our staging file, ignore the result,
-      return key                                //   and return success.
-  rename(path, dst)                             // otherwise publish the shard
-  return key
+  switch renameNoReplace(path, dst):            // no-clobber publish: fails if dst already exists
+      ok:      return key                       //   we published the shard
+      EEXIST:  rm(path); return key             //   already present ⇒ dedup. Do NOT validate its
+                                                //   hash; delete our file (ignore result), succeed.
+      other:   rm(path); return uploadError
 ```
 
 Three things make this safe without extra machinery:
@@ -170,11 +171,16 @@ Three things make this safe without extra machinery:
 - **Errors fail closed.** Any error while streaming deletes the partial file and returns an
   upload error; for a crash, the lease and the GC reclaim whatever is left behind. There is
   nothing to undo and no half-published state.
-- **An existing destination is success.** If `dst` already exists, the upload is done — by
-  the CAS invariant it is the same bytes. We do **not** validate the existing shard's hash;
-  we just delete our staging file (ignoring the delete result) and return the key. If that
-  existing shard were *corrupt*, detecting and repairing it is a scrub concern (`scrub.md`),
-  never something the hot upload path checks.
+- **Publish is one atomic step.** The result of a single no-replace rename tells us
+  everything: success means we placed the shard; `EEXIST` means it was already there. There
+  is no separate `exists` check and so no race between checking and renaming. On `EEXIST` the
+  upload is done — by the CAS invariant the existing shard is the same bytes — so we do
+  **not** validate its hash; we just delete our staging file (ignoring the delete result) and
+  return the key. If that existing shard were *corrupt*, detecting and repairing it is a scrub
+  concern (`scrub.md`), never something the hot upload path checks. (Plain POSIX `rename`
+  *replaces* silently and so can't report `EEXIST`; the no-replace variant is `renameat2`
+  with `RENAME_NOREPLACE`, Windows `MoveFile` without `REPLACE_EXISTING`, or a portable
+  `link`+`rm`.)
 
 **Explicit offset, not `O_APPEND`.** Keeping the offset makes a write idempotent — a transient
 `writeBytes` error can be retried with the same bytes at the same offset with no double-append

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -232,6 +232,63 @@ Resume cost is O(bytes-so-far) because SHA-2 is not seekable and the hash state 
 rebuilt from disk. This is acceptable for the sizes involved and is the only non-O(1) part
 of the design.
 
+## Distributed and remote staging
+
+The lock is the one primitive that is fundamentally process-local — `flock` does not cross
+machines, and over a network filesystem it is unreliable for this purpose. The lease
+replaces it with primitives a **shared filesystem already provides**, plus a clock:
+
+- atomic exclusive create (`O_EXCL`) — claim a unique name
+- atomic `rename` — renew, commit, and ownership handoff
+- atomic `unlink` — GC and abort
+- a wall-clock deadline — liveness
+
+So `_staging/` can live on a remote/shared disk (e.g. an NFS export) and be driven by
+uploaders running on **several machines at once**. The stateless `writeBytes` model is, if
+anything, *more* network-FS-friendly than a held-handle model: NFS's weak spots are all
+around open file state (silly-rename on unlink-while-open, lock recovery after a server
+reboot), and the lease touches none of it — it is all path-only ops (create / rename /
+unlink / pwrite-at-offset), which network filesystems support well. Dropping the
+`FileHandle` removed exactly the operations NFS handles worst.
+
+### Cross-machine handoff
+
+Machine-to-machine takeover is reboot-resume across machines: the stable `random256`
+identity locates the file on the shared disk, and re-hash-from-disk rebuilds
+`{offset, hash}`. Ownership transfer uses the same fencing rename — to take over, a machine
+renames to a new deadline; two claimants race the atomic rename, one wins, the other gets
+`ENOENT` and backs off. **The lease token doubles as the distributed mutual-exclusion
+primitive**: the same rename that detects crashes also transfers ownership.
+
+### Skew and partition cost throughput, not safety
+
+This is the property that makes it usable across machines, where writers and the GC may run
+on different clocks and behind partitions:
+
+- **Clock skew.** With bounded skew δ (NTP-synced), renew with margin > δ and behaviour is
+  fine. *Unbounded* skew only costs efficiency, never safety: a GC that reclaims early just
+  makes the writer's next renew/commit hit `ENOENT` and fail safe. No shard is corrupted.
+- **Partition.** A writer that loses the mount cannot renew → its lease expires → GC
+  reclaims → the writer fails safe via `ENOENT` on reconnect. A partition is just a long
+  pause, already covered by the fail-safe property.
+
+The local virtue — worst case is a restarted upload, never corruption — is exactly what you
+want in a distributed setting, where skew and partitions are the norm rather than the
+exception.
+
+### Requirements and limits
+
+- **Atomic `O_EXCL` create + `rename` + `unlink` on the shared FS are mandatory.** This
+  holds on NFSv3+/v4 — NFSv3 added exclusive-create-with-verifier precisely so `O_EXCL`
+  survives retransmits, and rename/unlink are single atomic RPCs. SMB/CIFS semantics vary
+  and must be checked.
+- **Object stores (S3/GCS) are not POSIX** — no atomic rename, no `O_EXCL`. The
+  deadline-in-name *idea* ports to their conditional-write / `If-None-Match` compare-and-set
+  primitives, but that is a distinct mapping, not the same syscalls.
+- **Durability is the server's.** `commit`'s fsync-before-rename relies on the server
+  actually flushing; network-FS durability and cache-coherence guarantees are weaker and
+  must be verified for the target filesystem.
+
 ## Trade-offs and caveats
 
 - **Leases are a timing assumption, not a truth.** A live-but-paused writer (STW GC pause,
@@ -246,8 +303,9 @@ of the design.
   legitimate long upload can pre-reserve, so it should be configurable.
 - **Wall-clock dependence.** Deadlines are wall-clock. On a single host (writer and GC
   share the clock) this is fine; NTP steps and suspend/resume are edge cases. Across hosts
-  over a shared filesystem (NFS) it is dangerous — but the lock design is dubious over NFS
-  too, so this is not a regression.
+  (see *Distributed and remote staging*) skew costs efficiency but not safety, *provided*
+  the shared filesystem supplies atomic `O_EXCL` create, `rename`, and `unlink` — those
+  atomic primitives, not clock agreement, are what the fencing rests on.
 - **`writeBytes` must never create.** Append/resume open the existing file only. Allowing
   create on the append path would let a reclaimed file be resurrected as a sparse file with
   a hole at offset 0 — silent corruption. Exclusive create happens exactly once, at
@@ -268,6 +326,7 @@ of the design.
 | Abandoned/leaked by a live process | File pinned for the process's lifetime | Reclaimed at the deadline |
 | Cleanup on abort | Mandatory — missed release leaks the file | Optional — self-heals after the deadline |
 | Survives reboot | No | Yes |
+| Works across machines / shared disk | No — lock is process-local | Yes — atomic rename + create + deadline (needs an FS that supplies them) |
 
 ## Relationship to the existing `casUpload` path
 

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -167,33 +167,45 @@ commit(handle, key, mode = normal):
   fsync(handle.path)                        // 1. file data durable before the shard is visible
   dst = `.cas/${shard(key)}`
 
-  if stat(dst) is ok:                       // 2. destination already present
-      if mode == normal: rm(handle.path); return ok   // trust CAS invariant (fast dedup path)
-      // mode == repair: do NOT trust it — that is why we are here. Fall through and replace.
-      setReadonly(dst, false)               //    clear the bit so the rename can overwrite (Windows)
+  if mode == normal and stat(dst) is ok:    // 2. fast path only — an optimization, not relied on
+      rm(handle.path); return ok            //    for correctness (see the rename handler below)
 
   newDirs = mkdir(dirOf(dst), {recursive})  // 3. create any missing prefix dirs; record which were new
-  rename(handle.path, dst)                  //    ENOENT ⇒ lease lost ⇒ error, restart upload
+  if mode == repair: setReadonly(dst, false)//    clear the bit so the rename can overwrite a corrupt shard
 
-  fsync(dirOf(dst))                         // 4. persist the new file entry, BEFORE reporting
+  switch rename(handle.path, dst):          // 4. the rename is the atomic, authoritative point
+    ok:               break
+    ENOENT(source):   error                 //    lease lost ⇒ restart upload
+    EEXIST/EACCES(dst): // dst appeared/locked AFTER step 2 — concurrent same-hash commit (Windows)
+        if mode == normal: rm(handle.path); return ok       //    dedup success — resolve here, not at stat
+        if mode == repair: setReadonly(dst, false); rename(handle.path, dst)  // replace, then continue
+
+  fsync(dirOf(dst))                         // 5. persist the new file entry, BEFORE reporting
   for d in newDirs (deepest → shallowest):  //    success — and persist every newly-created
       fsync(parentOf(d))                    //    directory's own entry in its parent, or a crash
                                             //    can still lose the prefix path (POSIX).
-  setReadonly(dst, true)                    // 5. chmod 444 / ReadOnly (durability of the bit
+  setReadonly(dst, true)                    // 6. chmod 444 / ReadOnly (durability of the bit
                                             //    itself is not critical: strategy-1.md)
-  // Windows: if dst already exists ReadOnly, MoveFileEx fails with access-denied; the normal
-  // path treats that as the stat(dst)-ok case above. A write-through move
-  // (MOVEFILE_WRITE_THROUGH) can substitute for the dir fsyncs.
+  // POSIX rename replaces an existing dst silently, so the EEXIST/EACCES branch is Windows-only
+  // (ReadOnly dst ⇒ MoveFileEx access-denied). A write-through move (MOVEFILE_WRITE_THROUGH)
+  // can substitute for the dir fsyncs.
 
 abort(handle):
   rm(handle.path)                           // ENOENT is fine — already reclaimed
 ```
 
-**The `exists(dst)` shortcut trusts the CAS invariant and is therefore only safe when the
-existing shard is assumed valid** — the ordinary dedup/concurrent-upload case. A
-scrub-driven **repair** commit (`scrub.md`) recommits a key *precisely because* the existing
-shard is corrupt, so it must not take the shortcut: it clears the read-only bit and replaces
-the bytes (`mode = repair` above). A caller that wants certainty rather than the fast path
+**The destination-already-exists decision is made at the `rename` (step 4), not at the
+preflight `stat` (step 2).** The preflight stat is only a fast early-out; relying on it for
+correctness is a TOCTOU bug, because on Windows another writer can create and lock `dst`
+*between* our stat and our rename — and then a harmless concurrent same-hash upload would
+wrongly report failure. Resolving "dst exists" in the rename's error branch covers that race:
+in `normal` mode it is dedup success (the shard is already present — `rm` the staging file and
+return ok); in `repair` mode it clears the read-only bit and replaces.
+
+**The `normal`-mode shortcut trusts the CAS invariant and is therefore only safe when the
+existing shard is assumed valid** — the ordinary dedup case. A scrub-driven **repair** commit
+(`scrub.md`) recommits a key *precisely because* the existing shard is corrupt, so it never
+trusts `dst`: it replaces the bytes. A caller that wants certainty rather than the fast path
 can run a **verifying** commit — re-hash `dst` and replace on mismatch — at the cost of an
 O(size) re-read of the existing shard.
 

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -45,6 +45,38 @@ Because `rename` and `unlink` on a single name are atomic, the name itself is a 
 token: there is never a window where both "the writer keeps the file" and "the GC deleted
 the file" believe they won.
 
+## Design philosophy
+
+Three principles tie the whole design together; every property below is a consequence of
+them.
+
+**Strategy belongs to the uploader; mechanism belongs to the GC.** Each uploader chooses
+its own lease strategy, and they need not agree. One holding an important document over a
+flaky connection can pre-assign a long lease up front; a routine uploader can take a short
+lease and renew on progress; a pool of hedged uploaders can all take short leases and race.
+These strategies coexist in one `_staging/` directory with **no coordination**, because the
+only thing an uploader communicates to the GC is a single number — the deadline in the
+filename. There is no registry, no negotiation, no shared state to keep consistent.
+
+**The contract is one line.** From the GC's side: *if a file's lease has expired, the file
+is eligible to be reclaimed.* That is the entire agreement — the GC needs no knowledge of
+uploader internals, progress semantics, or strategy. Note the precision: expiry makes a
+file *eligible* for reclamation, it does not reclaim it. The GC is lazy and oldest-first, so
+an uploader whose lease just lapsed can still win by renewing or committing before the GC
+reaches it; the fencing only bites if the GC actually unlinks first, and then the loser
+fails safe.
+
+**Nothing is guaranteed at 100%, and that is the point.** The lease is best-effort: a
+misjudged-slow uploader is reclaimed and restarts; a stalled one is reclaimed and a peer
+takes over; a partition resolves into a restart. Because *every* outcome is fail-safe — the
+worst case is wasted work, never a corrupted shard — the system does not need determinism,
+and so it needs no consensus, no locks, and no central authority. Embracing probability is
+what keeps it simple. The only near-deterministic layer is **hash verification**, and even
+that is probabilistic: content addressing rests on collision resistance, so "same hash ⇒
+same bytes" holds only up to the astronomically small probability of a collision. There is
+no truly deterministic subsystem here — only one whose failure odds are small enough to
+treat as certain.
+
 ## Name format
 
 The `<deadline>` must sort lexically as it sorts chronologically, so the GC can order the

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -116,12 +116,11 @@ existing `readBytes` / `writeFile` / `rename` effects in `fs/effects/node/module
 |---|---|---|
 | `createExclusive` | `(path) => IoResult<void>` | `O_CREAT\|O_EXCL`. Creates the staging file. With 256 random bits in the name `EEXIST` never happens in practice; it is just a sanity guard. |
 | `writeBytes` | `(path, offset, data: Vec) => IoResult<void>` | Mirror of `readBytes`. Opens the **existing** file (no create) and writes at `offset`. `ENOENT` ⇒ the GC already reclaimed this file ⇒ the upload failed; delete and restart. Bounded to ≤128 KiB per call. |
-| `renameNoReplace` | `(src, dst) => IoResult<void>` | **No-clobber rename**: fails with `EEXIST` if `dst` exists (rather than POSIX `rename`'s silent replace). Publishing analyzes the result — `ok` = published, `EEXIST` = dedup. Implement via `renameat2(RENAME_NOREPLACE)` (Linux), `MoveFile` without `REPLACE_EXISTING` (Windows), or `link`+`rm` (portable). Also used for lease renewal, where `dst` never pre-exists. |
+| `rename` | `(src, dst) => IoResult<void>` | Already exists. Publishes the shard (`_staging/…` → `.cas/<prefix>/<hash>`) and renews the lease (`…-<rand>` → a newer deadline). Replace-on-existing is fine — same hash ⇒ same bytes. |
 | `rm` | `(path) => IoResult<void>` | Already exists. Deletes a partial/aborted upload; also the GC's reclaim. |
 | `stat` | `(path) => IoResult<{size}>` | **New.** Used by resume to recover `offset = size`. |
 
-`createExclusive`, `writeBytes`, `stat`, and `renameNoReplace` are **new** (the existing node
-`rename` replaces silently, which the publish step must not do); `rm` and `mkdir` already
+`createExclusive`, `writeBytes`, and `stat` are **new**; `rename`, `rm`, and `mkdir` already
 exist. Marking a committed shard read-only (`chmod 444`) for immutability is an optional
 extra, not part of the core upload. The set is far smaller than the lock design's (no
 `FileHandle`, `openExclusive`, `appendHandle`, `commitHandle`, `abortHandle`, or
@@ -156,11 +155,8 @@ upload(stream, ttl):                          // returns the content hash (the C
   key = shaFinal(hash)                          // the address IS the hash of the bytes written
   dst = `.cas/${shard(key)}`
   mkdir(dirOf(dst), {recursive})                // create the hash-prefix directories
-  switch renameNoReplace(path, dst):            // no-clobber publish: fails if dst already exists
-      ok:      return key                       //   we published the shard
-      EEXIST:  rm(path); return key             //   already present ⇒ dedup. Do NOT validate its
-                                                //   hash; delete our file (ignore result), succeed.
-      other:   rm(path); return uploadError
+  rename(path, dst)                             // publish — replace is fine (see below)
+  return key
 ```
 
 Three things make this safe without extra machinery:
@@ -171,16 +167,12 @@ Three things make this safe without extra machinery:
 - **Errors fail closed.** Any error while streaming deletes the partial file and returns an
   upload error; for a crash, the lease and the GC reclaim whatever is left behind. There is
   nothing to undo and no half-published state.
-- **Publish is one atomic step.** The result of a single no-replace rename tells us
-  everything: success means we placed the shard; `EEXIST` means it was already there. There
-  is no separate `exists` check and so no race between checking and renaming. On `EEXIST` the
-  upload is done — by the CAS invariant the existing shard is the same bytes — so we do
-  **not** validate its hash; we just delete our staging file (ignoring the delete result) and
-  return the key. If that existing shard were *corrupt*, detecting and repairing it is a scrub
-  concern (`scrub.md`), never something the hot upload path checks. (Plain POSIX `rename`
-  *replaces* silently and so can't report `EEXIST`; the no-replace variant is `renameat2`
-  with `RENAME_NOREPLACE`, Windows `MoveFile` without `REPLACE_EXISTING`, or a portable
-  `link`+`rm`.)
+- **Publish is just a rename, replace and all.** It does not matter whether `dst` already
+  exists: by the CAS invariant the bytes are the same, so overwriting it with our
+  freshly-written-and-hashed file is harmless — if anything our copy is *less* likely to be
+  corrupt, since it was just hashed end to end. So there is no `exists` check and no special
+  dedup branch; we rename and return the key. Whichever shard ends up on disk, a corrupt one
+  is detected and repaired later by hash verification (`scrub.md`), never on the hot path.
 
 **Explicit offset, not `O_APPEND`.** Keeping the offset makes a write idempotent — a transient
 `writeBytes` error can be retried with the same bytes at the same offset with no double-append

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -175,10 +175,14 @@ commit(handle, key, mode = normal):
 
   switch rename(handle.path, dst):          // 4. the rename is the atomic, authoritative point
     ok:               break
-    ENOENT(source):   error                 //    lease lost ⇒ restart upload
+    ENOENT(source):   return error          //    lease lost ⇒ restart upload
     EEXIST/EACCES(dst): // dst appeared/locked AFTER step 2 — concurrent same-hash commit (Windows)
         if mode == normal: rm(handle.path); return ok       //    dedup success — resolve here, not at stat
-        if mode == repair: setReadonly(dst, false); rename(handle.path, dst)  // replace, then continue
+        if mode == repair:                                  //    corrupt dst was re-locked concurrently
+            setReadonly(dst, false)                         //    clear again and retry —
+            if rename(handle.path, dst) != ok: return error //    …but CHECK the retry; still locked or
+                                                            //    lease lost ⇒ fail, caller restarts
+    other:            return error          //    propagate any other rename error
 
   fsync(dirOf(dst))                         // 5. persist the new file entry, BEFORE reporting
   for d in newDirs (deepest → shallowest):  //    success — and persist every newly-created
@@ -209,11 +213,20 @@ trusts `dst`: it replaces the bytes. A caller that wants certainty rather than t
 can run a **verifying** commit — re-hash `dst` and replace on mismatch — at the cost of an
 O(size) re-read of the existing shard.
 
-The staging directory itself is **not** fsynced on `createExclusive`/`renew`: a staging
-file lost to a crash before commit just restarts the upload (fail-safe), so only `commit` —
-the point where success is acknowledged — needs durability, and it needs the file data
-(step 1), the destination directory entry, and any newly-created ancestor directory entries
-(step 4) all persisted before returning.
+By default the staging file's data and its directory entry are **not** fsynced on
+`createExclusive`/`writeBytes`/`renew`: a staging file lost to a crash before commit just
+restarts the upload (fail-safe), so only `commit` — the point where success is acknowledged
+— forces durability (the file data, the destination directory entry, and any newly-created
+ancestor directory entries, all persisted before returning).
+
+That default trades durability of *in-progress* work for speed, which is fine for a
+disposable upload but is in tension with the reboot-survivable resume claim below. A lease
+that must survive a **power loss** (not just a process exit) needs an **optional fsync
+cadence**: periodically — e.g. at each `renew` — fsync the staging file's data and the
+`_staging/` directory entry, so the partial bytes and the current deadline name are durable.
+This is the durability counterpart of the lease-length knob: an uploader that pre-assigns a
+long lease *because it needs the document* should also opt into the fsync cadence. Without
+it, resume is scoped to clean restarts (see *Reboot-survivable resume*).
 
 `append` writes at an **explicit offset** rather than `O_APPEND`. This makes every write
 idempotent: a transient failure can be retried with the same bytes at the same offset
@@ -338,6 +351,20 @@ survive a reboot:
 Resume cost is O(bytes-so-far) because SHA-2 is not seekable and the hash state must be
 rebuilt from disk. This is acceptable for the sizes involved and is the only non-O(1) part
 of the design.
+
+**Two reboot classes, two guarantees.** A *clean* restart — process exit or graceful reboot
+where the OS flushes its buffers — preserves the staging file and its name without any extra
+work, so resume is reliable. A *power loss* is different: with the default no-fsync staging
+path, the most recent `writeBytes` data, the latest `renew` rename, or even the staging
+directory entry may not have reached disk, so on reboot the file can be missing, rolled back
+to an older (now-expired) name, or truncated. Resume stays **fail-safe** regardless — step 3
+re-derives `size` and the hash from whatever *durably* survived, so it never resumes onto
+wrong bytes; it simply continues from the last durable offset or, in the worst case, restarts.
+But turning power-loss survival from "best-effort" into a *guarantee* requires the optional
+fsync cadence described under the write protocol (fsync the staging data + `_staging/` entry
+at each renew). In short: clean restarts resume for free; power-loss-durable resume is the
+long-lease writer's opt-in, consistent with the design's "you choose your own strategy"
+contract.
 
 ## Distributed and remote staging
 

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -289,14 +289,61 @@ exception.
   actually flushing; network-FS durability and cache-coherence guarantees are weaker and
   must be verified for the target filesystem.
 
+## Renewal policy: detecting stalls, not just deaths
+
+The lease only knows what the **renewal trigger** tells it, and *when* a writer renews
+decides what "alive" means:
+
+- **Heartbeat renewal** — renew on a timer for as long as the process runs. The lease
+  detects only process death and long pauses. A stuck-but-running uploader (blocked on a
+  dead source, a hung socket, a deadlock) keeps renewing and pins its file indefinitely.
+- **Progress-coupled renewal** — renew *only after a part is successfully written*. The
+  lease detects lack of *progress*. A stuck uploader stops renewing even though its process
+  is alive, so its deadline lapses and the GC reclaims it.
+
+Progress-coupling turns the lease into a **stall detector**: "alive but making no progress"
+is treated as dead, which for an upload is usually exactly right — a stalled upload that
+will never finish should release its space and its slot rather than pin them on the
+strength of a still-running process.
+
+### Competitive and failover uploads
+
+This enables two patterns for free:
+
+- **Competitive / hedged uploads.** Start several uploaders for the same content, each with
+  its own `<deadline>-<random256>` identity. The ones that stall stop renewing and get
+  GC'd; the fastest commits; CAS dedup (same hash ⇒ same bytes) makes the losers' commits
+  harmless. You get tail-latency hedging with no coordination — the system discards
+  stragglers automatically. *Concretely:* of two uploaders, one keeps receiving parts and
+  renews its name while the other is stuck and cannot, so the GC removes the stuck one and
+  the healthy one wins. The loser's partial bytes are simply discarded.
+- **True failover on one partial upload.** Two uploaders that share the *same* staging
+  identity (the cross-machine handoff above): if the holder stalls, its lease lapses and a
+  healthy uploader claims the same file via the fencing rename and resumes from
+  `offset = size`. Here the partial bytes are *inherited*, not discarded.
+
+The difference is only whether the `random256` identity is shared: independent identities
+give competitive redundancy (loser's bytes discarded); a shared identity gives resumable
+failover (bytes inherited).
+
+### The slow-vs-stuck threshold
+
+The lease cannot perfectly distinguish a *slow* source (legitimately bursty, long gaps
+between parts) from a *stuck* one (will never deliver). The TTL is the threshold you choose
+between them: long enough to tolerate the longest legitimate inter-part gap, short enough
+to reclaim genuine stalls promptly. Whichever way it errs, the fencing keeps it fail-safe —
+a misjudged-slow uploader restarts or hands off, never corrupts.
+
 ## Trade-offs and caveats
 
 - **Leases are a timing assumption, not a truth.** A live-but-paused writer (STW GC pause,
   container freeze, laptop sleep, debugger breakpoint) that exceeds its deadline is
   declared dead and reclaimed. The design **fails safe** — the writer detects the loss via
   `ENOENT` and aborts, never corrupting a shard — but it does waste that upload. Size the
-  TTL above the longest expected gap between appends, or renew on a background heartbeat
-  for idle-but-open handles.
+  TTL above the longest expected gap between appends. Whether an idle-but-alive writer is
+  kept or reclaimed is a deliberate choice of renewal policy (see *Renewal policy: detecting
+  stalls, not just deaths*): a background heartbeat tolerates stalls; progress-coupled
+  renewal reclaims them.
 - **Cap the maximum lease.** A buggy or wrong-clock writer can stamp an absurd far-future
   deadline and leak space indefinitely. The GC should enforce `deadline ≤ now + MAX`
   (reclaim or reject beyond the cap). The cap bounds the leak but also bounds how long a
@@ -327,6 +374,7 @@ exception.
 | Cleanup on abort | Mandatory — missed release leaks the file | Optional — self-heals after the deadline |
 | Survives reboot | No | Yes |
 | Works across machines / shared disk | No — lock is process-local | Yes — atomic rename + create + deadline (needs an FS that supplies them) |
+| Detects a stuck-but-alive writer | No — lock is held while the process lives | Yes, with progress-coupled renewal — enables competitive/failover uploads |
 
 ## Relationship to the existing `casUpload` path
 

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -150,12 +150,19 @@ openWrite(ttl):
   return { path, offset: 0, hash: shaInit }
 
 append(handle, chunk):
-  if near(deadline(handle.path)):           // renew lazily, only when close to expiry
-      handle = renew(handle)
+  handle = maybeRenew(handle)               // pre-write: don't write into a near-dead lease
   writeBytes(handle.path, handle.offset, chunk)   // ENOENT ⇒ lease lost ⇒ abort
+  handle = maybeRenew(handle)               // post-write: the successful write IS the progress
+                                            //   event (progress-coupled mode) — refresh now, or a
+                                            //   long gap after this chunk could expire a live,
+                                            //   progressing upload and have GC reclaim it
   return { ...handle,
            offset: handle.offset + len(chunk),
            hash:   shaUpdate(handle.hash, chunk) }
+
+maybeRenew(handle):                          // lazy: avoid a rename on every chunk
+  if remaining(deadline(handle.path)) < threshold: return renew(handle)
+  return handle
 
 renew(handle):
   newDl   = now() + ttl
@@ -163,9 +170,12 @@ renew(handle):
   rename(handle.path, newPath)              // ENOENT ⇒ GC reclaimed us ⇒ abort
   return { ...handle, path: newPath }
 
-commit(handle, key, mode = normal):
+commit(handle, key?, mode = normal):
+  computedKey = shaFinal(handle.hash)       // 0. the address is ALWAYS the hash of the bytes we wrote
+  if key? and key != computedKey: return error  //   key-known/resume mismatch ⇒ caller bug or bad
+                                            //   resume state ⇒ refuse (never write under a wrong address)
   fsync(handle.path)                        // 1. file data durable before the shard is visible
-  dst = `.cas/${shard(key)}`
+  dst = `.cas/${shard(computedKey)}`        //    dst is derived from computedKey, not a trusted arg
 
   if mode == normal and stat(dst) is ok:    // 2. fast path only — an optimization, not relied on
       rm(handle.path); return ok            //    for correctness (see the rename handler below)
@@ -197,6 +207,13 @@ commit(handle, key, mode = normal):
 abort(handle):
   rm(handle.path)                           // ENOENT is fine — already reclaimed
 ```
+
+**The shard address is always the hash of the bytes actually written (step 0).** `commit`
+finalizes the accumulated hash and derives `dst` from *that*, never from a trusted argument.
+A `key` may still be passed for the key-known and resume paths, but it is only *checked*
+against `computedKey`, never used to place the file — so a caller bug or a bad resume state
+fails the commit instead of writing bytes under the wrong CAS address. This is what lets the
+read path (and `scrub.md`) trust the path as the checksum.
 
 **The destination-already-exists decision is made at the `rename` (step 4), not at the
 preflight `stat` (step 2).** The preflight stat is only a fast early-out; relying on it for

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -77,6 +77,13 @@ same bytes" holds only up to the astronomically small probability of a collision
 no truly deterministic subsystem here — only one whose failure odds are small enough to
 treat as certain.
 
+The same honesty applies *after* commit. Lock-free staging minimises incorrect writes but
+cannot guarantee one never happens, and a committed shard can still rot on the media long
+after. The committed store therefore has its own always-on backstop — [block scrubbing and
+repair](scrub.md), the committed-store dual of this directory's GC — which continuously
+re-verifies shards against their hash and (in the future) repairs corruption by re-fetching
+the block by hash from a friendly peer.
+
 ## Name format
 
 The `<deadline>` must sort lexically as it sorts chronologically, so the GC can order the

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -143,6 +143,9 @@ find one. This makes the create-vs-append state machine total and self-checking:
 WriteHandle = { path, offset, hash }   // plain data, no OS resource
 
 openWrite(ttl):
+  mkdir(`_staging`, {recursive})            // ensure the staging dir exists — on a fresh store it does
+                                            //   not, and createExclusive (O_CREAT|O_EXCL) creates only
+                                            //   the leaf file, so it would ENOENT without this
   rand  = random256()
   dl    = now() + ttl                      // or a writer-chosen far-future deadline
   path  = `_staging/${fmt(dl)}-${rand}`

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -191,6 +191,31 @@ Both are the same mechanism (set a future deadline) at different magnitudes. A l
 buys reboot-survivability and low churn at the cost of slower reclamation of a crashed
 upload's space.
 
+## Liveness is bound to the upload, not the process
+
+A lock conflates two distinct facts — *the process is alive* and *the upload is alive* —
+because it ties the file's liveness to an fd's lifetime. That conflation is wrong at both
+ends:
+
+- **Process alive, upload dead.** An uploader aborts but its `rm`/close fails, or it simply
+  abandons the upload and moves on to other work while the process keeps running. The
+  `flock` / open handle stays held for the life of the *process*, not the life of the
+  *upload*. The GC can never reclaim the file, and the leak is invisible — the process
+  looks healthy and is doing useful work, yet it pins a dead upload until it exits.
+- **Process dead, upload should live.** A reboot drops the lock and kills an upload you
+  wanted to resume (see the next section).
+
+The lease binds liveness to the upload's own intent to stay alive — "is anyone still
+pushing the deadline forward?" — which is exactly the right predicate. Abandon the upload,
+leak the handle, or fail to abort, and the deadline still expires and the GC reclaims it.
+A long-lived process pins nothing, because there is no process-held resource to leak.
+
+The consequence: **cleanup is an optimization, not a correctness obligation.** `abort`
+reclaims space *sooner*; skipping or failing it costs one deadline's worth of space and
+then self-heals. With the lock, releasing is mandatory and every error path that misses it
+leaks a file for the process's whole lifetime — the classic "you forgot the `finally`"
+footgun, and the OS won't save you because the process is still alive.
+
 ## Reboot-survivable resume
 
 Because liveness is a durable filename rather than a process-held lock, an upload can
@@ -240,6 +265,8 @@ of the design.
 | Cleaner protocol | `tryLockExclusive`, hold handle during delete | `rm` files with past deadlines |
 | Manual `rm` in `_staging/` | Silently corrupts active writes on POSIX | Safe — worst case is a restarted upload |
 | Slow-but-alive writer | Never reclaimed | May be reclaimed (fails safe) |
+| Abandoned/leaked by a live process | File pinned for the process's lifetime | Reclaimed at the deadline |
+| Cleanup on abort | Mandatory — missed release leaks the file | Optional — self-heals after the deadline |
 | Survives reboot | No | Yes |
 
 ## Relationship to the existing `casUpload` path

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -293,7 +293,10 @@ to be added only behind a real, measured need.
   the size check still passes and we return success without having replaced the bad bytes. A
   verifying publish could confirm the rename actually installed our bytes (or re-hash `dst`)
   before returning `ok`, at an `O(size)` re-read cost — closing that gap instead of leaving it
-  to scrub.
+  to scrub. Reading `dst` back would also catch the contrived case where something has replaced
+  the shard path out-of-band with a directory or non-regular file of a coincidentally-matching
+  size (the size-only check would otherwise report success); the baseline treats that as `.cas/`
+  tampering, scrub's domain, not the hot path.
 - **Resumable / reboot-survivable uploads.** The baseline restarts a failed upload from
   scratch. A resume could instead re-hash the surviving staging bytes (`offset = stat(path).size`)
   and continue — surviving a reboot or handing the upload to another process. See

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -80,21 +80,24 @@ treat as certain.
 ## Name format
 
 The `<deadline>` must sort lexically as it sorts chronologically, so the GC can order the
-directory with a plain `readdir` + sort. Use UTC and fixed width — e.g. zero-padded epoch
-milliseconds:
+directory with a plain `readdir` + sort. The encoding is a **single store-wide constant**,
+not a per-client choice: **fixed-width, zero-padded UTC epoch milliseconds**.
 
 ```
 0000001750512000000-3f9a…<64 hex chars>
 ```
 
-or an ISO-8601 basic-format UTC stamp:
+The format must be canonical because the GC's oldest-first scan relies on expired files
+forming one contiguous lexical *prefix* (and over-cap files one *suffix*). Mixing encodings
+in the same `_staging/` breaks that invariant: every `0000…` epoch name sorts before, say,
+a `2026…` ISO stamp regardless of its actual deadline, so the front scan could stop on a
+live epoch file while expired ISO files sit unreclaimed after it. One encoding, fixed width,
+for every writer — no alternative spellings.
 
-```
-20260621T120000Z-3f9a…<64 hex chars>
-```
-
-Local time ("GST"/wall-clock-with-offset) must **not** be used: it fails to sort across
-DST transitions and offset changes.
+Two consequences of "fixed width": the digit count must be wide enough that no realistic
+deadline overflows it (millisecond epochs stay 13 digits until the year 2286; pad to a fixed
+larger width for headroom), and local time ("GST"/wall-clock-with-offset) must **not** be
+used — it fails to sort across DST transitions and offset changes.
 
 ## Effect set
 
@@ -109,7 +112,14 @@ runner-held token. Every effect is stateless and path-based, exactly like the ex
 | `writeBytes` | `(path, offset, data: Vec) => IoResult<void>` | The symmetric mirror of `readBytes`. Opens the **existing** file (no create), writes `data` at `offset`. `ENOENT` ⇒ the GC reclaimed this file ⇒ the writer lost its lease and must abort. Bounded to ≤128 KiB per call, matching `maxLengthBytes`. |
 | `rename` | `(src, dst) => IoResult<void>` | Already exists. Used both for **renew** (`<oldDeadline>-<rand>` → `<newDeadline>-<rand>`) and for **commit** (`_staging/...` → `.cas/<prefix>/<hash>`). |
 | `rm` | `(path) => IoResult<void>` | Already exists. Used for **abort** and by the GC. |
-| `stat` | `(path) => IoResult<{size, mtimeMs}>` | Used for **resume** (`offset = size`) and optional bookkeeping. `mtimeMs` is **not** required for correctness here — unlike `staging.md`, there is no open→lock gap to cover. |
+| `stat` | `(path) => IoResult<{size, mtimeMs}>` | **New.** Used for **resume** (`offset = size`) and optional bookkeeping. `mtimeMs` is **not** required for correctness here — unlike `staging.md`, there is no open→lock gap to cover. |
+| `fsync` | `(path) => IoResult<void>` | **New.** Flushes the staging file's data to disk. Required by `commit` *before* the final rename, so the bytes are durable before the shard becomes visible. There is no such effect in the current node set. |
+| `setReadonly` | `(path) => IoResult<void>` | **New.** Marks the committed shard read-only (`chmod 444` on POSIX; ReadOnly attribute on Windows). Required by `commit` *after* the rename. There is no such effect in the current node set. |
+
+`createExclusive`, `writeBytes`, `stat`, `fsync`, and `setReadonly` are **new** effects to
+add to `fs/effects/node/module.f.ts`; `rename` and `rm` already exist. The set is still far
+smaller than the lock design's (no `FileHandle`, `openExclusive`, `appendHandle`,
+`commitHandle`, `abortHandle`, or `tryLockExclusive`).
 
 `O_EXCL` is **not** mutual exclusion (the random suffix already guarantees uniqueness).
 Its job is **mode discrimination**: creation must not find an existing file; appends must

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -1,0 +1,252 @@
+# Lock-Free Staging via Deadline Leases
+
+## Purpose
+
+This is a lock-free alternative to the OS-lock design in [`staging.md`](staging.md).
+It solves the same problem — distinguishing an active staging upload from a crashed
+orphan — but replaces the `flock` / open-handle "dead-man's switch" with a **deadline
+encoded in the staging file's name**. A writer stays alive by keeping its file's
+deadline in the future; a garbage collector reclaims any file whose deadline has
+passed.
+
+The motivation is threefold:
+
+1. **No lock.** `flock` on POSIX is cooperative-advisory and does not block `unlink`,
+   which forces the elaborate `tryLockExclusive` + mtime-grace protocol of `staging.md`.
+   Windows needs `DELETE`-access handle gymnastics for rename-while-held. The lease has
+   none of this.
+2. **Platform symmetry.** The protocol is byte-for-byte identical on POSIX and Windows.
+   There is no advisory-vs-hard asymmetry, no open→lock race, and therefore no mandatory
+   mtime grace period.
+3. **Reboot-survivable uploads.** A lock is process-bound: a reboot drops it and the file
+   looks orphaned. A deadline in a durable filename is process-independent, so an upload
+   can survive a reboot and resume — a capability the lock design structurally cannot have.
+
+## Core idea
+
+A staging file's name carries its own expiry:
+
+```
+.cas/_staging/<deadline>-<random256>
+```
+
+- **`<deadline>`** — a wall-clock expiry, formatted so that lexical order equals
+  chronological order (fixed-width, zero-padded, UTC). This is the **generation**.
+- **`<random256>`** — 256 bits of randomness. This is the **stable identity** of the
+  upload; it never changes for the life of the staging file.
+
+A writer keeps the file alive by ensuring its deadline stays in the future, either by
+**renewing** (renaming to a new deadline) or by **pre-assigning** a far-future deadline
+at creation. The GC rule is simply:
+
+> A file is reclaimable when its `<deadline>` is in the past.
+
+Because `rename` and `unlink` on a single name are atomic, the name itself is a fencing
+token: there is never a window where both "the writer keeps the file" and "the GC deleted
+the file" believe they won.
+
+## Name format
+
+The `<deadline>` must sort lexically as it sorts chronologically, so the GC can order the
+directory with a plain `readdir` + sort. Use UTC and fixed width — e.g. zero-padded epoch
+milliseconds:
+
+```
+0000001750512000000-3f9a…<64 hex chars>
+```
+
+or an ISO-8601 basic-format UTC stamp:
+
+```
+20260621T120000Z-3f9a…<64 hex chars>
+```
+
+Local time ("GST"/wall-clock-with-offset) must **not** be used: it fails to sort across
+DST transitions and offset changes.
+
+## Effect set
+
+The lease design needs **no `FileHandle` type** and no held OS resource. The `WriteHandle`
+returned to the caller is plain data — `{ path, offset, hash }` — not an opaque
+runner-held token. Every effect is stateless and path-based, exactly like the existing
+`readBytes` / `writeFile` / `rename` effects in `fs/effects/node/module.f.ts`.
+
+| Effect | Signature | Notes |
+|---|---|---|
+| `createExclusive` | `(path) => IoResult<void>` | `O_CREAT\|O_EXCL`. Creates a brand-new staging file at a `<deadline>-<random256>` name. `EEXIST` is a hard error (a 256-bit collision or a bug), not a retry signal. |
+| `writeBytes` | `(path, offset, data: Vec) => IoResult<void>` | The symmetric mirror of `readBytes`. Opens the **existing** file (no create), writes `data` at `offset`. `ENOENT` ⇒ the GC reclaimed this file ⇒ the writer lost its lease and must abort. Bounded to ≤128 KiB per call, matching `maxLengthBytes`. |
+| `rename` | `(src, dst) => IoResult<void>` | Already exists. Used both for **renew** (`<oldDeadline>-<rand>` → `<newDeadline>-<rand>`) and for **commit** (`_staging/...` → `.cas/<prefix>/<hash>`). |
+| `rm` | `(path) => IoResult<void>` | Already exists. Used for **abort** and by the GC. |
+| `stat` | `(path) => IoResult<{size, mtimeMs}>` | Used for **resume** (`offset = size`) and optional bookkeeping. `mtimeMs` is **not** required for correctness here — unlike `staging.md`, there is no open→lock gap to cover. |
+
+`O_EXCL` is **not** mutual exclusion (the random suffix already guarantees uniqueness).
+Its job is **mode discrimination**: creation must not find an existing file; appends must
+find one. This makes the create-vs-append state machine total and self-checking:
+
+- A "new upload" that hits `EEXIST` → fail loud rather than truncate live data.
+- An "append" that hits `ENOENT` → the fencing signal to abort.
+
+## Write protocol
+
+```
+WriteHandle = { path, offset, hash }   // plain data, no OS resource
+
+openWrite(ttl):
+  rand  = random256()
+  dl    = now() + ttl                      // or a writer-chosen far-future deadline
+  path  = `_staging/${fmt(dl)}-${rand}`
+  createExclusive(path)                     // EEXIST ⇒ bug, fail
+  return { path, offset: 0, hash: shaInit }
+
+append(handle, chunk):
+  if near(deadline(handle.path)):           // renew lazily, only when close to expiry
+      handle = renew(handle)
+  writeBytes(handle.path, handle.offset, chunk)   // ENOENT ⇒ lease lost ⇒ abort
+  return { ...handle,
+           offset: handle.offset + len(chunk),
+           hash:   shaUpdate(handle.hash, chunk) }
+
+renew(handle):
+  newDl   = now() + ttl
+  newPath = `_staging/${fmt(newDl)}-${rand(handle.path)}`
+  rename(handle.path, newPath)              // ENOENT ⇒ GC reclaimed us ⇒ abort
+  return { ...handle, path: newPath }
+
+commit(handle, key):
+  fsync(handle.path)                        // bytes durable before the shard is visible
+  rename(handle.path, `.cas/${shard(key)}`) // ENOENT ⇒ lease lost ⇒ error, restart upload
+  setReadonly(`.cas/${shard(key)}`)         // chmod 444 / ReadOnly attribute
+
+abort(handle):
+  rm(handle.path)                           // ENOENT is fine — already reclaimed
+```
+
+`append` writes at an **explicit offset** rather than `O_APPEND`. This makes every write
+idempotent: a transient failure can be retried with the same bytes at the same offset
+without risk of a double-append diverging the file from the in-memory hash state. An
+`appendBytes(path, data)` convenience is just `writeBytes(path, stat(path).size, data)`,
+but the offset belongs in the primitive.
+
+## Why it is safe (the fencing argument)
+
+The full name is the lease token. The GC only ever unlinks a name whose embedded deadline
+has already passed. Consider a slow-but-alive writer that wakes after its deadline:
+
+- **Writer renews first, then GC acts.** `rename(old → new)` succeeds; the GC's later
+  `unlink(old)` hits `ENOENT` and is a no-op. The renewed file survives.
+- **GC acts first, then writer renews.** `unlink(old)` succeeds; the writer's
+  `rename(old → new)` hits `ENOENT` and the writer aborts.
+
+There is never an interleaving in which both sides win. The only data a reclaimed writer
+can have written goes to a now-unlinked inode and is discarded — exactly as in a clean
+abort. **No committed shard is ever corrupted; the worst case is a wasted, restarted
+upload.**
+
+This is a strictly better failure mode than the lock design, where `staging.md` documents
+that a cleaner which skips `tryLockExclusive` *silently corrupts* active POSIX writes.
+
+## Garbage collection
+
+GC reclaims files whose deadline is in the past, in oldest-deadline-first order:
+
+```
+gc():
+  for name in sort(readdir(`_staging/`)):   // lexical sort = chronological
+      if deadline(name) < now():
+          rm(`_staging/${name}`)            // ENOENT is fine
+      else:
+          break                             // the rest are not yet expired
+```
+
+GC can run lazily (piggy-backed on `openWrite`) rather than as a daemon, since staging
+space reclamation is not urgent.
+
+### Manual / degraded-mode GC
+
+A key property of this design: **no manual action in `_staging/` can corrupt a committed
+shard.** Nothing in `_staging/` is ever a shard, and any deletion of an active file is
+caught by the writer via `ENOENT` (worst case: the upload restarts). Therefore:
+
+- A human can `ls _staging/`, read the deadline prefix as a wall-clock time, and delete
+  anything in the past — no special tooling, no lock-aware cleaner, no platform branch.
+- The same `ls` + `rm` procedure works identically on POSIX and Windows.
+- Even a blunt "delete the first half of the sorted list" under space pressure is **safe**
+  (fencing guarantees it). It is simply not always *optimal*: if most files are active,
+  the first half may include not-yet-expired uploads, which then restart. The
+  delete-everything-whose-deadline-is-past rule wastes nothing.
+
+This "a tired operator can GC it correctly with `ls` and `rm`" property is the kind of
+thing that survives contact with production.
+
+## The lease knob: renew vs. pre-assign
+
+`<deadline>` gives each upload a tunable trade-off, set entirely by the writer:
+
+| Strategy | Renew cadence | If the writer crashes | Best for |
+|---|---|---|---|
+| **Short lease, frequently renewed** | rename every few seconds | reclaimed quickly | ordinary streaming uploads |
+| **Long, pre-assigned deadline** | none (or rare) | orphan lingers until the far deadline | large/important uploads; reboot survival |
+
+Both are the same mechanism (set a future deadline) at different magnitudes. A long lease
+buys reboot-survivability and low churn at the cost of slower reclamation of a crashed
+upload's space.
+
+## Reboot-survivable resume
+
+Because liveness is a durable filename rather than a process-held lock, an upload can
+survive a reboot:
+
+1. The writer pre-assigns (or had renewed to) a deadline beyond the expected downtime.
+2. The machine reboots. The lock-based design would lose its `flock` and the GC would eat
+   the file; here the file's deadline is still in the future, so it survives.
+3. On restart, the uploader locates its file by the **stable `random256` suffix**,
+   `stat`s it to get `size`, re-reads bytes `[0, size)` to rebuild its SHA state, and
+   resumes with `writeBytes(path, size, …)`.
+
+Resume cost is O(bytes-so-far) because SHA-2 is not seekable and the hash state must be
+rebuilt from disk. This is acceptable for the sizes involved and is the only non-O(1) part
+of the design.
+
+## Trade-offs and caveats
+
+- **Leases are a timing assumption, not a truth.** A live-but-paused writer (STW GC pause,
+  container freeze, laptop sleep, debugger breakpoint) that exceeds its deadline is
+  declared dead and reclaimed. The design **fails safe** — the writer detects the loss via
+  `ENOENT` and aborts, never corrupting a shard — but it does waste that upload. Size the
+  TTL above the longest expected gap between appends, or renew on a background heartbeat
+  for idle-but-open handles.
+- **Cap the maximum lease.** A buggy or wrong-clock writer can stamp an absurd far-future
+  deadline and leak space indefinitely. The GC should enforce `deadline ≤ now + MAX`
+  (reclaim or reject beyond the cap). The cap bounds the leak but also bounds how long a
+  legitimate long upload can pre-reserve, so it should be configurable.
+- **Wall-clock dependence.** Deadlines are wall-clock. On a single host (writer and GC
+  share the clock) this is fine; NTP steps and suspend/resume are edge cases. Across hosts
+  over a shared filesystem (NFS) it is dangerous — but the lock design is dubious over NFS
+  too, so this is not a regression.
+- **`writeBytes` must never create.** Append/resume open the existing file only. Allowing
+  create on the append path would let a reclaimed file be resurrected as a sparse file with
+  a hole at offset 0 — silent corruption. Exclusive create happens exactly once, at
+  `openWrite`.
+
+## Comparison with the lock design (`staging.md`)
+
+| Aspect | Lock (`staging.md`) | Deadline lease (this doc) |
+|---|---|---|
+| Liveness signal | OS-held `flock` / open handle | `<deadline>` in the filename |
+| Liveness truth | Hard (OS-truthful) | Soft (timing assumption), but **fails safe** |
+| POSIX/Windows | Asymmetric (advisory vs. hard) | Identical |
+| Open→acquire race | Real → mandatory mtime grace period | None (atomic `O_EXCL` create) |
+| `FileHandle` type / held fd | Required | None — `WriteHandle` is plain data |
+| Cleaner protocol | `tryLockExclusive`, hold handle during delete | `rm` files with past deadlines |
+| Manual `rm` in `_staging/` | Silently corrupts active writes on POSIX | Safe — worst case is a restarted upload |
+| Slow-but-alive writer | Never reclaimed | May be reclaimed (fails safe) |
+| Survives reboot | No | Yes |
+
+## Relationship to the existing `casUpload` path
+
+The same migration note from `staging.md` applies: `casUpload` (`fs/cas/module.f.ts`)
+currently stages into `.cas/.stage/` and would be unaffected by a lease GC scanning
+`_staging/`. Migrating `casUpload` to write `<deadline>-<random256>` names under
+`_staging/` brings it under one GC scope. Unlike the lock design, the lease has no mtime
+dependency, so the `rename`-preserves-mtime hazard described in `staging.md` does not
+apply here — a migrated `casUpload` only needs to stamp a fresh deadline into the name.

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -121,12 +121,14 @@ runner-held token. Every effect is stateless and path-based, exactly like the ex
 | `rm` | `(path) => IoResult<void>` | Already exists. Used for **abort** and by the GC. |
 | `stat` | `(path) => IoResult<{size, mtimeMs}>` | **New.** Used for **resume** (`offset = size`) and optional bookkeeping. `mtimeMs` is **not** required for correctness here — unlike `staging.md`, there is no open→lock gap to cover. |
 | `fsync` | `(path) => IoResult<void>` | **New.** Flushes a path to disk. On a **file** path it persists the data; on a **directory** path it persists that directory's entries (creations/renames) — the same `fsync(fd)` syscall on a directory fd. `commit` needs both: file data before the rename, and the destination directory after it (so the new shard entry survives a power loss). There is no such effect in the current node set. On Windows, a directory fsync has no exact equivalent; use a write-through rename (`MOVEFILE_WRITE_THROUGH`) to make the commit durable instead. |
-| `setReadonly` | `(path) => IoResult<void>` | **New.** Marks the committed shard read-only (`chmod 444` on POSIX; ReadOnly attribute on Windows). Required by `commit` *after* the rename. There is no such effect in the current node set. |
+| `setReadonly` | `(path, readonly: bool) => IoResult<void>` | **New.** Sets (`true`) or clears (`false`) the read-only mark (`chmod 444`/`644` on POSIX; ReadOnly attribute on Windows). `commit` sets it after the rename; the **repair** path and the Windows overwrite-existing path clear it first so the rename can replace the destination. There is no such effect in the current node set. |
 
 `createExclusive`, `writeBytes`, `stat`, `fsync`, and `setReadonly` are **new** effects to
-add to `fs/effects/node/module.f.ts`; `rename` and `rm` already exist. The set is still far
-smaller than the lock design's (no `FileHandle`, `openExclusive`, `appendHandle`,
-`commitHandle`, `abortHandle`, or `tryLockExclusive`).
+add to `fs/effects/node/module.f.ts`; `rename`, `rm`, and `mkdir` already exist (`commit`
+uses `mkdir({recursive})` to create missing shard-prefix directories, and `stat` to test
+whether the destination already exists). The set is still far smaller than the lock design's
+(no `FileHandle`, `openExclusive`, `appendHandle`, `commitHandle`, `abortHandle`, or
+`tryLockExclusive`).
 
 `O_EXCL` is **not** mutual exclusion (the random suffix already guarantees uniqueness).
 Its job is **mode discrimination**: creation must not find an existing file; appends must
@@ -161,31 +163,45 @@ renew(handle):
   rename(handle.path, newPath)              // ENOENT ⇒ GC reclaimed us ⇒ abort
   return { ...handle, path: newPath }
 
-commit(handle, key):
+commit(handle, key, mode = normal):
   fsync(handle.path)                        // 1. file data durable before the shard is visible
   dst = `.cas/${shard(key)}`
-  rename(handle.path, dst)                   // 2. ENOENT ⇒ lease lost ⇒ error, restart upload
-  fsync(dirOf(dst))                          // 3. make the new directory entry durable, BEFORE
-                                             //    reporting success — else a power loss after
-                                             //    commit returns can lose the rename and the
-                                             //    shard reverts/vanishes on reboot (POSIX).
-  setReadonly(dst)                           // 4. chmod 444 / ReadOnly attribute (durability of
-                                             //    the read-only bit itself is not critical:
-                                             //    strategy-1.md — content is correct without it)
-  // Windows: if dst already exists with the ReadOnly attribute, MoveFileEx fails with
-  // access-denied. By the CAS invariant (same hash ⇒ same bytes) the existing shard is
-  // already correct, so the right response is rm(handle.path) and return success — or
-  // clear ReadOnly on dst, then rename over it. (POSIX rename replaces silently.) Windows
-  // can also make the rename itself durable with a write-through move instead of a dir fsync.
+
+  if stat(dst) is ok:                       // 2. destination already present
+      if mode == normal: rm(handle.path); return ok   // trust CAS invariant (fast dedup path)
+      // mode == repair: do NOT trust it — that is why we are here. Fall through and replace.
+      setReadonly(dst, false)               //    clear the bit so the rename can overwrite (Windows)
+
+  newDirs = mkdir(dirOf(dst), {recursive})  // 3. create any missing prefix dirs; record which were new
+  rename(handle.path, dst)                  //    ENOENT ⇒ lease lost ⇒ error, restart upload
+
+  fsync(dirOf(dst))                         // 4. persist the new file entry, BEFORE reporting
+  for d in newDirs (deepest → shallowest):  //    success — and persist every newly-created
+      fsync(parentOf(d))                    //    directory's own entry in its parent, or a crash
+                                            //    can still lose the prefix path (POSIX).
+  setReadonly(dst, true)                    // 5. chmod 444 / ReadOnly (durability of the bit
+                                            //    itself is not critical: strategy-1.md)
+  // Windows: if dst already exists ReadOnly, MoveFileEx fails with access-denied; the normal
+  // path treats that as the stat(dst)-ok case above. A write-through move
+  // (MOVEFILE_WRITE_THROUGH) can substitute for the dir fsyncs.
 
 abort(handle):
   rm(handle.path)                           // ENOENT is fine — already reclaimed
 ```
 
+**The `exists(dst)` shortcut trusts the CAS invariant and is therefore only safe when the
+existing shard is assumed valid** — the ordinary dedup/concurrent-upload case. A
+scrub-driven **repair** commit (`scrub.md`) recommits a key *precisely because* the existing
+shard is corrupt, so it must not take the shortcut: it clears the read-only bit and replaces
+the bytes (`mode = repair` above). A caller that wants certainty rather than the fast path
+can run a **verifying** commit — re-hash `dst` and replace on mismatch — at the cost of an
+O(size) re-read of the existing shard.
+
 The staging directory itself is **not** fsynced on `createExclusive`/`renew`: a staging
 file lost to a crash before commit just restarts the upload (fail-safe), so only `commit` —
-the point where success is acknowledged — needs durability, and it needs *both* the file
-data (step 1) and the destination directory entry (step 3).
+the point where success is acknowledged — needs durability, and it needs the file data
+(step 1), the destination directory entry, and any newly-created ancestor directory entries
+(step 4) all persisted before returning.
 
 `append` writes at an **explicit offset** rather than `O_APPEND`. This makes every write
 idempotent: a transient failure can be retried with the same bytes at the same offset

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -135,11 +135,12 @@ vanishingly rare ones (power loss in one specific window, exotic cross-platform 
 It does not try to be crash-atomic.
 
 ```
-upload(stream, ttl):                          // returns the content hash (the CAS key)
-  rand     = random256()
-  deadline = now() + min(ttl, MAX)            // clamp so a bad clock cannot park a file far in the future
-  path     = `_staging/${fmt(deadline)}-${rand}`
-  mkdir(dirOf(path), {recursive})             // create _staging/ if absent (fresh store)
+upload(stream):                               // returns the content hash (the CAS key)
+  rand    = random256()
+  newPath = () => `_staging/${fmt(now() + delta)}-${rand}`   // delta is a fixed constant
+
+  mkdir(`_staging`, {recursive})              // create _staging/ if absent (fresh store)
+  path = newPath()
   createExclusive(path)
 
   offset = 0
@@ -149,8 +150,9 @@ upload(stream, ttl):                          // returns the content hash (the C
       writeBytes(path, offset, chunk)          // ENOENT ⇒ GC already reclaimed us ⇒ error (handled above)
       offset += len(chunk)
       hash    = shaUpdate(hash, chunk)
-      // long uploads: occasionally rename path to a later deadline to keep the lease alive
-      // (see "The lease knob"). A write that ENOENTs means GC already took the file ⇒ fail.
+      next = newPath()                         // renew the lease every chunk: rename to a fresh
+      rename(path, next)                       //   deadline (keeps `delta` constant — see below)
+      path = next
 
   key = shaFinal(hash)                          // the address IS the hash of the bytes written
   dst = `.cas/${shard(key)}`
@@ -179,6 +181,14 @@ Three things make this safe without extra machinery:
   not hash — a cheap stat, not a re-read — because a wrong-sized file is a real failure to
   catch now, while a same-sized-but-corrupt shard is the rare case left to hash verification
   (`scrub.md`), never the hot path.
+
+**Renewing every chunk keeps `delta` constant.** Renaming to a fresh `now() + delta` after each
+chunk means `delta` only has to cover the gap between two consecutive chunks, not the whole
+transfer — so it is a fixed constant, independent of payload size. The same `delta` doubles as
+the stall threshold: if a chunk ever takes longer than `delta` to arrive, the lease lapses, GC
+may reclaim the file, and the next `writeBytes`/`rename` fails `ENOENT` — the upload fails and
+restarts (fail-safe). Renewing every chunk is the simplest choice; *Future optimizations* notes
+a lazier variant.
 
 **Explicit offset, not `O_APPEND`.** Keeping the offset makes a write idempotent — a transient
 `writeBytes` error can be retried with the same bytes at the same offset with no double-append
@@ -221,10 +231,12 @@ gc(now):
       else: break                            // the rest are still live
 ```
 
-There is no separate "far-future" case to worry about: the deadline is clamped to `now + MAX`
-when the file is created (see the write protocol), so a wrong clock cannot park a file beyond
-the cap in the first place. GC can run lazily — piggy-backed on an upload — rather than as a
-daemon, since staging space reclamation is not urgent.
+Because `delta` is a fixed constant, a healthy writer's deadline is never more than `delta`
+ahead of `now`, so there is nothing exotic to scan for. (A grossly wrong clock could park a
+file far in the future and leak that one staging entry; that is a rare, single-file leak left
+to manual cleanup, not something the core handles — see *Future optimizations*.) GC can run
+lazily — piggy-backed on an upload — rather than as a daemon, since staging space reclamation
+is not urgent.
 
 ### Manual / degraded-mode GC
 
@@ -255,6 +267,43 @@ thing that survives contact with production.
 Both are the same mechanism (set a future deadline) at different magnitudes. A long lease
 buys reboot-survivability and low churn at the cost of slower reclamation of a crashed
 upload's space.
+
+## Future optimizations
+
+The algorithm above is the **baseline**: the simplest thing that is correct in the
+overwhelming majority of cases, with the rare residue left to hash verification (`scrub.md`).
+The items below are deliberately **not** in the core. They are recorded here so they have a
+home and do not creep back into the upload path as "fixes" — each is an *optional* extension,
+to be added only behind a real, measured need.
+
+- **Lazy lease renewal.** Instead of renaming after every chunk, renew only when the deadline
+  is near — e.g. at the `delta/2` half-life (`now() ≥ deadline − delta/2`). This cuts rename
+  frequency for fast/small-chunk streams. The cost is a smaller stall margin unless `delta` is
+  enlarged: renewing at the half-life tolerates an inter-chunk gap of only `~delta/2`, so set
+  `delta = 2 × maxGap` to keep the same tolerance. Baseline renews every chunk because it is
+  simpler and gives the full-`delta` margin for free.
+- **Stronger durability (`fsync`).** The baseline does not `fsync`; a power loss in a narrow
+  window can lose a partial upload or a just-published shard, and scrub repairs the rare lost
+  shard later. A writer that needs a hard durability guarantee could `fsync` the file and the
+  destination directory before returning, at a latency cost.
+- **Resumable / reboot-survivable uploads.** The baseline restarts a failed upload from
+  scratch. A resume could instead re-hash the surviving staging bytes (`offset = stat(path).size`)
+  and continue — surviving a reboot or handing the upload to another process. See
+  *Reboot-survivable resume*.
+- **Cross-machine / distributed uploads.** Running the same path-only protocol over shared
+  storage (e.g. NFS) lets several machines upload into one store. See *Distributed and remote
+  staging*.
+- **Stall detection, competitive and failover uploads.** Coupling renewal to actual progress
+  turns the lease into a stall detector and enables hedged/failover uploads. See *Renewal
+  policy: detecting stalls*.
+- **Clock-skew / far-future leak handling.** With a fixed `delta` a healthy deadline is at most
+  `now + delta`, but a grossly wrong clock could park a single staging file far in the future
+  and leak it. A periodic max-age sweep (delete `_staging/` entries whose deadline is absurdly
+  far ahead) would reclaim it; the baseline leaves this rare case to manual cleanup.
+
+The sections that follow document several of these extensions in detail. They are reference
+material for *if* and *when* an optimization is justified — not part of the algorithm a first
+implementation needs to ship.
 
 ## Liveness is bound to the upload, not the process
 
@@ -419,15 +468,12 @@ a misjudged-slow uploader restarts or hands off, never corrupts.
 - **Leases are a timing assumption, not a truth.** A live-but-paused writer (STW GC pause,
   container freeze, laptop sleep, debugger breakpoint) that exceeds its deadline is
   declared dead and reclaimed. The design **fails safe** — the writer detects the loss via
-  `ENOENT` and aborts, never corrupting a shard — but it does waste that upload. Size the
-  TTL above the longest expected gap between appends. Whether an idle-but-alive writer is
-  kept or reclaimed is a deliberate choice of renewal policy (see *Renewal policy: detecting
-  stalls, not just deaths*): a background heartbeat tolerates stalls; progress-coupled
-  renewal reclaims them.
-- **Cap the maximum lease.** The deadline is clamped to `now + MAX` when the file is created
-  (write protocol), so a buggy or wrong-clock writer cannot park a file far in the future and
-  leak space. `MAX` bounds how long a legitimate long upload can pre-reserve, so it should be
-  configurable.
+  `ENOENT` and aborts, never corrupting a shard — but it does waste that upload. Size `delta`
+  above the longest expected gap between chunks.
+- **A wrong clock can leak one staging file.** With a fixed `delta` a healthy deadline is at
+  most `now + delta`, but a grossly wrong clock could write a far-future name that GC never
+  reclaims. It is a rare, single-file leak (never corruption); the baseline leaves it to
+  manual cleanup, and *Future optimizations* notes a max-age sweep if it ever matters.
 - **Wall-clock dependence.** Deadlines are wall-clock. On a single host (writer and GC
   share the clock) this is fine; NTP steps and suspend/resume are edge cases. Across hosts
   (see *Distributed and remote staging*) skew costs efficiency but not safety, *provided*

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -146,8 +146,14 @@ renew(handle):
 
 commit(handle, key):
   fsync(handle.path)                        // bytes durable before the shard is visible
-  rename(handle.path, `.cas/${shard(key)}`) // ENOENT ⇒ lease lost ⇒ error, restart upload
-  setReadonly(`.cas/${shard(key)}`)         // chmod 444 / ReadOnly attribute
+  dst = `.cas/${shard(key)}`
+  rename(handle.path, dst)                   // ENOENT ⇒ lease lost ⇒ error, restart upload
+  setReadonly(dst)                           // chmod 444 / ReadOnly attribute
+  // Windows: if dst already exists with the ReadOnly attribute, MoveFileEx fails with
+  // access-denied. By the CAS invariant (same hash ⇒ same bytes) the existing shard is
+  // already correct, so the right response is rm(handle.path) and return success — or
+  // clear ReadOnly on dst, then rename over it. (POSIX rename replaces silently.)
+  // Same case as commitHandle in strategy-1.md.
 
 abort(handle):
   rm(handle.path)                           // ENOENT is fine — already reclaimed
@@ -179,16 +185,29 @@ that a cleaner which skips `tryLockExclusive` *silently corrupts* active POSIX w
 
 ## Garbage collection
 
-GC reclaims files whose deadline is in the past, in oldest-deadline-first order:
+GC reclaims a file whose deadline is either in the past (expired) **or** absurdly far in
+the future (beyond the `now + MAX` lease cap — a buggy or wrong-clock writer; see *Cap the
+maximum lease*). Because names sort chronologically, expired files form a **prefix** of the
+sorted listing and over-cap files form a **suffix**, with the live leases in the middle. GC
+reclaims from both ends and stops as soon as it reaches a live lease, so it never has to
+examine the middle:
 
 ```
-gc():
-  for name in sort(readdir(`_staging/`)):   // lexical sort = chronological
-      if deadline(name) < now():
-          rm(`_staging/${name}`)            // ENOENT is fine
-      else:
-          break                             // the rest are not yet expired
+gc(now, MAX):
+  names = sort(readdir(`_staging/`))         // lexical sort = chronological
+  for name in names:                         // front → back: expired prefix
+      if deadline(name) < now: rm(`_staging/${name}`)   // ENOENT is fine
+      else: break
+  for name in reverse(names):                // back → front: over-cap suffix
+      if deadline(name) > now + MAX: rm(`_staging/${name}`)
+      else: break
 ```
+
+A single early `break` on the front alone would be wrong: an absurd far-future name sorts
+*after* the normal future leases, so the front scan would stop before ever reaching it and
+the cap would never be enforced — the space would leak until that date. The back scan closes
+that gap. (A plain full scan is also correct; the directory listing is already O(n). The
+two-ended form just preserves the skip-the-middle optimization.)
 
 GC can run lazily (piggy-backed on `openWrite`) rather than as a daemon, since staging
 space reclamation is not urgent.
@@ -285,12 +304,37 @@ unlink / pwrite-at-offset), which network filesystems support well. Dropping the
 
 ### Cross-machine handoff
 
-Machine-to-machine takeover is reboot-resume across machines: the stable `random256`
-identity locates the file on the shared disk, and re-hash-from-disk rebuilds
-`{offset, hash}`. Ownership transfer uses the same fencing rename — to take over, a machine
-renames to a new deadline; two claimants race the atomic rename, one wins, the other gets
-`ENOENT` and backs off. **The lease token doubles as the distributed mutual-exclusion
-primitive**: the same rename that detects crashes also transfers ownership.
+Ownership transfer uses the same fencing rename — to take over, a machine renames to a new
+deadline; two claimants race the atomic rename, one wins, the other gets `ENOENT` and backs
+off. **The lease token doubles as the distributed mutual-exclusion primitive**: the same
+rename that detects crashes also transfers ownership.
+
+What the rename does **not** do is quiesce a previous holder that is mid-write. The fence
+protects *path lookups*: once renamed, no one can `open` the old name. But on POSIX/NFS an
+fd a stale holder opened **before** the rename still refers to the same inode, so an
+in-flight `writeBytes` (its internal `open`+`pwrite`) can land *after* the claimant has
+renamed, statted, and re-hashed the file. The claimant would then commit a shard whose
+bytes changed after its hash state was built — a CAS corruption. There are two safe
+takeover modes:
+
+- **Discard-and-restart (default).** The claimant does **not** inherit bytes. It starts a
+  fresh staging file under its own `<deadline>-<random256>` identity and re-uploads. This
+  collapses into the competitive pattern below, is trivially correct (no shared inode, no
+  race), and is fully in the design's spirit — the worst case is wasted work.
+- **Inherit-with-quiescence (optimization).** To reuse the partial bytes, the claimant must
+  (1) after winning the rename, wait a **quiescence grace** longer than the maximum possible
+  duration of a single in-flight `writeBytes` before it stats/re-hashes — by then any
+  straddling write has landed and no new one can start, because the stale holder's next
+  `writeBytes` opens the now-gone old name and fails `ENOENT`; **and** (2) verify
+  end-to-end at commit — re-hash the finished file from disk and compare it to `key` before
+  the rename — so that if the grace is ever mis-sized the mismatch is caught and the upload
+  restarts rather than committing bad bytes. (For an inherited file the claimant is already
+  re-reading to rebuild hash state, so this verification largely overlaps work it must do
+  anyway.)
+
+Either way, machine-to-machine takeover otherwise works like reboot-resume: the stable
+`random256` identity locates the file, and (in inherit mode) re-hash-from-disk rebuilds
+`{offset, hash}`.
 
 ### Skew and partition cost throughput, not safety
 
@@ -349,14 +393,17 @@ This enables two patterns for free:
   stragglers automatically. *Concretely:* of two uploaders, one keeps receiving parts and
   renews its name while the other is stuck and cannot, so the GC removes the stuck one and
   the healthy one wins. The loser's partial bytes are simply discarded.
-- **True failover on one partial upload.** Two uploaders that share the *same* staging
-  identity (the cross-machine handoff above): if the holder stalls, its lease lapses and a
-  healthy uploader claims the same file via the fencing rename and resumes from
-  `offset = size`. Here the partial bytes are *inherited*, not discarded.
+- **True failover on one partial upload.** A healthy uploader takes over a stalled holder's
+  partial file via the fencing rename. By default this is **discard-and-restart** (a fresh
+  identity), which is exactly the competitive case. Reusing the partial bytes
+  (`resume from offset = size`) is possible but requires the **inherit-with-quiescence**
+  discipline from *Cross-machine handoff* — the fencing rename alone does not stop a stale
+  holder's in-flight `writeBytes` from mutating the inherited inode, so a naive resume can
+  commit corrupted bytes.
 
 The difference is only whether the `random256` identity is shared: independent identities
-give competitive redundancy (loser's bytes discarded); a shared identity gives resumable
-failover (bytes inherited).
+give competitive redundancy (loser's bytes discarded); a shared identity *can* give
+resumable failover, but only with the quiescence + commit-verification safeguards above.
 
 ### The slow-vs-stuck threshold
 

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -108,151 +108,79 @@ used — it fails to sort across DST transitions and offset changes.
 
 ## Effect set
 
-The lease design needs **no `FileHandle` type** and no held OS resource. The `WriteHandle`
-returned to the caller is plain data — `{ path, offset, hash }` — not an opaque
-runner-held token. Every effect is stateless and path-based, exactly like the existing
-`readBytes` / `writeFile` / `rename` effects in `fs/effects/node/module.f.ts`.
+The design needs **no `FileHandle` type** and no held OS resource — the uploader's state is
+plain data (`path`, `offset`, `hash`). Every effect is stateless and path-based, like the
+existing `readBytes` / `writeFile` / `rename` effects in `fs/effects/node/module.f.ts`.
 
 | Effect | Signature | Notes |
 |---|---|---|
-| `createExclusive` | `(path) => IoResult<void>` | `O_CREAT\|O_EXCL`. Creates a brand-new staging file at a `<deadline>-<random256>` name. `EEXIST` is a hard error (a 256-bit collision or a bug), not a retry signal. |
-| `writeBytes` | `(path, offset, data: Vec) => IoResult<void>` | The symmetric mirror of `readBytes`. Opens the **existing** file (no create), writes `data` at `offset`. `ENOENT` ⇒ the GC reclaimed this file ⇒ the writer lost its lease and must abort. Bounded to ≤128 KiB per call, matching `maxLengthBytes`. |
-| `rename` | `(src, dst) => IoResult<void>` | Already exists. Used both for **renew** (`<oldDeadline>-<rand>` → `<newDeadline>-<rand>`) and for **commit** (`_staging/...` → `.cas/<prefix>/<hash>`). |
-| `rm` | `(path) => IoResult<void>` | Already exists. Used for **abort** and by the GC. |
-| `stat` | `(path) => IoResult<{size, mtimeMs}>` | **New.** Used for **resume** (`offset = size`) and optional bookkeeping. `mtimeMs` is **not** required for correctness here — unlike `staging.md`, there is no open→lock gap to cover. |
-| `fsync` | `(path) => IoResult<void>` | **New.** Flushes a path to disk. On a **file** path it persists the data; on a **directory** path it persists that directory's entries (creations/renames) — the same `fsync(fd)` syscall on a directory fd. `commit` needs both: file data before the rename, and the destination directory after it (so the new shard entry survives a power loss). There is no such effect in the current node set. On Windows, a directory fsync has no exact equivalent; use a write-through rename (`MOVEFILE_WRITE_THROUGH`) to make the commit durable instead. |
-| `setReadonly` | `(path, readonly: bool) => IoResult<void>` | **New.** Sets (`true`) or clears (`false`) the read-only mark (`chmod 444`/`644` on POSIX; ReadOnly attribute on Windows). `commit` sets it after the rename; the **repair** path and the Windows overwrite-existing path clear it first so the rename can replace the destination. There is no such effect in the current node set. |
+| `createExclusive` | `(path) => IoResult<void>` | `O_CREAT\|O_EXCL`. Creates the staging file. With 256 random bits in the name `EEXIST` never happens in practice; it is just a sanity guard. |
+| `writeBytes` | `(path, offset, data: Vec) => IoResult<void>` | Mirror of `readBytes`. Opens the **existing** file (no create) and writes at `offset`. `ENOENT` ⇒ the GC already reclaimed this file ⇒ the upload failed; delete and restart. Bounded to ≤128 KiB per call. |
+| `rename` | `(src, dst) => IoResult<void>` | Already exists. Renews the lease (`…-<rand>` → a newer deadline) and publishes the shard (`_staging/…` → `.cas/<prefix>/<hash>`). |
+| `rm` | `(path) => IoResult<void>` | Already exists. Deletes a partial/aborted upload; also the GC's reclaim. |
+| `stat` | `(path) => IoResult<{size}>` | **New.** Used by resume to recover `offset = size`. |
 
-`createExclusive`, `writeBytes`, `stat`, `fsync`, and `setReadonly` are **new** effects to
-add to `fs/effects/node/module.f.ts`; `rename`, `rm`, and `mkdir` already exist (`commit`
-uses `mkdir({recursive})` to create missing shard-prefix directories, and `stat` to test
-whether the destination already exists). The set is still far smaller than the lock design's
-(no `FileHandle`, `openExclusive`, `appendHandle`, `commitHandle`, `abortHandle`, or
+`createExclusive`, `writeBytes`, and `stat` are **new**; `rename`, `rm`, and `mkdir` already
+exist. Marking a committed shard read-only (`chmod 444`) for immutability is an optional
+extra, not part of the core upload. The set is far smaller than the lock design's (no
+`FileHandle`, `openExclusive`, `appendHandle`, `commitHandle`, `abortHandle`, or
 `tryLockExclusive`).
-
-`O_EXCL` is **not** mutual exclusion (the random suffix already guarantees uniqueness).
-Its job is **mode discrimination**: creation must not find an existing file; appends must
-find one. This makes the create-vs-append state machine total and self-checking:
-
-- A "new upload" that hits `EEXIST` → fail loud rather than truncate live data.
-- An "append" that hits `ENOENT` → the fencing signal to abort.
 
 ## Write protocol
 
+The upload is deliberately simple. It covers the failures that actually happen — the upload
+is interrupted, the staging directory is missing, the process dies — and leaves the
+vanishingly rare ones (power loss in one specific window, exotic cross-platform races) to be
+**detected and repaired later by hash verification** (`scrub.md`), per the design philosophy.
+It does not try to be crash-atomic.
+
 ```
-WriteHandle = { path, offset, hash }   // plain data, no OS resource
+upload(stream, ttl):                          // returns the content hash (the CAS key)
+  rand     = random256()
+  deadline = now() + min(ttl, MAX)            // clamp so a bad clock cannot park a file far in the future
+  path     = `_staging/${fmt(deadline)}-${rand}`
+  mkdir(dirOf(path), {recursive})             // create _staging/ if absent (fresh store)
+  createExclusive(path)
 
-openWrite(ttl):
-  mkdir(`_staging`, {recursive})            // ensure the staging dir exists — on a fresh store it does
-                                            //   not, and createExclusive (O_CREAT|O_EXCL) creates only
-                                            //   the leaf file, so it would ENOENT without this
-  rand  = random256()
-  dl    = now() + ttl                      // or a writer-chosen far-future deadline
-  path  = `_staging/${fmt(dl)}-${rand}`
-  createExclusive(path)                     // EEXIST ⇒ bug, fail
-  return { path, offset: 0, hash: shaInit }
+  offset = 0
+  hash   = shaInit
+  for chunk in stream:
+      on any error below: rm(path); return uploadError      // partial upload ⇒ delete + fail
+      writeBytes(path, offset, chunk)          // ENOENT ⇒ GC already reclaimed us ⇒ error (handled above)
+      offset += len(chunk)
+      hash    = shaUpdate(hash, chunk)
+      // long uploads: occasionally rename path to a later deadline to keep the lease alive
+      // (see "The lease knob"). A write that ENOENTs means GC already took the file ⇒ fail.
 
-append(handle, chunk):
-  handle = maybeRenew(handle)               // pre-write: don't write into a near-dead lease
-  writeBytes(handle.path, handle.offset, chunk)   // ENOENT ⇒ lease lost ⇒ abort
-  handle = maybeRenew(handle)               // post-write: the successful write IS the progress
-                                            //   event (progress-coupled mode) — refresh now, or a
-                                            //   long gap after this chunk could expire a live,
-                                            //   progressing upload and have GC reclaim it
-  return { ...handle,
-           offset: handle.offset + len(chunk),
-           hash:   shaUpdate(handle.hash, chunk) }
-
-maybeRenew(handle):                          // lazy: avoid a rename on every chunk
-  if remaining(deadline(handle.path)) < threshold: return renew(handle)
-  return handle
-
-renew(handle):
-  newDl   = now() + ttl
-  newPath = `_staging/${fmt(newDl)}-${rand(handle.path)}`
-  rename(handle.path, newPath)              // ENOENT ⇒ GC reclaimed us ⇒ abort
-  return { ...handle, path: newPath }
-
-commit(handle, key?, mode = normal):
-  computedKey = shaFinal(handle.hash)       // 0. the address is ALWAYS the hash of the bytes we wrote
-  if key? and key != computedKey: return error  //   key-known/resume mismatch ⇒ caller bug or bad
-                                            //   resume state ⇒ refuse (never write under a wrong address)
-  fsync(handle.path)                        // 1. file data durable before the shard is visible
-  dst = `.cas/${shard(computedKey)}`        //    dst is derived from computedKey, not a trusted arg
-
-  if mode == normal and stat(dst) is ok:    // 2. fast path only — an optimization, not relied on
-      rm(handle.path); return ok            //    for correctness (see the rename handler below)
-
-  newDirs = mkdir(dirOf(dst), {recursive})  // 3. create any missing prefix dirs; record which were new
-  if mode == repair: setReadonly(dst, false)//    clear the bit so the rename can overwrite a corrupt shard
-
-  switch rename(handle.path, dst):          // 4. the rename is the atomic, authoritative point
-    ok:               break
-    ENOENT(source):   return error          //    lease lost ⇒ restart upload
-    EEXIST/EACCES(dst): // dst appeared/locked AFTER step 2 — concurrent same-hash commit (Windows)
-        if mode == normal: rm(handle.path); return ok       //    dedup success — resolve here, not at stat
-        if mode == repair:                                  //    corrupt dst was re-locked concurrently
-            setReadonly(dst, false)                         //    clear again and retry —
-            if rename(handle.path, dst) != ok: return error //    …but CHECK the retry; still locked or
-                                                            //    lease lost ⇒ fail, caller restarts
-    other:            return error          //    propagate any other rename error
-
-  fsync(dirOf(dst))                         // 5. persist the new file entry, BEFORE reporting
-  for d in newDirs (deepest → shallowest):  //    success — and persist every newly-created
-      fsync(parentOf(d))                    //    directory's own entry in its parent, or a crash
-                                            //    can still lose the prefix path (POSIX).
-  setReadonly(dst, true)                    // 6. chmod 444 / ReadOnly (durability of the bit
-                                            //    itself is not critical: strategy-1.md)
-  // POSIX rename replaces an existing dst silently, so the EEXIST/EACCES branch is Windows-only
-  // (ReadOnly dst ⇒ MoveFileEx access-denied). A write-through move (MOVEFILE_WRITE_THROUGH)
-  // can substitute for the dir fsyncs.
-
-abort(handle):
-  rm(handle.path)                           // ENOENT is fine — already reclaimed
+  key = shaFinal(hash)                          // the address IS the hash of the bytes written
+  dst = `.cas/${shard(key)}`
+  mkdir(dirOf(dst), {recursive})                // create the hash-prefix directories
+  rename(path, dst)                             // publish the shard
+  return key
 ```
 
-**The shard address is always the hash of the bytes actually written (step 0).** `commit`
-finalizes the accumulated hash and derives `dst` from *that*, never from a trusted argument.
-A `key` may still be passed for the key-known and resume paths, but it is only *checked*
-against `computedKey`, never used to place the file — so a caller bug or a bad resume state
-fails the commit instead of writing bytes under the wrong CAS address. This is what lets the
-read path (and `scrub.md`) trust the path as the checksum.
+Three things make this safe without extra machinery:
 
-**The destination-already-exists decision is made at the `rename` (step 4), not at the
-preflight `stat` (step 2).** The preflight stat is only a fast early-out; relying on it for
-correctness is a TOCTOU bug, because on Windows another writer can create and lock `dst`
-*between* our stat and our rename — and then a harmless concurrent same-hash upload would
-wrongly report failure. Resolving "dst exists" in the rename's error branch covers that race:
-in `normal` mode it is dedup success (the shard is already present — `rm` the staging file and
-return ok); in `repair` mode it clears the read-only bit and replaces.
+- **The key is computed, not supplied.** `key = shaFinal(hash)` over the bytes actually
+  written, and `dst` is derived from it — so bytes can never land under a wrong address. A
+  key-known caller passes its expected key only to *compare* and fail on mismatch.
+- **Errors fail closed.** Any error while streaming deletes the partial file and returns an
+  upload error; for a crash, the lease and the GC reclaim whatever is left behind. There is
+  nothing to undo and no half-published state.
+- **The rename just publishes.** If `dst` already exists, the CAS invariant says it is the
+  same bytes, so replacing it (POSIX renames over it) or skipping is equally fine. If that
+  existing shard were *corrupt*, that is a scrub/repair concern (`scrub.md`), not something
+  the hot upload path checks.
 
-**The `normal`-mode shortcut trusts the CAS invariant and is therefore only safe when the
-existing shard is assumed valid** — the ordinary dedup case. A scrub-driven **repair** commit
-(`scrub.md`) recommits a key *precisely because* the existing shard is corrupt, so it never
-trusts `dst`: it replaces the bytes. A caller that wants certainty rather than the fast path
-can run a **verifying** commit — re-hash `dst` and replace on mismatch — at the cost of an
-O(size) re-read of the existing shard.
+**Explicit offset, not `O_APPEND`.** Keeping the offset makes a write idempotent — a transient
+`writeBytes` error can be retried with the same bytes at the same offset with no double-append
+(`appendBytes(path, data)` would just be `writeBytes(path, stat(path).size, data)`).
 
-By default the staging file's data and its directory entry are **not** fsynced on
-`createExclusive`/`writeBytes`/`renew`: a staging file lost to a crash before commit just
-restarts the upload (fail-safe), so only `commit` — the point where success is acknowledged
-— forces durability (the file data, the destination directory entry, and any newly-created
-ancestor directory entries, all persisted before returning).
-
-That default trades durability of *in-progress* work for speed, which is fine for a
-disposable upload but is in tension with the reboot-survivable resume claim below. A lease
-that must survive a **power loss** (not just a process exit) needs an **optional fsync
-cadence**: periodically — e.g. at each `renew` — fsync the staging file's data and the
-`_staging/` directory entry, so the partial bytes and the current deadline name are durable.
-This is the durability counterpart of the lease-length knob: an uploader that pre-assigns a
-long lease *because it needs the document* should also opt into the fsync cadence. Without
-it, resume is scoped to clean restarts (see *Reboot-survivable resume*).
-
-`append` writes at an **explicit offset** rather than `O_APPEND`. This makes every write
-idempotent: a transient failure can be retried with the same bytes at the same offset
-without risk of a double-append diverging the file from the in-memory hash state. An
-`appendBytes(path, data)` convenience is just `writeBytes(path, stat(path).size, data)`,
-but the offset belongs in the primitive.
+**Durability is best-effort by design.** The hot path does not `fsync`. A power loss that
+loses a just-published shard, or a partial upload, is rare and self-correcting: a lost partial
+restarts, and a lost shard is detected by hash verification and re-fetched (`scrub.md`).
+Paying a per-chunk or per-commit fsync tax to shrink an already-tiny probability is exactly
+the trade-off this design declines to make.
 
 ## Why it is safe (the fencing argument)
 
@@ -274,32 +202,21 @@ that a cleaner which skips `tryLockExclusive` *silently corrupts* active POSIX w
 
 ## Garbage collection
 
-GC reclaims a file whose deadline is either in the past (expired) **or** absurdly far in
-the future (beyond the `now + MAX` lease cap — a buggy or wrong-clock writer; see *Cap the
-maximum lease*). Because names sort chronologically, expired files form a **prefix** of the
-sorted listing and over-cap files form a **suffix**, with the live leases in the middle. GC
-reclaims from both ends and stops as soon as it reaches a live lease, so it never has to
-examine the middle:
+GC reclaims any file whose deadline is in the past. Because names sort chronologically, the
+expired files are a **prefix** of the sorted listing, so the scan stops at the first live
+lease:
 
 ```
-gc(now, MAX):
-  names = sort(readdir(`_staging/`))         // lexical sort = chronological
-  for name in names:                         // front → back: expired prefix
+gc(now):
+  for name in sort(readdir(`_staging/`)):    // lexical sort = chronological
       if deadline(name) < now: rm(`_staging/${name}`)   // ENOENT is fine
-      else: break
-  for name in reverse(names):                // back → front: over-cap suffix
-      if deadline(name) > now + MAX: rm(`_staging/${name}`)
-      else: break
+      else: break                            // the rest are still live
 ```
 
-A single early `break` on the front alone would be wrong: an absurd far-future name sorts
-*after* the normal future leases, so the front scan would stop before ever reaching it and
-the cap would never be enforced — the space would leak until that date. The back scan closes
-that gap. (A plain full scan is also correct; the directory listing is already O(n). The
-two-ended form just preserves the skip-the-middle optimization.)
-
-GC can run lazily (piggy-backed on `openWrite`) rather than as a daemon, since staging
-space reclamation is not urgent.
+There is no separate "far-future" case to worry about: the deadline is clamped to `now + MAX`
+when the file is created (see the write protocol), so a wrong clock cannot park a file beyond
+the cap in the first place. GC can run lazily — piggy-backed on an upload — rather than as a
+daemon, since staging space reclamation is not urgent.
 
 ### Manual / degraded-mode GC
 
@@ -372,19 +289,14 @@ Resume cost is O(bytes-so-far) because SHA-2 is not seekable and the hash state 
 rebuilt from disk. This is acceptable for the sizes involved and is the only non-O(1) part
 of the design.
 
-**Two reboot classes, two guarantees.** A *clean* restart — process exit or graceful reboot
-where the OS flushes its buffers — preserves the staging file and its name without any extra
-work, so resume is reliable. A *power loss* is different: with the default no-fsync staging
-path, the most recent `writeBytes` data, the latest `renew` rename, or even the staging
-directory entry may not have reached disk, so on reboot the file can be missing, rolled back
-to an older (now-expired) name, or truncated. Resume stays **fail-safe** regardless — step 3
-re-derives `size` and the hash from whatever *durably* survived, so it never resumes onto
-wrong bytes; it simply continues from the last durable offset or, in the worst case, restarts.
-But turning power-loss survival from "best-effort" into a *guarantee* requires the optional
-fsync cadence described under the write protocol (fsync the staging data + `_staging/` entry
-at each renew). In short: clean restarts resume for free; power-loss-durable resume is the
-long-lease writer's opt-in, consistent with the design's "you choose your own strategy"
-contract.
+Resume is **best-effort**, like everything else here. A clean restart (process exit or
+graceful reboot) preserves the staging file and its name, so resume just works. A power loss
+may lose the most recent bytes or the latest rename — in which case resume re-derives `size`
+and the hash from whatever durably survived and continues, or, in the worst case, the file is
+gone and the upload simply restarts. Either way nothing corrupts: the bytes under the final
+hash are always what was hashed. We do not add an fsync cadence to make power-loss survival a
+hard guarantee — that is the kind of low-probability hardening this design deliberately skips,
+leaving the rare lost shard to hash verification (`scrub.md`).
 
 ## Distributed and remote staging
 
@@ -412,32 +324,14 @@ deadline; two claimants race the atomic rename, one wins, the other gets `ENOENT
 off. **The lease token doubles as the distributed mutual-exclusion primitive**: the same
 rename that detects crashes also transfers ownership.
 
-What the rename does **not** do is quiesce a previous holder that is mid-write. The fence
-protects *path lookups*: once renamed, no one can `open` the old name. But on POSIX/NFS an
-fd a stale holder opened **before** the rename still refers to the same inode, so an
-in-flight `writeBytes` (its internal `open`+`pwrite`) can land *after* the claimant has
-renamed, statted, and re-hashed the file. The claimant would then commit a shard whose
-bytes changed after its hash state was built — a CAS corruption. There are two safe
-takeover modes:
-
-- **Discard-and-restart (default).** The claimant does **not** inherit bytes. It starts a
-  fresh staging file under its own `<deadline>-<random256>` identity and re-uploads. This
-  collapses into the competitive pattern below, is trivially correct (no shared inode, no
-  race), and is fully in the design's spirit — the worst case is wasted work.
-- **Inherit-with-quiescence (optimization).** To reuse the partial bytes, the claimant must
-  (1) after winning the rename, wait a **quiescence grace** longer than the maximum possible
-  duration of a single in-flight `writeBytes` before it stats/re-hashes — by then any
-  straddling write has landed and no new one can start, because the stale holder's next
-  `writeBytes` opens the now-gone old name and fails `ENOENT`; **and** (2) verify
-  end-to-end at commit — re-hash the finished file from disk and compare it to `key` before
-  the rename — so that if the grace is ever mis-sized the mismatch is caught and the upload
-  restarts rather than committing bad bytes. (For an inherited file the claimant is already
-  re-reading to rebuild hash state, so this verification largely overlaps work it must do
-  anyway.)
-
-Either way, machine-to-machine takeover otherwise works like reboot-resume: the stable
-`random256` identity locates the file, and (in inherit mode) re-hash-from-disk rebuilds
-`{offset, hash}`.
+Takeover is **discard-and-restart**: the claimant does not inherit the stalled file's bytes,
+it just starts a fresh upload under its own `<deadline>-<random256>` identity. This is
+trivially correct — no shared file, no in-flight-write race to reason about — and collapses
+into the competitive pattern below; the worst case is that the partial bytes are thrown away.
+(Inheriting a stalled holder's partial bytes is *not* safe to do casually: a fencing rename
+moves the name but does not stop a previous holder's still-open fd from completing a write
+into the same inode, so a naive resume could hash bytes that then change. Since the whole
+point is to keep this simple, we don't inherit — we re-upload.)
 
 ### Skew and partition cost throughput, not safety
 
@@ -464,9 +358,10 @@ exception.
 - **Object stores (S3/GCS) are not POSIX** — no atomic rename, no `O_EXCL`. The
   deadline-in-name *idea* ports to their conditional-write / `If-None-Match` compare-and-set
   primitives, but that is a distinct mapping, not the same syscalls.
-- **Durability is the server's.** `commit`'s fsync-before-rename relies on the server
-  actually flushing; network-FS durability and cache-coherence guarantees are weaker and
-  must be verified for the target filesystem.
+- **Durability is the server's.** The upload path does not fsync, so a network-FS or server
+  crash can lose a partial upload or a just-published shard; the partial restarts and the lost
+  shard is caught by hash verification (`scrub.md`). Cache-coherence guarantees vary by
+  filesystem and should be checked for the target.
 
 ## Renewal policy: detecting stalls, not just deaths
 
@@ -496,17 +391,12 @@ This enables two patterns for free:
   stragglers automatically. *Concretely:* of two uploaders, one keeps receiving parts and
   renews its name while the other is stuck and cannot, so the GC removes the stuck one and
   the healthy one wins. The loser's partial bytes are simply discarded.
-- **True failover on one partial upload.** A healthy uploader takes over a stalled holder's
-  partial file via the fencing rename. By default this is **discard-and-restart** (a fresh
-  identity), which is exactly the competitive case. Reusing the partial bytes
-  (`resume from offset = size`) is possible but requires the **inherit-with-quiescence**
-  discipline from *Cross-machine handoff* — the fencing rename alone does not stop a stale
-  holder's in-flight `writeBytes` from mutating the inherited inode, so a naive resume can
-  commit corrupted bytes.
+- **Failover on a stalled upload.** A healthy uploader takes over by starting its own fresh
+  upload of the same content; the stalled one's lease expires and the GC reclaims it. This is
+  **discard-and-restart** — the same as the competitive case — and needs no coordination.
 
-The difference is only whether the `random256` identity is shared: independent identities
-give competitive redundancy (loser's bytes discarded); a shared identity *can* give
-resumable failover, but only with the quiescence + commit-verification safeguards above.
+In both patterns the stalled uploader's partial bytes are simply discarded; we never inherit
+a stalled file's bytes (see *Cross-machine handoff*).
 
 ### The slow-vs-stuck threshold
 
@@ -526,19 +416,18 @@ a misjudged-slow uploader restarts or hands off, never corrupts.
   kept or reclaimed is a deliberate choice of renewal policy (see *Renewal policy: detecting
   stalls, not just deaths*): a background heartbeat tolerates stalls; progress-coupled
   renewal reclaims them.
-- **Cap the maximum lease.** A buggy or wrong-clock writer can stamp an absurd far-future
-  deadline and leak space indefinitely. The GC should enforce `deadline ≤ now + MAX`
-  (reclaim or reject beyond the cap). The cap bounds the leak but also bounds how long a
-  legitimate long upload can pre-reserve, so it should be configurable.
+- **Cap the maximum lease.** The deadline is clamped to `now + MAX` when the file is created
+  (write protocol), so a buggy or wrong-clock writer cannot park a file far in the future and
+  leak space. `MAX` bounds how long a legitimate long upload can pre-reserve, so it should be
+  configurable.
 - **Wall-clock dependence.** Deadlines are wall-clock. On a single host (writer and GC
   share the clock) this is fine; NTP steps and suspend/resume are edge cases. Across hosts
   (see *Distributed and remote staging*) skew costs efficiency but not safety, *provided*
   the shared filesystem supplies atomic `O_EXCL` create, `rename`, and `unlink` — those
   atomic primitives, not clock agreement, are what the fencing rests on.
-- **`writeBytes` must never create.** Append/resume open the existing file only. Allowing
-  create on the append path would let a reclaimed file be resurrected as a sparse file with
-  a hole at offset 0 — silent corruption. Exclusive create happens exactly once, at
-  `openWrite`.
+- **`writeBytes` must never create.** It opens the existing file only. Allowing create on the
+  write path would let a reclaimed file be resurrected as a sparse file with a hole at offset
+  0 — silent corruption. Exclusive create happens exactly once, when the upload starts.
 
 ## Comparison with the lock design (`staging.md`)
 
@@ -548,7 +437,7 @@ a misjudged-slow uploader restarts or hands off, never corrupts.
 | Liveness truth | Hard (OS-truthful) | Soft (timing assumption), but **fails safe** |
 | POSIX/Windows | Asymmetric (advisory vs. hard) | Identical |
 | Open→acquire race | Real → mandatory mtime grace period | None (atomic `O_EXCL` create) |
-| `FileHandle` type / held fd | Required | None — `WriteHandle` is plain data |
+| `FileHandle` type / held fd | Required | None — the handle is plain data (path/offset/hash) |
 | Cleaner protocol | `tryLockExclusive`, hold handle during delete | `rm` files with past deadlines |
 | Manual `rm` in `_staging/` | Silently corrupts active writes on POSIX | Safe — worst case is a restarted upload |
 | Slow-but-alive writer | Never reclaimed | May be reclaimed (fails safe) |

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -18,9 +18,13 @@ The motivation is threefold:
 2. **Platform symmetry.** The protocol is byte-for-byte identical on POSIX and Windows.
    There is no advisory-vs-hard asymmetry, no open→lock race, and therefore no mandatory
    mtime grace period.
-3. **Reboot-survivable uploads.** A lock is process-bound: a reboot drops it and the file
-   looks orphaned. A deadline in a durable filename is process-independent, so an upload
-   can survive a reboot and resume — a capability the lock design structurally cannot have.
+3. **Reboot-survivable uploaders are possible.** A lock is process-bound: a reboot drops it
+   and the file looks orphaned. A deadline in a durable filename is process-independent, so
+   the *design* admits uploaders that survive a reboot and resume — a capability the lock
+   design structurally cannot have. The GC tolerates many uploaders of different sophistication
+   at once; the **baseline uploader specified here is deliberately the simplest one** and does
+   not itself resume (a failed upload just restarts). Resume is an optional uploader feature
+   (see *Future optimizations*), not a guarantee of the baseline.
 
 ## Core idea
 
@@ -137,9 +141,10 @@ It does not try to be crash-atomic.
 ```
 upload(stream):                               // returns the content hash (the CAS key)
   rand    = random256()
-  newPath = () => `_stage/${fmt(now() + delta)}-${rand}`   // delta is a fixed constant
+  // all paths are under the store root `.cas/` (e.g. `~/.cas/`); shard(key) is `<prefix>/<hash>`
+  newPath = () => `.cas/_stage/${fmt(now() + delta)}-${rand}`   // delta is a fixed constant
 
-  mkdir(`_stage`, {recursive})              // create _stage/ if absent (fresh store)
+  mkdir(`.cas/_stage`, {recursive})         // create .cas/_stage/ if absent (fresh store)
   path = newPath()
   createExclusive(path)
 
@@ -155,7 +160,7 @@ upload(stream):                               // returns the content hash (the C
       path = next
 
   key = shaFinal(hash)                          // the address IS the hash of the bytes written
-  dst = `.cas/${shard(key)}`
+  dst = `.cas/${shard(key)}`                    // `.cas/<prefix>/<hash>` (never `.cas/.cas/...`)
   mkdir(dirOf(dst), {recursive})                // create the hash-prefix dirs — ignore the result
   rename(path, dst)                             // publish                      — ignore the result
   rm(path)                                      // remove our staging file if still there — ignore the result

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -115,7 +115,7 @@ existing `readBytes` / `writeFile` / `rename` effects in `fs/effects/node/module
 | Effect | Signature | Notes |
 |---|---|---|
 | `createExclusive` | `(path) => IoResult<void>` | `O_CREAT\|O_EXCL`. Creates the staging file. With 256 random bits in the name `EEXIST` never happens in practice; it is just a sanity guard. |
-| `writeBytes` | `(path, offset, data: Vec) => IoResult<void>` | Mirror of `readBytes`. Opens the **existing** file (no create) and writes at `offset`. `ENOENT` ⇒ the GC already reclaimed this file ⇒ the upload failed; delete and restart. Bounded to ≤128 KiB per call. |
+| `writeBytes` | `(path, offset, data: Vec) => IoResult<void>` | Mirror of `readBytes`. Opens the **existing** file (no create) and writes at `offset`. Writes the **entire** `Vec` or returns an error — no partial writes (the runner loops over short writes), so the later size check can't pass over a hole. `ENOENT` ⇒ the GC already reclaimed this file ⇒ the upload failed; delete and restart. Bounded to ≤128 KiB per call. |
 | `rename` | `(src, dst) => IoResult<void>` | Already exists. Publishes the shard (`_staging/…` → `.cas/<prefix>/<hash>`) and renews the lease (`…-<rand>` → a newer deadline). Replace-on-existing is fine — same hash ⇒ same bytes. |
 | `rm` | `(path) => IoResult<void>` | Already exists. Deletes a partial/aborted upload; also the GC's reclaim. |
 | `stat` | `(path) => IoResult<{size}>` | **New.** Used at the end of `upload` to confirm the published shard exists with the expected size, and by resume to recover `offset = size`. |
@@ -172,15 +172,15 @@ Three things make this safe without extra machinery:
   upload error; for a crash, the lease and the GC reclaim whatever is left behind. There is
   nothing to undo and no half-published state.
 - **Publish ignores results and checks the end state.** The three publish steps — `mkdir -p`
-  the prefix dirs, `rename`, then `rm` the staging file — all run best-effort with their
-  results ignored. Success is decided afterward by *observing* the target: it exists and its
-  size equals the bytes we received. This needs no branching on platform rename semantics and
-  no dedup special-case: if `dst` already existed, the same hash means the same size, so the
-  check passes regardless of whether the rename replaced it or was a no-op; if `dst` is
-  missing or truncated, the size check fails and we report an upload error. We compare *size*,
-  not hash — a cheap stat, not a re-read — because a wrong-sized file is a real failure to
-  catch now, while a same-sized-but-corrupt shard is the rare case left to hash verification
-  (`scrub.md`), never the hot path.
+  the prefix dirs, `rename` (which **replaces** an existing `dst`), then `rm` the staging file
+  — all run best-effort with their results ignored. Success is decided afterward by *observing*
+  the target: it exists and its size equals the bytes we received. This needs no branching on
+  platform rename semantics and no dedup special-case. Because the rename replaces, a re-upload
+  of the same content overwrites whatever was at `dst` with our freshly-written bytes — so it
+  also *repairs* a same-sized corrupt shard for free, rather than skipping it. We compare
+  *size*, not hash — a cheap stat, not a re-read — because a wrong-sized file is a real failure
+  to catch now, while a shard that was already same-sized-but-corrupt *before* this upload is
+  the rare case left to hash verification (`scrub.md`), never the hot path.
 
 **Renewing every chunk keeps `delta` constant.** Renaming to a fresh `now() + delta` after each
 chunk means `delta` only has to cover the gap between two consecutive chunks, not the whole

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -155,7 +155,10 @@ upload(stream, ttl):                          // returns the content hash (the C
   key = shaFinal(hash)                          // the address IS the hash of the bytes written
   dst = `.cas/${shard(key)}`
   mkdir(dirOf(dst), {recursive})                // create the hash-prefix directories
-  rename(path, dst)                             // publish the shard
+  if exists(dst):                               // already present ⇒ dedup. Do NOT validate its hash.
+      rm(path)                                  //   delete our staging file, ignore the result,
+      return key                                //   and return success.
+  rename(path, dst)                             // otherwise publish the shard
   return key
 ```
 
@@ -167,10 +170,11 @@ Three things make this safe without extra machinery:
 - **Errors fail closed.** Any error while streaming deletes the partial file and returns an
   upload error; for a crash, the lease and the GC reclaim whatever is left behind. There is
   nothing to undo and no half-published state.
-- **The rename just publishes.** If `dst` already exists, the CAS invariant says it is the
-  same bytes, so replacing it (POSIX renames over it) or skipping is equally fine. If that
-  existing shard were *corrupt*, that is a scrub/repair concern (`scrub.md`), not something
-  the hot upload path checks.
+- **An existing destination is success.** If `dst` already exists, the upload is done — by
+  the CAS invariant it is the same bytes. We do **not** validate the existing shard's hash;
+  we just delete our staging file (ignoring the delete result) and return the key. If that
+  existing shard were *corrupt*, detecting and repairing it is a scrub concern (`scrub.md`),
+  never something the hot upload path checks.
 
 **Explicit offset, not `O_APPEND`.** Keeping the offset makes a write idempotent — a transient
 `writeBytes` error can be retried with the same bytes at the same offset with no double-append

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -27,7 +27,7 @@ The motivation is threefold:
 A staging file's name carries its own expiry:
 
 ```
-.cas/_staging/<deadline>-<random256>
+.cas/_stage/<deadline>-<random256>
 ```
 
 - **`<deadline>`** — a wall-clock expiry, formatted so that lexical order equals
@@ -54,7 +54,7 @@ them.
 its own lease strategy, and they need not agree. One holding an important document over a
 flaky connection can pre-assign a long lease up front; a routine uploader can take a short
 lease and renew on progress; a pool of hedged uploaders can all take short leases and race.
-These strategies coexist in one `_staging/` directory with **no coordination**, because the
+These strategies coexist in one `_stage/` directory with **no coordination**, because the
 only thing an uploader communicates to the GC is a single number — the deadline in the
 filename. There is no registry, no negotiation, no shared state to keep consistent.
 
@@ -96,7 +96,7 @@ not a per-client choice: **fixed-width, zero-padded UTC epoch milliseconds**.
 
 The format must be canonical because the GC's oldest-first scan relies on expired files
 forming one contiguous lexical *prefix* (and over-cap files one *suffix*). Mixing encodings
-in the same `_staging/` breaks that invariant: every `0000…` epoch name sorts before, say,
+in the same `_stage/` breaks that invariant: every `0000…` epoch name sorts before, say,
 a `2026…` ISO stamp regardless of its actual deadline, so the front scan could stop on a
 live epoch file while expired ISO files sit unreclaimed after it. One encoding, fixed width,
 for every writer — no alternative spellings.
@@ -116,7 +116,7 @@ existing `readBytes` / `writeFile` / `rename` effects in `fs/effects/node/module
 |---|---|---|
 | `createExclusive` | `(path) => IoResult<void>` | `O_CREAT\|O_EXCL`. Creates the staging file. With 256 random bits in the name `EEXIST` never happens in practice; it is just a sanity guard. |
 | `writeBytes` | `(path, offset, data: Vec) => IoResult<void>` | Mirror of `readBytes`. Opens the **existing** file (no create) and writes at `offset`. Writes the **entire** `Vec` or returns an error — no partial writes (the runner loops over short writes), so the later size check can't pass over a hole. `ENOENT` ⇒ the GC already reclaimed this file ⇒ the upload failed; delete and restart. Bounded to ≤128 KiB per call. |
-| `rename` | `(src, dst) => IoResult<void>` | Already exists. Publishes the shard (`_staging/…` → `.cas/<prefix>/<hash>`) and renews the lease (`…-<rand>` → a newer deadline). Replace-on-existing is fine — same hash ⇒ same bytes. |
+| `rename` | `(src, dst) => IoResult<void>` | Already exists. Publishes the shard (`_stage/…` → `.cas/<prefix>/<hash>`) and renews the lease (`…-<rand>` → a newer deadline). Replace-on-existing is fine — same hash ⇒ same bytes. |
 | `rm` | `(path) => IoResult<void>` | Already exists. Deletes a partial/aborted upload; also the GC's reclaim. |
 | `stat` | `(path) => IoResult<{size}>` | **New.** Used at the end of `upload` to confirm the published shard exists with the expected size, and by resume to recover `offset = size`. |
 
@@ -137,9 +137,9 @@ It does not try to be crash-atomic.
 ```
 upload(stream):                               // returns the content hash (the CAS key)
   rand    = random256()
-  newPath = () => `_staging/${fmt(now() + delta)}-${rand}`   // delta is a fixed constant
+  newPath = () => `_stage/${fmt(now() + delta)}-${rand}`   // delta is a fixed constant
 
-  mkdir(`_staging`, {recursive})              // create _staging/ if absent (fresh store)
+  mkdir(`_stage`, {recursive})              // create _stage/ if absent (fresh store)
   path = newPath()
   createExclusive(path)
 
@@ -226,8 +226,8 @@ lease:
 
 ```
 gc(now):
-  for name in sort(readdir(`_staging/`)):    // lexical sort = chronological
-      if deadline(name) < now: rm(`_staging/${name}`)   // ENOENT is fine
+  for name in sort(readdir(`_stage/`)):    // lexical sort = chronological
+      if deadline(name) < now: rm(`_stage/${name}`)   // ENOENT is fine
       else: break                            // the rest are still live
 ```
 
@@ -240,11 +240,11 @@ is not urgent.
 
 ### Manual / degraded-mode GC
 
-A key property of this design: **no manual action in `_staging/` can corrupt a committed
-shard.** Nothing in `_staging/` is ever a shard, and any deletion of an active file is
+A key property of this design: **no manual action in `_stage/` can corrupt a committed
+shard.** Nothing in `_stage/` is ever a shard, and any deletion of an active file is
 caught by the writer via `ENOENT` (worst case: the upload restarts). Therefore:
 
-- A human can `ls _staging/`, read the deadline prefix as a wall-clock time, and delete
+- A human can `ls _stage/`, read the deadline prefix as a wall-clock time, and delete
   anything in the past — no special tooling, no lock-aware cleaner, no platform branch.
 - The same `ls` + `rm` procedure works identically on POSIX and Windows.
 - Even a blunt "delete the first half of the sorted list" under space pressure is **safe**
@@ -286,6 +286,14 @@ to be added only behind a real, measured need.
   window can lose a partial upload or a just-published shard, and scrub repairs the rare lost
   shard later. A writer that needs a hard durability guarantee could `fsync` the file and the
   destination directory before returning, at a latency cost.
+- **Verify-on-publish (turn replace into a guaranteed repair).** The baseline reports success
+  from the size check, and its replace-`rename` overwrites `dst` with the freshly-written
+  bytes — so a re-upload normally *repairs* a corrupt same-sized shard for free. The residual
+  gap: if that `rename` ever fails or no-ops over a pre-existing same-sized **corrupt** shard,
+  the size check still passes and we return success without having replaced the bad bytes. A
+  verifying publish could confirm the rename actually installed our bytes (or re-hash `dst`)
+  before returning `ok`, at an `O(size)` re-read cost — closing that gap instead of leaving it
+  to scrub.
 - **Resumable / reboot-survivable uploads.** The baseline restarts a failed upload from
   scratch. A resume could instead re-hash the surviving staging bytes (`offset = stat(path).size`)
   and continue — surviving a reboot or handing the upload to another process. See
@@ -298,7 +306,7 @@ to be added only behind a real, measured need.
   policy: detecting stalls*.
 - **Clock-skew / far-future leak handling.** With a fixed `delta` a healthy deadline is at most
   `now + delta`, but a grossly wrong clock could park a single staging file far in the future
-  and leak it. A periodic max-age sweep (delete `_staging/` entries whose deadline is absurdly
+  and leak it. A periodic max-age sweep (delete `_stage/` entries whose deadline is absurdly
   far ahead) would reclaim it; the baseline leaves this rare case to manual cleanup.
 
 The sections that follow document several of these extensions in detail. They are reference
@@ -366,7 +374,7 @@ replaces it with primitives a **shared filesystem already provides**, plus a clo
 - atomic `unlink` — GC and abort
 - a wall-clock deadline — liveness
 
-So `_staging/` can live on a remote/shared disk (e.g. an NFS export) and be driven by
+So `_stage/` can live on a remote/shared disk (e.g. an NFS export) and be driven by
 uploaders running on **several machines at once**. The stateless `writeBytes` model is, if
 anything, *more* network-FS-friendly than a held-handle model: NFS's weak spots are all
 around open file state (silly-rename on unlink-while-open, lock recovery after a server
@@ -493,7 +501,7 @@ a misjudged-slow uploader restarts or hands off, never corrupts.
 | Open→acquire race | Real → mandatory mtime grace period | None (atomic `O_EXCL` create) |
 | `FileHandle` type / held fd | Required | None — the handle is plain data (path/offset/hash) |
 | Cleaner protocol | `tryLockExclusive`, hold handle during delete | `rm` files with past deadlines |
-| Manual `rm` in `_staging/` | Silently corrupts active writes on POSIX | Safe — worst case is a restarted upload |
+| Manual `rm` in `_stage/` | Silently corrupts active writes on POSIX | Safe — worst case is a restarted upload |
 | Slow-but-alive writer | Never reclaimed | May be reclaimed (fails safe) |
 | Abandoned/leaked by a live process | File pinned for the process's lifetime | Reclaimed at the deadline |
 | Cleanup on abort | Mandatory — missed release leaks the file | Optional — self-heals after the deadline |
@@ -505,7 +513,7 @@ a misjudged-slow uploader restarts or hands off, never corrupts.
 
 The same migration note from `staging.md` applies: `casUpload` (`fs/cas/module.f.ts`)
 currently stages into `.cas/.stage/` and would be unaffected by a lease GC scanning
-`_staging/`. Migrating `casUpload` to write `<deadline>-<random256>` names under
-`_staging/` brings it under one GC scope. Unlike the lock design, the lease has no mtime
+`_stage/`. Migrating `casUpload` to write `<deadline>-<random256>` names under
+`_stage/` brings it under one GC scope. Unlike the lock design, the lease has no mtime
 dependency, so the `rename`-preserves-mtime hazard described in `staging.md` does not
 apply here — a migrated `casUpload` only needs to stamp a fresh deadline into the name.

--- a/issues/cas/staging-lease.md
+++ b/issues/cas/staging-lease.md
@@ -118,7 +118,7 @@ existing `readBytes` / `writeFile` / `rename` effects in `fs/effects/node/module
 | `writeBytes` | `(path, offset, data: Vec) => IoResult<void>` | Mirror of `readBytes`. Opens the **existing** file (no create) and writes at `offset`. `ENOENT` ⇒ the GC already reclaimed this file ⇒ the upload failed; delete and restart. Bounded to ≤128 KiB per call. |
 | `rename` | `(src, dst) => IoResult<void>` | Already exists. Publishes the shard (`_staging/…` → `.cas/<prefix>/<hash>`) and renews the lease (`…-<rand>` → a newer deadline). Replace-on-existing is fine — same hash ⇒ same bytes. |
 | `rm` | `(path) => IoResult<void>` | Already exists. Deletes a partial/aborted upload; also the GC's reclaim. |
-| `stat` | `(path) => IoResult<{size}>` | **New.** Used by resume to recover `offset = size`. |
+| `stat` | `(path) => IoResult<{size}>` | **New.** Used at the end of `upload` to confirm the published shard exists with the expected size, and by resume to recover `offset = size`. |
 
 `createExclusive`, `writeBytes`, and `stat` are **new**; `rename`, `rm`, and `mkdir` already
 exist. Marking a committed shard read-only (`chmod 444`) for immutability is an optional
@@ -154,9 +154,11 @@ upload(stream, ttl):                          // returns the content hash (the C
 
   key = shaFinal(hash)                          // the address IS the hash of the bytes written
   dst = `.cas/${shard(key)}`
-  mkdir(dirOf(dst), {recursive})                // create the hash-prefix directories
-  rename(path, dst)                             // publish — replace is fine (see below)
-  return key
+  mkdir(dirOf(dst), {recursive})                // create the hash-prefix dirs — ignore the result
+  rename(path, dst)                             // publish                      — ignore the result
+  rm(path)                                      // remove our staging file if still there — ignore the result
+  if stat(dst).size == offset: return ok(key)   // success iff the target exists with the expected size
+  else:                        return uploadError
 ```
 
 Three things make this safe without extra machinery:
@@ -167,12 +169,16 @@ Three things make this safe without extra machinery:
 - **Errors fail closed.** Any error while streaming deletes the partial file and returns an
   upload error; for a crash, the lease and the GC reclaim whatever is left behind. There is
   nothing to undo and no half-published state.
-- **Publish is just a rename, replace and all.** It does not matter whether `dst` already
-  exists: by the CAS invariant the bytes are the same, so overwriting it with our
-  freshly-written-and-hashed file is harmless — if anything our copy is *less* likely to be
-  corrupt, since it was just hashed end to end. So there is no `exists` check and no special
-  dedup branch; we rename and return the key. Whichever shard ends up on disk, a corrupt one
-  is detected and repaired later by hash verification (`scrub.md`), never on the hot path.
+- **Publish ignores results and checks the end state.** The three publish steps — `mkdir -p`
+  the prefix dirs, `rename`, then `rm` the staging file — all run best-effort with their
+  results ignored. Success is decided afterward by *observing* the target: it exists and its
+  size equals the bytes we received. This needs no branching on platform rename semantics and
+  no dedup special-case: if `dst` already existed, the same hash means the same size, so the
+  check passes regardless of whether the rename replaced it or was a no-op; if `dst` is
+  missing or truncated, the size check fails and we report an upload error. We compare *size*,
+  not hash — a cheap stat, not a re-read — because a wrong-sized file is a real failure to
+  catch now, while a same-sized-but-corrupt shard is the rare case left to hash verification
+  (`scrub.md`), never the hot path.
 
 **Explicit offset, not `O_APPEND`.** Keeping the offset makes a write idempotent — a transient
 `writeBytes` error can be retried with the same bytes at the same offset with no double-append

--- a/issues/cas/staging.md
+++ b/issues/cas/staging.md
@@ -2,10 +2,10 @@
 
 ## Purpose
 
-Files written to `.cas/_staging/` are work-in-progress uploads. The final hash
+Files written to `.cas/_stage/` are work-in-progress uploads. The final hash
 (and therefore the final shard path) is not known until the full stream has been
 consumed, so the file must live somewhere temporary while data accumulates. The
-`_staging/` directory serves that role.
+`_stage/` directory serves that role.
 
 A staging file is created by `openExclusive`, written incrementally by
 `appendHandle`, and either promoted to its final path by `commitHandle` (rename +
@@ -40,7 +40,7 @@ On POSIX, `flock` is a **cooperative advisory** mechanism. It has no effect on
   the path is gone.
 
 This means a cleaner that naively calls `unlink` on everything it finds in
-`_staging/` will silently delete active staging files on POSIX. The writer
+`_stage/` will silently delete active staging files on POSIX. The writer
 continues writing to the now-unnamed inode — `appendHandle` succeeds — but
 `commitHandle`'s rename step fails with `ENOENT` because the source path no
 longer exists. The committed file is never written; the data is lost.
@@ -135,11 +135,11 @@ read-only bit is missing.
 
 ## Cleaning scope
 
-Only files under `.cas/_staging/` are eligible for cleaning. Committed shard
+Only files under `.cas/_stage/` are eligible for cleaning. Committed shard
 files under `.cas/<prefix>/` are permanent, immutable, and never cleaned.
 
-The `_` prefix ensures `_staging/` is excluded from the `list` operation, which
-validates each directory name via `cBase32ToVec` and would reject `_staging` as
+The `_` prefix ensures `_stage/` is excluded from the `list` operation, which
+validates each directory name via `cBase32ToVec` and would reject `_stage` as
 an invalid base-32 prefix anyway.
 
 ## Compatibility with the existing `casUpload` path
@@ -150,16 +150,16 @@ ad-hoc staging directory that predates the formal Strategy 1 design and does not
 follow the `tryLockExclusive` cleaning protocol — it creates per-upload temp files
 but holds no persistent flock.
 
-The formal design uses `_staging/` because:
+The formal design uses `_stage/` because:
 - The `_` prefix is the project convention for non-hash directories (excluded by
   `list` via `cBase32ToVec`).
 - `.stage/` uses a dot prefix, which is valid on POSIX but can conflict with hidden
   directory conventions and is less clearly "internal infrastructure."
 
-During the transition, a cleaner implementing Strategy 1 would scan `_staging/` and
+During the transition, a cleaner implementing Strategy 1 would scan `_stage/` and
 miss any orphans left by `casUpload` in `.stage/`. Two options:
 
-1. **Migrate `casUpload`** to write into `_staging/` so all staging files share one
+1. **Migrate `casUpload`** to write into `_stage/` so all staging files share one
    cleaning scope. This is the recommended path once Strategy 1 effects are
    implemented.
 2. **Scan both** — teach the cleaner to cover `.stage/` as well. However, this
@@ -170,4 +170,4 @@ miss any orphans left by `casUpload` in `.stage/`. Two options:
    old immediately after the rename — even older than the grace-period threshold —
    making a mtime-based check classify a just-started active upload as a stale orphan.
    This option must not be used until `casUpload` acquires an OS-level hold on its
-   staging file (e.g. via `openExclusive` after migrating to `_staging/`).
+   staging file (e.g. via `openExclusive` after migrating to `_stage/`).

--- a/issues/cas/strategy-1.md
+++ b/issues/cas/strategy-1.md
@@ -20,7 +20,7 @@ twice and guarantees the CAS directory contains only complete, verified objects.
 
 ## Write pipeline
 
-1. `openWrite()` — creates a staging file under `.cas/_staging/` and acquires an
+1. `openWrite()` — creates a staging file under `.cas/_stage/` and acquires an
    OS-level hold (open file descriptor on Windows; `flock` on POSIX). Returns an
    opaque `WriteHandle` token that represents this live resource.
 2. `append(handle, chunk)` — writes a chunk through the held file descriptor while
@@ -40,7 +40,7 @@ primitive.
 
 ## Staging directory
 
-The staging directory is `.cas/_staging/`. The `_` prefix ensures it cannot be
+The staging directory is `.cas/_stage/`. The `_` prefix ensures it cannot be
 confused with a hash-prefixed shard path and is excluded naturally by the `list`
 operation (which validates each name via `cBase32ToVec`).
 
@@ -88,7 +88,7 @@ simultaneously the "in progress, do not touch" signal and the dead-man's switch.
 
 ## Cleaning
 
-Only files under `.cas/_staging/` are eligible for cleaning. Committed shard files
+Only files under `.cas/_stage/` are eligible for cleaning. Committed shard files
 are permanent and never cleaned.
 
 A staging file is safe to delete when its lock can be acquired (POSIX) or its

--- a/issues/cas/strategy-1.md
+++ b/issues/cas/strategy-1.md
@@ -1,5 +1,17 @@
 # Strategy 1: Staging + Rename
 
+> **Staging mechanism — chosen design.** The OS-lock dead-man's switch described below
+> (`flock` on POSIX, open handle on Windows) has been superseded by the lock-free
+> **deadline-lease** design in [staging-lease.md](staging-lease.md). The lease replaces the
+> lock with a deadline encoded in the staging file name: it is lock-free,
+> platform-symmetric, drops the POSIX `flock`/`unlink` advisory hazard and the mandatory
+> mtime grace period, and additionally survives reboots, works across machines, and supports
+> competitive/failover uploads — all while failing safe (worst case is a restarted upload,
+> never a corrupted shard). See the comparison table in that doc. The rename-to-commit
+> pipeline and read-only-after-commit semantics in this document still apply unchanged; only
+> the dead-man's switch (the `## Lock as dead-man's switch` section and its lock-based
+> effects) is replaced.
+
 ## Overview
 
 Large files are written to a staging area first, then atomically renamed to their
@@ -59,6 +71,9 @@ the rename. Alternatively, `commitHandle` may clear the ReadOnly attribute on th
 destination before renaming over it; both paths preserve correctness.
 
 ## Lock as dead-man's switch
+
+> **Superseded** by the deadline-lease design — see [staging-lease.md](staging-lease.md).
+> This section documents the original lock-based approach; the lease replaces it.
 
 The `WriteHandle` holds a live OS resource for the entire duration of staging:
 

--- a/issues/cas/strategy-1.md
+++ b/issues/cas/strategy-1.md
@@ -8,9 +8,11 @@
 > mtime grace period, and additionally survives reboots, works across machines, and supports
 > competitive/failover uploads — all while failing safe (worst case is a restarted upload,
 > never a corrupted shard). See the comparison table in that doc. The rename-to-commit
-> pipeline and read-only-after-commit semantics in this document still apply unchanged; only
-> the dead-man's switch (the `## Lock as dead-man's switch` section and its lock-based
-> effects) is replaced.
+> pipeline still applies; the dead-man's switch (the `## Lock as dead-man's switch` section
+> and its lock-based effects) is replaced. **Read-only-after-commit (`chmod 444`) is no longer
+> part of the core contract** — the lease baseline treats it as an *optional* immutability
+> extra (see staging-lease.md), not a guaranteed step; the read-only discussion below is
+> retained as reference for deployments that choose to enable it.
 
 ## Overview
 


### PR DESCRIPTION
Document a lock-free alternative to the OS-lock staging design: a
deadline encoded in the staging file name (<deadline>-<random256>)
replaces flock/open-handle as the dead-man's switch. Covers the
FileHandle-free effect set, the rename-based fencing argument,
oldest-first plus manual GC, reboot-survivable resume, and a comparison
against the lock design.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Pk6S9JxpaDnAf8kQdhArBq