### PR TITLE
Add test for cas_get with binary content as base64

### DIFF
--- a/fs/cas/mcp/proof.f.ts
+++ b/fs/cas/mcp/proof.f.ts
@@ -495,4 +495,21 @@ export const proof = {
         assert(resultOf(resp).isError === true)
         assert(textOf(resp).includes('/home/user/cas_upload/'))
     },
+
+    // cas_get with content:true on octet-stream (no magic bytes, not UTF-8) returns inline base64.
+    getOctetStreamWithContentIncludesBase64: () => {
+        const binaryContent = u8ListToVec(msb)([0xFF, 0xFE, 0x00, 0x01])
+        const binaryB64 = base64Encode(binaryContent) as string
+        const [addResp] = session(call(2, 'cas_add', { content: binaryB64, type: 'base64' }))
+        const hash = textOf(addResp)
+        const [, getResp] = session(
+            call(2, 'cas_add', { content: binaryB64, type: 'base64' }),
+            call(3, 'cas_get', { hash, content: true }),
+        )
+        assert(!resultOf(getResp).isError)
+        const result = JSON.parse(textOf(getResp)) as CasGetResult
+        assertEq(result.mime_type, 'application/octet-stream')
+        assertEq(result.type, 'base64')
+        assertEq(result.content, binaryB64)
+    },
 }


### PR DESCRIPTION
## Summary
Added a new test case to verify that `cas_get` correctly returns binary octet-stream content as base64 when the `content: true` parameter is specified.

## Key Changes
- Added `getOctetStreamWithContentIncludesBase64` test function that:
  - Creates binary content with non-UTF-8 bytes (0xFF, 0xFE, 0x00, 0x01)
  - Encodes it as base64 and uploads it via `cas_add`
  - Retrieves it via `cas_get` with `content: true`
  - Verifies the response includes:
    - Correct MIME type (`application/octet-stream`)
    - Correct content type (`base64`)
    - Original binary content returned as base64

## Implementation Details
The test validates that binary files without magic bytes or UTF-8 encoding are properly handled by the CAS system, ensuring they are returned in base64 format when inline content is requested.

https://claude.ai/code/session_01VZNe38DpijTgfaDpiam2dt