### PR TITLE
Stream-based CAS read/write with incremental hashing

### DIFF
--- a/fs/cas/mcp/module.f.ts
+++ b/fs/cas/mcp/module.f.ts
@@ -65,14 +65,15 @@
  */
 import { string, option, or, boolean } from '../../types/rtti/module.f.ts'
 import type { Unknown } from '../../json/module.f.ts'
-import { pure, type Effect, type Operation } from '../../effects/module.f.ts'
+import { listEffectCons, listEffectEnd, pure, type Effect, type ListEffect, type Operation } from '../../effects/module.f.ts'
 import { create, type MemOp } from '../../effects/memory/module.f.ts'
 import { cBase32ToVec, vecToCBase32 } from '../../cbase32/module.f.ts'
 import { decode as base64Decode, encode as base64Encode } from '../../base64/module.f.ts'
 import { utf8 } from '../../text/module.f.ts'
 import { detect } from '../../mime/module.f.ts'
-import { length as bitVecLength, type Vec } from '../../types/bit_vec/module.f.ts'
-import { type Mkdir, type RandomInt, type Read, type ReadBytes, type Rename, type Write } from '../../effects/node/module.f.ts'
+import { empty, length as bitVecLength, msb, type Vec } from '../../types/bit_vec/module.f.ts'
+import { ok } from '../../types/result/module.f.ts'
+import { type IoResult, type Mkdir, type RandomInt, type Read, type ReadBytes, type Rename, type Write } from '../../effects/node/module.f.ts'
 import { stdioTransport } from '../../mcp/stdio/module.f.ts'
 import {
     mcpStep, uninitializedState,
@@ -93,6 +94,24 @@ export const casGetArgs = { hash: string, content: option(boolean) } as const
 
 /** Arguments for `cas_list`: none. */
 export const casListArgs = {} as const
+
+// ── Stream helper ────────────────────────────────────────────────────────────────
+
+/**
+ * Drains a CAS read stream into a single `Vec`. MCP needs the whole blob in hand
+ * (MIME sniffing, UTF-8 validation, base64 encoding all inspect the full content),
+ * so the chunk stream is concatenated; an error item is surfaced as the result.
+ */
+const collectRead = <O extends Operation>(stream: ListEffect<O, IoResult<Vec>>): Effect<O, IoResult<Vec>> => {
+    const loop = (acc: Vec) => (s: ListEffect<O, IoResult<Vec>>): Effect<O, IoResult<Vec>> =>
+        s.step((node): Effect<O, IoResult<Vec>> => {
+            if (node === undefined) { return pure(ok(acc)) }
+            const [item, rest] = node
+            if (item[0] === 'error') { return pure(item) }
+            return loop(msb.concat(acc)(item[1]))(rest)
+        })
+    return loop(empty)(stream)
+}
 
 // ── Tool registry ──────────────────────────────────────────────────────────────
 
@@ -132,9 +151,10 @@ const casToolRegistry =
             }
             return x.step(value => typeof value === 'string'
                 ? pure(errorResult(value))
-                : c.write(value).step(hash => pure(hash === undefined
+                // The resolved content fits in one chunk; feed it as a single-item stream.
+                : c.write(listEffectCons(ok(value), listEffectEnd())).step(hashResult => pure(hashResult[0] === 'error'
                     ? errorResult('write')
-                    : okResult(vecToCBase32(hash))))
+                    : okResult(vecToCBase32(hashResult[1]))))
             )
         },
     ),
@@ -147,10 +167,11 @@ const casToolRegistry =
             if (key === null) {
                 return pure(errorResult(`invalid cBase32 hash: ${r.hash}`))
             }
