### PR TITLE
Add 15 todo issues for DRY refactoring and code deduplication

### DIFF
--- a/fs/bnf/todo/data-tosequence-reuse.md
+++ b/fs/bnf/todo/data-tosequence-reuse.md
@@ -1,0 +1,48 @@
+## data-tosequence-reuse. `bnf/data` re-implements `toSequence`
+
+**Priority:** P5
+**Status:** open
+
+### Problem
+
+`fs/bnf/module.f.ts:104-107` exports the string → terminal-range-sequence
+conversion:
+
+```ts
+const mapOneEncode = map(oneEncode)
+export const toSequence = (s: string): readonly TerminalRange[] =>
+    toArray(mapOneEncode(stringToCodePointList(s)))
+```
+
+`fs/bnf/data/module.f.ts:102,104-107` redeclares `mapOneEncode` and inlines
+the identical expression:
+
+```ts
+const mapOneEncode = map(oneEncode)
+const data = (dr: DataRule): NewRule => {
+    switch (typeof dr) {
+        case 'string': {
+            return sequence(toArray(mapOneEncode(stringToCodePointList(dr))))
+```
+
+`bnf/data` already imports `oneEncode` from `../module.f.ts`, so it depends
+on that module anyway — it re-imports the primitive and re-derives the
+composite instead of importing the composite.
+
+### Proposal
+
+Import `toSequence` in `fs/bnf/data/module.f.ts`, replace the `'string'`
+case body with `sequence(toSequence(dr))`, and delete the local
+`mapOneEncode` (and the then-unused `stringToCodePointList`/`map` imports if
+nothing else uses them).
+
+### Tasks
+
+- [ ] Replace the inline expression with `toSequence`; drop the duplicate
+      helper and any now-unused imports.
+- [ ] `npx tsc`, `fjs t`.
+
+### Related
+
+- `AGENTS.md` — "When a sibling module already has the type or helper you
+  need, import it."

--- a/fs/bnf/todo/nullable-analysis-shared.md
+++ b/fs/bnf/todo/nullable-analysis-shared.md
@@ -1,0 +1,106 @@
+## nullable-analysis-shared. Compute the nullable/empty-tag analysis once, in `bnf/data`
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+Both parser backends independently derive the same grammar property — "can
+this rule match empty input, and which variant tag represents the empty
+match" — and their two implementations disagree on the sequence case.
+
+`fs/bnf/descent/module.f.ts:60-93` (`emptyTagMapAdd`, exposed as
+`createEmptyTagMap` at `:99-101`) computes it as a standalone recursive pass
+with encoding `EmptyTagEntry = string | boolean`:
+
+```ts
+if (typeof rule === 'number') {
+    return [ruleSet, { ...map, [name]: false }, false]
+} else if (rule instanceof Array) {
+    let emptyTag: EmptyTagEntry = rule.length == 0
+    for (const item of rule) {
+        ...
+        if (emptyTag === false) { emptyTag = itemEmptyTag !== false }
+    }
+    ...
+} else { /* variant: emptyTag = tag of a nullable branch */ }
+```
+
+`fs/bnf/ll1/module.f.ts:112-158` (`dispatchRule`) recomputes the same
+property inline while building the dispatch map, with encoding
+`EmptyTag = string | true | undefined`:
+
+```ts
+} else if (rule instanceof Array) {
+    let emptyTag: EmptyTag = true
+    for (const item of rule) {
+        ...
+        emptyTag = dr.emptyTag !== undefined ? true : undefined   // AND over the prefix
+    }
+```
+
+Consequences:
+
+1. **The streaming invariant lives in two places** that must stay in sync;
+   `descentParser` even carries a `getEmptyTag` adapter
+   (`descent/module.f.ts:111-114`) whose only job is translating `false` to
+   `undefined`, i.e. converting between the two encodings.
+2. **The implementations diverge on sequences.** ll1 computes the standard
+   definition — a sequence is nullable iff *every* item is nullable (once
+   `emptyTag` becomes `undefined` it stays `undefined`). descent's loop only
+   updates `emptyTag` while it is `false`, so once the *first* item turns out
+   nullable the result is pinned to `true` regardless of later non-nullable
+   items. For a sequence `[nullable, nonNullable]` descent reports nullable,
+   ll1 reports not nullable. In `descentParser` the value only feeds the
+   reported AST tag at EOF/failure (`descent/module.f.ts:122-124,148-149`),
+   so the impact is subtle — but two "same" analyses silently disagreeing is
+   exactly the failure mode duplication invites.
+
+### Proposal
+
+Move a single nullability pass into `fs/bnf/data/module.f.ts` — the module
+that already owns `RuleSet` — as
+
+```ts
+export type EmptyTag = string | true | undefined
+export const emptyTagMap = (ruleSet: RuleSet): StringMap<string, EmptyTag> => ...
+```
+
+using ll1's encoding (no adapter needed) and the standard AND semantics for
+sequences (a sequence is nullable iff all items are nullable), with a proof
+case covering `[nullable, nonNullable]` to pin the resolved semantics down.
+
+Then:
+
+- `descent` deletes `emptyTagMapAdd` / `createEmptyTagMap` / `getEmptyTag`
+  and re-exports or imports `emptyTagMap` (its `proof.f.ts` calls
+  `createEmptyTagMap` seven times, so keep a re-export or update the proof).
+- `ll1`'s `dispatchRule` reads `emptyTag` from the precomputed map instead of
+  threading `let emptyTag` through its build loop — the dispatch-merge logic
+  stays, only the nullability *derivation* is deleted. This also removes the
+  `let`-mutation smell, the same one
+  [669-bnf-data-shared-helpers](./669-bnf-data-shared-helpers.md) flags in
+  descent's copy.
+- While unifying, confirm which sequence semantics the descent proofs
+  actually depend on; if any proof relies on descent's first-item behavior,
+  that is a bug capture, not a feature to preserve.
+
+### Tasks
+
+- [ ] Add `emptyTagMap` (encoding `string | true | undefined`, AND semantics
+      for sequences) to `fs/bnf/data/module.f.ts` with proof coverage
+      including a `[nullable, nonNullable]` sequence.
+- [ ] Replace `createEmptyTagMap`/`getEmptyTag` in `fs/bnf/descent` with the
+      shared pass; update `fs/bnf/descent/proof.f.ts` and the module JSDoc.
+- [ ] Drop the inline `emptyTag` derivation from `dispatchRule` in
+      `fs/bnf/ll1`; read the precomputed map instead.
+- [ ] `npx tsc`, `fjs t`; verify `fs/djs/tokenizer-new` (a `descentParser`
+      consumer) still passes.
+
+### Related
+
+- [669-bnf-data-shared-helpers](./669-bnf-data-shared-helpers.md) — flags the
+  `let`-mutation in `emptyTagMapAdd`; subsumed on the descent side by this
+  extraction.
+- [rule-visitor](./rule-visitor.md) — the shared pass becomes one instance of
+  the proposed `Rule` visitor.

