### PR TITLE
todo/new-pl.md: editorial fixes, clarifications, and new Module Identity section

### DIFF
--- a/todo/new-pl.md
+++ b/todo/new-pl.md
@@ -23,18 +23,18 @@ And this is understandable because JSON (JavaScript Object Notation) is derived 
 }
 ```
 
-Even if don't like sometimes the syntax, the semantic of these basic types makes a lot of practical sense in modern computer science and software engineering, that have most popular basic types and but allow grouping by order (arrays), and mapping (objects).
+Even if we don't always like the syntax, the semantics of these basic types make a lot of practical sense in modern computer science and software engineering, having the most popular basic types and allowing grouping by order (arrays) and mapping (objects).
 
 ## Data JavaScript
 
-FunctionalScript already defines a subset of JavaScript which is much more strict, has no side effects and supports all JSON types. We also would like to make it serialazable, which makes it a kind of ideal PL for handling data and communications, including as data for AI agents and models. Example:
+FunctionalScript already defines a subset of JavaScript which is stricter, has no side effects and supports all JSON types. We also would like to make it serializable, which makes it a kind of ideal PL for handling data and communications, including as data for AI agents and models. Example:
 
 ```js
 export const hello = "Hello, world!"
 export const add = (a, b) => a + b
 ```
 
-One of the subset of FunctionalScript is DJS (Data JavaScript), when the module contains only data, for example
+One of the subsets of FunctionalScript is DJS (Data JavaScript), when the module contains only data, for example
 
 ```js
 export default {
@@ -60,7 +60,7 @@ Moving further, we will use FunctionalScript as a foundation to build our progra
 
 ## Content-Addressability
 
-FunctionalScript programs can be run as content-addressable, but their behavior could be different compare to running the same program on JavaScript engine, for example:
+FunctionalScript programs can be run as content-addressable, but their behavior could be different compared to running the same program on a JavaScript engine, for example:
 
 ```js
 const assert = (a, b) => {
@@ -71,7 +71,9 @@ const assert = (a, b) => {
 export default assert([], [])
 ```
 
-While content-addressability makes some FunctionalScript very cool, we still would like to have some additional features in a programming language that is design from scratch. For example, we would like to have a hash of an object, a kind of universal, serializable object identity.
+Under content-addressability, both `[]` literals refer to the same canonical empty-array value, so `assert` passes. Running the same code on a standard JS engine would throw because `[] !== []` (different references).
+
+While content-addressability makes some FunctionalScript very cool, we still would like to have some additional features in a programming language designed from scratch. For example, we would like to have a hash of an object — a kind of universal, serializable object identity.
 
 ```js
 const emptyArrayId1 = Object.id([])
@@ -80,24 +82,24 @@ const emptyArrayId2 = Object.id([])
 export default assert(emptyArrayId1, emptyArrayId2)
 ```
 
-Without this `Object.id` core function, FunctionalScript could be more like content-equatable instead of fully content-addressable.
+`Object.id` returns the canonical content-hash of its argument, so two structurally equal values always yield the same id. Without this `Object.id` core function, FunctionalScript could be more like content-equatable instead of fully content-addressable.
 
 ## Numbers
 
-Currently, the literal `2` has type `number` which is, usually, 64-bit floating point number, also known as `double`. Initially, JavaScript didn't have biginteger, but, currently they are in ECMAScript standard. Because ECMAScript can't break backward compatibility, they introduced another syntax to describe bigint literals: `2n`, but JSON doesn't support the syntax. While we can have JSON parsers and writers that read and write bigints, the syntax is not the same anymore. So, in a PL design from scratch we would like to have bigint by default:
+Currently, the literal `2` has type `number` which is, usually, a 64-bit floating-point number (IEEE 754 double). Initially, JavaScript didn't have biginteger, but currently they are in the ECMAScript standard. Because ECMAScript can't break backward compatibility, they introduced another syntax to describe bigint literals: `2n`, but JSON doesn't support this syntax. While we can have JSON parsers and writers that read and write bigints, the syntax is not the same anymore. So, in a PL designed from scratch we would like to have bigint by default:
 
 ```ts
-const a = 2 // typeof(a) === 'bigint'
-const b = 2.0 // typeof(b) === 'number'
+const a = 2   // typeof(a) === 'bigint'
+const b = 2.0 // typeof(b) === 'number' (IEEE 754 64-bit double)
 ```
 
 ## UTF8 String
 
-Current implementation of a `string` in JavaScript is UTF16. While we can have a proposal that ECMAScript supports a new type `utf8`, something like `u'Hello, world!'`, the default JS string will be always UTF16. In a new PL, we don't want to have UTF16 at all, only UTF8.
+Current implementation of a `string` in JavaScript is UTF-16. While we can have a proposal that ECMAScript supports a new type `utf8`, something like `u'Hello, world!'`, the default JS string will always be UTF-16. In a new PL, we don't want to have UTF-16 at all, only UTF-8.
 
 ## Separation Between Arrays and Objects
 
-Arrays shouldn't be a subset of objects. It should be a separate type
+Arrays shouldn't be a subset of objects. It should be a separate type.
 
 ```js
 assert(typeof([]) === 'array') // I wish
@@ -105,22 +107,24 @@ assert(typeof([]) === 'array') // I wish
 
 ## Always Lexicographical Order
 
-Properties inside objects should be sorted by lexicographical order. Currently, JS objects preserve properties order:
+Properties inside objects should be sorted in lexicographical order. Currently, JS objects preserve insertion order:
 
 ```js
 JSON.stringify({b:0,a:0}) // returns `{"b":0,"a":0}`
 ```
 
-Always in lexicographical order, and a number is not an exception.
+In the new PL, all keys are strings and always sorted lexicographically (pure string comparison, no special numeric treatment).
 
 ```ts
 const x = { 11: 11, 2: 2, a: 3, b: 5 } // { '11': 11, '2': 2, a: 3, b: 5 }
 const y = { 2: 2, b: 5, a: 3, 11: 11 } // { '11': 11, '2': 2, a: 3, b: 5 }
 ```
 
+Note: JS already sorts integer-like keys numerically before string keys, so the output above matches current JS behavior. In the new PL the same result would be produced by pure lexicographic order (`'11' < '2' < 'a' < 'b'`), which happens to agree here. The key difference is that JS's numeric-key special-casing is eliminated — the rule is simply: sort by string comparison.
+
 ## Assigning
 
-Assigning `undefined` to a property should remove the property
+Assigning `undefined` to a property should remove the property.
 
 ```ts
 const x = { a: undefined } // {}
@@ -149,17 +153,21 @@ ECMAScript proposal for `BigInt.bitLen()`
 
 ## Type Annotations
 
-Switch back to `.js` extension if [Type Annotations](https://github.com/tc39/proposal-type-annotations) lands in ECMAScript
+Switch back to `.js` extension if [Type Annotations](https://github.com/tc39/proposal-type-annotations) lands in ECMAScript.
+
+## Module Identity
+
+Because content-addressability is a core goal, module identity should be hash-based rather than path-based. A module is identified by the hash of its content, not its file path. Paths become human-friendly aliases that resolve to a hash at publish time. This enables reliable deduplication, caching, and dependency pinning without a lockfile.
 
 ## Last Expression is Return and Export (Compatible with JSON)
 
-Currently, this JavaScript code doesn't export the object, like JSON would do
+Currently, this JavaScript code doesn't export the object the way JSON would:
 
 ```js
 { "a": 5 }
 ```
 
-**Proposal:** The last expression is a result of a function. In case of a module, the last expression is exported.
+**Proposal:** The last expression is the result of a function. In the case of a module, the last expression is exported.
 
 ```js
 const g = () => 5
@@ -173,6 +181,8 @@ const a = f()
 
 ## Effect Syntax Sugar
 
+Algebraic effects generalize `async`/`await`, exceptions, and other control-flow abstractions into a single declarative mechanism. The proposed syntax mirrors `async`/`await` but is not tied to a specific effect type:
+
 ```js
 const a = effect() => {
     const x = perform b()
@@ -180,4 +190,4 @@ const a = effect() => {
 }
 ```
 
-Similar to `async`/`await` but declarative.
+`effect` marks a function that may perform effects; `perform` suspends the computation and delegates to the nearest handler, similar to how `await` delegates to the runtime scheduler.


### PR DESCRIPTION
## Summary

- Fix grammar and typos (\"serialazable\", \"design from scratch\", \"Even if don't like\", etc.)
- Clarify the Content-Addressability section: add a note explaining why the `assert([], [])` example passes under CAS but fails on a standard JS engine, and describe what `Object.id` returns
- Clarify the Lexicographical Order section: explain that JS's numeric-key special-casing is eliminated and the rule is pure string comparison
- Clarify Numbers section: note that `2.0` is IEEE 754 64-bit double
- Add **Module Identity** section: proposes hash-based (rather than path-based) module identity as a natural extension of content-addressability
- Expand **Effect Syntax Sugar** section: briefly explain algebraic effects and the role of `effect`/`perform` keywords

## Test plan

- [ ] Read the rendered markdown and confirm all examples are consistent with the surrounding prose

---
_Generated by [Claude Code](https://claude.ai/code/session_01Htj1bb8yKp4UGwMDutdsdd)_