### PR TITLE
Update dependencies and CI tooling versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@
           }
         },
         {
-          "uses": "actions/setup-node@v6",
+          "uses": "actions/setup-node@v6.4.0",
           "with": {
-            "node-version": "26.3.1"
+            "node-version": "26.4.0"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.32.4"
+          "run": "npm install -g functionalscript@0.33.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -75,13 +75,13 @@
           }
         },
         {
-          "uses": "actions/setup-node@v6",
+          "uses": "actions/setup-node@v6.4.0",
           "with": {
-            "node-version": "26.3.1"
+            "node-version": "26.4.0"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.32.4"
+          "run": "npm install -g functionalscript@0.33.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -116,13 +116,13 @@
           }
         },
         {
-          "uses": "actions/setup-node@v6",
+          "uses": "actions/setup-node@v6.4.0",
           "with": {
-            "node-version": "26.3.1"
+            "node-version": "26.4.0"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.32.4"
+          "run": "npm install -g functionalscript@0.33.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -157,13 +157,13 @@
           }
         },
         {
-          "uses": "actions/setup-node@v6",
+          "uses": "actions/setup-node@v6.4.0",
           "with": {
-            "node-version": "26.3.1"
+            "node-version": "26.4.0"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.32.4"
+          "run": "npm install -g functionalscript@0.33.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -199,13 +199,13 @@
           }
         },
         {
-          "uses": "actions/setup-node@v6",
+          "uses": "actions/setup-node@v6.4.0",
           "with": {
-            "node-version": "26.3.1"
+            "node-version": "26.4.0"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.32.4"
+          "run": "npm install -g functionalscript@0.33.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -252,13 +252,13 @@
           }
         },
         {
-          "uses": "actions/setup-node@v6",
+          "uses": "actions/setup-node@v6.4.0",
           "with": {
-            "node-version": "26.3.1"
+            "node-version": "26.4.0"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.32.4"
+          "run": "npm install -g functionalscript@0.33.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -296,7 +296,7 @@
         {
           "uses": "bytecodealliance/actions/wasmtime/setup@v1",
           "with": {
-            "version": "45.0.2"
+            "version": "46.0.1"
           }
         },
         {
@@ -389,19 +389,19 @@
       "runs-on": "ubuntu-26.04-arm",
       "steps": [
         {
-          "uses": "denoland/setup-deno@v2",
+          "uses": "denoland/setup-deno@v2.0.4",
           "with": {
-            "deno-version": "2.8.3"
+            "deno-version": "2.9.0"
           }
         },
         {
-          "run": "deno install -g -A npm:functionalscript@0.32.4"
+          "run": "deno install -g -A npm:functionalscript@0.33.0"
         },
         {
           "uses": "actions/checkout@v7"
         },
         {
-          "run": "deno run -A npm:functionalscript@0.32.4 t"
+          "run": "deno run -A npm:functionalscript@0.33.0 t"
         },
         {
           "run": "deno install --frozen"
@@ -424,7 +424,7 @@
           }
         },
         {
-          "run": "bun install -g functionalscript@0.32.4"
+          "run": "bun install -g functionalscript@0.33.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -433,7 +433,7 @@
           "run": "bun install --frozen-lockfile"
         },
         {
-          "run": "bunx functionalscript@0.32.4 t"
+          "run": "bunx functionalscript@0.33.0 t"
         },
         {
           "run": "bun test --coverage"
@@ -447,13 +447,13 @@
       "runs-on": "ubuntu-26.04-arm",
       "steps": [
         {
-          "uses": "actions/setup-node@v6",
+          "uses": "actions/setup-node@v6.4.0",
           "with": {
-            "node-version": "22.23.0"
+            "node-version": "22.23.1"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.32.4"
+          "run": "npm install -g functionalscript@0.33.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -473,9 +473,9 @@
       "runs-on": "ubuntu-26.04-arm",
       "steps": [
         {
-          "uses": "actions/setup-node@v6",
+          "uses": "actions/setup-node@v6.4.0",
           "with": {
-            "node-version": "24.17.0"
+            "node-version": "24.18.0"
           }
         },
         {
@@ -496,13 +496,13 @@
       "runs-on": "ubuntu-26.04-arm",
       "steps": [
         {
-          "uses": "actions/setup-node@v6",
+          "uses": "actions/setup-node@v6.4.0",
           "with": {
-            "node-version": "26.3.1"
+            "node-version": "26.4.0"
           }
         },
         {
-          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260621.1"
+          "run": "npm install -g @typescript/native-preview@7.0.0-dev.20260627.2"
         },
         {
           "uses": "actions/checkout@v7"
@@ -531,20 +531,20 @@
       "runs-on": "ubuntu-26.04-arm",
       "steps": [
         {
-          "uses": "actions/setup-node@v6",
+          "uses": "actions/setup-node@v6.4.0",
           "with": {
-            "node-version": "26.3.1"
+            "node-version": "26.4.0"
           }
         },
         {
-          "uses": "actions/cache@v5",
+          "uses": "actions/cache@v6.1.0",
           "with": {
             "path": "~/.cache/ms-playwright",
-            "key": "ubuntu-26.04-arm-playwright-1.61.0"
+            "key": "ubuntu-26.04-arm-playwright-1.61.1"
           }
         },
         {
-          "run": "npm install -g playwright@1.61.0"
+          "run": "npm install -g playwright@1.61.1"
         },
         {
           "run": "playwright install-deps"

--- a/bun.lock
+++ b/bun.lock
@@ -5,22 +5,22 @@
     "": {
       "name": "functionalscript",
       "devDependencies": {
-        "@playwright/test": "1.61.0",
-        "@types/node": "26.0.0",
+        "@playwright/test": "1.61.1",
+        "@types/node": "26.0.1",
         "typescript": "6.0.3",
       },
     },
   },
   "packages": {
-    "@playwright/test": ["@playwright/test@1.61.0", "", { "dependencies": { "playwright": "1.61.0" }, "bin": { "playwright": "cli.js" } }, "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA=="],
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
-    "@types/node": ["@types/node@26.0.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA=="],
+    "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
-    "playwright": ["playwright@1.61.0", "", { "dependencies": { "playwright-core": "1.61.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ=="],
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
 
-    "playwright-core": ["playwright-core@1.61.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA=="],
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 

--- a/deno.lock
+++ b/deno.lock
@@ -1,20 +1,20 @@
 {
   "version": "5",
   "specifiers": {
-    "npm:@playwright/test@1.61.0": "1.61.0",
-    "npm:@types/node@26.0.0": "26.0.0",
+    "npm:@playwright/test@1.61.1": "1.61.1",
+    "npm:@types/node@26.0.1": "26.0.1",
     "npm:typescript@6.0.3": "6.0.3"
   },
   "npm": {
-    "@playwright/test@1.61.0": {
-      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+    "@playwright/test@1.61.1": {
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dependencies": [
         "playwright"
       ],
       "bin": true
     },
-    "@types/node@26.0.0": {
-      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+    "@types/node@26.0.1": {
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "dependencies": [
         "undici-types"
       ]
@@ -24,12 +24,12 @@
       "os": ["darwin"],
       "scripts": true
     },
-    "playwright-core@1.61.0": {
-      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+    "playwright-core@1.61.1": {
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "bin": true
     },
-    "playwright@1.61.0": {
-      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+    "playwright@1.61.1": {
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dependencies": [
         "playwright-core"
       ],
@@ -49,8 +49,8 @@
   "workspace": {
     "packageJson": {
       "dependencies": [
-        "npm:@playwright/test@1.61.0",
-        "npm:@types/node@26.0.0",
+        "npm:@playwright/test@1.61.1",
+        "npm:@types/node@26.0.1",
         "npm:typescript@6.0.3"
       ]
     }

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -25,32 +25,32 @@ export const images = {
 // published FunctionalScript release; do not tie it to package.json's current
 // in-repo version. A separate maintenance job advances this pin.
 // https://www.npmjs.com/package/functionalscript
-export const functionalscript = '0.32.4' as const
+export const functionalscript = '0.33.0' as const
 
 // https://bun.sh/
 export const bun = '1.3.14'
 
 // https://deno.com/
-export const deno = '2.8.3'
+export const deno = '2.9.0'
 
 // https://www.npmjs.com/package/playwright
-export const playwright = '1.61.0'
+export const playwright = '1.61.1'
 
 // https://nodejs.org/en/download
 export const node = {
-    default: '26.3.1',
-    node22: '22.23.0',
-    node24: '24.17.0',
+    default: '26.4.0',
+    node22: '22.23.1',
+    node24: '24.18.0',
 } as const
 
 // https://github.com/bytecodealliance/wasmtime/releases
-export const wasmtime = '45.0.2'
+export const wasmtime = '46.0.1'
 
 // https://github.com/wasmerio/wasmer/releases
 export const wasmer = '7.1.0'
 
 // https://www.npmjs.com/package/@typescript/native-preview?activeTab=versions
-export const tsgo = '7.0.0-dev.20260621.1'
+export const tsgo = '7.0.0-dev.20260627.2'
 
 // GitHub Action versions used by CI step builders. The key is the action
 // `owner/name`; call sites compose the full ref as
@@ -60,11 +60,11 @@ export const actions = {
     // https://github.com/marketplace/actions/checkout
     'actions/checkout': 'v7',
     // https://github.com/marketplace/actions/setup-node-js-environment
-    'actions/setup-node': 'v6',
+    'actions/setup-node': 'v6.4.0',
     // https://github.com/marketplace/actions/cache
-    'actions/cache': 'v5',
+    'actions/cache': 'v6.1.0',
     // https://github.com/marketplace/actions/setup-deno
-    'denoland/setup-deno': 'v2',
+    'denoland/setup-deno': 'v2.0.4',
     // https://github.com/marketplace/actions/setup-bun
     'oven-sh/setup-bun': 'v2.2.0',
     // https://github.com/bytecodealliance/actions

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "fjs": "fs/fjs/module.js"
       },
       "devDependencies": {
-        "@playwright/test": "1.61.0",
-        "@types/node": "26.0.0",
+        "@playwright/test": "1.61.1",
+        "@types/node": "26.0.1",
         "typescript": "6.0.3"
       },
       "engines": {
@@ -21,13 +21,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
-      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.0"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
-      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -62,13 +62,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
-      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -81,9 +81,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
-      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   },
   "homepage": "https://github.com/functionalscript/functionalscript#readme",
   "devDependencies": {
-    "@playwright/test": "1.61.0",
-    "@types/node": "26.0.0",
+    "@playwright/test": "1.61.1",
+    "@types/node": "26.0.1",
     "typescript": "6.0.3"
   }
 }


### PR DESCRIPTION
## Summary
This PR updates various development dependencies, runtime versions, and GitHub Actions to their latest stable releases across the CI/CD pipeline and project configuration.

## Key Changes

### Runtime & Tool Versions
- **Node.js**: Updated default from 26.3.1 to 26.4.0, node22 from 22.23.0 to 22.23.1, and node24 from 24.17.0 to 24.18.0
- **Deno**: Bumped from 2.8.3 to 2.9.0
- **FunctionalScript**: Updated from 0.32.4 to 0.33.0 across all CI workflows
- **Playwright**: Upgraded from 1.61.0 to 1.61.1
- **Wasmtime**: Updated from 45.0.2 to 46.0.1
- **TypeScript Native Preview**: Updated from 7.0.0-dev.20260621.1 to 7.0.0-dev.20260627.2

### GitHub Actions
- **actions/setup-node**: Pinned from v6 to v6.4.0
- **actions/cache**: Upgraded from v5 to v6.1.0
- **denoland/setup-deno**: Pinned from v2 to v2.0.4

### Development Dependencies
- **@playwright/test**: Updated from 1.61.0 to 1.61.1
- **@types/node**: Updated from 26.0.0 to 26.0.1

## Implementation Details
All version updates are reflected in both the CI workflow configuration (`ci.yml`) and the source configuration module (`fs/ci/config/module.f.ts`), ensuring consistency across the build pipeline. The changes maintain the existing CI structure while bringing all tools and dependencies to their latest stable versions.

https://claude.ai/code/session_012SFUzZeT9Bx1BCftfstQn5