--- a/fs/bnf/todo/rule-visitor.md
+++ b/fs/bnf/todo/rule-visitor.md
@@ -1,0 +1,66 @@
+## rule-visitor. Share the `Rule` three-way discrimination via a visitor in `bnf/data`
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+The `typeof rule === 'number'` → `rule instanceof Array` → `else` (variant)
+discrimination over the data `Rule` ADT is hand-rolled at four sites:
+
+- `fs/bnf/data/module.f.ts:104-116` — `data()` (over `DataRule`, adds the
+  `'string'` case)
+- `fs/bnf/descent/module.f.ts:67-92` — `emptyTagMapAdd`
+- `fs/bnf/descent/module.f.ts:121-160` — `descentParser`'s inner `f`
+- `fs/bnf/ll1/module.f.ts:116-157` — `dispatchRule`
+
+That this is a maintenance liability is already visible in
+[667-bnf-repeat-flatten](./667-bnf-repeat-flatten.md), whose task list says
+*"Add the `typeof rule === 'string'` branch to every dispatch site
+(`dispatchMap`, `emptyTagMapAdd`, `descentParser`, `parserRuleSet`)"* —
+adding one grammar shape requires four parallel edits, each re-deriving the
+same discriminator.
+
+### Proposal
+
+Add a visitor over the data `Rule` ADT in `fs/bnf/data/module.f.ts` (the
+module that owns the type), mirroring the proven `visit` pattern in
+`fs/types/rtti/common`:
+
+```ts
+export type RuleVisitor<R> = {
+    readonly terminal: (r: TerminalRange) => R
+    readonly sequence: (s: Sequence) => R
+    readonly variant: (v: Variant) => R
+}
+export const matchRule = <R>(v: RuleVisitor<R>) => (rule: Rule): R =>
+    typeof rule === 'number' ? v.terminal(rule)
+    : rule instanceof Array ? v.sequence(rule)
+    : v.variant(rule)
+```
+
+`emptyTagMapAdd`, `descentParser`'s `f`, and `dispatchRule` each become one
+`matchRule({ terminal, sequence, variant })` call. When
+[667-bnf-repeat-flatten](./667-bnf-repeat-flatten.md) lands, `repeat` becomes
+a single new visitor member — the compiler then forces every backend to
+handle it, instead of four manual edits.
+
+Keep it exactly this narrow: a discriminator, not a recursion scheme —
+each call site keeps its own recursion/accumulator structure.
+
+### Tasks
+
+- [ ] Add `RuleVisitor`/`matchRule` to `fs/bnf/data/module.f.ts` with proof
+      coverage.
+- [ ] Rewrite the three backend dispatch sites (and `data()` if the
+      `DataRule` variant with the `'string'` case folds in cleanly — it may
+      need its own `DataRuleVisitor` or stay as-is).
+- [ ] `npx tsc`, `fjs t`.
+
+### Related
+
+- [667-bnf-repeat-flatten](./667-bnf-repeat-flatten.md) — the four-site
+  lockstep edit this removes.
+- [nullable-analysis-shared](./nullable-analysis-shared.md) — the shared
+  nullability pass is a natural first consumer.
+- `fs/types/rtti/common/module.f.ts` — existing `visit` precedent.

--- a/fs/cli/todo/positional-arity-check.md
+++ b/fs/cli/todo/positional-arity-check.md
@@ -1,0 +1,59 @@
+## positional-arity-check. Positional-argument arity validation is hand-rolled per command
+
+**Priority:** P5
+**Status:** open
+
+### Problem
+
+`fs/cli`'s `dispatch` owns command routing and help, but no arity
+validation, so each handler re-implements "exactly N required positional
+args, else `errorExit`". Two consumers today, in
+`fs/cas/cli/module.f.ts`:
+
+```ts
+// add (:26-29)
+handler: ({ home, args: [path, ...rest] }) => {
+    if (path === undefined || rest.length !== 0) {
+        return errorExit("'cas add' expects one parameter")
+    }
+// get (:40-43)
+handler: ({ home, args: [hashCBase32, path, ...rest] }) => {
+    if (hashCBase32 === undefined || path === undefined || rest.length !== 0) {
+        return errorExit("'cas get' expects two parameters")
+    }
+```
+
+### Proposal
+
+A combinator in `fs/cli/module.f.ts`, the layer that already owns
+`Command`/`dispatch`:
+
+```ts
+export const exact = <O extends NodeOp>(name: string, n: number) =>
+    (run: (args: readonly string[], o: NodeProgramOptions) => Effect<O, number>) =>
+    (o: NodeProgramOptions): Effect<O | Write, number> =>
+        o.args.length === n
+            ? run(o.args, o)
+            : errorExit(`'${name}' expects ${n} parameter${n === 1 ? '' : 's'}`)
+```
+
+`add`/`get` wrap their bodies in `exact('cas add', 1)` /
+`exact('cas get', 2)` and destructure a known-length `args`. A richer
+declarative variant — `Command` gaining an optional `arity`/`params` field
+that `dispatch` validates and folds into the help text — fits the repo's
+data-driven-registry preference better; choose whichever the
+`66g-fjs-run-commands` reshaping of `Commands` prefers, and land this
+alongside that work rather than as a standalone micro-PR.
+
+### Tasks
+
+- [ ] Pick combinator vs `Command`-field validation (coordinate with
+      `fs/fjs/todo/66g-fjs-run-commands.md`).
+- [ ] Migrate `cas add` / `cas get`; keep their error strings.
+- [ ] `npx tsc`, `fjs t`.
+
+### Related
+
+- `fs/fjs/todo/66g-fjs-run-commands.md` — the `Commands` reshaping this
+  should ride along with.
+- `fs/cas/cli/module.f.ts:26-29,40-43` — the two current copies.

