### PR TITLE
Document cas_get metadata-only streaming proposal

### DIFF
--- a/fs/bnf/todo/layered-parser.md
+++ b/fs/bnf/todo/layered-parser.md
@@ -26,8 +26,9 @@ Every layer reuses the same BNF engine.
 
 ### Transducers, recognizers, and streaming
 
-A transducer's step is Mealy-style — `(state, inSymbol) => (state, outSymbol*)`,
-producing zero or more output symbols per input. A **recognizer** (see
+A transducer's step is Mealy-style, which is exactly the existing
+`StateScan<I, S, O>` (`fs/types/function/operator`): `(inSymbol, state) =>
+[outSymbol*, state]`, driven by `stateScan` over a `List`. A **recognizer** (see
 [recognizer-backend](./recognizer-backend.md)) is the degenerate transducer that
 emits nothing and only reports a verdict; so **UTF-8 validation is just the
 byte→code-point decoder with its output discarded** — the same automaton the

--- a/fs/bnf/todo/layered-parser.md
+++ b/fs/bnf/todo/layered-parser.md
@@ -3,15 +3,45 @@
 **Priority:** P3
 **Status:** open
 
-A tokenizer accepts a sequence of code-points as input tokens together with meta information (file name, position). It uses our BNF parser to output new tokens.
+Each layer is a parser acting as a **transducer**: it consumes a stream of
+symbols of one alphabet and emits a stream of symbols of the next, each carrying
+meta information (file name, position, the original symbols). Stacking these
+transducers is another way to construct automata — composition in **series**
+(pipeline), as opposed to the parallel/product combination of recognizers.
 
-Each token type is represented by a single symbol, e.g. `s` for string, `n` for number, `i` for identifier. All other information (actual value, position, etc.) is carried as meta information. This sequence of tokens is then the input into a new parser layer.
+The bottom layer is a **text decoder**: it accepts a stream of **bytes** and
+emits a stream of **code-points** (e.g. UTF-8 decoding). On top of it a
+**tokenizer** accepts code-points and emits **tokens**, and on top of that a
+parser builds the **AST**:
 
 ```
-code-points + meta ==BNF==> tokens(symbol + meta) ==BNF==> AST
+bytes ==BNF==> code-points + meta ==BNF==> tokens(symbol + meta) ==BNF==> AST
 ```
 
-Both layers reuse the same BNF engine.
+Each token type is represented by a single symbol, e.g. `s` for string, `n` for
+number, `i` for identifier. All other information (actual value, position, etc.)
+is carried as meta information.
+
+Every layer reuses the same BNF engine.
+
+### Transducers, recognizers, and streaming
+
+A transducer's step is Mealy-style — `(state, inSymbol) => (state, outSymbol*)`,
+producing zero or more output symbols per input. A **recognizer** (see
+[recognizer-backend](./recognizer-backend.md)) is the degenerate transducer that
+emits nothing and only reports a verdict; so **UTF-8 validation is just the
+byte→code-point decoder with its output discarded** — the same automaton the
+text layer uses, projected to accept/reject.
+
+Two mechanics the layers need:
+
+- **Maximal munch** in the tokenizer: a DFA *recognizes*, but tokenizing must
+  decide where to *cut* — emit a token at the longest accepting prefix, then
+  restart. This is the one mechanism the token transducer adds over plain
+  recognition.
+- **Streaming survives composition**: transducers compose as streaming folds,
+  so the whole `bytes → … → AST` pipeline stays incremental — what large inputs
+  (big source files, streamed blobs) require.
 
 ### Open Questions
 

--- a/fs/bnf/todo/recognizer-backend.md
+++ b/fs/bnf/todo/recognizer-backend.md
@@ -42,18 +42,44 @@ type Recognizer<S> = {
 an incremental input, including the effectful CAS chunk stream) and lets callers
 **short-circuit** once the state reaches an absorbing sink.
 
+#### Build from the data representation, not the functional one
+
+BNF has two representations and the automata builders consume the **second**:
+
+```
+functional grammar (fs/bnf)  ──toData──▶  data RuleSet (fs/bnf/data)  ──build──▶  automata
+   (composable authoring)                 (serializable IR)
+```
+
+The data IR is exactly the substrate for automaton construction:
+`Rule = Variant | Sequence | TerminalRange` — alternation, concatenation, and
+terminal ranges, with name references for recursion. `dispatchMap` / `parser`
+are already *one* family built from `RuleSet`; the recognizer and DFA backends
+are **new builders over the same `RuleSet`**, siblings of `dispatchMap` — not a
+separate front end. So: author `magic | utf8` functionally, `toData` it, compile.
+
 Two backends, distinguished by grammar class — this distinction is load-bearing:
 
-1. **DFA backend — regular subset.** For grammars with no center-embedding
-   (only self-/tail-recursion, i.e. `repeat`-style), compile to a finite DFA
-   (reuse / generalize `fs/fsm` subset construction). `S` is a genuine finite
-   state; union/product of grammars falls out of subset construction. This is
-   the **scanner/lexer tier**: magic-bytes, UTF-8, token scanners.
+1. **DFA backend — regular subset.** The genuinely new builder: analyze the
+   `RuleSet` graph and, for grammars with no center-embedding (only
+   self-/tail-recursion, i.e. `repeat`-style), compile to a finite DFA (reuse /
+   generalize `fs/fsm` subset construction). `S` is a genuine finite state;
+   union/product of grammars falls out of subset construction. This is the
+   **scanner/lexer tier**: magic-bytes, UTF-8, token scanners.
 
-2. **Recognizer over LL(1) BNF — context-free.** Walk the existing dispatch
-   table with an explicit stack, discard the AST, return accept/reject + final
-   configuration. `S` is a parser configuration (stack), **not** finite. This
-   is the tier above the scanner (PL/structure recognition).
+2. **Recognizer over LL(1) BNF — context-free.** Largely *subtraction* from the
+   existing matcher: `fs/bnf/data` already walks the dispatch and returns
+   `MatchResult = [AstRule, boolean, Remainder]`; the recognizer is the same
+   walk without accumulating the `AstRule`, returning accept/reject + final
+   configuration. `S` is a parser configuration (stack), **not** finite. This is
+   the tier above the scanner (PL/structure recognition).
+
+**Alphabet is the runner's choice, not the IR's.** The data `TerminalRange` is a
+24-bit range and the existing runners are `CodePoint`-oriented, but UTF-8/magic
+detection is inherently **byte-level** while PL/Markdown is **code-point-level**.
+The IR is alphabet-agnostic (ranges over integers) and `step` is symbol-numeric,
+so keep the automaton/runner parametric in the symbol space: a byte runner for
+UTF-8/magic, a code-point runner for the language tier — same `RuleSet`.
 
 The grand goal — recognize programming languages, Markdown, etc. — is the
 **layered** composition of the two:
@@ -69,11 +95,13 @@ do not oversell it past that.
 ### Tasks
 
 - [ ] Define the `Recognizer<S>` interface (`init` / `step` / `finish`) as the
-      shared streaming contract for all backends
-- [ ] DFA backend: BNF (regular subset) → finite DFA, with a clear
-      regularity criterion and a sensible fallback when a grammar exceeds it
-- [ ] AST-less LL(1) recognizer over the existing dispatch table (stack machine,
-      returns accept/reject + final configuration)
+      shared streaming contract for all backends; keep it parametric in the
+      symbol space (byte vs code-point runner) over the same `RuleSet`
+- [ ] DFA backend: `RuleSet` (regular subset) → finite DFA, built as a sibling
+      of `dispatchMap`, with a clear regularity criterion (self-/tail-recursion
+      only) and a sensible fallback when a grammar exceeds it
+- [ ] AST-less LL(1) recognizer: derive from the existing `fs/bnf/data` matcher
+      by dropping `AstRule` accumulation; return accept/reject + final config
 - [ ] Union/product (grammar combination) for the DFA backend via subset
       construction; document the analogous state-pairing for the LL recognizer
 - [ ] First consumer: the `cas_get` magic-byte + UTF-8 detector consumes the

--- a/fs/bnf/todo/recognizer-backend.md
+++ b/fs/bnf/todo/recognizer-backend.md
@@ -28,18 +28,25 @@ AST, which is the wrong shape (and wrong cost) for these.
 ### Proposal
 
 Treat **BNF as the single source, with a family of backends** that share one
-streaming interface:
+streaming contract — and that contract **already exists** as the `Scan` family
+in `fs/types/function/operator` (drivers `fold` / `foldScan` / `stateScan` /
+`scan` in `fs/types/list`). No new interface to invent:
 
 ```ts
-type Recognizer<S> = {
-    readonly init:   S
-    readonly step:   (s: S, symbol: number) => S   // δ — pure, foldable
-    readonly finish: (s: S) => Verdict              // λ
-}
+type Fold<I, O>         = (input: I) => (acc: O) => O               // δ: (symbol)(state) => state
+type StateScan<I, S, O> = (input: I, prior: S) => readonly[O, S]    // Mealy step: emits output + next state
+type Scan<I, O>         = (input: I) => readonly[O, Scan<I, O>]     // state-hidden form; stateScanToScan unifies
 ```
 
-`step` being a pure `δ` is what makes recognizers **streamable** (fold/scan over
-an incremental input, including the effectful CAS chunk stream) and lets callers
+- A **recognizer** is the output-less case: `Fold<Symbol, State>` for `δ`, plus
+  a separate `λ: (State) => Verdict` on the final state. Driven by `foldScan`
+  (stream of states) / `fold` (final state) — exactly what `fs/fsm`'s
+  `run = foldScan(runOp)` already does.
+- A **transducer** is `StateScan<Symbol, State, Out>` (the Mealy step that emits
+  output), driven by `stateScan(op)(init): List<Out>`.
+
+`δ` being a pure step is what makes both **streamable** (fold/scan over an
+incremental input, including the effectful CAS chunk stream) and lets callers
 **short-circuit** once the state reaches an absorbing sink.
 
 #### Build from the data representation, not the functional one
@@ -169,11 +176,11 @@ Bigger automata are built from BNF pieces in two complementary ways:
   collect all verdicts (e.g. `magic × utf8` in the CAS detector). Falls out of
   subset construction / state-pairing.
 - **Cascade (series)** — each stage is a **transducer** whose output stream is
-  the next stage's input (`bytes → code-points → tokens → AST`). The interface
-  generalizes `Recognizer<S>` to a Mealy step `(s, symbol) => [s, out*]`; a
-  recognizer is the transducer that emits nothing. See
-  [layered-parser](./layered-parser.md). Both stay streaming, so the whole
-  pipeline is incremental.
+  the next stage's input (`bytes → code-points → tokens → AST`). A transducer is
+  just `StateScan<I, S, O>` (the Mealy step that emits output); a recognizer is
+  the output-less `Fold<I, S>`. See [layered-parser](./layered-parser.md). Both
+  stay streaming via `scan` / `stateScan` / `foldScan`, so the whole pipeline is
+  incremental.
 
 ### Tasks
 
@@ -181,11 +188,11 @@ Bigger automata are built from BNF pieces in two complementary ways:
       `fs/bnf/ll1` for the current dispatch/matcher), leaving `fs/bnf/data` as
       the pure serializable IR; new backends land as sibling modules
       (`fs/bnf/recognizer`, `fs/bnf/dfa`)
