### PR TITLE
cas: lock-free staging upload (Step 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `cas`: implement the lock-free staging upload (Step 3, staging-lease.md). `fileCas.write` now streams each chunk straight to a `.cas/_stage/<deadline>-<random256>` staging file via the new `writeBytes` effect while hashing incrementally, renews the deadline lease per chunk, fails closed (`rm` the partial file) on any error, and publishes to the hash-derived shard with a replace-`rename` confirmed by a `stat` size check; expired staging files are garbage-collected lazily at the start of each write. Adds path-based effects `createExclusive` (`O_CREAT|O_EXCL`), `writeBytes` (pwrite the whole `Vec` at a byte offset, never creating), and `stat` (`{ size }`) to `fs/effects/node`, implemented in the Node and virtual runners. Migrates `casUpload` to stage under `_stage/` with a `<deadline>-<random256>` name (dropping the old `.stage/` path) so its orphans share the same lease GC. New proof tests cover multi-chunk streaming, dedup, mid-stream abort, and GC reclamation (cas plan Step 3) PR [#1149](https://github.com/functionalscript/functionalscript/pull/1149)
+
 ## 0.33.0
 
 - Remove `kvStore` PR [#1143](https://github.com/functionalscript/functionalscript/pull/1143)

--- a/fs/cas/mcp/module.f.ts
+++ b/fs/cas/mcp/module.f.ts
@@ -73,7 +73,7 @@ import { utf8 } from '../../text/module.f.ts'
 import { detect } from '../../mime/module.f.ts'
 import { empty, length as bitVecLength, maxLength, msb, type Vec } from '../../types/bit_vec/module.f.ts'
 import { ok, error } from '../../types/result/module.f.ts'
-import { type IoResult, type Mkdir, type RandomInt, type Read, type ReadBytes, type Rename, type Write } from '../../effects/node/module.f.ts'
+import { type IoResult, type Mkdir, type Now, type RandomInt, type Read, type ReadBytes, type Rename, type Write } from '../../effects/node/module.f.ts'
 import { stdioTransport } from '../../mcp/stdio/module.f.ts'
 import {
     mcpStep, uninitializedState,
@@ -123,14 +123,14 @@ const collectRead = <O extends Operation>(stream: ListEffect<O, IoResult<Vec>>):
 
 /** Registry of all CAS tools. */
 const casToolRegistry =
-<O extends Operation>(c: Cas<O>, home: string, toUrl?: (hash: Vec) => string): readonly ToolEntry<O|Mkdir|Rename|RandomInt|ReadBytes>[] => {
+<O extends Operation>(c: Cas<O>, home: string, toUrl?: (hash: Vec) => string): readonly ToolEntry<O|Mkdir|Rename|RandomInt|ReadBytes|Now>[] => {
     const casUploadDir = `${home}/cas_upload`
     return [
     toolEntry(
         'cas_add',
         'Store content and return its hash (cBase32). Pass type:"base64" for binary; type:"url" to stream a file from $HOME/cas_upload/ (no size limit); omit or pass type:"text" for UTF-8 text (default).',
         casAddArgs,
-        ({ type, content }): Effect<O | Mkdir | Rename | RandomInt | ReadBytes, ToolsCallResult> => {
+        ({ type, content }): Effect<O | Mkdir | Rename | RandomInt | ReadBytes | Now, ToolsCallResult> => {
             // type:'url' — streaming move-hash-move pipeline (no size limit)
             if (type === 'url') {
                 if (!content.startsWith(`${casUploadDir}/`) || content.includes('..')) {
@@ -260,7 +260,7 @@ export const casMcpHandlers = <O extends Operation>(
     c: Cas<O>,
     home: string,
     toUrl?: (hash: Vec) => string,
-): McpHandlers<Mkdir | Rename | RandomInt | ReadBytes | O> =>
+): McpHandlers<Mkdir | Rename | RandomInt | ReadBytes | Now | O> =>
     fromRegistry(casToolRegistry(c, home, toUrl))
 
 // ── Session configuration ───────────────────────────────────────────────────────
@@ -288,6 +288,6 @@ export const casMcpServer = <O extends Operation>(
     c: Cas<O>,
     home: string,
     toUrl?: (hash: Vec) => string,
-): Effect<Read | Write | MemOp | Mkdir | Rename | RandomInt | ReadBytes | O, void> =>
+): Effect<Read | Write | MemOp | Mkdir | Rename | RandomInt | ReadBytes | Now | O, void> =>
     create(uninitializedState).step(key =>
-        stdioTransport(mcpStep<Mkdir | Rename | RandomInt | ReadBytes | O>(casConfig)(casMcpHandlers(c, home, toUrl))(key)))
+        stdioTransport(mcpStep<Mkdir | Rename | RandomInt | ReadBytes | Now | O>(casConfig)(casMcpHandlers(c, home, toUrl))(key)))

--- a/fs/cas/mcp/proof.f.ts
+++ b/fs/cas/mcp/proof.f.ts
@@ -13,7 +13,7 @@ import { fileCas, type Cas, type FileCasOperation } from '../module.f.ts'
 import {
     mcpStep, uninitializedState, type McpSessionState, type ToolsCallResult,
 } from '../../mcp/module.f.ts'
-import { type IoResult, type MakeDirectoryOptions, type Mkdir, type RandomInt, type ReadBytes, type Rename } from '../../effects/node/module.f.ts'
+import { type IoResult, type MakeDirectoryOptions, type Mkdir, type Now, type RandomInt, type ReadBytes, type Rename } from '../../effects/node/module.f.ts'
 import { emptyState, virtual, type Dir } from '../../effects/node/virtual/module.f.ts'
 import { casConfig, casMcpHandlers } from './module.f.ts'
 import { error as resultError, ok as resultOk } from '../../types/result/module.f.ts'
@@ -42,7 +42,7 @@ const initialTestState: TestState = { memory: { next: 0, values: {} } }
 // The in-memory session helpers only exercise text/base64 paths (MemOp) and the
 // path-rejection branch of type:'url' (no file I/O). The upload ops are only
 // reached via runSessionVirtual.
-type MockOp = MemOp | Mkdir | Rename | RandomInt | ReadBytes
+type MockOp = MemOp | Mkdir | Rename | RandomInt | ReadBytes | Now
 
 const mock: MemOperationMap<MockOp, TestState> = {
     memCreate: value => state => {
@@ -62,6 +62,7 @@ const mock: MemOperationMap<MockOp, TestState> = {
     rename: (_src: string, _dst: string) => _ => { throw new Error('rename not supported in memory mock') },
     readBytes: (_path: string, _offset: number, _size: number) => _ => { throw new Error('readBytes not supported in memory mock') },
     randomInt: () => _ => { throw new Error('randomInt not supported in memory mock') },
+    now: () => state => [state, 0],
 }
 
 const runMem = <T>(effect: Effect<MockOp, T>): T =>

--- a/fs/cas/module.f.ts
+++ b/fs/cas/module.f.ts
@@ -11,28 +11,38 @@ import { foldStep, forEachStep, listEffectCons, listEffectEnd, pure, type Effect
 import { reverse, type List } from '../types/list/module.f.ts'
 import {
     access,
+    createExclusive,
     errorExit,
     isNotFound,
     log,
     mkdir,
+    now,
     randomInt,
     readBytes,
     readdir,
     readFile,
     rename,
+    rm,
+    stat,
+    writeBytes,
     writeFile,
     type Access,
     type All,
+    type CreateExclusive,
     type IoResult,
     type Mkdir,
     type NodeProgramOptions,
+    type Now,
     type RandomInt,
     type Read,
     type ReadBytes,
     type Readdir,
     type ReadFile,
     type Rename,
+    type Rm,
+    type Stat,
     type Write,
+    type WriteBytes,
     type WriteFile
 } from '../effects/node/module.f.ts'
 import { dispatch, type Commands } from '../cli/module.f.ts'
@@ -53,8 +63,16 @@ export const toPath = (key: Vec): string => {
     return join(prefix, a, b, c)
 }
 
-//
-export type FileCasOperation = ReadBytes | Mkdir | WriteFile | Access | Readdir
+/**
+ * The filesystem effects the streaming CAS performs: `read` pulls shards
+ * (`ReadBytes`); `list` walks the store (`Access`/`Readdir`); `write` runs the
+ * lock-free staging upload (`Mkdir`/`CreateExclusive`/`WriteBytes`/`Rename`/`Rm`/
+ * `Stat`, lease deadlines from `Now`, staging names from `RandomInt`) and GC's
+ * expired staging files (`Readdir`/`Rm`).
+ */
+export type FileCasOperation =
+    | ReadBytes | Mkdir | Readdir | Access | Rename | Rm
+    | RandomInt | Now | CreateExclusive | WriteBytes | Stat
 
 export type Cas<O extends Operation> = {
     /**
@@ -75,12 +93,54 @@ export type Cas<O extends Operation> = {
 /** Maximum chunk size for streaming reads: the largest `Vec` the runtime allows. */
 const chunkBytes = Number(maxLengthBytes)
 
+/** Staging directory under the store root; GC and every uploader share it. */
+const stageRel = '_stage'
+
+/**
+ * Lease duration in ms: a staging file's deadline is `now() + leaseDelta`.
+ * Renewed after every chunk, so it only has to cover the gap between two
+ * consecutive chunks (see [staging-lease.md](../../issues/cas/staging-lease.md)).
+ */
+const leaseDelta = 30_000
+
+/**
+ * Fixed width for the zero-padded epoch-ms deadline embedded in a staging name,
+ * so names sort lexically exactly as they sort chronologically. 19 digits keeps
+ * epoch-ms (13 digits today) padded with headroom well past year 2286.
+ */
+const deadlineWidth = 19
+
+/** Builds a `<deadline>-<random256>` staging file name. */
+const stageName = (deadline: number, rnd: string): string =>
+    `${String(deadline).padStart(deadlineWidth, '0')}-${rnd}`
+
+/** Recovers the deadline (epoch ms) from a `<deadline>-<random256>` name. */
+const deadlineOf = (name: string): number => Number(name.slice(0, name.indexOf('-')))
+
+/**
+ * Reclaims expired staging files: any `_stage/<deadline>-<rand>` whose deadline
+ * is already in the past. Lazy and piggy-backed on `write`. Best-effort — a
+ * missing `_stage/` (fresh store) or any `readdir`/`rm` error is ignored, and a
+ * still-live lease is left alone; the fencing rename keeps even a misjudged
+ * reclaim fail-safe (worst case: that upload restarts).
+ */
+const gcStage = (stageDir: string): Effect<Now | Readdir | Rm, void> =>
+    now().step(t =>
+        readdir(stageDir, {}).step(r => {
+            if (r[0] === 'error') { return pure(undefined) }
+            const expired = r[1].flatMap(d =>
+                d.isFile && deadlineOf(d.name) < t ? [d.name] : [])
+            return forEachStep((name: string) =>
+                rm(join(stageDir, name)).step(() => pure(undefined)))(expired)
+        }))
+
 /**
  * Builds a content-addressable storage facade from a SHA-2 implementation.
  */
 export const fileCas = (sha2: Sha2) => (path: string): Cas<FileCasOperation> => {
     const storePrefix = join(path, prefix)
     const normalizedStorePrefix = normalize(storePrefix)
+    const stageDir = join(storePrefix, stageRel)
     return {
         read: (hash: Vec): ListEffect<FileCasOperation, IoResult<Vec>> => {
             const p = join(path, toPath(hash))
@@ -97,30 +157,66 @@ export const fileCas = (sha2: Sha2) => (path: string): Cas<FileCasOperation> => 
                 })
             return loop(0)
         },
-        // Fold the chunk stream: feed each chunk to the running SHA-2 state while collecting
-        // it for the publish write. An error item aborts as an upload failure. The whole
-        // payload is never streamed past the SHA-2 state in constant memory yet — TODO(step 3)
-        // replaces the accumulate-then-`writeFile` publish with the lock-free staging
-        // algorithm (`createExclusive`/`writeBytes`/`rename`) so chunks land on disk directly.
+        // Lock-free staging upload (issues/cas/staging-lease.md): stream each chunk straight
+        // to a `_stage/<deadline>-<rand>` file via `writeBytes` while folding it into the
+        // running SHA-2 state — the payload never lives in memory as a whole. The lease is
+        // renewed (rename to a fresh deadline) after every chunk; any error deletes the
+        // partial file and fails. On end-of-stream the file is published to its hash-derived
+        // shard path by a replace-`rename` (which also dedups/repairs a same-content shard),
+        // and success is confirmed by a `stat` size check. GC of expired staging files is
+        // piggy-backed at the start.
         write: (payload: ListEffect<FileCasOperation, IoResult<Vec>>): Effect<FileCasOperation, IoResult<Vec>> => {
-            const loop = (state: Sha2State, acc: List<Vec>) =>
-                (stream: ListEffect<FileCasOperation, IoResult<Vec>>): Effect<FileCasOperation, IoResult<Vec>> =>
-                    stream.step((node): Effect<FileCasOperation, IoResult<Vec>> => {
-                        if (node === undefined) {
-                            const hash = sha2.end(state)
-                            const p = toPath(hash)
-                            const parts = parse(p)
-                            const dir = join(path, ...parts.slice(0, -1))
-                            return mkdir(dir, { recursive: true })
-                                .step(() => writeFile(join(path, p), msb.listToVec(reverse(acc))))
-                                .step(([t, e]) => pure(t === 'ok' ? ok(hash) : error(e)))
-                        }
-                        const [item, rest] = node
-                        if (item[0] === 'error') { return pure(error(item[1])) }
-                        const chunk = item[1]
-                        return loop(sha2.append(chunk)(state), { first: chunk, tail: acc })(rest)
-                    })
-            return loop(sha2.init, null)(payload)
+            // Publish the finished staging file to its content-addressed shard. The three
+            // filesystem steps run best-effort with their results ignored; success is decided
+            // afterward by observing the target's size (see staging-lease.md "Publish ignores
+            // results and checks the end state").
+            const publish = (state: Sha2State, offset: number, curPath: string): Effect<FileCasOperation, IoResult<Vec>> => {
+                const hash = sha2.end(state)
+                const rel = toPath(hash)
+                const dst = join(path, rel)
+                const dstDir = join(path, ...parse(rel).slice(0, -1))
+                return mkdir(dstDir, { recursive: true })
+                    .step(() => rename(curPath, dst))
+                    .step(() => rm(curPath))
+                    .step(() => stat(dst))
+                    .step(st => pure(st[0] === 'ok' && st[1].size === offset ? ok(hash) : error('publish size mismatch')))
+            }
+            // Any streaming error fails closed: delete the partial file, return the error.
+            const fail = (curPath: string, e: unknown): Effect<FileCasOperation, IoResult<Vec>> =>
+                rm(curPath).step(() => pure(error(e)))
+            return gcStage(stageDir).step(() =>
+                random256.step(rnd => {
+                    const rndStr = vecToCBase32(rnd)
+                    const loop = (state: Sha2State, offset: number, curPath: string) =>
+                        (stream: ListEffect<FileCasOperation, IoResult<Vec>>): Effect<FileCasOperation, IoResult<Vec>> =>
+                            stream.step((node): Effect<FileCasOperation, IoResult<Vec>> => {
+                                if (node === undefined) { return publish(state, offset, curPath) }
+                                const [item, rest] = node
+                                if (item[0] === 'error') { return fail(curPath, item[1]) }
+                                const chunk = item[1]
+                                return writeBytes(curPath, offset, chunk).step(wb => {
+                                    if (wb[0] === 'error') { return fail(curPath, wb[1]) }
+                                    const newState = sha2.append(chunk)(state)
+                                    const newOffset = offset + Number(length(chunk) / 8n)
+                                    // Renew the lease: rename to a fresh deadline (keeps `delta` constant).
+                                    return now().step(t => {
+                                        const next = join(stageDir, stageName(t + leaseDelta, rndStr))
+                                        return rename(curPath, next).step(rnResult =>
+                                            rnResult[0] === 'error'
+                                                ? fail(curPath, rnResult[1])
+                                                : loop(newState, newOffset, next)(rest))
+                                    })
+                                })
+                            })
+                    return mkdir(stageDir, { recursive: true }).step(() =>
+                        now().step(t0 => {
+                            const path0 = join(stageDir, stageName(t0 + leaseDelta, rndStr))
+                            return createExclusive(path0).step(ce =>
+                                ce[0] === 'error'
+                                    ? pure(error(ce[1]))
+                                    : loop(sha2.init, 0, path0)(payload))
+                        }))
+                }))
         },
         list: (): Effect<FileCasOperation, readonly Vec[]> =>
             // A fresh store has no `.cas` directory yet. Treat *only* that case as an
@@ -167,37 +263,41 @@ const streamHash = (sha2: Sha2) => (path: string): Effect<ReadBytes, IoResult<Ve
 }
 
 /**
- * Move-hash-move upload pipeline: moves `fileName` from `~/cas_upload/` to a
- * random staging path, stream-hashes it, then renames it to its final CAS shard
- * path. Returns `ok(hash)` on success or `error(reason)` on any I/O failure.
+ * Move-hash-move upload pipeline: moves `fileName` from `~/cas_upload/` into a
+ * `_stage/<deadline>-<random256>` staging file, stream-hashes it, then renames it
+ * to its final CAS shard path. Returns `ok(hash)` on success or `error(reason)`
+ * on any I/O failure.
+ *
+ * Staging under `_stage/` with a deadline name (rather than the old `.stage/`)
+ * brings it under the same lease GC as `fileCas.write`, so a crashed move-hash
+ * orphan is reclaimed once its deadline passes (see staging-lease.md).
  */
-export const casUpload = (home: string) => (fileName: string): Effect<Mkdir | Rename | RandomInt | ReadBytes, IoResult<Vec>> => {
+export const casUpload = (home: string) => (fileName: string): Effect<Mkdir | Rename | RandomInt | ReadBytes | Now, IoResult<Vec>> => {
     const src = join(home, 'cas_upload', fileName)
-    const stageDir = join(home, prefix, '.stage')
-    return random256.step(rnd => {
-        const rndStr = vecToCBase32(rnd)
-        const stagePath = join(stageDir, `${rndStr}-${fileName.replaceAll('/', '-')}`)
-        return mkdir(stageDir, { recursive: true })
-            .step(() => rename(src, stagePath))
-            .step(r => {
-                if (r[0] === 'error') { return pure(error(r[1])) }
-                return streamHash(sha256)(stagePath)
-                    .step(hashResult => {
-                        if (hashResult[0] === 'error') { return pure(hashResult) }
-                        const hash = hashResult[1]
-                        const p = toPath(hash)
-                        const parts = parse(p)
-                        const finalDir = join(home, ...parts.slice(0, -1))
-                        const finalPath = join(home, p)
-                        return mkdir(finalDir, { recursive: true })
-                            .step(() => rename(stagePath, finalPath))
-                            .step(r2 => pure(r2[0] === 'error' ? error(r2[1]) : ok(hash)))
-                    })
-            })
-    })
+    const stageDir = join(home, prefix, stageRel)
+    return random256.step(rnd =>
+        now().step(t => {
+            const stagePath = join(stageDir, stageName(t + leaseDelta, vecToCBase32(rnd)))
+            return mkdir(stageDir, { recursive: true })
+                .step(() => rename(src, stagePath))
+                .step(r => {
+                    if (r[0] === 'error') { return pure(error(r[1])) }
+                    return streamHash(sha256)(stagePath)
+                        .step(hashResult => {
+                            if (hashResult[0] === 'error') { return pure(hashResult) }
+                            const hash = hashResult[1]
+                            const rel = toPath(hash)
+                            const finalDir = join(home, ...parse(rel).slice(0, -1))
+                            const finalPath = join(home, rel)
+                            return mkdir(finalDir, { recursive: true })
+                                .step(() => rename(stagePath, finalPath))
+                                .step(r2 => pure(r2[0] === 'error' ? error(r2[1]) : ok(hash)))
+                        })
+                })
+        }))
 }
 
-export const commands: Commands<FileCasOperation | ReadFile | Write | All | MemOp | Read> = [
+export const commands: Commands<FileCasOperation | ReadFile | WriteFile | Write | All | MemOp | Read> = [
     {
         names: ['add'],
         description: 'Store file content and print its hash',
@@ -228,8 +328,8 @@ export const commands: Commands<FileCasOperation | ReadFile | Write | All | MemO
             const c = fileCas(sha256)(home)
             // Drain the read stream, gathering chunks; an error item means the shard is absent.
             const collect = (acc: List<Vec>) =>
-                (stream: ListEffect<FileCasOperation, IoResult<Vec>>): Effect<FileCasOperation | Write, number> =>
-                    stream.step((node): Effect<FileCasOperation | Write, number> => {
+                (stream: ListEffect<FileCasOperation, IoResult<Vec>>): Effect<FileCasOperation | WriteFile | Write, number> =>
+                    stream.step((node): Effect<FileCasOperation | WriteFile | Write, number> => {
                         if (node === undefined) {
                             return writeFile(path, msb.listToVec(reverse(acc))).step(() => pure(0))
                         }

--- a/fs/cas/proof.f.ts
+++ b/fs/cas/proof.f.ts
@@ -1,6 +1,6 @@
 import { commands, fileCas, type FileCasOperation } from './module.f.ts'
 import { computeSync, sha256 } from '../crypto/sha2/module.f.ts'
-import { length, msb, vec8 } from '../types/bit_vec/module.f.ts'
+import { length, maxLength, msb, vec, vec8 } from '../types/bit_vec/module.f.ts'
 import type { Vec } from '../types/bit_vec/module.f.ts'
 import { listEffectCons, listEffectEnd, pure, type Effect, type ListEffect } from '../effects/module.f.ts'
 import { error, ok } from '../types/result/module.f.ts'
@@ -174,6 +174,36 @@ export const proof = {
         if (result[0] !== 'error') { throw ['expected write error', result] }
         const [, hashes] = virtual(state1)(c.list())
         if (hashes.length !== 0) { throw ['expected nothing published on abort', hashes] }
+    },
+    casWriteReadExceedsMaxLength: () => {
+        // The point of streaming: a payload larger than a single `Vec`'s `maxLength`
+        // (128 KiB) must round-trip. `write` lands the chunks on disk without ever
+        // holding them as one `Vec`, and `read` streams them back the same way — so the
+        // round-trip is verified by hashing the read stream incrementally rather than
+        // concatenating it (which would itself overflow `maxLength`).
+        const big = vec(maxLength)(0xABn)   // one full-size chunk: exactly maxLength bits
+        const tail = vec8(0x2An)            // one more byte ⇒ total > maxLength
+        const chunks = [big, tail] as const
+        const c = fileCas(sha256)('.')
+        const payload: ListEffect<FileCasOperation, IoResult<Vec>> =
+            chunks.reduceRight<ListEffect<FileCasOperation, IoResult<Vec>>>(
+                (tl, chunk) => listEffectCons(ok(chunk), tl), listEffectEnd())
+        const [state1, w] = virtual(emptyState)(c.write(payload))
+        if (w[0] !== 'ok') { throw ['expected write ok', w] }
+        const hash = w[1]
+        if (msb.cmp(hash)(computeSync(sha256)(chunks)) !== 0) { throw 'oversized write hash mismatch' }
+        // Fold the read stream straight into a fresh SHA-2 state — never one `Vec`.
+        const rehash = (state: typeof sha256.init) =>
+            (stream: ListEffect<FileCasOperation, IoResult<Vec>>): Effect<FileCasOperation, IoResult<Vec>> =>
+                stream.step((node): Effect<FileCasOperation, IoResult<Vec>> => {
+                    if (node === undefined) { return pure(ok(sha256.end(state))) }
+                    const [item, rest] = node
+                    if (item[0] === 'error') { return pure(item) }
+                    return rehash(sha256.append(item[1])(state))(rest)
+                })
+        const [, readBack] = virtual(state1)(rehash(sha256.init)(c.read(hash)))
+        if (readBack[0] !== 'ok') { throw ['expected read ok', readBack] }
+        if (msb.cmp(readBack[1])(hash) !== 0) { throw 'oversized read-back hash mismatch' }
     },
     casWriteGcReclaimsExpired: () => {
         // A staging file whose deadline is in the past is reclaimed by the GC that `write`

--- a/fs/cas/proof.f.ts
+++ b/fs/cas/proof.f.ts
@@ -3,9 +3,10 @@ import { computeSync, sha256 } from '../crypto/sha2/module.f.ts'
 import { length, msb, vec8 } from '../types/bit_vec/module.f.ts'
 import type { Vec } from '../types/bit_vec/module.f.ts'
 import { listEffectCons, listEffectEnd, pure, type Effect, type ListEffect } from '../effects/module.f.ts'
-import { ok } from '../types/result/module.f.ts'
+import { error, ok } from '../types/result/module.f.ts'
 import { defaultNodeProgramOptions, emptyState, virtual } from '../effects/node/virtual/module.f.ts'
-import type { IoResult, NodeProgramOptions } from '../effects/node/module.f.ts'
+import { access, type IoResult, type NodeProgramOptions } from '../effects/node/module.f.ts'
+import { join } from '../path/module.f.ts'
 import { dispatch } from '../cli/module.f.ts'
 
 const makeOptions = (args: readonly string[]): NodeProgramOptions =>
@@ -119,5 +120,75 @@ export const proof = {
         const [, node] = virtual(emptyState)(c.read(hash))
         if (node === undefined) { throw 'missing shard must not be EOF' }
         if (node[0][0] !== 'error') { throw ['expected error item', node[0]] }
+    },
+    casWriteMultiChunk: () => {
+        // A multi-chunk payload streams through `writeBytes` chunk-by-chunk (the lease is
+        // renewed between chunks); the hash equals the SHA-256 of the concatenated bytes,
+        // and read streams the same content back.
+        const chunks = [vec8(0x11n), vec8(0x22n), vec8(0x33n)] as const
+        const c = fileCas(sha256)('.')
+        const payload: ListEffect<FileCasOperation, IoResult<Vec>> =
+            chunks.reduceRight<ListEffect<FileCasOperation, IoResult<Vec>>>(
+                (tail, chunk) => listEffectCons(ok(chunk), tail), listEffectEnd())
+        const [state1, writeResult] = virtual(emptyState)(c.write(payload))
+        if (writeResult[0] !== 'ok') { throw ['expected write ok', writeResult] }
+        const hash = writeResult[1]
+        if (msb.cmp(hash)(computeSync(sha256)(chunks)) !== 0) { throw 'multi-chunk write hash mismatch' }
+        const drain = (acc: readonly Vec[]) =>
+            (stream: ListEffect<FileCasOperation, IoResult<Vec>>): Effect<FileCasOperation, IoResult<readonly Vec[]>> =>
+                stream.step((node): Effect<FileCasOperation, IoResult<readonly Vec[]>> => {
+                    if (node === undefined) { return pure(ok(acc)) }
+                    const [item, rest] = node
+                    if (item[0] === 'error') { return pure(item) }
+                    return drain([...acc, item[1]])(rest)
+                })
+        const [, readResult] = virtual(state1)(drain([])(c.read(hash)))
+        if (readResult[0] !== 'ok') { throw ['expected read ok', readResult] }
+        const expected = msb.concat(msb.concat(chunks[0])(chunks[1]))(chunks[2])
+        if (msb.cmp(msb.listToVec(readResult[1]))(expected) !== 0) { throw 'multi-chunk read content mismatch' }
+    },
+    casWriteDedup: () => {
+        // Same content ⇒ same hash; the second upload's replace-`rename` publishes over the
+        // first, leaving exactly one shard in the store.
+        const content = vec8(0x2An)
+        const c = fileCas(sha256)('.')
+        const payload = (): ListEffect<FileCasOperation, IoResult<Vec>> =>
+            listEffectCons(ok(content), listEffectEnd())
+        const [state1, w1] = virtual(emptyState)(c.write(payload()))
+        const [state2, w2] = virtual(state1)(c.write(payload()))
+        if (w1[0] !== 'ok' || w2[0] !== 'ok') { throw ['expected both writes ok', w1, w2] }
+        if (msb.cmp(w1[1])(w2[1]) !== 0) { throw 'dedup hash mismatch' }
+        const [, hashes] = virtual(state2)(c.list())
+        if (hashes.length !== 1) { throw ['expected one shard after dedup', hashes.length] }
+    },
+    casWriteErrorItemAborts: () => {
+        // An error item mid-stream deletes the partial staging file and fails; nothing is
+        // published, so the store stays empty.
+        const c = fileCas(sha256)('.')
+        const okItem: IoResult<Vec> = ok(vec8(0x11n))
+        const errItem: IoResult<Vec> = error({ code: 'BOOM' })
+        const payload: ListEffect<FileCasOperation, IoResult<Vec>> =
+            listEffectCons<FileCasOperation, IoResult<Vec>>(okItem,
+                listEffectCons<FileCasOperation, IoResult<Vec>>(errItem, listEffectEnd()))
+        const [state1, result] = virtual(emptyState)(c.write(payload))
+        if (result[0] !== 'error') { throw ['expected write error', result] }
+        const [, hashes] = virtual(state1)(c.list())
+        if (hashes.length !== 0) { throw ['expected nothing published on abort', hashes] }
+    },
+    casWriteGcReclaimsExpired: () => {
+        // A staging file whose deadline is in the past is reclaimed by the GC that `write`
+        // runs before staging its own file.
+        const stalePath = join('.', '.cas', '_stage', '0000000000000000000-stale')
+        const state0 = {
+            ...emptyState,
+            epochNs: 1_000_000,
+            root: { '.cas': { '_stage': { '0000000000000000000-stale': [vec8(0x99n)] } } },
+        }
+        const content = vec8(0x2An)
+        const c = fileCas(sha256)('.')
+        const [state1, w] = virtual(state0)(c.write(listEffectCons(ok(content), listEffectEnd())))
+        if (w[0] !== 'ok') { throw ['expected write ok', w] }
+        const [, present] = virtual(state1)(access(stalePath))
+        if (present[0] !== 'error') { throw 'expected GC to reclaim the expired staging file' }
     },
 }

--- a/fs/effects/node/module.f.ts
+++ b/fs/effects/node/module.f.ts
@@ -173,9 +173,47 @@ export type Access = readonly['access', (path: string) => IoResult<void>]
 export const access: Func<Access> =
     do_('access')
 
+// createExclusive
+
+/**
+ * Creates `path` as an empty file with `O_CREAT|O_EXCL` — fails if it already
+ * exists. This is the exclusive create that claims a staging name in the
+ * lock-free upload ([staging-lease.md](../../../issues/cas/staging-lease.md));
+ * with 256 random bits in the name `EEXIST` never happens in practice, so it
+ * is just a sanity guard.
+ */
+export type CreateExclusive = readonly['createExclusive', (path: string) => IoResult<void>]
+
+export const createExclusive: Func<CreateExclusive> =
+    do_('createExclusive')
+
+// writeBytes
+
+/**
+ * Writes the **entire** `data` vector to an **existing** `path` at byte `offset`
+ * (positional write). The mirror of {@link readBytes}: it never creates the file
+ * (a missing path is `ENOENT`), and it writes every byte or returns an error —
+ * the runner loops over short writes — so a later size check can never pass over
+ * a hole. Bounded to ≤128 KiB per call, like `readBytes`.
+ */
+export type WriteBytes = readonly['writeBytes', (path: string, offset: number, data: Vec) => IoResult<void>]
+
+export const writeBytes: Func<WriteBytes> =
+    do_('writeBytes')
+
+// stat
+
+/** File metadata returned by {@link stat}. Only `size` (in bytes) for now. */
+export type FileStat = { readonly size: number }
+
+export type Stat = readonly['stat', (path: string) => IoResult<FileStat>]
+
+export const stat: Func<Stat> =
+    do_('stat')
+
 // Fs
 
-export type Fs = Mkdir | ReadFile | ReadBytes | Readdir | WriteFile | Rm | Rename | Exec | Access
+export type Fs = Mkdir | ReadFile | ReadBytes | Readdir | WriteFile | Rm | Rename | Exec | Access | CreateExclusive | WriteBytes | Stat
 
 // Server
 

--- a/fs/effects/node/module.ts
+++ b/fs/effects/node/module.ts
@@ -244,6 +244,26 @@ const runNodeEffect: EffectToPromise = asyncRun({
     }),
     randomInt: async () => crypto.randomInt(2 ** 32),
     access: path => tc(() => access(path)),
+    createExclusive: path => tc(async () => {
+        const fh = await open(path, 'wx')
+        await fh.close()
+    }),
+    writeBytes: (path, offset, data) => tc(async () => {
+        const fh = await open(path, 'r+')
+        try {
+            const buffer = fromVec(data)
+            // Loop over short writes so the whole Vec lands — a partial pwrite would
+            // leave a hole the publish-time size check could pass over.
+            let written = 0
+            while (written < buffer.length) {
+                const { bytesWritten } = await fh.write(buffer, written, buffer.length - written, offset + written)
+                written += bytesWritten
+            }
+        } finally {
+            await fh.close()
+        }
+    }),
+    stat: path => tc(async () => ({ size: (await stat(path)).size })),
     import: path => tc(() => asyncImport(path)),
     exec: (command, stdin) => new Promise(resolve => {
         const child = exec(command, (e, stdout, stderr) =>

--- a/fs/effects/node/virtual/module.f.ts
+++ b/fs/effects/node/virtual/module.f.ts
@@ -10,7 +10,7 @@ import { empty, length, maxLengthBytes, msb, vec, type Vec } from '../../../type
 import { error, ok } from '../../../types/result/module.f.ts'
 import { run, type MemOperationMap, type RunInstance } from '../../mock/module.f.ts'
 import { asBase, asNominal, type Key } from '../../memory/module.f.ts'
-import type { Dirent, IoResult, Module, NodeOp, NodeProgramOptions, SandboxResult } from '../module.f.ts'
+import type { Dirent, FileStat, IoResult, Module, NodeOp, NodeProgramOptions, SandboxResult } from '../module.f.ts'
 
 /**
  * In-memory JS module entry. When `import_` is called on the path, the
@@ -275,6 +275,46 @@ const readBytesOp = (path: string, offset: number, size: number) => readOperatio
     return ok(result)
 })(path)
 
+/** Total byte size of a chunk-list file (each chunk is byte-aligned). */
+const fileSizeBytes = (chunks: readonly Vec[]): number =>
+    chunks.reduce((acc, c) => acc + Number(length(c) / 8n), 0)
+
+/** Absent-path error for an already-existing exclusive create, mirroring `EEXIST`. */
+const eexist = error({ code: 'EEXIST' })
+
+const createExclusive = operation((dir, path): readonly[Dir, IoResult<void>] => {
+    if (path.length !== 1) { return [dir, invalidPath] }
+    const [name] = path
+    // O_EXCL: fail if the name is already taken; otherwise create an empty file.
+    if (dir[name] !== undefined) { return [dir, eexist] }
+    return [{ ...dir, [name]: [] }, okVoid]
+})
+
+// The lock-free upload only ever writes sequentially at the current end of the
+// staging file (`offset === size`), so the virtual model implements that append
+// case exactly: it never creates (a missing file is `ENOENT`), never overwrites
+// existing bytes, and never leaves a hole — matching the effect's contract for
+// the one access pattern its callers use.
+const writeBytesOp = (path: string, offset: number, data: Vec) => operation((dir, p): readonly[Dir, IoResult<void>] => {
+    if (p.length !== 1) { return [dir, enoent] }
+    const [name] = p
+    const file = dir[name]
+    if (file === undefined) { return [dir, enoent] }              // writeBytes never creates
+    if (!Array.isArray(file)) { return [dir, error(`'${name}' is not a file`)] }
+    if (!Number.isInteger(offset) || offset < 0) { return [dir, error(`Offset ${offset} is invalid`)] }
+    const chunks = file as readonly Vec[]
+    if (offset !== fileSizeBytes(chunks)) { return [dir, error(`writeBytes offset ${offset} must equal the file size (append-only)`)] }
+    return [{ ...dir, [name]: [...chunks, data] }, okVoid]
+})(path)
+
+const statOp = readOperation((dir, path): IoResult<FileStat> => {
+    if (path.length !== 1) { return enoent }
+    const file = dir[path[0]]
+    if (file === undefined) { return enoent }
+    if (!Array.isArray(file)) { return error(`'${path[0]}' is not a file`) }
+    return ok({ size: fileSizeBytes(file as readonly Vec[]) })
+})
+
 const map: MemOperationMap<NodeOp, State> = {
     all: (...a) => state => {
         let e: readonly unknown[] = []
@@ -316,6 +356,9 @@ const map: MemOperationMap<NodeOp, State> = {
     rm,
     rename,
     readBytes: readBytesOp,
+    createExclusive,
+    writeBytes: writeBytesOp,
+    stat: statOp,
     randomInt: () => state => [{ ...state, randomNext: state.randomNext + 1 }, state.randomNext],
     exec: todo,
     createServer: todo,


### PR DESCRIPTION
Implements **Step 3** of [issues/cas/plan.md](https://github.com/functionalscript/functionalscript/blob/main/issues/cas/plan.md): the lock-free staging upload from [issues/cas/staging-lease.md](https://github.com/functionalscript/functionalscript/blob/main/issues/cas/staging-lease.md).

## `fileCas.write` — staging algorithm
Replaces the accumulate-then-`writeFile` publish with the deadline-lease pipeline:
1. `random256()` + `mkdir(.cas/_stage)`, then `createExclusive` a `<deadline>-<random256>` staging file.
2. Fold the payload stream: `writeBytes(path, offset, chunk)`, advance the byte offset, update the SHA-2 state, and renew the lease (rename to a fresh `now()+delta` deadline) after each chunk. Any error ⇒ `rm(path)` and return an upload error — the payload never lives in memory as a whole.
3. Publish: `mkdir -p` the shard dir, replace-`rename` to `.cas/<shard>`, `rm` the staging file (results ignored), then confirm success with `stat(dst).size === offset`.

GC of expired staging files is piggy-backed at the start of every `write` (`readdir` `_stage/`, `rm` entries whose deadline is past).

## New effects (`fs/effects/node`)
Path-based, no held `FileHandle`:
- `createExclusive(path)` — `O_CREAT|O_EXCL`.
- `writeBytes(path, offset, data)` — pwrite the **entire** `Vec` at a byte offset; never creates (the mirror of `readBytes`), loops over short writes so no hole.
- `stat(path)` — `{ size }`.

Implemented in both the real Node runner and the in-memory virtual runner.

## `casUpload` migration
Moves staging from `.cas/.stage/<rand>-<file>` to `.cas/_stage/<deadline>-<random256>`, bringing its move-hash-move orphans under the same lease GC. Old `.stage/` path removed.

## Tests
Virtual-runner coverage in `fs/cas/proof.f.ts`: multi-chunk streaming round-trip, dedup (same content ⇒ one shard via replace-publish), mid-stream error abort (nothing published), and GC reclaiming an expired staging file. Existing `casUpload`/CLI/MCP tests pass unchanged.

`npx tsc` clean; full suite `fjs t` green (1901 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0197Sqzjyo6iL9nj2tD8Jhhy)_