--- a/fs/effects/node/virtual/todo/dir-spine-descend.md
+++ b/fs/effects/node/virtual/todo/dir-spine-descend.md
@@ -1,0 +1,86 @@
+## dir-spine-descend. Share the immutable `Dir`-spine descent
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+Three helpers in `fs/effects/node/virtual/module.f.ts` independently
+implement "recurse down `path` segments through the `Dir` tree, bail when an
+intermediate node isn't a directory, then rebuild the immutable spine with a
+spread":
+
+- `operation`'s inner `f` — `:62-74`
+- `extractEntity` — `:188-193`
+- `insertEntityAt` — `:220-226`
+
+```ts
+// operation.f
+const [first, ...rest] = path
+const subDir = dir[first]
+if (typeof subDir !== 'object' || Array.isArray(subDir)) { return op(dir, path) }
+const [newSubDir, r] = f(subDir as Dir, rest)
+return [{ ...dir, [first]: newSubDir }, r]
+
+// extractEntity / insertEntityAt: same spine, different guard set and
+// short-circuit policy, plus `if (result[0] === 'error') { return [dir, result] }`
+```
+
+All three split head/rest, look up the sub-dir, guard "not a directory",
+recurse, and rebuild via `{ ...dir, [first]: newSub }` — each with its own
+`as Dir` cast. Only the leaf action (apply `op` / remove entry / insert
+entity) and the intermediate-miss policy differ.
+
+### Proposal
+
+A private `descend` combinator parameterized by the leaf and the
+"path not navigable" fallback:
+
+```ts
+const descend = <T>(
+    leaf: (dir: Dir, path: readonly string[]) => readonly [Dir, T],
+    onMiss: (dir: Dir, path: readonly string[]) => readonly [Dir, T],
+) => {
+    const go = (dir: Dir, path: readonly string[]): readonly [Dir, T] => {
+        if (path.length <= 1) { return leaf(dir, path) }
+        const [first, ...rest] = path
+        const sub = dir[first]
+        if (typeof sub !== 'object' || Array.isArray(sub)) { return onMiss(dir, path) }
+        const [newSub, r] = go(sub, rest)
+        return [{ ...dir, [first]: newSub }, r]
+    }
+    return go
+}
+```
+
+`operation`, `extractEntity`, and `insertEntityAt` each supply their
+leaf/miss functions. Known deltas the spike must reconcile before
+committing to the shape:
+
+- `operation` applies `op(dir, path)` at the failed node (not an error
+  short-circuit) and also at `path.length === 0`; extract/insert
+  short-circuit `enoent`/`'not a directory'` and reject the root case.
+- extract/insert propagate a leaf `error` *without* rebuilding the spine
+  (`return [dir, result]`), while `operation` always rebuilds; the
+  combinator must preserve the discard-on-error behavior (or the spike must
+  show rebuilding an unchanged subtree is observably identical — it isn't
+  for object identity, but `State` equality is structural in proofs).
+- extract/insert guard `undefined`/`Array`/`function`; `operation` guards
+  `typeof !== 'object' || Array`. Unify or parameterize.
+
+If the three don't collapse without contortion, scope down to sharing
+between `extractEntity` and `insertEntityAt` only (their spines are
+identical including the error-propagation policy) and leave `operation`
+as-is.
+
+### Tasks
+
+- [ ] Spike the combinator across all three; fall back to
+      extract/insert-only sharing if `operation` doesn't fit cleanly.
+- [ ] `npx tsc`, `fjs t`; rename/rm/mkdir proofs pass unchanged.
+
+### Related
+
+- [resolve-file-helper](./resolve-file-helper.md) — leaf-level counterpart.
+- [name-entity-kind-discrimination-once](./name-entity-kind-discrimination-once.md)
+  — the guards above should use those predicates once extracted.

--- a/fs/effects/node/virtual/todo/is-proper-prefix-path.md
+++ b/fs/effects/node/virtual/todo/is-proper-prefix-path.md
@@ -1,0 +1,50 @@
+## is-proper-prefix-path. `isProperPrefix` belongs in `fs/path`
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`fs/effects/node/virtual/module.f.ts:229-230` defines a pure path-segment
+predicate inline in the FS interpreter:
+
+```ts
+const isProperPrefix = (prefix: readonly string[], path: readonly string[]): boolean =>
+    prefix.length < path.length && prefix.every((seg, i) => seg === path[i])
+```
+
+used by `rename` (`:240`) to reject renaming a directory into its own
+subtree or onto an ancestor. "Is `prefix` a strict ancestor path of `path`"
+is path semantics, not interpreter logic — `fs/path` already owns
+segment-level path reasoning (`parse`, `normalize`, `relativize`), and
+`relativize` even does the string-level cousin (`path.startsWith(base)`).
+Per AGENTS.md, moving conceptually distinct logic to its natural module is
+appropriate even with a single consumer.
+
+A segment-based containment predicate is also the pure primitive the CAS
+path-boundary hardening wants: `fs/cas/mcp/module.f.ts` currently checks
+containment with string-level `startsWith`/`includes('..')`, and
+`fs/cas/todo/66j-normalize-home-paths.md` asks for "compare normalized
+paths … with proper directory boundary checking". This issue does not
+re-file that security work — it only creates the primitive it would build
+on.
+
+### Proposal
+
+Export `isProperPrefix(prefix: readonly string[], path: readonly string[]):
+boolean` from `fs/path/module.f.ts` (with proof coverage: equal paths,
+proper prefix, mismatching segment, prefix longer than path); import it in
+the virtual FS `rename`. Keep it pure and segment-based — Node
+`realpath`/symlink resolution stays with the CAS security todos.
+
+### Tasks
+
+- [ ] Move the predicate to `fs/path/module.f.ts` with JSDoc + proof cases;
+      update `rename` to import it.
+- [ ] `npx tsc`, `fjs t`.
+
+### Related
+
+- `fs/cas/todo/66j-normalize-home-paths.md` — future consumer of the
+  primitive.
+- `fs/path/module.f.ts` `relativize` — the string-level cousin.

