### PR TITLE
Add mcp handler test to proof suite

### DIFF
--- a/fs/fjs/proof.f.ts
+++ b/fs/fjs/proof.f.ts
@@ -29,6 +29,12 @@ export const proof = {
         // `run` strips the command and file name, so `main` sees two arguments
         assertEq(code, 2)
     },
+    mcp: () => {
+        // stdin is empty in the virtual environment, so the server sees EOF
+        // immediately and shuts down cleanly, exercising the `mcp` handler.
+        const [, code] = run({})(['mcp'])
+        assertEq(code, 0)
+    },
     throw: {
         runImportError: () => {
             run({})(['run', 'missing.f.ts'])


### PR DESCRIPTION
## Summary
Added a new test case to the proof suite that validates the `mcp` handler's behavior when stdin is empty in the virtual environment.

## Key Changes
- Added `mcp` test function that verifies the mcp handler exits cleanly with code 0 when receiving EOF on stdin
- The test exercises the virtual environment's stdin handling by running the mcp command with an empty input stream
- Includes explanatory comment documenting why stdin is empty and how this tests the handler's shutdown behavior

## Implementation Details
The test follows the existing pattern in the proof suite:
- Uses the `run()` function with an empty object to invoke the mcp command
- Asserts that the exit code is 0, confirming clean shutdown
- Validates that the mcp handler properly handles EOF conditions without errors

https://claude.ai/code/session_01Edw3M6QxDgXUGobHJm4MK6