-- [ ] Define the `Recognizer<S>` interface (`init` / `step` / `finish`) as the
-      shared streaming contract for all backends; keep it parametric in the
-      symbol space (byte vs code-point runner) over the same `RuleSet`
-- [ ] Generalize to a `Transducer<S>` (Mealy step `(s, symbol) => [s, out*]`)
-      for cascade/layered composition; a recognizer is the no-output case
+- [ ] Use the existing `Scan` family as the streaming contract (no new type):
+      `Fold<I, S>` for a recognizer + a separate `λ: (S) => Verdict`,
+      `StateScan<I, S, O>` for a transducer; drivers `foldScan` / `stateScan` /
+      `scan`. Keep it parametric in the symbol space (byte vs code-point runner)
+      over the same `RuleSet`. (`fs/fsm`'s `run = foldScan(runOp)` is precedent.)
 - [ ] Tokenizer stage needs maximal munch (emit at the longest accepting
       prefix, then restart) — a mechanism over plain recognition
 - [ ] DFA backend: `RuleSet` (regular subset) → finite DFA, built as a sibling
@@ -218,3 +225,6 @@ Bigger automata are built from BNF pieces in two complementary ways:
   concrete consumer (streaming MIME/UTF-8 recognizer)
 - `fs/fsm`, `fs/types/byte_set`, `fs/types/range_map` — engines to reuse as the
   DFA backend rather than describe grammars against directly
+- `fs/types/function/operator` (`Fold` / `StateScan` / `Scan`) and `fs/types/list`
+  (`fold` / `foldScan` / `stateScan` / `scan`) — the existing streaming contract
+  and drivers; recognizers and transducers are instances, not new types

--- a/fs/bnf/todo/recognizer-backend.md
+++ b/fs/bnf/todo/recognizer-backend.md
@@ -58,6 +58,12 @@ are already *one* family built from `RuleSet`; the recognizer and DFA backends
 are **new builders over the same `RuleSet`**, siblings of `dispatchMap` — not a
 separate front end. So: author `magic | utf8` functionally, `toData` it, compile.
 
+Module layout follows from this: `fs/bnf/data` should hold only the
+serializable IR (`RuleSet` + `toData`), and each parser/automaton builder lives
+in its own sibling module — `fs/bnf/ll1` for the current LL(1) dispatch/matcher,
+then `fs/bnf/recognizer` and `fs/bnf/dfa` for the new backends. The IR stays
+free of any one parser's machinery.
+
 Two backends, distinguished by grammar class — this distinction is load-bearing:
 
 1. **DFA backend — regular subset.** The genuinely new builder: analyze the
@@ -106,6 +112,10 @@ do not oversell it past that.
 
 ### Tasks
 
+- [ ] Move the parsers out of `fs/bnf/data` into their own modules (e.g.
+      `fs/bnf/ll1` for the current dispatch/matcher), leaving `fs/bnf/data` as
+      the pure serializable IR; new backends land as sibling modules
+      (`fs/bnf/recognizer`, `fs/bnf/dfa`)
 - [ ] Define the `Recognizer<S>` interface (`init` / `step` / `finish`) as the
       shared streaming contract for all backends; keep it parametric in the
       symbol space (byte vs code-point runner) over the same `RuleSet`

--- a/fs/bnf/todo/recognizer-backend.md
+++ b/fs/bnf/todo/recognizer-backend.md
@@ -81,12 +81,17 @@ symbol *is*: a `Rule` over ranges/sequence/variant does not know whether symbol
 just capacity (enough for Unicode `0x10FFFF`, and bytes trivially), not a
 code-point commitment, and `step` is symbol-numeric. So a **byte runner** for
 UTF-8/magic and a **code-point runner** for the PL/Markdown tier are just two
-consumers feeding different symbol streams to the *same* `RuleSet`. The only
-code-point coupling is in the string-literal terminal constructors (`str` /
-`set` / `range`, via `stringToCodePointList`) — and even those coincide with
-byte values for `0x00..0xFF`, or are bypassed with `rangeEncode` / `oneEncode`
-on raw bytes. (The matcher's `CodePoint[]` typing is nominal — structurally
-numbers.)
+consumers feeding different symbol streams to the *same* `RuleSet`.
+
+There is no code-point coupling in BNF itself. The string-literal constructors
+(`str` / `set` / `range`, via `stringToCodePointList`) are just **text-authoring
+helpers** sitting *above* the agnostic core; a parallel family of **binary
+helpers** — byte / hex literals, byte sequences, byte-range sets — would author
+byte grammars the same way, all bottoming out in the agnostic `rangeEncode` /
+`oneEncode` primitives. (`fs/mime`'s `fromSentinel` hex-signature notation,
+`0x1_89_50_4e_47…n`, is a precedent for compact byte-sequence literals — just
+targeting `Vec` today rather than `RuleSet` terminals. The matcher's
+`CodePoint[]` typing is likewise nominal — structurally numbers.)
 
 The grand goal — recognize programming languages, Markdown, etc. — is the
 **layered** composition of the two:
@@ -109,6 +114,9 @@ do not oversell it past that.
       only) and a sensible fallback when a grammar exceeds it
 - [ ] AST-less LL(1) recognizer: derive from the existing `fs/bnf/data` matcher
       by dropping `AstRule` accumulation; return accept/reject + final config