--- a/fs/effects/node/virtual/todo/resolve-file-helper.md
+++ b/fs/effects/node/virtual/todo/resolve-file-helper.md
@@ -1,0 +1,77 @@
+## resolve-file-helper. Extract the single-segment file resolver
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+Four operation handlers in `fs/effects/node/virtual/module.f.ts` open-code
+the identical preamble "this is a 1-segment path resolving to a chunk-list
+file, otherwise produce the right `IoResult` error":
+
+- `readFile` — `:105-110`
+- `readBytesOp` — `:249-253, 259`
+- `writeBytesOp` — `:299-303, 305` (tuple-wrapped in `[dir, …]`)
+- `statOp` — `:313-317`
+
+```ts
+if (path.length !== 1) { return enoent }
+const file = dir[path[0]]
+if (typeof file === 'function') { throw new Error(`'${path[0]}' is a JsModule; readFile not supported`) }
+if (file === undefined) { return enoent }
+if (!Array.isArray(file)) { return error(`'${path[0]}' is not a file`) }
+const chunks = file as readonly Vec[]
+```
+
+Each site repeats the path-length guard, the enoent-vs-JsModule-throw-vs-
+not-a-file error selection, and an `as readonly Vec[]` cast (AGENTS.md
+treats `as` as a last resort; four copies of one is worse than none).
+`statOp` and `writeBytesOp` omit the JsModule throw, so the copies have
+already drifted slightly.
+
+This is distinct from
+[name-entity-kind-discrimination-once](./name-entity-kind-discrimination-once.md):
+that issue extracts low-level *type predicates* (`isBinFile`/`isJsModule`/
+`isDir`); even after it lands, each site still repeats this mid-level
+guard-and-select block.
+
+### Proposal
+
+A private resolver next to the operation handlers, returning the chunk list
+or the appropriate error:
+
+```ts
+// the file's chunks, or the right IoResult error; throws only for a JsModule
+const resolveFile = (op: string) => (dir: Dir, path: readonly string[]): IoResult<readonly Vec[]> => {
+    if (path.length !== 1) { return enoent }
+    const file = dir[path[0]]
+    if (typeof file === 'function') { throw new Error(`'${path[0]}' is a JsModule; ${op} not supported`) }
+    if (file === undefined) { return enoent }
+    if (!Array.isArray(file)) { return error(`'${path[0]}' is not a file`) }
+    return ok(file)
+}
+```
+
+`readFile`/`readBytesOp`/`statOp` destructure the result and continue on
+`ok`; `writeBytesOp` additionally wraps errors in its `[dir, …]` tuple.
+Decide during implementation whether `statOp`/`writeBytesOp` adopting the
+JsModule throw is acceptable (it makes their behavior on a JsModule loud
+instead of `'not a file'`) — if not, thread the JsModule policy as a
+parameter rather than keeping four copies.
+
+If `resolveFile` narrows via `Array.isArray`, the four `as readonly Vec[]`
+casts disappear with it.
+
+### Tasks
+
+- [ ] Add `resolveFile`; rewrite the four handlers on top of it, settling
+      the JsModule policy for `statOp`/`writeBytesOp` explicitly.
+- [ ] `npx tsc`, `fjs t`; virtual-FS proofs pass unchanged (or with
+      deliberate, documented JsModule-policy updates).
+
+### Related
+
+- [name-entity-kind-discrimination-once](./name-entity-kind-discrimination-once.md)
+  — lower-level predicates; composes with this.
+- [dir-spine-descend](./dir-spine-descend.md) — the leaf functions there
+  would call this resolver.

--- a/fs/mime/todo/single-signature-table.md
+++ b/fs/mime/todo/single-signature-table.md
@@ -1,0 +1,69 @@
+## single-signature-table. Declare the magic-byte signatures once
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+Every recognized signature (PNG, JPEG, 2×GIF, PDF, 3×ZIP, WebP) is declared
+twice in `fs/mime/module.f.ts`, in two representations that must stay in
+byte-for-byte lockstep:
+
+- sentinel-`Vec` form for the pure path — `table` at `:56-69` plus the
+  WebP special case `riff`/`webp`/`isWebp` at `:73-79`, consumed by
+  `detect` (`:88-94`);
+- byte-pattern form for the streaming path — `signatures` at `:119-132`
+  (WebP's gap expressed as `null` wildcards), consumed by
+  `magicStep`/`detectVec`/`detectStream`.
+
+The comment at `:116` admits it: *"The streaming counterpart of
+`table`/`isWebp`: the same signatures expressed as byte patterns…"*. Adding
+or correcting a signature means editing both lists, and WebP is
+special-cased in both (a bespoke `isWebp` here, a wildcard run there).
+
+Note the consumer situation: `detectStream` is the only export with a real
+consumer (`fs/cas/mcp/module.f.ts:88`); `detect` and `detectVec` are
+exercised only by `fs/mime/proof.f.ts`.
+
+### Proposal
+
+Make `signatures` (the wildcard-capable byte-pattern list) the single source
+of truth — it is strictly more general than `table` + `isWebp` since it
+already expresses WebP's gap. Re-express `detect` through the streaming
+eliminator that already exists:
+
+```ts
+export const detect = (bytes: Vec): Nullable<string> => {
+    const fold = (m: MagicState) => { /* fold u8List(msb)(bytes) through magicStep */ }
+    return magicMime(...)
+}
+```
+
+i.e. `detect(bytes) = magicMime(fold(magicStep, magicInit, bytes))`, then
+delete `table`, `sig`-based literals, `riff`, `webp`, and `isWebp`.
+`detectVec` already proves the streaming machine reproduces `detect`'s
+verdict on whole buffers, so the pure-`Vec` scaffolding is redundant.
+
+Alternatively, if `detect`'s `startsWith`-based implementation is worth
+keeping for performance, derive `table` from `signatures` (fold a
+wildcard-free pattern into a `fromSentinel` bigint) so the byte values still
+appear once — but the fold-through-`magicStep` variant is smaller and needs
+no new helper.
+
+Keep the doc-comment signature table (`:20-27`) as the human-readable
+overview; it is documentation, not a third implementation.
+
+### Tasks
+
+- [ ] Rewrite `detect` on top of `magicStep`/`magicMime` (or derive `table`
+      from `signatures`); delete the duplicate declarations.
+- [ ] Confirm `detect`'s "too short to match" behavior is preserved (a
+      `scan`-state machine at EOF yields `null`, matching today's prefix
+      semantics).
+- [ ] `npx tsc`, `fjs t`; `fs/mime/proof.f.ts` must pass unchanged.
+
+### Related
+
+- `fs/mime/module.f.ts:116` — the comment acknowledging the duplication.
+- `fs/cas/mcp/module.f.ts:88` — the sole external consumer
+  (`detectStream`).

