### PR TITLE
effects/node: hoist randomInt's call-invariant constants out of the per-call closure

### DIFF
--- a/fs/effects/node/module.ts
+++ b/fs/effects/node/module.ts
@@ -189,6 +189,10 @@ const readStdinByte = async (): Promise<number | null> => {
     }
 }
 
+const randomMax = Number(1n << 32n)
+
+const { randomInt } = crypto
+
 const runNodeEffect: EffectToPromise = asyncRun({
     ...memoryOperationMap(),
     all: async (...effects) => await Promise.all(effects.map(runNodeEffect)),
@@ -235,7 +239,7 @@ const runNodeEffect: EffectToPromise = asyncRun({
             await fh.close()
         }
     }),
-    randomInt: async () => crypto.randomInt(2 ** 32),
+    randomInt: async () => randomInt(randomMax),
     access: path => asyncTryCatch(() => access(path)),
     createExclusive: path => asyncTryCatch(async () => {
         const fh = await open(path, 'wx')


### PR DESCRIPTION
## Summary
- Hoists `crypto.randomInt` (via `const { randomInt } = crypto`) and the `2 ** 32` bound (precomputed once as `randomMax = Number(1n << 32n)`) out of the `randomInt` effect handler in `fs/effects/node/module.ts`, so neither is recomputed on every call.
- No behavior change — same bound, same source of randomness.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `node ./fs/fjs/module.ts t` — 2073/2073 passing