+- [ ] Add binary terminal helpers (byte / hex literals, byte sequences,
+      byte-range sets) as a sibling to the text `str` / `set` / `range` helpers,
+      for authoring byte grammars like magic-bytes / UTF-8
 - [ ] Union/product (grammar combination) for the DFA backend via subset
       construction; document the analogous state-pairing for the LL recognizer
 - [ ] First consumer: the `cas_get` magic-byte + UTF-8 detector consumes the

--- a/fs/bnf/todo/recognizer-backend.md
+++ b/fs/bnf/todo/recognizer-backend.md
@@ -64,6 +64,16 @@ in its own sibling module — `fs/bnf/ll1` for the current LL(1) dispatch/matche
 then `fs/bnf/recognizer` and `fs/bnf/dfa` for the new backends. The IR stays
 free of any one parser's machinery.
 
+`toData` is itself a special case of a more general mechanism. The functional
+grammar embeds *functions* (lazy rules `() => DataRule`; `rtti` schemas are
+thunks `() => Info` the same way), and the planned `Function.getAst` /
+`fromAst` ([new-pl.md](../../../todo/new-pl.md)) returns any function's IR as
+serializable data (JSON) and reconstructs it. So the whole eDSL — including its
+function-valued parts — becomes plain data, and via `Object.id` that AST is the
+value's canonical identity: **content-addressable**. That closes the loop back
+to the CAS this work started from — a serialized grammar/automaton/type is
+hashable and storable in it.
+
 #### Compatibility is a build-time check (throw, don't fall back)
 
 Each builder targets a specific automaton class, and the type system **cannot**
@@ -201,6 +211,9 @@ Bigger automata are built from BNF pieces in two complementary ways:
   values, many artifacts (TS type, validator, parser) derived by function
 - `fs/html` — the markup-level sibling: an embedded DSL of nested element
   values, not an external syntax (JSX)
+- [new-pl.md](../../../todo/new-pl.md) — `Function.getAst` / `fromAst` (functions
+  as serializable IR); `toData` is the grammar-specific case, and the serialized
+  forms become content-addressable via `Object.id`
 - [cas-get-large-files](../../cas/mcp/todo/cas-get-large-files.md) — first
   concrete consumer (streaming MIME/UTF-8 recognizer)
 - `fs/fsm`, `fs/types/byte_set`, `fs/types/range_map` — engines to reuse as the

--- a/fs/bnf/todo/recognizer-backend.md
+++ b/fs/bnf/todo/recognizer-backend.md
@@ -86,6 +86,16 @@ runtime check that behaves like a static one. This is already the pattern in
 not LL(1) (a first/first conflict). Every builder follows it, each with its own
 constraint (LL(1) conflict-free, regular, …).
 
+This is the FunctionalScript meta-programming strategy — **no new language**.
+Grammars are ordinary FS values; the builders are ordinary functions; `const g =
+dfaParser(grammar)` *is* the compile step, just eager evaluation, with no bespoke
+compiler pass or new syntax. It is the same approach `fs/types/rtti` takes for
+**types**: a type is a schema *value* from which `ts/` derives the TypeScript
+type, `validate/` a validator, and `parse/` a deserializer — one value, many
+artifacts by function (the cas/mcp tool args already use one rtti struct for both
+`inputSchema` and `validate`). `rtti`:types :: `bnf`:grammars — define a value,
+derive automata/artifacts from it by function, fail eagerly at load if ill-formed.
+
 Two backends, distinguished by grammar class — this distinction is load-bearing:
 
 1. **DFA backend — regular subset.** The genuinely new builder: analyze the
@@ -178,6 +188,8 @@ Bigger automata are built from BNF pieces in two complementary ways:
 - [layered-parser](./layered-parser.md) — same "one BNF engine, multiple layers"
   instinct; the DFA backend is the scanner tier
 - [parser-structure](./parser-structure.md) — the AST-producing backend
+- `fs/types/rtti` — the type-level sibling of this strategy: types as schema
+  values, many artifacts (TS type, validator, parser) derived by function
 - [cas-get-large-files](../../cas/mcp/todo/cas-get-large-files.md) — first
   concrete consumer (streaming MIME/UTF-8 recognizer)
 - `fs/fsm`, `fs/types/byte_set`, `fs/types/range_map` — engines to reuse as the

--- a/fs/bnf/todo/recognizer-backend.md
+++ b/fs/bnf/todo/recognizer-backend.md
@@ -110,6 +110,20 @@ Reality check: a DFA alone cannot recognize a programming language, and
 Markdown is not even context-free. The DFA backend is the scanner tier only;
 do not oversell it past that.
 