--- a/fs/sul/todo/id-prefix-tag-factory.md
+++ b/fs/sul/todo/id-prefix-tag-factory.md
@@ -1,0 +1,61 @@
+## id-prefix-tag-factory. `raw`/`hash` prefix-tag scheme written twice in `sul/id`
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`fs/sul/id/module.f.ts` implements the "a 256-bit id is tagged by its top
+set bit at `offset`; membership is `asBase(v) >> offset === 1n`" scheme
+twice, byte-identical modulo the offset:
+
+```ts
+const rawPrefixOffset = 0xFEn                                  // :63
+const rawPrefix = 1n << rawPrefixOffset                        // :65
+export const isRaw = (v: Id): boolean =>
+    asBase(v) >> rawPrefixOffset === 1n                        // :88-89
+
+const hashPrefixOffset = 0xFFn                                 // :100
+const hashPrefix = 1n << hashPrefixOffset                      // :102
+export const isHash = (v: Id): boolean =>
+    asBase(v) >> hashPrefixOffset === 1n                       // :111-112
+```
+
+Each pairing also carries a redundant `assertEq` of the resulting mask
+(`:67-72`, `:104-109`). Adding a third tag class (or shifting the layout)
+means repeating the triple again.
+
+### Proposal
+
+A module-scope factory, per the AGENTS.md curried-helper style:
+
+```ts
+const prefixTag = (offset: bigint) => ({
+    prefix: 1n << offset,
+    is: (v: Id): boolean => asBase(v) >> offset === 1n,
+} as const)
+
+const raw = prefixTag(0xFEn)
+const hash = prefixTag(0xFFn)
+export const isRaw: (v: Id) => boolean = raw.is
+export const isHash: (v: Id) => boolean = hash.is
+```
+
+`rawId`/`toRaw`/`hashId` use `raw.prefix`/`hash.prefix`. The offsets and the
+membership algorithm each appear once; the two `assertEq` mask checks can
+collapse to one (or move into the proof).
+
+Note the membership test is "the *topmost* set bit is exactly at `offset`"
+(not merely "bit set") — the factory preserves that; keep a comment saying
+so, since it is what makes `isRaw` false for hash ids.
+
+### Tasks
+
+- [ ] Add `prefixTag`; instantiate `raw`/`hash`; keep the exported
+      `isRaw`/`isHash` signatures unchanged.
+- [ ] `npx tsc`, `fjs t`; `fs/sul/proof.f.ts` passes unchanged.
+
+### Related
+
+- [186](./186.md), [66m-sul-literal-level-reuse](./66m-sul-literal-level-reuse.md) —
+  neighboring sul reuse work; this one is local to `sul/id` and independent.

--- a/fs/text/utf8/todo/error-tag-layout-constants.md
+++ b/fs/text/utf8/todo/error-tag-layout-constants.md
@@ -1,0 +1,50 @@
+## error-tag-layout-constants. Name the partial-state/error-tag bit layout once
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`codePointToUtf8`'s error branch (`fs/text/utf8/module.f.ts:107-128`) and
+`utf8StateToError` (`:148-173`) are exact inverses that both hardcode the
+same un-named partial-state flag offsets:
+
+- `0b1000_0000_0000_0000` at `:108` and `:166`
+- `0b0000_0100_0000_0000` at `:115` and `:158`
+- `0b0000_0010_0000_0000` at `:121` and `:159`
+- `0b0000_0000_1000_0000` at `:127`
+
+The "partial UTF-8 state ↔ error-tagged code point" bit layout is documented
+only as a table in `fs/text/README.md` (the "utf8 error" sections), so the
+contract lives in three places (two code, one doc) that must agree, with
+nothing tying them together.
+
+### Proposal
+
+Define named constants (or a small encode/decode pair) for the layout flags
+once — e.g. next to `errorMask` in `fs/text/code_point/module.f.ts`, or at
+the top of `fs/text/utf8/module.f.ts` if the layout is considered
+utf8-private — and use them in both functions. Names should follow the
+README's terminology so the doc table and the constants are trivially
+cross-checkable.
+
+**Caution:** this borders the open `666-utf16-encode-errormask` contract
+work and any change must be proven byte-identical against
+`fs/text/utf8/proof.f.ts` before landing. It is a naming/single-source
+cleanup, not a behavior change — if the layout itself is revisited by the
+utf16 work, land that first and fold this in.
+
+### Tasks
+
+- [ ] Name the flag constants once; rewrite `codePointToUtf8`'s error branch
+      and `utf8StateToError` in terms of them.
+- [ ] Cross-link the constants and the README table.
+- [ ] `npx tsc`, `fjs t`; proofs must pass unchanged.
+
+### Related
+
+- `fs/text/README.md` — the layout's specification tables.
+- `fs/text/todo/666-utf16-encode-errormask.md` — adjacent errorMask
+  contract work; coordinate ordering.
+- [lead-byte-classifier-dedup](./lead-byte-classifier-dedup.md) — sibling
+  cleanup in the same function family.