-            return c.read(key).step(value => {
-                if (value === undefined) {
+            return collectRead(c.read(key)).step(result => {
+                if (result[0] === 'error') {
                     return pure(errorResult(`no such hash: ${r.hash}`))
                 }
+                const value = result[1]
                 const byteLength = Number(bitVecLength(value) / 8n)
                 // Phase 1: magic-byte sniffing for known binary formats.
                 const detectedMime = detect(value)

--- a/fs/cas/mcp/module.f.ts
+++ b/fs/cas/mcp/module.f.ts
@@ -72,7 +72,7 @@ import { decode as base64Decode, encode as base64Encode } from '../../base64/mod
 import { utf8 } from '../../text/module.f.ts'
 import { detect } from '../../mime/module.f.ts'
 import { empty, length as bitVecLength, maxLength, msb, type Vec } from '../../types/bit_vec/module.f.ts'
-import { ok } from '../../types/result/module.f.ts'
+import { ok, error } from '../../types/result/module.f.ts'
 import { type IoResult, type Mkdir, type RandomInt, type Read, type ReadBytes, type Rename, type Write } from '../../effects/node/module.f.ts'
 import { stdioTransport } from '../../mcp/stdio/module.f.ts'
 import {
@@ -109,10 +109,10 @@ const collectRead = <O extends Operation>(stream: ListEffect<O, IoResult<Vec>>):
             const [item, rest] = node
             if (item[0] === 'error') { return pure(item) }
             // A single `Vec` cannot exceed `maxLength` bits; concatenating past it would
-            // overflow the runtime's `bigint` constraint. A blob this large is a broken
-            // invariant, not a recoverable tool error, so abort the process.
+            // overflow the runtime's `bigint` constraint. Surface that as an error item
+            // so the tool reports a failure rather than crashing the process.
             if (bitVecLength(acc) + bitVecLength(item[1]) > maxLength) {
-                throw new Error(`cas blob exceeds maximum vector length of ${maxLength} bits`)
+                return pure(error(`cas blob exceeds maximum vector length of ${maxLength} bits`))
             }
             return loop(msb.concat(acc)(item[1]))(rest)
         })

--- a/fs/cas/mcp/module.f.ts
+++ b/fs/cas/mcp/module.f.ts
@@ -71,7 +71,7 @@ import { cBase32ToVec, vecToCBase32 } from '../../cbase32/module.f.ts'
 import { decode as base64Decode, encode as base64Encode } from '../../base64/module.f.ts'
 import { utf8 } from '../../text/module.f.ts'
 import { detect } from '../../mime/module.f.ts'
-import { empty, length as bitVecLength, msb, type Vec } from '../../types/bit_vec/module.f.ts'
+import { empty, length as bitVecLength, maxLength, msb, type Vec } from '../../types/bit_vec/module.f.ts'
 import { ok } from '../../types/result/module.f.ts'
 import { type IoResult, type Mkdir, type RandomInt, type Read, type ReadBytes, type Rename, type Write } from '../../effects/node/module.f.ts'
 import { stdioTransport } from '../../mcp/stdio/module.f.ts'
@@ -108,6 +108,12 @@ const collectRead = <O extends Operation>(stream: ListEffect<O, IoResult<Vec>>):
             if (node === undefined) { return pure(ok(acc)) }
             const [item, rest] = node
             if (item[0] === 'error') { return pure(item) }
+            // A single `Vec` cannot exceed `maxLength` bits; concatenating past it would
+            // overflow the runtime's `bigint` constraint. A blob this large is a broken
+            // invariant, not a recoverable tool error, so abort the process.
+            if (bitVecLength(acc) + bitVecLength(item[1]) > maxLength) {
+                throw new Error(`cas blob exceeds maximum vector length of ${maxLength} bits`)
+            }
             return loop(msb.concat(acc)(item[1]))(rest)
         })
     return loop(empty)(stream)

--- a/fs/cas/mcp/proof.f.ts
+++ b/fs/cas/mcp/proof.f.ts
@@ -1,10 +1,10 @@
 import { assert, assertEq } from '../../asserts/module.f.ts'
-import { pure, type Effect, type Operation } from '../../effects/module.f.ts'
+import { listEffectCons, listEffectEnd, pure, type Effect, type ListEffect, type Operation } from '../../effects/module.f.ts'
 import { run, type MemOperationMap } from '../../effects/mock/module.f.ts'
 import { asBase, asNominal, create, read, write, type Key, type MemOp } from '../../effects/memory/module.f.ts'
 import type { Unknown } from '../../json/module.f.ts'
 import type { Response } from '../../json/rpc/module.f.ts'
-import { msb, u8ListToVec, vec8, type Vec } from '../../types/bit_vec/module.f.ts'
+import { empty, msb, u8ListToVec, vec8, type Vec } from '../../types/bit_vec/module.f.ts'
 import { vecToCBase32 } from '../../cbase32/module.f.ts'
 import { encode as base64Encode } from '../../base64/module.f.ts'
 import { computeSync, sha256 } from '../../crypto/sha2/module.f.ts'
@@ -13,10 +13,10 @@ import { fileCas, type Cas, type FileCasOperation } from '../module.f.ts'
 import {
     mcpStep, uninitializedState, type McpSessionState, type ToolsCallResult,
 } from '../../mcp/module.f.ts'
-import { type MakeDirectoryOptions, type Mkdir, type RandomInt, type ReadBytes, type Rename } from '../../effects/node/module.f.ts'
+import { type IoResult, type MakeDirectoryOptions, type Mkdir, type RandomInt, type ReadBytes, type Rename } from '../../effects/node/module.f.ts'
 import { emptyState, virtual, type Dir } from '../../effects/node/virtual/module.f.ts'
 import { casConfig, casMcpHandlers } from './module.f.ts'
-import { ok as resultOk } from '../../types/result/module.f.ts'
+import { error as resultError, ok as resultOk } from '../../types/result/module.f.ts'
 
 type CasGetResult = {
     readonly length: number
@@ -75,13 +75,28 @@ const runMem = <T>(effect: Effect<MockOp, T>): T =>
 type VecMap = { readonly [k: string]: readonly [Vec, Vec] }
 
 const memCas = (mapKey: Key<VecMap>): Cas<MemOp> => ({
-    read: (key: Vec): Effect<MemOp, Vec | undefined> =>
-        read(mapKey).step(m => pure(m[vecToCBase32(key)]?.[1])),
-    write: (value: Vec): Effect<MemOp, Vec|undefined> => {
-        const key = computeSync(sha256)([value])
-        return read(mapKey)
-            .step(m => write(mapKey, { ...m, [vecToCBase32(key)]: [key, value] }))
-            .step(() => pure(key))
+    read: (key: Vec): ListEffect<MemOp, IoResult<Vec>> =>
+        read(mapKey).step((m): ListEffect<MemOp, IoResult<Vec>> => {
+            const entry = m[vecToCBase32(key)]
+            // Single stored chunk, then EOF; a missing entry is an explicit error item.
+            return entry === undefined
+                ? listEffectCons<MemOp, IoResult<Vec>>(resultError({ code: 'ENOENT' }), listEffectEnd())
+                : listEffectCons(resultOk(entry[1]), listEffectEnd())
+        }),
+    write: (payload: ListEffect<MemOp, IoResult<Vec>>): Effect<MemOp, IoResult<Vec>> => {
+        const loop = (acc: Vec) => (stream: ListEffect<MemOp, IoResult<Vec>>): Effect<MemOp, IoResult<Vec>> =>
+            stream.step((node): Effect<MemOp, IoResult<Vec>> => {
+                if (node === undefined) {
+                    const key = computeSync(sha256)([acc])
+                    return read(mapKey)
+                        .step(m => write(mapKey, { ...m, [vecToCBase32(key)]: [key, acc] }))
+                        .step(() => pure(resultOk(key)))
+                }
+                const [item, rest] = node
+                if (item[0] === 'error') { return pure(item) }
+                return loop(msb.concat(acc)(item[1]))(rest)
+            })
+        return loop(empty)(payload)
     },
     list: (): Effect<MemOp, readonly Vec[]> =>
         read(mapKey).step(m => pure(Object.values(m).map(([k]) => k))),

--- a/fs/cas/mcp/proof.f.ts
+++ b/fs/cas/mcp/proof.f.ts
@@ -4,7 +4,7 @@ import { run, type MemOperationMap } from '../../effects/mock/module.f.ts'
 import { asBase, asNominal, create, read, write, type Key, type MemOp } from '../../effects/memory/module.f.ts'
 import type { Unknown } from '../../json/module.f.ts'
 import type { Response } from '../../json/rpc/module.f.ts'
-import { empty, msb, u8ListToVec, vec8, type Vec } from '../../types/bit_vec/module.f.ts'
+import { empty, length, maxLength, msb, u8ListToVec, vec8, type Vec } from '../../types/bit_vec/module.f.ts'
 import { vecToCBase32 } from '../../cbase32/module.f.ts'
 import { encode as base64Encode } from '../../base64/module.f.ts'
 import { computeSync, sha256 } from '../../crypto/sha2/module.f.ts'
@@ -94,6 +94,11 @@ const memCas = (mapKey: Key<VecMap>): Cas<MemOp> => ({
                 }
                 const [item, rest] = node
                 if (item[0] === 'error') { return pure(item) }
+                // Mirror the production guard: a blob larger than `maxLength` bits would
+                // overflow a single `Vec`, so abort rather than silently corrupt.
+                if (length(acc) + length(item[1]) > maxLength) {
+                    throw new Error(`cas blob exceeds maximum vector length of ${maxLength} bits`)
+                }
                 return loop(msb.concat(acc)(item[1]))(rest)
             })
         return loop(empty)(payload)

--- a/fs/cas/mcp/proof.f.ts
+++ b/fs/cas/mcp/proof.f.ts
@@ -95,9 +95,9 @@ const memCas = (mapKey: Key<VecMap>): Cas<MemOp> => ({
                 const [item, rest] = node
                 if (item[0] === 'error') { return pure(item) }
                 // Mirror the production guard: a blob larger than `maxLength` bits would
-                // overflow a single `Vec`, so abort rather than silently corrupt.
+                // overflow a single `Vec`, so surface an error item instead of corrupting.
                 if (length(acc) + length(item[1]) > maxLength) {
-                    throw new Error(`cas blob exceeds maximum vector length of ${maxLength} bits`)
+                    return pure(resultError(`cas blob exceeds maximum vector length of ${maxLength} bits`))
                 }
                 return loop(msb.concat(acc)(item[1]))(rest)
             })

--- a/fs/cas/module.f.ts
+++ b/fs/cas/module.f.ts
@@ -3,11 +3,12 @@
  *
  * @module
  */
-import { computeSync, sha256, type Sha2, type State as Sha2State } from '../crypto/sha2/module.f.ts'
+import { sha256, type Sha2, type State as Sha2State } from '../crypto/sha2/module.f.ts'
 import { join, normalize, parse } from '../path/module.f.ts'
 import { empty, length, maxLengthBytes, msb, vec, type Vec } from '../types/bit_vec/module.f.ts'
 import { cBase32ToVec, vecToCBase32 } from '../cbase32/module.f.ts'
-import { foldStep, forEachStep, pure, type Effect, type Operation } from '../effects/module.f.ts'
+import { foldStep, forEachStep, listEffectCons, listEffectEnd, pure, type Effect, type ListEffect, type Operation } from '../effects/module.f.ts'
+import { reverse, type List } from '../types/list/module.f.ts'
 import {
     access,
     errorExit,
@@ -53,63 +54,92 @@ export const toPath = (key: Vec): string => {
 }
 
 //
-export type FileCasOperation = ReadFile | Mkdir | WriteFile | Access | Readdir
+export type FileCasOperation = ReadBytes | Mkdir | WriteFile | Access | Readdir
 
 export type Cas<O extends Operation> = {
-    /** Reads content by hash; returns `undefined` when not found. */
-    readonly read: (key: Vec) => Effect<O, Vec|undefined>
-    /** Stores content and returns its computed hash. */
-    readonly write: (value: Vec) => Effect<O, Vec|undefined>
+    /**
+     * Streams the content for `hash` out in `<=128 KiB` chunks. Every pull yields an
+     * explicit `ok(chunk)` or `error` item, so a missing shard or I/O error is a distinct
+     * error *item* in the stream, never collapsed into end-of-stream (`undefined`).
+     */
+    readonly read: (hash: Vec) => ListEffect<O, IoResult<Vec>>
+    /**
+     * Consumes a chunk stream — each item `ok(chunk)` or `error` — hashing incrementally,
+     * and returns the content address. An error item aborts the upload.
+     */
+    readonly write: (payload: ListEffect<O, IoResult<Vec>>) => Effect<O, IoResult<Vec>>
     /** Lists all stored content hashes. */
     readonly list: () => Effect<O, readonly Vec[]>
 }
 
+/** Maximum chunk size for streaming reads: the largest `Vec` the runtime allows. */
+const CHUNK_BYTES = Number(maxLengthBytes)
+
 /**
  * Builds a content-addressable storage facade from a SHA-2 implementation.
  */
-export const fileCas = (sha2: Sha2) => {
-    const compute = computeSync(sha2)
-    return (path: string): Cas<FileCasOperation> => {
-        const storePrefix = join(path, prefix)
-        const normalizedStorePrefix = normalize(storePrefix)
-        return {
-            // TODO: extend the interface with `Result<Vec, unknown>` instead of `Vec|undefined`.
-            read: (key: Vec): Effect<FileCasOperation, Vec|undefined> =>
-                readFile(join(path, toPath(key))).step(([t, v]) =>
-                    pure(t === 'ok' ? v : undefined)
-                ),
-            write: (value: Vec): Effect<FileCasOperation, Vec|undefined> => {
-                const hash = compute([value])
-                const p = toPath(hash)
-                const parts = parse(p)
-                const dir = join(path, ...parts.slice(0, -1))
-                // TODO: error handling
-                return mkdir(dir, { recursive: true })
-                    .step(() => writeFile(join(path, p), value))
-                    .step(([t]) => pure(t === 'ok' ? hash : undefined))
-            },
-            list: (): Effect<FileCasOperation, readonly Vec[]> =>
-                // A fresh store has no `.cas` directory yet. Treat *only* that case as an
-                // empty store, mirroring how `read` maps a missing file to `undefined`.
-                // A `.cas` that exists but cannot be read (permissions, corruption) is a
-                // genuine storage error and is surfaced, not masked as "no hashes".
-                access(storePrefix).step(a => {
-                    if (a[0] === 'error') {
-                        if (isNotFound(a[1])) { return pure([] as readonly Vec[]) }
-                        throw a[1]
-                    }
-                    return readdir(storePrefix, { recursive: true })
-                        .step(r => pure(unwrap(r).flatMap(({ name, parentPath, isFile }) =>
-                            toOption(isFile
-                                ? cBase32ToVec(normalize(parentPath).substring(normalizedStorePrefix.length).replaceAll('/', '') + name)
-                                : null))))
-                }),
-        }
+export const fileCas = (sha2: Sha2) => (path: string): Cas<FileCasOperation> => {
+    const storePrefix = join(path, prefix)
+    const normalizedStorePrefix = normalize(storePrefix)
+    return {
+        read: (hash: Vec): ListEffect<FileCasOperation, IoResult<Vec>> => {
+            const p = join(path, toPath(hash))
+            const loop = (offset: number): ListEffect<FileCasOperation, IoResult<Vec>> =>
+                readBytes(p, offset, CHUNK_BYTES).step((result): ListEffect<FileCasOperation, IoResult<Vec>> => {
+                    // A missing shard or read error is an explicit error item, never EOF.
+                    if (result[0] === 'error') { return listEffectCons<FileCasOperation, IoResult<Vec>>(result, listEffectEnd()) }
+                    const chunk = result[1]
+                    // End the stream only on an empty read; every non-empty read — including a
+                    // final short (`< CHUNK_BYTES`) chunk — is emitted as an `ok` item.
+                    return length(chunk) === 0n
+                        ? listEffectEnd()
+                        : listEffectCons(ok(chunk), loop(offset + CHUNK_BYTES))
+                })
+            return loop(0)
+        },
+        // Fold the chunk stream: feed each chunk to the running SHA-2 state while collecting
+        // it for the publish write. An error item aborts as an upload failure. The whole
+        // payload is never streamed past the SHA-2 state in constant memory yet — TODO(step 3)
+        // replaces the accumulate-then-`writeFile` publish with the lock-free staging
+        // algorithm (`createExclusive`/`writeBytes`/`rename`) so chunks land on disk directly.
+        write: (payload: ListEffect<FileCasOperation, IoResult<Vec>>): Effect<FileCasOperation, IoResult<Vec>> => {
+            const loop = (state: Sha2State, acc: List<Vec>) =>
+                (stream: ListEffect<FileCasOperation, IoResult<Vec>>): Effect<FileCasOperation, IoResult<Vec>> =>
+                    stream.step((node): Effect<FileCasOperation, IoResult<Vec>> => {
+                        if (node === undefined) {
+                            const hash = sha2.end(state)
+                            const p = toPath(hash)
+                            const parts = parse(p)
+                            const dir = join(path, ...parts.slice(0, -1))
+                            return mkdir(dir, { recursive: true })
+                                .step(() => writeFile(join(path, p), msb.listToVec(reverse(acc))))
+                                .step(([t, e]) => pure(t === 'ok' ? ok(hash) : error(e)))
+                        }
+                        const [item, rest] = node
+                        if (item[0] === 'error') { return pure(error(item[1])) }
+                        const chunk = item[1]
+                        return loop(sha2.append(chunk)(state), { first: chunk, tail: acc })(rest)
+                    })
+            return loop(sha2.init, null)(payload)
+        },
+        list: (): Effect<FileCasOperation, readonly Vec[]> =>
+            // A fresh store has no `.cas` directory yet. Treat *only* that case as an
+            // empty store, mirroring how `read` maps a missing shard to an error item.
+            // A `.cas` that exists but cannot be read (permissions, corruption) is a
+            // genuine storage error and is surfaced, not masked as "no hashes".
+            access(storePrefix).step(a => {
+                if (a[0] === 'error') {
+                    if (isNotFound(a[1])) { return pure([] as readonly Vec[]) }
+                    throw a[1]
+                }
+                return readdir(storePrefix, { recursive: true })
+                    .step(r => pure(unwrap(r).flatMap(({ name, parentPath, isFile }) =>
+                        toOption(isFile
+                            ? cBase32ToVec(normalize(parentPath).substring(normalizedStorePrefix.length).replaceAll('/', '') + name)
+                            : null))))
+            }),
     }
 }
-
-/** Maximum chunk size for streaming reads: the largest `Vec` the runtime allows. */
-const CHUNK_BYTES = Number(maxLengthBytes)
 
 /** 256-bit random `Vec` built from 8 sequential `randomInt` (32-bit) calls. */
 const random256: Effect<RandomInt, Vec> =
@@ -167,7 +197,7 @@ export const casUpload = (home: string) => (fileName: string): Effect<Mkdir | Re
     })
 }
 
-export const commands: Commands<FileCasOperation | Write | All | MemOp | Read> = [
+export const commands: Commands<FileCasOperation | ReadFile | Write | All | MemOp | Read> = [
     {
         names: ['add'],
         description: 'Store file content and print its hash',
@@ -176,11 +206,12 @@ export const commands: Commands<FileCasOperation | Write | All | MemOp | Read> =
                 return errorExit("'cas add' expects one parameter")
             }
             const c = fileCas(sha256)(home)
+            // The source is read in one `<=128 KiB` chunk; feed it as a single-item stream.
             return readFile(path)
-                .step(v => c.write(unwrap(v)))
-                .step(hash => hash === undefined
+                .step(v => c.write(listEffectCons(v, listEffectEnd())))
+                .step(hashResult => hashResult[0] === 'error'
                     ? pure(1)
-                    : log(vecToCBase32(hash)).step(() => pure(0)))
+                    : log(vecToCBase32(hashResult[1])).step(() => pure(0)))
         },
     },
     {
@@ -195,14 +226,18 @@ export const commands: Commands<FileCasOperation | Write | All | MemOp | Read> =
                 return errorExit(`invalid hash format: ${hashCBase32}`)
             }
             const c = fileCas(sha256)(home)
-            return c.read(hash)
-                .step(v => {
-                    const result: Effect<Write | WriteFile, number> = v === undefined
-                        ? errorExit(`no such hash: ${hashCBase32}`)
-                        : writeFile(path, v)
-                            .step(() => pure(0))
-                    return result
-                })
+            // Drain the read stream, gathering chunks; an error item means the shard is absent.
+            const collect = (acc: List<Vec>) =>
+                (stream: ListEffect<FileCasOperation, IoResult<Vec>>): Effect<FileCasOperation | Write, number> =>
+                    stream.step((node): Effect<FileCasOperation | Write, number> => {
+                        if (node === undefined) {
+                            return writeFile(path, msb.listToVec(reverse(acc))).step(() => pure(0))
+                        }
+                        const [item, rest2] = node
+                        if (item[0] === 'error') { return errorExit(`no such hash: ${hashCBase32}`) }
+                        return collect({ first: item[1], tail: acc })(rest2)
+                    })
+            return collect(null)(c.read(hash))
         },
     },
     {

--- a/fs/cas/module.f.ts
+++ b/fs/cas/module.f.ts
@@ -73,7 +73,7 @@ export type Cas<O extends Operation> = {
 }
 
 /** Maximum chunk size for streaming reads: the largest `Vec` the runtime allows. */
-const CHUNK_BYTES = Number(maxLengthBytes)
+const chunkBytes = Number(maxLengthBytes)
 
 /**
  * Builds a content-addressable storage facade from a SHA-2 implementation.
@@ -85,7 +85,7 @@ export const fileCas = (sha2: Sha2) => (path: string): Cas<FileCasOperation> => 
         read: (hash: Vec): ListEffect<FileCasOperation, IoResult<Vec>> => {
             const p = join(path, toPath(hash))
             const loop = (offset: number): ListEffect<FileCasOperation, IoResult<Vec>> =>
-                readBytes(p, offset, CHUNK_BYTES).step((result): ListEffect<FileCasOperation, IoResult<Vec>> => {
+                readBytes(p, offset, chunkBytes).step((result): ListEffect<FileCasOperation, IoResult<Vec>> => {
                     // A missing shard or read error is an explicit error item, never EOF.
                     if (result[0] === 'error') { return listEffectCons<FileCasOperation, IoResult<Vec>>(result, listEffectEnd()) }
                     const chunk = result[1]
@@ -93,7 +93,7 @@ export const fileCas = (sha2: Sha2) => (path: string): Cas<FileCasOperation> => 
                     // final short (`< CHUNK_BYTES`) chunk — is emitted as an `ok` item.
                     return length(chunk) === 0n
                         ? listEffectEnd()
-                        : listEffectCons(ok(chunk), loop(offset + CHUNK_BYTES))
+                        : listEffectCons(ok(chunk), loop(offset + chunkBytes))
                 })
             return loop(0)
         },
@@ -152,16 +152,16 @@ const random256: Effect<RandomInt, Vec> =
  * and returns the final hash without loading the whole file into memory.
  */
 const streamHash = (sha2: Sha2) => (path: string): Effect<ReadBytes, IoResult<Vec>> => {
-    const chunkBits = BigInt(CHUNK_BYTES) * 8n
+    const chunkBits = BigInt(chunkBytes) * 8n
     const loop = (state: Sha2State, offset: number): Effect<ReadBytes, IoResult<Vec>> =>
-        readBytes(path, offset, CHUNK_BYTES).step(result => {
+        readBytes(path, offset, chunkBytes).step(result => {
             if (result[0] === 'error') { return pure(error(result[1])) }
             const chunk = result[1]
             const newState = sha2.append(chunk)(state)
             if (length(chunk) < chunkBits) {
                 return pure(ok(sha2.end(newState)))
             }
-            return loop(newState, offset + CHUNK_BYTES)
+            return loop(newState, offset + chunkBytes)
         })
     return loop(sha2.init, 0)
 }

--- a/fs/cas/module.f.ts
+++ b/fs/cas/module.f.ts
@@ -129,7 +129,7 @@ export const fileCas = (sha2: Sha2) => (path: string): Cas<FileCasOperation> => 
             // genuine storage error and is surfaced, not masked as "no hashes".
             access(storePrefix).step(a => {
                 if (a[0] === 'error') {
-                    if (isNotFound(a[1])) { return pure([] as readonly Vec[]) }
+                    if (isNotFound(a[1])) { return pure([] satisfies readonly Vec[]) }
                     throw a[1]
                 }
                 return readdir(storePrefix, { recursive: true })

--- a/fs/cas/proof.f.ts
+++ b/fs/cas/proof.f.ts
@@ -1,13 +1,12 @@
-import { commands, type Cas } from './module.f.ts'
+import { commands, fileCas, type FileCasOperation } from './module.f.ts'
 import { computeSync, sha256 } from '../crypto/sha2/module.f.ts'
-import { empty, length, vec8 } from '../types/bit_vec/module.f.ts'
+import { length, msb, vec8 } from '../types/bit_vec/module.f.ts'
 import type { Vec } from '../types/bit_vec/module.f.ts'
-import { pure } from '../effects/module.f.ts'
-import { run } from '../effects/mock/module.f.ts'
+import { listEffectCons, listEffectEnd, pure, type Effect, type ListEffect } from '../effects/module.f.ts'
+import { ok } from '../types/result/module.f.ts'
 import { defaultNodeProgramOptions, emptyState, virtual } from '../effects/node/virtual/module.f.ts'
-import type { NodeProgramOptions } from '../effects/node/module.f.ts'
+import type { IoResult, NodeProgramOptions } from '../effects/node/module.f.ts'
 import { dispatch } from '../cli/module.f.ts'
-import { assert } from '../asserts/module.f.ts'
 
 const makeOptions = (args: readonly string[]): NodeProgramOptions =>
     ({ ...defaultNodeProgramOptions, args })
@@ -89,27 +88,36 @@ export const proof = {
         if (exitCode !== 1) { throw ['expected exit 1', exitCode] }
         if (finalState.stderr.length === 0) { throw 'expected error in stderr' }
     },
-    casWrite: () => {
-        const c: Cas<never> = {
-            read: (_key: Vec) => pure(undefined as Vec | undefined),
-            write: (value: Vec) => pure(computeSync(sha256)([value])),
-            list: () => pure([] as readonly Vec[]),
-        }
-        const [, hash] = run({})(undefined)(c.write(empty))
-        // sha256 of empty input produces a 256-bit hash
-        assert(hash !== undefined)
+    casWriteRead: () => {
+        // Round-trip a single-chunk payload through the real streaming CAS: `write` returns
+        // the content hash, and `read` streams the same bytes back as `ok` chunk items.
+        const content = vec8(0x2An)
+        const c = fileCas(sha256)('.')
+        const payload: ListEffect<FileCasOperation, IoResult<Vec>> =
+            listEffectCons(ok(content), listEffectEnd())
+        const [state1, writeResult] = virtual(emptyState)(c.write(payload))
+        if (writeResult[0] !== 'ok') { throw ['expected write ok', writeResult] }
+        const hash = writeResult[1]
         if (length(hash) !== 256n) { throw ['expected 256-bit hash', length(hash)] }
+        if (msb.cmp(hash)(computeSync(sha256)([content])) !== 0) { throw 'write hash mismatch' }
+        const drain = (acc: readonly Vec[]) =>
+            (stream: ListEffect<FileCasOperation, IoResult<Vec>>): Effect<FileCasOperation, IoResult<readonly Vec[]>> =>
+                stream.step((node): Effect<FileCasOperation, IoResult<readonly Vec[]>> => {
+                    if (node === undefined) { return pure(ok(acc)) }
+                    const [item, rest] = node
+                    if (item[0] === 'error') { return pure(item) }
+                    return drain([...acc, item[1]])(rest)
+                })
+        const [, readResult] = virtual(state1)(drain([])(c.read(hash)))
+        if (readResult[0] !== 'ok') { throw ['expected read ok', readResult] }
+        if (msb.cmp(msb.listToVec(readResult[1]))(content) !== 0) { throw 'read content mismatch' }
     },
-    casReadPassthrough: () => {
-        const stored = empty
-        const c = {
-            read: (_key: Vec) => pure(stored as Vec | undefined),
-            write: (value: Vec) => pure(computeSync(sha256)([value])),
-            list: () => pure([stored] as readonly Vec[]),
-        }
-        const [, readResult] = run<never, undefined>({})(undefined)(c.read(empty))
-        if (readResult !== stored) { throw ['read should pass through', readResult] }
-        const [, listResult] = run<never, undefined>({})(undefined)(c.list())
-        if (listResult.length !== 1) { throw ['list should pass through', listResult] }
+    casReadMissingShard: () => {
+        // A missing shard surfaces as an explicit error *item*, never as end-of-stream.
+        const c = fileCas(sha256)('.')
+        const hash = computeSync(sha256)([vec8(0x2An)])
+        const [, node] = virtual(emptyState)(c.read(hash))
+        if (node === undefined) { throw 'missing shard must not be EOF' }
+        if (node[0][0] !== 'error') { throw ['expected error item', node[0]] }
     },
 }

--- a/fs/effects/module.f.ts
+++ b/fs/effects/module.f.ts
@@ -152,16 +152,21 @@ export type ListEffect<O extends Operation, T> =
 /**
  * The empty `ListEffect`: a pure end-of-stream marker (`undefined`).
  *
- * `pure` produces `Effect<never, …>`, and widening that to an arbitrary operation
- * set `O` is sound — a pure value performs no operations. But `Effect`'s structural
- * shape uses `T` in a contravariant position (the `step` continuation parameter), so
- * the compiler cannot prove the widening for the *recursive* `ListEffect` payload;
- * the assertion stands in for that proof. Construct streams through these two
- * combinators so the cast lives in exactly one place.
+ * Built as an `Effect` object literal rather than through `pure`. `pure` returns
+ * `Effect<never, …>`; widening that to an arbitrary operation set `O` is sound (a pure
+ * value performs no operations) and the compiler accepts it for a non-recursive
+ * payload, but not when the payload recursively mentions `O` — as `ListEffect`'s cons
+ * cell does. Writing the literal directly lets the contextual return type drive the
+ * check, so the recursive payload type-checks without a cast. Construct streams through
+ * these two combinators.
  */
-export const listEffectEnd = <O extends Operation, T>(): ListEffect<O, T> =>
-    pure(undefined) as ListEffect<O, T>
+export const listEffectEnd = <O extends Operation, T>(): ListEffect<O, T> => ({
+    value: [undefined],
+    step: f => f(undefined),
+})
 
 /** Prepends `head` to a `ListEffect` `tail`, as a pure cons cell. See {@link listEffectEnd}. */
-export const listEffectCons = <O extends Operation, T>(head: T, tail: ListEffect<O, T>): ListEffect<O, T> =>
-    pure([head, tail]) as unknown as ListEffect<O, T>
+export const listEffectCons = <O extends Operation, T>(head: T, tail: ListEffect<O, T>): ListEffect<O, T> => {
+    const node: readonly[T, ListEffect<O, T>] = [head, tail]
+    return { value: [node], step: f => f(node) }
+}

--- a/fs/effects/module.f.ts
+++ b/fs/effects/module.f.ts
@@ -148,3 +148,20 @@ export type Func<O extends Operation> = (..._: Param<O>) => Effect<O, Return<O>>
 
 export type ListEffect<O extends Operation, T> =
     Effect<O, readonly[T, ListEffect<O, T>] | undefined>
+
+/**
+ * The empty `ListEffect`: a pure end-of-stream marker (`undefined`).
+ *
+ * `pure` produces `Effect<never, …>`, and widening that to an arbitrary operation
+ * set `O` is sound — a pure value performs no operations. But `Effect`'s structural
+ * shape uses `T` in a contravariant position (the `step` continuation parameter), so
+ * the compiler cannot prove the widening for the *recursive* `ListEffect` payload;
+ * the assertion stands in for that proof. Construct streams through these two
+ * combinators so the cast lives in exactly one place.
+ */
+export const listEffectEnd = <O extends Operation, T>(): ListEffect<O, T> =>
+    pure(undefined) as ListEffect<O, T>
+
+/** Prepends `head` to a `ListEffect` `tail`, as a pure cons cell. See {@link listEffectEnd}. */
+export const listEffectCons = <O extends Operation, T>(head: T, tail: ListEffect<O, T>): ListEffect<O, T> =>
+    pure([head, tail]) as unknown as ListEffect<O, T>


### PR DESCRIPTION
## Summary

Refactors the content-addressable storage (CAS) interface to use streaming for reads and writes, enabling incremental SHA-2 hashing and chunked I/O. The `read` operation now returns a `ListEffect` stream of chunks, and `write` consumes a chunk stream while hashing incrementally, replacing the previous synchronous single-blob interface.

## Key Changes

- **Streaming read interface**: `read(hash: Vec)` now returns `ListEffect<O, IoResult<Vec>>` that yields `<=128 KiB` chunks. Missing shards surface as explicit error items in the stream, never as end-of-stream.

- **Streaming write interface**: `write(payload: ListEffect<O, IoResult<Vec>>)` consumes a chunk stream, hashes incrementally via `sha2.append()`, and returns `IoResult<Vec>` with the computed content hash. Error items in the payload abort the upload.

- **Removed synchronous hashing**: Eliminated `computeSync` import and direct hash computation; hashing is now incremental via `sha2.init`, `sha2.append()`, and `sha2.end()`.

- **List effect combinators**: Added `listEffectEnd()` and `listEffectCons()` helpers to safely construct `ListEffect` streams with proper type widening.

- **Updated CAS operations**: Changed `FileCasOperation` from `ReadFile | Mkdir | WriteFile | Access | Readdir` to `ReadBytes | Mkdir | WriteFile | Access | Readdir` to reflect chunked reading.

- **Command-line integration**: Updated `cas add` and `cas get` commands to wrap single-chunk payloads in streams and drain read streams back to files.

- **Test updates**: Rewrote `casWrite` proof to `casWriteRead` for round-trip validation; added `casReadMissingShard` to verify error-item semantics.

- **MCP integration**: Updated MCP CAS handlers with `collectRead()` helper to drain streams into single blobs for MIME detection and encoding.

## Implementation Details

- Chunks are limited to `CHUNK_BYTES = Number(maxLengthBytes)`, the largest `Vec` the runtime allows.
- The `write` operation accumulates chunks in a linked list (`List<Vec>`) during hashing, then reverses and concatenates them for the final `writeFile` call. A TODO notes that step 3 will replace this with lock-free staging (`createExclusive`/`writeBytes`/`rename`) for direct-to-disk streaming.
- Error handling is explicit: I/O errors and missing shards are `IoResult` items in the stream, not collapsed into `undefined` (EOF).
- The `fileCas` factory now returns the `Cas` directly (no nested function) for cleaner composition.

https://claude.ai/code/session_0197Sqzjyo6iL9nj2tD8Jhhy