+#### Two ways to combine automata
+
+Bigger automata are built from BNF pieces in two complementary ways:
+
+- **Product (parallel)** — run several recognizers over the *same* input and
+  collect all verdicts (e.g. `magic × utf8` in the CAS detector). Falls out of
+  subset construction / state-pairing.
+- **Cascade (series)** — each stage is a **transducer** whose output stream is
+  the next stage's input (`bytes → code-points → tokens → AST`). The interface
+  generalizes `Recognizer<S>` to a Mealy step `(s, symbol) => [s, out*]`; a
+  recognizer is the transducer that emits nothing. See
+  [layered-parser](./layered-parser.md). Both stay streaming, so the whole
+  pipeline is incremental.
+
 ### Tasks
 
 - [ ] Move the parsers out of `fs/bnf/data` into their own modules (e.g.
@@ -119,6 +133,10 @@ do not oversell it past that.
 - [ ] Define the `Recognizer<S>` interface (`init` / `step` / `finish`) as the
       shared streaming contract for all backends; keep it parametric in the
       symbol space (byte vs code-point runner) over the same `RuleSet`
+- [ ] Generalize to a `Transducer<S>` (Mealy step `(s, symbol) => [s, out*]`)
+      for cascade/layered composition; a recognizer is the no-output case
+- [ ] Tokenizer stage needs maximal munch (emit at the longest accepting
+      prefix, then restart) — a mechanism over plain recognition
 - [ ] DFA backend: `RuleSet` (regular subset) → finite DFA, built as a sibling
       of `dispatchMap`, with a clear regularity criterion (self-/tail-recursion
       only) and a sensible fallback when a grammar exceeds it

--- a/fs/bnf/todo/recognizer-backend.md
+++ b/fs/bnf/todo/recognizer-backend.md
@@ -1,0 +1,90 @@
+## Recognizer backend (no AST) and BNF→DFA for regular grammars
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+The FSM/DFA modules (`fs/fsm`, `fs/types/range_map`, `fs/types/byte_set`) carry
+working state-machine engines, but they lack a **declarative, combinable**
+front end: a DFA is written as raw `[stateIn, ByteSet, stateOut]` rules, which
+are awkward to describe, reuse, and combine. BNF is already our declarative
+grammar form, so the engines should be *backends behind BNF*, not parallel
+hand-written representations.
+
+Separately, several callers need to **recognize** input without building an
+AST — they only want "did it match, and what is the final state":
+
+- `fs/cas/mcp` `cas_get` metadata detection (magic-byte MIME + UTF-8 validity)
+  over a streaming blob — see
+  [cas-get-large-files](../../cas/mcp/todo/cas-get-large-files.md);
+- "is this valid JSON / valid identifier" checks that should not allocate a tree;
+- the scanner/lexer tier of the layered parser
+  ([layered-parser](./layered-parser.md)).
+
+Today the only way to "run a grammar" is the LL(1) dispatch that produces an
+AST, which is the wrong shape (and wrong cost) for these.
+
+### Proposal
+
+Treat **BNF as the single source, with a family of backends** that share one
+streaming interface:
+
+```ts
+type Recognizer<S> = {
+    readonly init:   S
+    readonly step:   (s: S, symbol: number) => S   // δ — pure, foldable
+    readonly finish: (s: S) => Verdict              // λ
+}
+```
+
+`step` being a pure `δ` is what makes recognizers **streamable** (fold/scan over
+an incremental input, including the effectful CAS chunk stream) and lets callers
+**short-circuit** once the state reaches an absorbing sink.
+
+Two backends, distinguished by grammar class — this distinction is load-bearing:
+
+1. **DFA backend — regular subset.** For grammars with no center-embedding
+   (only self-/tail-recursion, i.e. `repeat`-style), compile to a finite DFA
+   (reuse / generalize `fs/fsm` subset construction). `S` is a genuine finite
+   state; union/product of grammars falls out of subset construction. This is
+   the **scanner/lexer tier**: magic-bytes, UTF-8, token scanners.
+
+2. **Recognizer over LL(1) BNF — context-free.** Walk the existing dispatch
+   table with an explicit stack, discard the AST, return accept/reject + final
+   configuration. `S` is a parser configuration (stack), **not** finite. This
+   is the tier above the scanner (PL/structure recognition).
+
+The grand goal — recognize programming languages, Markdown, etc. — is the
+**layered** composition of the two:
+
+```
+bytes/code-points ──DFA (regular)──▶ tokens ──CF recognizer/parser──▶ structure
+```
+
+Reality check: a DFA alone cannot recognize a programming language, and
+Markdown is not even context-free. The DFA backend is the scanner tier only;
+do not oversell it past that.
+
+### Tasks
+
+- [ ] Define the `Recognizer<S>` interface (`init` / `step` / `finish`) as the
+      shared streaming contract for all backends
+- [ ] DFA backend: BNF (regular subset) → finite DFA, with a clear
+      regularity criterion and a sensible fallback when a grammar exceeds it
+- [ ] AST-less LL(1) recognizer over the existing dispatch table (stack machine,
+      returns accept/reject + final configuration)
+- [ ] Union/product (grammar combination) for the DFA backend via subset
+      construction; document the analogous state-pairing for the LL recognizer
+- [ ] First consumer: the `cas_get` magic-byte + UTF-8 detector consumes the
+      DFA backend (length and `finish` stay outside the recognizer)
+
+### Related
+
+- [layered-parser](./layered-parser.md) — same "one BNF engine, multiple layers"
+  instinct; the DFA backend is the scanner tier
+- [parser-structure](./parser-structure.md) — the AST-producing backend
+- [cas-get-large-files](../../cas/mcp/todo/cas-get-large-files.md) — first
+  concrete consumer (streaming MIME/UTF-8 recognizer)
+- `fs/fsm`, `fs/types/byte_set`, `fs/types/range_map` — engines to reuse as the
+  DFA backend rather than describe grammars against directly

--- a/fs/bnf/todo/recognizer-backend.md
+++ b/fs/bnf/todo/recognizer-backend.md
@@ -64,6 +64,28 @@ in its own sibling module — `fs/bnf/ll1` for the current LL(1) dispatch/matche
 then `fs/bnf/recognizer` and `fs/bnf/dfa` for the new backends. The IR stays
 free of any one parser's machinery.
 
+#### Compatibility is a build-time check (throw, don't fall back)
+
+Each builder targets a specific automaton class, and the type system **cannot**
+express "this grammar is regular / LL(1)". So a builder must **throw** when its
+input grammar is not in its class — e.g. `dfaParser` on a non-regular grammar:
+there is no DFA for it, and silently falling back to another engine would hide
+an authoring error and defeat the reason the caller chose a finite-state
+streaming automaton.
+
+A runtime throw is acceptable because it happens **eagerly, at module load**:
+grammars are built into top-level consts —
+
+```ts
+const myGrammar = dfaParser(bnfGrammar)   // evaluated at import; throws on load
+```
+
+— so an incompatible grammar fails fast on import/in CI and cannot ship. It is a
+runtime check that behaves like a static one. This is already the pattern in
+`fs/bnf/data`: the dispatch builder throws `can not merge …` when a grammar is
+not LL(1) (a first/first conflict). Every builder follows it, each with its own
+constraint (LL(1) conflict-free, regular, …).
+
 Two backends, distinguished by grammar class — this distinction is load-bearing:
 
 1. **DFA backend — regular subset.** The genuinely new builder: analyze the
@@ -139,7 +161,8 @@ Bigger automata are built from BNF pieces in two complementary ways:
       prefix, then restart) — a mechanism over plain recognition
 - [ ] DFA backend: `RuleSet` (regular subset) → finite DFA, built as a sibling
       of `dispatchMap`, with a clear regularity criterion (self-/tail-recursion
-      only) and a sensible fallback when a grammar exceeds it
+      only); **throw at build/module-load time** when the grammar is not regular
+      (no DFA exists) — do not fall back to another engine
 - [ ] AST-less LL(1) recognizer: derive from the existing `fs/bnf/data` matcher
       by dropping `AstRule` accumulation; return accept/reject + final config
 - [ ] Add binary terminal helpers (byte / hex literals, byte sequences,

--- a/fs/bnf/todo/recognizer-backend.md
+++ b/fs/bnf/todo/recognizer-backend.md
@@ -179,7 +179,9 @@ Bigger automata are built from BNF pieces in two complementary ways:
   the next stage's input (`bytes → code-points → tokens → AST`). A transducer is
   just `StateScan<I, S, O>` (the Mealy-shaped step that emits output); a
   recognizer is the output-less `Fold<I, S>`. `StateScan`'s state need not be
-  finite — `S = bigint` counts (the CAS `length`), `S` a stack parses — so
+  finite — its power is the power of `S`: finite → DFA (the scanner tier),
+  a stack → pushdown machine (the context-free / AST tier, exactly the LL(1)
+  recognizer's stack configuration), `bigint` → counting (the CAS `length`). So
   transducers are not limited to finite state; the DFA backend is the
   finite-state restriction. See [layered-parser](./layered-parser.md). Both stay
   streaming via `scan` / `stateScan` / `foldScan`, so the whole pipeline is

--- a/fs/bnf/todo/recognizer-backend.md
+++ b/fs/bnf/todo/recognizer-backend.md
@@ -74,12 +74,19 @@ Two backends, distinguished by grammar class — this distinction is load-bearin
    configuration. `S` is a parser configuration (stack), **not** finite. This is
    the tier above the scanner (PL/structure recognition).
 
-**Alphabet is the runner's choice, not the IR's.** The data `TerminalRange` is a
-24-bit range and the existing runners are `CodePoint`-oriented, but UTF-8/magic
-detection is inherently **byte-level** while PL/Markdown is **code-point-level**.
-The IR is alphabet-agnostic (ranges over integers) and `step` is symbol-numeric,
-so keep the automaton/runner parametric in the symbol space: a byte runner for
-UTF-8/magic, a code-point runner for the language tier — same `RuleSet`.
+**BNF is symbol-agnostic; the alphabet is the runner's choice.** Both BNF
+levels — functional and the serializable data IR — are neutral about what a
+symbol *is*: a `Rule` over ranges/sequence/variant does not know whether symbol
+`0x41` is the code point `A` or the byte `0x41`. `TerminalRange`'s 24 bits are
+just capacity (enough for Unicode `0x10FFFF`, and bytes trivially), not a
+code-point commitment, and `step` is symbol-numeric. So a **byte runner** for
+UTF-8/magic and a **code-point runner** for the PL/Markdown tier are just two
+consumers feeding different symbol streams to the *same* `RuleSet`. The only
+code-point coupling is in the string-literal terminal constructors (`str` /
+`set` / `range`, via `stringToCodePointList`) — and even those coincide with
+byte values for `0x00..0xFF`, or are bypassed with `rangeEncode` / `oneEncode`
+on raw bytes. (The matcher's `CodePoint[]` typing is nominal — structurally
+numbers.)
 
 The grand goal — recognize programming languages, Markdown, etc. — is the
 **layered** composition of the two:

--- a/fs/bnf/todo/recognizer-backend.md
+++ b/fs/bnf/todo/recognizer-backend.md
@@ -86,15 +86,24 @@ runtime check that behaves like a static one. This is already the pattern in
 not LL(1) (a first/first conflict). Every builder follows it, each with its own
 constraint (LL(1) conflict-free, regular, …).
 
-This is the FunctionalScript meta-programming strategy — **no new language**.
-Grammars are ordinary FS values; the builders are ordinary functions; `const g =
-dfaParser(grammar)` *is* the compile step, just eager evaluation, with no bespoke
-compiler pass or new syntax. It is the same approach `fs/types/rtti` takes for
-**types**: a type is a schema *value* from which `ts/` derives the TypeScript
-type, `validate/` a validator, and `parse/` a deserializer — one value, many
-artifacts by function (the cas/mcp tool args already use one rtti struct for both
-`inputSchema` and `validate`). `rtti`:types :: `bnf`:grammars — define a value,
-derive automata/artifacts from it by function, fail eagerly at load if ill-formed.
+This is the FunctionalScript meta-programming strategy — **no new language**,
+or equivalently: an **embedded DSL**. Grammars are ordinary FS values; the
+builders are ordinary functions; `const g = dfaParser(grammar)` *is* the compile
+step, just eager evaluation, with no bespoke compiler pass or new syntax. The
+contrast is an **external** DSL — React/JSX, TypeScript's type syntax — which
+needs its own parser/transpiler; FunctionalScript builds the DSL *inside* the
+host language instead. The same move recurs across the codebase:
+
+- `fs/html` — markup as nested element values (`['a', { href }, 'Example']`),
+  not JSX; serialized by an emitter function;
+- `fs/types/rtti` — a type is a schema *value* from which `ts/` derives the
+  TypeScript type, `validate/` a validator, and `parse/` a deserializer (the
+  cas/mcp tool args already use one rtti struct for both `inputSchema` and
+  `validate`);
+- `fs/bnf` — a grammar value from which the builders derive automata.
+
+`rtti`:types :: `bnf`:grammars :: `html`:markup — define a value, derive
+artifacts from it by function, fail eagerly at load if ill-formed.
 
 Two backends, distinguished by grammar class — this distinction is load-bearing:
 
@@ -190,6 +199,8 @@ Bigger automata are built from BNF pieces in two complementary ways:
 - [parser-structure](./parser-structure.md) — the AST-producing backend
 - `fs/types/rtti` — the type-level sibling of this strategy: types as schema
   values, many artifacts (TS type, validator, parser) derived by function
+- `fs/html` — the markup-level sibling: an embedded DSL of nested element
+  values, not an external syntax (JSX)
 - [cas-get-large-files](../../cas/mcp/todo/cas-get-large-files.md) — first
   concrete consumer (streaming MIME/UTF-8 recognizer)
 - `fs/fsm`, `fs/types/byte_set`, `fs/types/range_map` — engines to reuse as the

--- a/fs/bnf/todo/recognizer-backend.md
+++ b/fs/bnf/todo/recognizer-backend.md
@@ -177,9 +177,12 @@ Bigger automata are built from BNF pieces in two complementary ways:
   subset construction / state-pairing.
 - **Cascade (series)** — each stage is a **transducer** whose output stream is
   the next stage's input (`bytes → code-points → tokens → AST`). A transducer is
-  just `StateScan<I, S, O>` (the Mealy step that emits output); a recognizer is
-  the output-less `Fold<I, S>`. See [layered-parser](./layered-parser.md). Both
-  stay streaming via `scan` / `stateScan` / `foldScan`, so the whole pipeline is
+  just `StateScan<I, S, O>` (the Mealy-shaped step that emits output); a
+  recognizer is the output-less `Fold<I, S>`. `StateScan`'s state need not be
+  finite — `S = bigint` counts (the CAS `length`), `S` a stack parses — so
+  transducers are not limited to finite state; the DFA backend is the
+  finite-state restriction. See [layered-parser](./layered-parser.md). Both stay
+  streaming via `scan` / `stateScan` / `foldScan`, so the whole pipeline is
   incremental.
 
 ### Tasks

--- a/fs/cas/mcp/todo/cas-get-large-files.md
+++ b/fs/cas/mcp/todo/cas-get-large-files.md
@@ -43,37 +43,76 @@ without holding the full blob:
 
 ### Proposal
 
-Add a function that derives `cas_get` metadata directly from the read stream,
-without ever collecting the content, and use it in `fs/cas/mcp`.
+Derive `cas_get` metadata with a **byte-accepting state machine** rather than
+by buffering. The machine consumes bytes and transitions; at end-of-stream we
+ask it for the meta properties. Crucially, this is not "buffer the prefix":
+the `text` vs `base64` decision depends on whether the *whole* blob is valid
+UTF-8 (a blob can be valid for the first 128 KB and go invalid on the last
+byte), so any prefix buffer is incorrect — only a streaming validator that
+sees every byte is. The state machine is the right shape for that, and length
+and magic-byte detection fold into the same pass.
 
-1. **New stream MIME/metadata detector** (in `fs/mime`, beside `detect`).
-   It consumes the CAS read stream `List<O, IoResult<Vec>>` (each item an
-   `Effect<O, IoResult<Vec>>` chunk) and returns the metadata only:
+#### The state machine
+
+A small immutable state with three independent sub-states, all folds over the
+byte stream:
+
+```ts
+type DetectState = {
+    readonly length: bigint     // running byte count
+    readonly magic: MagicState  // viable signatures, or a resolved mime, or ruled-out
+    readonly utf8: Utf8State     // DFA state: accepting / mid-sequence / invalid
+}
+
+// push bytes (one chunk at a time), then read off the answer at EOF
+const push = (s: DetectState, bytes: Vec): DetectState => ...
+const finish = (s: DetectState): { length: bigint, mime_type: string, type: 'text' | 'base64' } => ...
+```
+
+- **length** — increment by the chunk's byte length.
+- **magic** — signature elimination: drop any signature whose byte at the
+  current position doesn't match the incoming byte; commit when one fully
+  matches (WebP's `RIFF`…`WEBP` gap handled as two anchored markers). This is
+  the streaming form of today's `fs/mime` `detect` table and **settles within
+  12 bytes** — thereafter it is in an absorbing state.
+- **utf8** — a classic UTF-8 DFA (e.g. Höhrmann): accept byte, track whether
+  we are at a code-point boundary, inside a multi-byte sequence, or have seen
+  an illegal sequence. **Invalid is absorbing** — once invalid, always invalid.
+
+`finish` reproduces today's three-way result: magic hit → `base64` + detected
+mime; else `utf8` ended at a boundary with no invalidity → `text` +
+`text/plain`; else → `base64` + `application/octet-stream`.
+
+#### Why a state machine beats buffering
+
+- **Correctness:** UTF-8 classification must see all bytes; a leading-bytes
+  buffer cannot decide it. The DFA does it in O(1) space.
+- **Cheap on large blobs:** both `magic` and `utf8` reach absorbing states
+  early. Once `magic` is resolved and `utf8` can no longer change the outcome,
+  `push` only needs `length += chunkBytes` — no per-byte iteration. A large
+  blob costs ≈ length-counting regardless of size.
+- **Composition:** three orthogonal folds in one pass; no buffer to size, no
+  giant `Vec` to materialize. Fits the functional style of the module.
+- **Simpler `cas_get`:** collapses the current three-phase branching into a
+  single fold plus one `finish` lookup.
+
+#### Wiring
+
+1. **Add the state machine in `fs/mime`**, beside `detect` (the pure prefix
+   form stays for callers that already hold a `Vec`). Provide `push` / `finish`
+   plus a stream driver that folds the CAS read stream
+   `List<O, IoResult<Vec>>` (each item an `Effect<O, IoResult<Vec>>` chunk),
+   short-circuiting on a read `error` item into the `IoResult` error:
 
    ```ts
    export const detectStream =
        <O extends Operation>(stream: List<O, IoResult<Vec>>):
        Effect<O, IoResult<{
-           readonly length: bigint            // total bytes, summed across chunks
+           readonly length: bigint
            readonly mime_type: string
            readonly type: 'text' | 'base64'
        }>>
    ```
-
-   While draining the stream it:
-   - buffers only the leading bytes needed to run the existing `detect`
-     (≤ 96 bits) — once `detect` returns non-`null`, the magic-byte answer is
-     fixed and later chunks no longer need to be inspected for it;
-   - feeds each chunk to an incremental UTF-8 validator so the `text` vs
-     `base64` decision is reached without materializing the whole blob;
-   - accumulates the total length from chunk lengths;
-   - discards chunk content as it goes, so memory stays bounded regardless of
-     blob size;
-   - surfaces a read `error` item as the `IoResult` error.
-
-   The three-way result mirrors today's phases: magic-byte hit → `base64` +
-   detected mime; else valid UTF-8 → `text` + `text/plain`; else → `base64` +
-   `application/octet-stream`.
 
 2. **Use it in `cas_get`.** When `content` is not `true`, build the response
    from `detectStream(c.read(key))` alone — never call `collectRead`. Large
@@ -86,20 +125,23 @@ without ever collecting the content, and use it in `fs/cas/mcp`.
 
 - Separates *inspection* (cheap, streaming, size-independent) from *transfer*
   (bounded by `maxLength`). The metadata-only call should never fail on size.
-- Keeps magic-byte logic in `fs/mime` where `detect` already lives; the stream
-  variant is the streaming counterpart of the pure one.
+- Keeps magic-byte logic in `fs/mime` where `detect` already lives; the state
+  machine is the streaming counterpart of the pure one.
 - Matches the documented `cas_get` decision protocol (inspect first, fetch
   later) by making the inspect step actually work for large blobs.
 
 ### Tasks
 
-- [ ] Add `detectStream` (streaming MIME + UTF-8 + length) in `fs/mime`
-- [ ] Add an incremental UTF-8 validator (or reuse one) for per-chunk checking
+- [ ] Add the `DetectState` machine (`push` / `finish`) in `fs/mime`:
+      length counter, signature-elimination magic matcher, UTF-8 DFA
+- [ ] Add the `detectStream` driver folding the read stream through `push`
+- [ ] Short-circuit `push` to length-only once `magic` and `utf8` are absorbed
 - [ ] Rewire `cas_get` to use `detectStream` when `content !== true`
 - [ ] Keep `collectRead` only on the `content: true` path
 - [ ] Proof tests: large multi-chunk blob returns metadata (no error) with
       `content: false`; correct `type`/`mime_type` for text, png, octet-stream;
-      `length` matches actual byte count
+      a blob that is valid UTF-8 until a trailing invalid byte classifies as
+      `base64`; `length` matches actual byte count
 - [ ] Update `fs/cas/mcp/README.md` and the module JSDoc to note that
       metadata-only `cas_get` is size-independent
 

--- a/fs/cas/mcp/todo/cas-get-large-files.md
+++ b/fs/cas/mcp/todo/cas-get-large-files.md
@@ -217,7 +217,7 @@ Open integration points when reusing `fs/fsm/`:
 ### Tasks
 
 - [ ] Consume the recognizer/DFA backend for `A_magic`/`A_utf8`
-      ([fs/bnf recognizer-backend](../../bnf/todo/recognizer-backend.md)) rather
+      ([fs/bnf recognizer-backend](../../../bnf/todo/recognizer-backend.md)) rather
       than describing the DFA by hand; keep `A_len` and `finish` outside it
 - [ ] Add the `DetectState` machine (`push` / `finish`) in `fs/mime`:
       length counter, signature-elimination magic matcher, UTF-8 DFA
@@ -234,7 +234,7 @@ Open integration points when reusing `fs/fsm/`:
 
 ### Related
 
-- [fs/bnf recognizer-backend](../../bnf/todo/recognizer-backend.md) — the
+- [fs/bnf recognizer-backend](../../../bnf/todo/recognizer-backend.md) — the
   streaming recognizer / BNF→DFA backend this detector should consume; `cas_get`
   is its first concrete consumer
 - [66j-cas-large-file-support](../../todo/66j-cas-large-file-support.md) —

--- a/fs/cas/mcp/todo/cas-get-large-files.md
+++ b/fs/cas/mcp/todo/cas-get-large-files.md
@@ -216,8 +216,9 @@ Open integration points when reusing `fs/fsm/`:
 
 ### Tasks
 
-- [ ] Evaluate reusing `fs/fsm/` for the `A_magic`/`A_utf8` factors (byte DFA +
-      streaming `run`) vs a hand-rolled DFA; keep `A_len` and `finish` outside it
+- [ ] Consume the recognizer/DFA backend for `A_magic`/`A_utf8`
+      ([fs/bnf recognizer-backend](../../bnf/todo/recognizer-backend.md)) rather
+      than describing the DFA by hand; keep `A_len` and `finish` outside it
 - [ ] Add the `DetectState` machine (`push` / `finish`) in `fs/mime`:
       length counter, signature-elimination magic matcher, UTF-8 DFA
 - [ ] Add the `detectStream` driver folding the read stream through `push`
@@ -233,6 +234,9 @@ Open integration points when reusing `fs/fsm/`:
 
 ### Related
 
+- [fs/bnf recognizer-backend](../../bnf/todo/recognizer-backend.md) — the
+  streaming recognizer / BNF→DFA backend this detector should consume; `cas_get`
+  is its first concrete consumer
 - [66j-cas-large-file-support](../../todo/66j-cas-large-file-support.md) —
   streaming upload; this is the read-side counterpart for `cas_get`
 - `content: true` on a blob larger than `maxLength` is still unsupported and

--- a/fs/cas/mcp/todo/cas-get-large-files.md
+++ b/fs/cas/mcp/todo/cas-get-large-files.md
@@ -1,0 +1,111 @@
+## `cas_get` fails on large blobs even without content
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+`cas_get` always drains the whole blob into a single `Vec` before it can
+answer, even when the caller only asked for metadata.
+
+In `fs/cas/mcp/module.f.ts` the handler does:
+
+```ts
+return collectRead(c.read(key)).step(result => { ... })
+```
+
+`collectRead` concatenates every chunk of the read stream
+(`List<O, IoResult<Vec>>`) into one `Vec`. A single `Vec` cannot exceed
+`maxLength` bits, so for any blob larger than one chunk (`maxLengthBytes`,
+128 KiB) the concatenation eventually trips:
+
+```ts
+if (bitVecLength(acc) + bitVecLength(v) > maxLength) {
+    return pure(error(`cas blob exceeds maximum vector length of ${maxLength} bits`))
+}
+```
+
+So `cas_get` returns an error for large blobs **even with the default
+`content: false`** — the exact case where the caller wants only
+`{ length, mime_type, type, url }` and is deliberately avoiding the byte
+transfer. The whole point of the metadata-only call (inspect size and type,
+decide whether to fetch via `url` or `content: true`) is defeated: the agent
+can never learn that a blob is large because the inspection itself fails.
+
+This also wastes memory and time. The metadata `cas_get` returns is derivable
+without holding the full blob:
+
+- `length` — sum of the chunk lengths.
+- `mime_type` / `type` via magic-byte sniffing — only needs the leading bytes
+  (`fs/mime` `detect` looks at the first 12 bytes / 96 bits at most, for WebP).
+- `mime_type: text/plain` / `type: text` via UTF-8 validation — can be checked
+  incrementally per chunk instead of over one giant `Vec`.
+
+### Proposal
+
+Add a function that derives `cas_get` metadata directly from the read stream,
+without ever collecting the content, and use it in `fs/cas/mcp`.
+
+1. **New stream MIME/metadata detector** (in `fs/mime`, beside `detect`).
+   It consumes the CAS read stream `List<O, IoResult<Vec>>` (each item an
+   `Effect<O, IoResult<Vec>>` chunk) and returns the metadata only:
+
+   ```ts
+   export const detectStream =
+       <O extends Operation>(stream: List<O, IoResult<Vec>>):
+       Effect<O, IoResult<{
+           readonly length: bigint            // total bytes, summed across chunks
+           readonly mime_type: string
+           readonly type: 'text' | 'base64'
+       }>>
+   ```
+
+   While draining the stream it:
+   - buffers only the leading bytes needed to run the existing `detect`
+     (≤ 96 bits) — once `detect` returns non-`null`, the magic-byte answer is
+     fixed and later chunks no longer need to be inspected for it;
+   - feeds each chunk to an incremental UTF-8 validator so the `text` vs
+     `base64` decision is reached without materializing the whole blob;
+   - accumulates the total length from chunk lengths;
+   - discards chunk content as it goes, so memory stays bounded regardless of
+     blob size;
+   - surfaces a read `error` item as the `IoResult` error.
+
+   The three-way result mirrors today's phases: magic-byte hit → `base64` +
+   detected mime; else valid UTF-8 → `text` + `text/plain`; else → `base64` +
+   `application/octet-stream`.
+
+2. **Use it in `cas_get`.** When `content` is not `true`, build the response
+   from `detectStream(c.read(key))` alone — never call `collectRead`. Large
+   blobs then return correct `{ length, mime_type, type, url }` instead of an
+   error. Only when `content: true` is requested does the handler collect the
+   bytes (the existing `collectRead` path / base64 or UTF-8 encoding), where
+   the `maxLength` ceiling is a genuine limitation worth its own follow-up.
+
+#### Rationale
+
+- Separates *inspection* (cheap, streaming, size-independent) from *transfer*
+  (bounded by `maxLength`). The metadata-only call should never fail on size.
+- Keeps magic-byte logic in `fs/mime` where `detect` already lives; the stream
+  variant is the streaming counterpart of the pure one.
+- Matches the documented `cas_get` decision protocol (inspect first, fetch
+  later) by making the inspect step actually work for large blobs.
+
+### Tasks
+
+- [ ] Add `detectStream` (streaming MIME + UTF-8 + length) in `fs/mime`
+- [ ] Add an incremental UTF-8 validator (or reuse one) for per-chunk checking
+- [ ] Rewire `cas_get` to use `detectStream` when `content !== true`
+- [ ] Keep `collectRead` only on the `content: true` path
+- [ ] Proof tests: large multi-chunk blob returns metadata (no error) with
+      `content: false`; correct `type`/`mime_type` for text, png, octet-stream;
+      `length` matches actual byte count
+- [ ] Update `fs/cas/mcp/README.md` and the module JSDoc to note that
+      metadata-only `cas_get` is size-independent
+
+### Related
+
+- [66j-cas-large-file-support](../../todo/66j-cas-large-file-support.md) —
+  streaming upload; this is the read-side counterpart for `cas_get`
+- `content: true` on a blob larger than `maxLength` is still unsupported and
+  should be addressed separately (return via `url` instead of inline content)

--- a/fs/cas/mcp/todo/cas-get-large-files.md
+++ b/fs/cas/mcp/todo/cas-get-large-files.md
@@ -141,6 +141,45 @@ is live and its chunk step is `+chunkLen`, so the bulk of a large blob skips
 per-byte iteration — the formal statement of "large blobs cost ≈
 length-counting."
 
+#### Reusing `fs/fsm/` as the engine
+
+`fs/fsm/` already implements this Moore machine over a **byte alphabet**, so the
+`A_magic` and `A_utf8` factors need not be hand-rolled:
+
+- alphabet = `ByteSet` (`fs/types/byte_set`, a 256-bit set); rules are
+  `[stateIn, ByteSet, stateOut]`;
+- `dfa(grammar)` runs subset construction once; `run(dfa)` is `foldScan` over
+  the input — i.e. `δ` threaded over the byte stream, emitting one state per
+  byte (the resumable `push` we need);
+- the empty-subset state is the absorbing `Reject` sink for free;
+- **the product is free too**: merging the magic and utf8 rule sets from the
+  shared `''` start makes each DFA state a subset that holds live states of
+  *both* sub-machines, so the end state encodes both verdicts (the powerset
+  states in `fs/fsm/README.md`, e.g. `['floatBegin','int']`, are exactly this).
+
+What stays outside `fs/fsm/`:
+
+- **`A_len`** — an FSM is finite-state and cannot count; length is a separate
+  `+chunkLen` accumulator.
+- **`finish`/`λ`** — interpret the final FSM state into `{ mime_type, type }`.
+
+`fs/bnf/` itself is **not** the right layer: its execution model is LL(1)
+grammar → AST over a *code-point* alphabet, which both builds a parse tree we
+don't want and is not byte-oriented. It is the grammar-*description* layer
+(`fs/fsc/bnf.f.ts` uses it for the FS tokenizer); we could later describe the
+magic/utf8 grammar with it and lower to an `fs/fsm/` grammar, but there is no
+ready bnf→byte-fsm lowering today, so that is extra scaffolding, not a shortcut.
+
+Open integration points when reusing `fs/fsm/`:
+
+- bridge the effectful `List<O, IoResult<Vec>>` chunks into bytes and thread the
+  DFA state across `Vec` chunk boundaries (`run` consumes a single pure
+  `List<number>`);
+- wrap `run` to stop stepping once the state is the combined sink and switch to
+  length-only counting (the short-circuit above is not automatic);
+- `fs/fsm/` keys states by stringified subsets — fine for build-once, slightly
+  heavier per-step than an int-indexed table; revisit only if it shows up hot.
+
 #### Wiring
 
 1. **Add the state machine in `fs/mime`**, beside `detect` (the pure prefix
@@ -177,6 +216,8 @@ length-counting."
 
 ### Tasks
 
+- [ ] Evaluate reusing `fs/fsm/` for the `A_magic`/`A_utf8` factors (byte DFA +
+      streaming `run`) vs a hand-rolled DFA; keep `A_len` and `finish` outside it
 - [ ] Add the `DetectState` machine (`push` / `finish`) in `fs/mime`:
       length counter, signature-elimination magic matcher, UTF-8 DFA
 - [ ] Add the `detectStream` driver folding the read stream through `push`

--- a/fs/cas/mcp/todo/cas-get-large-files.md
+++ b/fs/cas/mcp/todo/cas-get-large-files.md
@@ -96,6 +96,51 @@ mime; else `utf8` ended at a boundary with no invalidity → `text` +
 - **Simpler `cas_get`:** collapses the current three-phase branching into a
   single fold plus one `finish` lookup.
 
+#### Formal model & extension
+
+The detector is a **Moore machine** `(Q, Σ, δ, q₀, λ)` over the byte alphabet
+`Σ = 0…255`, where `δ` is `push`, `λ` is `finish`, and the answer is
+`finish(foldl push q₀ bytes)`. Because `δ*` is associative
+(`δ*(q, xy) = δ*(δ*(q, x), y)`), the fold may consume whole `Vec` chunks, not
+single bytes.
+
+`DetectState` is the **product** of three independent automata over the same
+alphabet — the factors never read each other; they meet only in `λ`:
+
+```
+A = A_len × A_magic × A_utf8
+
+δ((n,m,u), x) = (n+1, δ_magic(m,x), δ_utf8(u,x))
+q₀            = (0,   S_all,        Accept)
+λ((n,m,u))    = classify(n, λ_magic m, λ_utf8 u)   -- magic > utf8 > fallback
+```
+
+| factor    | `Q`                                   | `λ`                       | absorbing            |
+|-----------|---------------------------------------|---------------------------|----------------------|
+| `A_len`   | `ℕ` (the `(ℕ,+)` monoid)              | the count                 | none; δ is `+chunkLen` |
+| `A_magic` | `(position i, viable set S)` + `Matched(m)` / `Dead` | matched mime, else `null` | `Matched`/`Dead` (≤12 bytes) |
+| `A_utf8`  | ~9-state UTF-8 DFA                    | boundary→valid, else invalid | `Reject`          |
+
+**Extending = adding a factor.** To detect a new property: define
+`A_new = (Q_new, δ_new, q₀_new, λ_new)` over the same alphabet, add one field
+to the state, one line to `δ`, one component to `q₀`, and one clause to
+`classify`. The output combiner is the *only* cross-cutting edit, and it is a
+pure function of the factors' outputs — **existing transitions are never
+touched** (open for extension, closed for modification). Examples:
+
+- more signatures → just data appended to `A_magic`'s table (no new factor);
+- **verify-on-read** ([66g-cas-get-verify-option](../../todo/66g-cas-get-verify-option.md))
+  → add `A_sha256`, a streaming-hash factor whose `λ` compares the digest to
+  the requested key, riding the same single pass as detection;
+- BOM / UTF-16 sniffing, ASCII-only sub-lattice, line-ending style → small
+  independent factors each.
+
+**Short-circuit as a sink condition.** A factor is settled at `q` when
+`δ(q,x)=q` for all `x`. Once `A_magic` and `A_utf8` are in sinks, only `A_len`
+is live and its chunk step is `+chunkLen`, so the bulk of a large blob skips
+per-byte iteration — the formal statement of "large blobs cost ≈
+length-counting."
+
 #### Wiring
 
 1. **Add the state machine in `fs/mime`**, beside `detect` (the pure prefix

--- a/fs/types/function/operator/module.f.ts
+++ b/fs/types/function/operator/module.f.ts
@@ -35,12 +35,17 @@ export type Scan<I, O> = (input: I) => readonly[O, Scan<I,O>]
  * — a [finite-state transducer](https://en.wikipedia.org/wiki/Finite-state_transducer)
  * — but only its signature. The state `S` (and `I`, `O`) is an arbitrary type,
  * not a finite set, so a `StateScan` is strictly more expressive than a Mealy
- * machine: a finite `S`/`I`/`O` recovers the classical finite-state machine
- * (e.g. the DFA states in `../../../fsm/module.f.ts`), but an unbounded `S` —
- * say `bigint` — can count, which no finite automaton can, and `O` may be a
- * list (0+ symbols per input), not the single symbol strict Mealy emits.
- * (Functional/coalgebraic usage still calls this `(input, state) => [output,
- * state]` shape a "Mealy machine", finiteness aside.)
+ * machine — its power is the power of `S`:
+ * - a finite `S`/`I`/`O` recovers the classical finite-state machine (e.g. the
+ *   DFA states in `../../../fsm/module.f.ts`);
+ * - an `S` that is a stack makes it a
+ *   [pushdown / stack machine](https://en.wikipedia.org/wiki/Pushdown_automaton)
+ *   (context-free power — balanced brackets, nested structure, the AST tier);
+ * - an unbounded `S` like `bigint` can count, which no finite automaton can.
+ *
+ * And `O` may be a list (0+ symbols per input), not the single symbol strict
+ * Mealy emits. (Functional/coalgebraic usage still calls this `(input, state)
+ * => [output, state]` shape a "Mealy machine", finiteness aside.)
  *
  * A {@link Fold} is the output-less special case (state only); driving a
  * `StateScan` over a `List` is `stateScan` in `../../list/module.f.ts`, and

--- a/fs/types/function/operator/module.f.ts
+++ b/fs/types/function/operator/module.f.ts
@@ -26,12 +26,21 @@ export const strictEqual = <T>(a: T) => (b: T): boolean =>
 export type Scan<I, O> = (input: I) => readonly[O, Scan<I,O>]
 
 /**
- * One step of a [Mealy machine](https://en.wikipedia.org/wiki/Mealy_machine):
- * given an `input` symbol and the `prior` state, produce an `output` and the
- * next state. Equivalently a [finite-state transducer](
- * https://en.wikipedia.org/wiki/Finite-state_transducer) step — it both maps an
- * input stream to an output stream and threads state, so it can model
- * tokenizers, decoders, and other stream-to-stream stages.
+ * One step of a stream transducer: given an `input` symbol and the `prior`
+ * state, produce an `output` and the next state. It both maps an input stream
+ * to an output stream and threads state, so it models tokenizers, decoders, and
+ * other stream-to-stream stages.
+ *
+ * This is the *shape* of a [Mealy machine](https://en.wikipedia.org/wiki/Mealy_machine)
+ * — a [finite-state transducer](https://en.wikipedia.org/wiki/Finite-state_transducer)
+ * — but only its signature. The state `S` (and `I`, `O`) is an arbitrary type,
+ * not a finite set, so a `StateScan` is strictly more expressive than a Mealy
+ * machine: a finite `S`/`I`/`O` recovers the classical finite-state machine
+ * (e.g. the DFA states in `../../../fsm/module.f.ts`), but an unbounded `S` —
+ * say `bigint` — can count, which no finite automaton can, and `O` may be a
+ * list (0+ symbols per input), not the single symbol strict Mealy emits.
+ * (Functional/coalgebraic usage still calls this `(input, state) => [output,
+ * state]` shape a "Mealy machine", finiteness aside.)
  *
  * A {@link Fold} is the output-less special case (state only); driving a
  * `StateScan` over a `List` is `stateScan` in `../../list/module.f.ts`, and

--- a/fs/types/function/operator/module.f.ts
+++ b/fs/types/function/operator/module.f.ts
@@ -25,6 +25,18 @@ export const strictEqual = <T>(a: T) => (b: T): boolean =>
 
 export type Scan<I, O> = (input: I) => readonly[O, Scan<I,O>]
 
+/**
+ * One step of a [Mealy machine](https://en.wikipedia.org/wiki/Mealy_machine):
+ * given an `input` symbol and the `prior` state, produce an `output` and the
+ * next state. Equivalently a [finite-state transducer](
+ * https://en.wikipedia.org/wiki/Finite-state_transducer) step — it both maps an
+ * input stream to an output stream and threads state, so it can model
+ * tokenizers, decoders, and other stream-to-stream stages.
+ *
+ * A {@link Fold} is the output-less special case (state only); driving a
+ * `StateScan` over a `List` is `stateScan` in `../../list/module.f.ts`, and
+ * {@link stateScanToScan} hides the state to recover a {@link Scan}.
+ */
 export type StateScan<I, S, O> = (input: I, prior: S) => readonly[O, S]
 
 export const stateScanToScan = <I, S, O>(op: StateScan<I, S, O>) => (prior: S): Scan<I, O> => i => {


### PR DESCRIPTION
## Summary

This PR adds a design document outlining a proposal to fix `cas_get` failures on large blobs when only metadata is requested.

## Changes

- **New file:** `fs/cas/mcp/todo/cas-get-large-files.md`
  - Documents the problem: `cas_get` with `content: false` fails on blobs larger than 128 KiB because it collects the entire blob into a single `Vec` even when only metadata is needed
  - Proposes a streaming MIME/metadata detector (`detectStream`) that derives metadata without materializing the full blob content
  - Outlines implementation tasks including adding incremental UTF-8 validation, rewiring `cas_get` to use the streaming path for metadata-only requests, and adding proof tests
  - Clarifies the separation between inspection (cheap, streaming, size-independent) and transfer (bounded by `maxLength`)

## Key Points

- The issue prevents agents from inspecting large blobs to decide whether to fetch via URL or inline content
- The proposal keeps magic-byte detection logic in `fs/mime` while adding a streaming variant
- Metadata derivation (length, MIME type, text vs binary) can be done incrementally without holding the full blob in memory
- Only the `content: true` path would continue to use `collectRead`, where the `maxLength` ceiling remains a genuine limitation

https://claude.ai/code/session_015fqpYTTLUbeTH6AxNBcPpa