--- a/fs/text/utf8/todo/lead-byte-classifier-dedup.md
+++ b/fs/text/utf8/todo/lead-byte-classifier-dedup.md
@@ -1,0 +1,68 @@
+## lead-byte-classifier-dedup. `utf8ByteToCodePointOp` repeats the byte classifier
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`utf8ByteToCodePointOp` (`fs/text/utf8/module.f.ts:184-227`) contains the
+same three-way byte classifier twice — once for the fresh-state dispatch and
+once for error recovery after a bad continuation byte:
+
+```ts
+// state === null (:188-192)
+if (byte < contTag) return [[byte], null]
+if (byte >= 0b1100_0010 && byte <= 0b1111_0100) return [[], [byte]]
+return [[byte | errorMask], null]
+
+// recovery after utf8StateToError (:223-226)
+const error = utf8StateToError(state)
+if (byte < contTag) return [[error, byte], null]
+if (byte >= 0b1100_0010 && byte <= 0b1111_0100) return [[error], [byte]]
+return [[error, byte | errorMask], null]
+```
+
+The two blocks differ only in whether `error` is prepended to the emitted
+list. The valid-lead-byte range bounds `0b1100_0010`/`0b1111_0100` are
+un-named magic literals repeated at `:190` and `:225` — the same smell the
+tag/mask-constant extraction (PR #1020) removed for `contTag`/`lead2Tag`/…,
+which did not touch these bounds or this duplicated dispatch.
+
+### Proposal
+
+Hoist named bounds and a classifier next to `contByte`/`contPayload`:
+
+```ts
+const leadMin = 0b1100_0010
+const leadMax = 0b1111_0100
+const isLeadByte = (b: number): boolean => b >= leadMin && b <= leadMax
+```
+
+and write the dispatch once, parameterized by the emitted prefix:
+
+```ts
+const restart = (prefix: readonly I32[]) => (byte: number): readonly [readonly I32[], Utf8State] =>
+    byte < contTag ? [[...prefix, byte], null]
+    : isLeadByte(byte) ? [[...prefix], [byte]]
+    : [[...prefix, byte | errorMask], null]
+```
+
+called as `restart([])(byte)` from the `state === null` arm and
+`restart([utf8StateToError(state)])(byte)` from the recovery arm. One
+dispatch, one copy of the RFC 3629 lead-byte bounds. This follows the
+AGENTS.md rule: the shared structure appears once, only the difference (the
+prefix) lives at the call sites.
+
+### Tasks
+
+- [ ] Add `leadMin`/`leadMax`/`isLeadByte` and the shared dispatch helper;
+      rewrite both arms of `utf8ByteToCodePointOp`.
+- [ ] `npx tsc`, `fjs t`; `fs/text/utf8/proof.f.ts` must pass unchanged
+      (this is a pure refactor — byte-identical behavior).
+
+### Related
+
+- CHANGELOG PR #1020 — extracted the tag/payload-mask constants; this
+  finishes the job for the lead-byte range and the duplicated dispatch.
+- [error-tag-layout-constants](./error-tag-layout-constants.md) — the
+  neighboring implicit-contract cleanup.

--- a/fs/types/todo/bit-set-factory.md
+++ b/fs/types/todo/bit-set-factory.md
@@ -1,0 +1,78 @@
+## bit-set-factory. `byte_set` and `nibble_set` are one bitmask-set algebra
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+`fs/types/nibble_set/module.f.ts` and `fs/types/byte_set/module.f.ts`
+implement the same bitmask-as-set algebra, line for line, differing only in
+the numeric domain (`number` with `universe = 0xFFFF` vs `bigint` with the
+256-bit universe) and the `BigInt(n)` shift-operand conversion. The
+`nibble_set` module header even documents it: *"It implements the same
+bitmask-as-set algebra as `byte_set`"*.
+
+| operation | `byte_set` (bigint) | `nibble_set` (number) |
+|-----------|---------------------|-----------------------|
+| `has` | `n => s => ((s >> BigInt(n)) & 1n) === 1n` (`:15`) | `n => s => ((s >> n) & 1) === 1` (`:31`) |
+| `one` | `n => 1n << BigInt(n)` (`:24`) | `n => 1 << n` (`:28`) |
+| `range` | `([b, e]) => one(e - b + 1) - 1n << BigInt(b)` (`:27`) | `([a, b]) => one(b - a + 1) - 1 << a` (`:43`) |
+| `complement` | `n => universe ^ n` (`:38`) | `s => universe ^ s` (`:37`) |
+| `set` / `setRange` / `unset` | `:45-52` | `:34-46` |
+
+`nibble_set` is also an *incomplete* copy: it lacks the binary set ops
+(`union`/`intersect`/`difference`) that `byte_set` has (`:32-42`).
+
+This is exactly the AGENTS.md DRY case: same algorithm, two real consumers,
+differing only in constants — the situation `fs/base_n` already solves for
+base-N codecs with a parameterized factory.
+
+### Proposal
+
+Introduce a factory, e.g. `fs/types/bit_set/module.f.ts`:
+
+```ts
+export type BitSetOps<T> = {
+    readonly empty: T
+    readonly universe: T
+    readonly one: (n: number) => T
+    readonly or: (a: T) => (b: T) => T
+    readonly and: (a: T) => (b: T) => T
+    readonly xor: (a: T) => (b: T) => T
+    readonly dec: (a: T) => T          // for `range`: one(len) - 1
+    readonly shl: (a: T) => (n: number) => T
+}
+export const bitSet = <T>(ops: BitSetOps<T>) => ({ has, one, range, set, setRange, unset, union, intersect, complement, difference })
+```
+
+(or a smaller parameter set — e.g. just `{ zero, universeBits, fromNumber }`
+— whatever proves minimal in practice). `byte_set` becomes
+`bitSet(bigintOps)` with its 256-bit universe; `nibble_set` becomes
+`bitSet(numberOps)` with `0xFFFF` and picks up `union`/`intersect`/
+`difference` for free (export them only when a consumer appears, per
+AGENTS.md). `byte_set`'s `toRangeMap` stays local — it is genuinely
+byte-specific.
+
+Rider: both modules inline `readonly [number, number]` for `range`'s
+parameter; the factory should use `Range` from `fs/types/range/module.f.ts`.
+
+`has` on a `bigint` set may deserve a domain-specific override if the
+generic form costs (see [185](./185.md) for the mask-based direction) —
+the factory can accept per-domain overrides or `byte_set` can shadow the
+generic `has`.
+
+### Tasks
+
+- [ ] Add `fs/types/bit_set/module.f.ts` (+ `proof.f.ts`, register in
+      `deno.json` exports) with the parameterized algebra.
+- [ ] Rewrite `byte_set` and `nibble_set` as instantiations, preserving
+      their public APIs and JSDoc (including nibble_set's
+      "prefer byte_set / JSON-serializable" guidance).
+- [ ] `npx tsc`, `fjs t`; both proofs pass unchanged.
+
+### Related
+
+- [185](./185.md) — `byte_set`-internal `range`/`one` via `bigint.mask`;
+  orthogonal — the shared `range` can use `mask` internally once extracted.
+- `fs/base_n/module.f.ts` — the codebase's precedent for
+  constants-parameterized codec factories.

--- a/nanvm-lib/todo/159.md
+++ b/nanvm-lib/todo/159.md
@@ -127,18 +127,58 @@ The three public functions become one-line wrappers passing
 `obj_to_string` / `arr_to_string` / `fn_to_string`. This is the lowest-risk
 item — no macro, just a generic helper.
 
+### 5. `IntoIterator`, `Default`, and the `ToX` constructor traits — same axis, missing from the inventory
+
+Three more trait families follow the exact "one impl per nominal newtype,
+byte-identical modulo names" shape and must ride whatever mechanism items
+1–3 land, or they stay a lockstep-edit hazard when a wrapper/variant is
+added:
+
+```rust
+// vm/impls/into_iterator.rs:8-30 — three impls differing only in `Item`
+impl<A: IVm> IntoIterator for Array<A>  { type Item = Any<A>;      /* self.index_iter() */ }
+impl<A: IVm> IntoIterator for Object<A> { type Item = Property<A>; /* self.index_iter() */ }
+impl<A: IVm> IntoIterator for String<A> { type Item = u16;         /* self.index_iter() */ }
+
+// vm/impls/default.rs:5-21 — three impls differing only in the constructor
+impl<A: IVm> Default for Array<A>  { fn default() -> Self { empty().to_array() } }
+impl<A: IVm> Default for Object<A> { fn default() -> Self { empty().to_object() } }
+impl<A: IVm> Default for String<A> { fn default() -> Self { empty().to_string() } }
+```
+
+and the constructor traits themselves — `ToObject` (`vm/object/to_object.rs:4-13`),
+`ToArray` (`vm/array/to_array.rs:4-13`), `ToString` (`vm/string/to_string.rs:4-19`)
+— are the same blanket-trait skeleton modulo wrapper/internal/item type
+(`ToString` additionally carries a `try_` variant).
+
+Since the `into_iter`/`default` bodies are already trait-method delegations,
+a sealed helper trait carrying `Internal`/`Item` (the same
+source-of-truth-table axis as items 1–3) plus one blanket
+`impl<A: IVm, W: …>` per family collapses `into_iterator.rs` and
+`default.rs` to zero hand-written impls.
+
 ### Notes
 
-- All four items are pure boilerplate collapse; behavior is unchanged, so
+- All items are pure boilerplate collapse; behavior is unchanged, so
   `cargo test` / `cargo clippy` / `cargo fmt --check` should pass without
   edits to call sites.
 - Already-correct abstractions to leave alone: `IContainer` defaults,
   `ContainerFmt`, the bigint `abs_*_vec` helpers, and the `Dispatch` visitor
-  (`vm/dispatch.rs`). One minor inconsistency worth noting separately:
-  `string_coercion.rs:24–30` re-implements the dispatch match by hand instead
-  of calling `Unpacked::dispatch`.
+  (`vm/dispatch.rs`).
+- The hand-written primitive-coercion dispatch matches are filed separately
+  as [primitive-coercion-dispatch](./primitive-coercion-dispatch.md) — they
+  are plain-code fixes, independent of the trait-boilerplate mechanism here.
+- The `macro_rules!` sketches above predate the `Avoid macro_rules!` rule in
+  `AGENTS.md`; per
+  [65Y-nanvm-conversion-macros](./65y-nanvm-conversion-macros.md), rework
+  them along the sealed-trait → `build.rs` → accept-duplication ladder
+  before any code lands.
 
 ### Related
 
 - [i81](./README.md), [i33](./README.md) — concrete `Any<T>` / wrapper-type
   design; this cleanup is consistent with moving operations onto wrappers.
+- [65Y-nanvm-conversion-macros](./65y-nanvm-conversion-macros.md) — the
+  `From`/`TryFrom` families on the same axis, and the no-macro constraint.
+- [primitive-coercion-dispatch](./primitive-coercion-dispatch.md) — the
+  coercion dispatch note previously in this file's Notes section.

--- a/nanvm-lib/todo/bigint-shift-decode.md
+++ b/nanvm-lib/todo/bigint-shift-decode.md
@@ -1,0 +1,74 @@
+## bigint-shift-decode. `Shl`/`Shr` duplicate the shift-amount decode
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`vm/bigint/shl.rs:18-30` and `vm/bigint/shr.rs:13-25` open with the same
+prelude — decode the shift amount from a `BigInt` right-hand side —
+differing only in the degenerate-case results:
+
+```rust
+// shl.rs
+let n_len = self.length();
+if n_len == 0 { return Ok(self); }
+let shift = match rhs.length() {
+    0 => return Ok(self),
+    1 => rhs[0],
+    _ => return too_large(),          // <- differs
+};
+let (word_shift, bit_shift) = shift.div_mod(64);
+
+// shr.rs
+let n_len = self.length();
+if n_len == 0 { return self; }
+let shift = match rhs.length() {
+    0 => return self,
+    1 => rhs[0],
+    _ => return Self::default(),      // <- differs
+};
+let (word_shift, bit_shift) = shift.div_mod(64);
+```
+
+The bit-shift carry loops further down are mirror images and genuinely
+different — leave those. The decode prelude is the shared part, and it must
+stay in sync (e.g. if multi-word shift amounts are ever supported, both
+sites change).
+
+### Proposal
+
+A private helper on `BigInt<A>` (plain generic method, no macro):
+
+```rust
+/// Decoded (word_shift, bit_shift), or None when the operand is empty or
+/// the amount doesn't fit one word — the caller picks its degenerate result.
+fn shift_amount(&self, rhs: &Self) -> Option<(u64, u64)> {
+    if self.length() == 0 { return None; }
+    let shift = match rhs.length() {
+        0 => return None,
+        1 => rhs[0],
+        _ => return None,
+    };
+    Some(shift.div_mod(64))
+}
+```
+
+Caveat: the three `None` cases map to *different* results in `shl`
+(`Ok(self)`, `Ok(self)`, `too_large()`), so a single `Option` is too
+coarse — either return a small enum
+(`enum ShiftDecode { Noop, TooWide, Amount(u64, u64) }`) or keep the
+zero-length checks at the call sites and share only the one-word decode.
+Pick whichever leaves `shl`/`shr` reading as a `match` with the op-specific
+values in the arms.
+
+### Tasks
+
+- [ ] Extract the decode with an explicit `Noop`/`TooWide`/`Amount`
+      discrimination; rewrite `shl`/`shr` on top.
+- [ ] `cargo test`, `cargo clippy`, `cargo fmt -- --check`.
+
+### Related
+
+- `vm/bigint/mod.rs` `abs_add_vec`/`abs_sub_vec`/`abs_cmp_vec` — precedent
+  for shared bigint helpers.

--- a/nanvm-lib/todo/primitive-coercion-dispatch.md
+++ b/nanvm-lib/todo/primitive-coercion-dispatch.md
@@ -1,0 +1,59 @@
+## primitive-coercion-dispatch. Route `any_to_number`/`any_to_string` through `Unpacked::dispatch`
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`vm/number_coercion.rs:25-31` and `vm/string_coercion.rs:24-30` each map a
+`Primitive<A>` onto the five primitive methods of a `Dispatch` impl with the
+same hand-written 5-arm match, byte-identical modulo the dispatcher:
+
+```rust
+match a.to_primitive(Some(ToPrimitivePreferredType::Number))? {
+    Primitive::Nullish(n) => NumberCoercion.nullish(n),
+    Primitive::Boolean(b) => NumberCoercion.bool(b),
+    Primitive::Number(n) => NumberCoercion.number(n),
+    Primitive::String(s) => NumberCoercion.string(s),
+    Primitive::BigInt(bi) => NumberCoercion.bigint(bi),
+}
+```
+
+The fan-out primitive already exists: `Unpacked<A>::dispatch`
+(`vm/unpacked.rs`) covers all 8 variants, `From<Primitive<A>> for
+Unpacked<A>` exists (`vm/primitive.rs`), and both `NumberCoercion` and
+`StringCoercion` are full `Dispatch<A>` impls (their object/array/function
+arms are what `to_primitive` guarantees unreachable — verify how they're
+implemented before relying on them).
+
+[159](./159.md)'s Notes flag the `string_coercion.rs` copy as "worth noting
+separately"; this is that separate note, extended to the pair — which makes
+it a real 2-consumer DRY case, actionable today with plain code (no macro,
+no trait scaffolding).
+
+### Proposal
+
+Each helper collapses to one line:
+
+```rust
+Unpacked::from(a.to_primitive(Some(ToPrimitivePreferredType::Number))?).dispatch(NumberCoercion)
+```
+
+Precondition to verify: the `Dispatch` impls' object/array/function arms
+must behave sensibly if ever reached (today they can't be, since
+`to_primitive` never returns an object) — if they `unreachable!()`, keep
+them, since the invariant is unchanged; if they're absent, this refactor is
+what forces writing them, and a 3-method cost may outweigh the 5-arm dedup.
+Decide with the code in front of you; if the trade is bad, close as
+won't-fix with a comment at both match sites cross-referencing each other.
+
+### Tasks
+
+- [ ] Check `NumberCoercion`/`StringCoercion`'s non-primitive `Dispatch`
+      arms; collapse both matches if the trade is favorable.
+- [ ] `cargo test`, `cargo clippy`, `cargo fmt -- --check`.
+
+### Related
+
+- [159](./159.md) — Notes section mentions the `string_coercion.rs` copy;
+  update that note to point here (or delete it) when this lands.

--- a/nanvm-lib/todo/string-utf16-from-impls.md
+++ b/nanvm-lib/todo/string-utf16-from-impls.md
@@ -1,0 +1,56 @@
+## string-utf16-from-impls. Move UTF-16 string conversions out of `impls/from.rs`
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`vm/impls/from.rs` is the grab-bag of `From` impls for the `Unpacked`/`Any`
+wrapping conversions, but two of its impls are string-domain logic — UTF-16
+encode/decode between `String<A>` and Rust strings (`from.rs:27-40`):
+
+```rust
+impl<A: IVm> From<&str> for String<A> {
+    fn from(value: &str) -> Self { value.encode_utf16().to_string() }
+}
+// TODO: Should we use `TryFrom` instead since we can have an error?
+impl<A: IVm> From<String<A>> for std::string::String {
+    fn from(value: String<A>) -> Self {
+        char::decode_utf16(value)
+            .map(|r| r.unwrap_or(char::REPLACEMENT_CHARACTER))
+            .collect()
+    }
+}
+```
+
+The lossy-decode policy (`REPLACEMENT_CHARACTER`) and the open `TryFrom`
+question are string-conversion concerns; `vm/string/` already owns the
+u16-side logic (`to_string.rs` with `ToString`/`try_to_string`, `index.rs`,
+…) but has no conversion file. Separation of concerns: this is a move, and a
+single consumer is enough justification per AGENTS.md.
+
+### Proposal
+
+Move both impls (and `From<&str> for Any<A>` at `from.rs:20-25`, which is
+just `String::from` + `to_any`, if it reads better next to them) into a new
+`vm/string/from.rs` (or fold into `to_string.rs`). `impls/from.rs` then
+holds only `Unpacked`/`Any` variant wrapping — the set
+[65Y-nanvm-conversion-macros](./65y-nanvm-conversion-macros.md) plans to
+collapse, which that cleanup gets cleaner by not having to step around the
+string impls.
+
+Resolve or re-file the `TryFrom` TODO while moving: either keep the lossy
+`From` and document the replacement-character policy in its doc comment, or
+switch to `TryFrom` and fix the call sites.
+
+### Tasks
+
+- [ ] Move the impls to `vm/string/`; register the module in
+      `vm/string/mod.rs`; delete them from `impls/from.rs`.
+- [ ] Settle the `TryFrom` TODO (document lossy policy or convert).
+- [ ] `cargo test`, `cargo clippy`, `cargo fmt -- --check`.
+
+### Related
+
+- [65Y-nanvm-conversion-macros](./65y-nanvm-conversion-macros.md) — wants
+  `impls/from.rs` to be pure variant-wrapping boilerplate.


### PR DESCRIPTION
## Summary

This PR adds 15 new todo issues documenting opportunities for DRY (Don't Repeat Yourself) refactoring across the codebase. These issues identify duplicated logic, shared patterns, and code that should be unified into single implementations.

## Issues Added

### BNF Parser Infrastructure
- **nullable-analysis-shared**: Move the nullable/empty-tag analysis computation from both parser backends into a shared `bnf/data` module, resolving disagreement on sequence handling between descent and ll1 implementations
- **rule-visitor**: Extract the repeated `Rule` ADT three-way discrimination pattern into a shared visitor in `bnf/data`
- **data-tosequence-reuse**: Eliminate duplicate `toSequence` implementation in `bnf/data` by importing from the parent module

### Virtual Filesystem
- **dir-spine-descend**: Share the immutable `Dir`-spine descent pattern used in three helpers (`operation`, `extractEntity`, `insertEntityAt`)
- **resolve-file-helper**: Extract the repeated single-segment file resolver preamble used in four operation handlers
- **is-proper-prefix-path**: Move the pure `isProperPrefix` path predicate from the virtual FS interpreter to `fs/path` module

### Type System & Bit Operations
- **bit-set-factory**: Unify `byte_set` and `nibble_set` bitmask-set algebra implementations via a parameterized factory
- **id-prefix-tag-factory**: Consolidate the repeated prefix-tag scheme in `sul/id` using a factory pattern

### Text & Encoding
- **lead-byte-classifier-dedup**: Extract the duplicated UTF-8 lead-byte classifier from `utf8ByteToCodePointOp`
- **error-tag-layout-constants**: Name the partial-state/error-tag bit layout constants once instead of hardcoding them in two places
- **single-signature-table**: Eliminate duplicate magic-byte signature declarations in `fs/mime` by deriving from a single source of truth

### VM & Runtime
- **bigint-shift-decode**: Extract the shared shift-amount decode prelude from `Shl` and `Shr` operations
- **primitive-coercion-dispatch**: Route `any_to_number`/`any_to_string` through the existing `Unpacked::dispatch` instead of hand-rolling 5-arm matches
- **string-utf16-from-impls**: Move UTF-16 string conversion impls from `impls/from.rs` to `vm/string/`

### CLI
- **positional-arity-check**: Extract positional-argument arity validation from individual command handlers into a shared combinator

## Priority Distribution
- P3 (3 issues): nullable-analysis-shared, bit-set-factory, single-signature-table, resolve-file-helper
- P4 (8 issues): dir-spine-descend, rule-visitor, bigint-shift-decode, primitive-coercion-dispatch, string-utf16-from-impls, is-proper-prefix-path, error-tag-layout-constants, lead-byte-classifier-dedup
- P5 (2 issues): positional-arity-check, data-tosequence-reuse
- P3 (1 issue): id-prefix-tag-factory

## Implementation Notes

Each issue includes:
- Clear problem statement with code citations
- Concrete proposal with example signatures
- Explicit task checklist
- Cross-references to related work and dependencies

The issues follow established patterns in the codebase (e.g., `fs/base_n` factory precedent, `fs/types/rtti/common` visitor pattern) and are scoped to be actionable without requiring architectural changes.

https://claude.ai/code/session_01GWpx4aCDeEBiMrKu4PMhMz