### PR TITLE
Add skip-property specification for test marker

### DIFF
--- a/fs/emergent_testing/todo/skip-property.md
+++ b/fs/emergent_testing/todo/skip-property.md
@@ -1,0 +1,169 @@
+## skip-property. Add a `skip` test marker for tests that cannot run
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+The proposed `todo` marker ([todo-property](./todo-property.md)) assumes a
+test's outcome is the *same on every engine*: expected-throw everywhere today,
+expected-return everywhere after the fix. Two classes of captured-but-unfixed
+behaviour break that assumption:
+
+- **Engine-dependent bugs.** Bun has different `bigint` limitations than Node:
+  the same leaf throws on Bun and returns on Node. Whichever direction a strict
+  `todo` marker points, one runner is red. And since proofs are pure data
+  trees, the proof cannot branch on the engine — the tree does not know where
+  it is running.
+- **Harmful-to-run tests.** A captured behaviour may hang, exhaust memory, or
+  crash the process. Neither a normal test nor a `todo` test can hold it,
+  because both *execute* the leaf.
+
+Today such bugs fall back to the exact anti-patterns `todo` was designed to
+eliminate: commented-out tests and markdown-only notes.
+
+### Proposal
+
+Add a third marker, `skip`. Everything under a `skip` key is **collected but
+never executed**: leaves appear in the report as skipped and are tallied as
+technical debt, but their functions are not called.
+
+```ts
+export const proof = {
+    bigMath: {
+        works: () => assertEq(mulVec(a, b), c),
+        // Bun bigint limitation: throws on Bun, passes on Node.
+        // Neither expectation is uniform across engines, so don't run it.
+        skip: { hugeExponent: () => assertEq(pow(2n, big), expected) },
+    },
+}
+```
+
+#### `skip` is an inherited region, like `throw`
+
+Unlike `todo` (local last-key), `skip` is OR-accumulated along the ancestor
+path, exactly like `throws`: skipping a whole subtree (`skip: { …group }`) is
+the natural use. Leaves under it are still collected by `collectTests` — so
+each skipped path is individually visible in the report — they are just never
+called.
+
+Consequences of never executing:
+
+- **`skip` dominates `throw` and `todo`.** Under `skip`, the `expectFailure`
+  inversion is moot — there is no result to invert.
+- **A skipped generator is one skipped leaf.** Expanding a generator requires
+  calling it, so `skip: { gen: () => ({ a, b }) }` reports a single skipped
+  leaf `.gen`, not `.gen().a` / `.gen().b`.
+- **No static guard needed.** `skip: fn` (one skipped leaf) and `skip: { … }`
+  (skipped subtree) are both meaningful, unlike `todo`, which only accepts a
+  zero-argument function.
+
+#### Choosing between `todo` and `skip`
+
+Rule of thumb: *can the expectation be stated uniformly across engines, and is
+the test safe to execute?* Then use `todo` — it self-removes by flipping red
+when the behaviour lands. Otherwise use `skip`.
+
+`skip` deliberately gives up the flip-red signal: nothing ever tells us Bun
+fixed bigints. Two conventions compensate:
+
+- **Pair every `skip` with a `todo/{slug}.md` issue** stating the *unskip
+  trigger* — the precise condition (an engine release, a dependency fix) that
+  allows the marker to come off. This mirrors the **Trigger** requirement of
+  `todo/blocked/` issues: a skip without a stated trigger is just a wish.
+- **The `skip` tally in the summary** keeps the debt count visible on every
+  run.
+
+#### Counting and reporting
+
+Skipped leaves do not execute, so they contribute to neither `pass` nor `fail`
+and never affect the exit code. Instead:
+
+- The `fjs t` reporter prints each skipped leaf with a `# SKIP` annotation
+  (paired with `# TODO` — TAP has exactly this directive pair) and adds a
+  `skip` tally to the summary (`pass / fail / todo / skip`).
+- Unlike the `todo` tally, `skip` maps onto external runners **natively**:
+  Node `--test` accepts a `skip` option, and Bun and Playwright both have
+  `test.skip`. So the `register` path reports skips in the framework's own
+  output rather than silently dropping them.
+
+#### Rejected alternative: informational run
+
+A middle ground — execute skipped tests but ignore the verdict, reporting
+`skip: 3 (1 now passing)` — would partially restore the fixed-signal. Rejected
+as the primary mode: some skips exist precisely because executing the leaf is
+harmful (hang, OOM, process crash), so a true never-execute mode must exist
+anyway, and one marker with one meaning is simpler. Revisit only if unskip
+triggers prove too weak in practice.
+
+### Implementation
+
+Mirrors the `throws` plumbing in `fs/emergent_testing/module.f.ts` plus one
+option on the `test` effect:
+
+- **`TestEntry`** — add `readonly skip: boolean` next to `throws`.
+- **`parseTestSet` / `collectTests`** — inherit `skip` exactly like `throws`
+  (`skip || ck === 'skip'`). When `skip` is set, a non-leaf value that is a
+  zero-arg function is still a leaf; generators are not expanded (they are
+  leaves that never run).
+- **`runModule`** — when `entry.skip`, do not call `test`; report a skipped
+  result and increment the `skip` counter in `TestState` (no `pass`/`fail`
+  change, no return-value walk).
+- **`registerModule`** — register skipped leaves with a `skip` flag instead of
+  a test body; no subtest registration, no ` ...` star suffix.
+- **`TestFn` / `Test` effect (`fs/effects/node/module.f.ts`)** — extend the
+  options record `{ expectFailure }` with `skip`; the Node implementation
+  passes `{ skip: true }` through to `node:test` natively; the Bun/Playwright
+  inline wrappers delegate to the framework's `test.skip`.
+- **Reporter** — print `# SKIP` lines via `Reporter.result` (or a dedicated
+  `skipped` event) and extend `Reporter.summary` with the `skip` count;
+  `defaultReporter` prints `pass / fail / todo / skip`.
+- **No `fn.name === 'skip'` check** — structural-key-only, matching `throw`
+  and `todo` guidance.
+
+### Migration
+
+No existing proof uses a `skip` key (verified by grep over `fs/**/*.f.ts`), so
+this marker reinterprets nothing.
+
+### Open questions
+
+- Should the summary line omit `skip: 0` / `todo: 0` when zero, to keep the
+  common case short?
+- Skip reasons: the `skip` key cannot carry a reason string (its value is the
+  test itself). Is the paired `todo/{slug}.md` issue sufficient, or should a
+  convention like `skip: { 'bun-bigint-limit': fn }` (descriptive child key)
+  be encouraged in docs?
+
+### Tasks
+
+- [ ] Add `skip` to `TestEntry`; inherit it in `parseTestSet` / `collectTests`
+      like `throws`.
+- [ ] Short-circuit skipped leaves in `runModule` (no execution, no walk) and
+      count them in a new `TestState.skip`.
+- [ ] Extend the `test` effect options with `skip`; map to `node:test`'s
+      native `skip` option and to `test.skip` in the Bun/Playwright wrappers;
+      use it in `registerModule`.
+- [ ] Print `# SKIP` per leaf and `pass / fail / todo / skip` in
+      `defaultReporter` (`fjs t`).
+- [ ] Add proofs in `fs/emergent_testing/proof.f.ts`: skipped leaf not
+      executed, skipped subtree collected as individual paths, skipped
+      generator reported as one leaf, `skip` dominating `throw`/`todo`,
+      counters unaffected by skips.
+- [ ] Document `skip` in `fs/emergent_testing/README.md` next to the `todo`
+      marker: the choosing rule, the unskip-trigger pairing convention, and
+      the rejected informational-run alternative.
+- [ ] Update `AGENTS.md`: a `skip` marker must be paired with a
+      `todo/{slug}.md` stating its unskip trigger.
+- [ ] Confirm `fjs t` proofs pass with full branch coverage and `npx tsc` is
+      clean.
+
+### Related
+
+- [todo-property](./todo-property.md) — `todo` covers engine-independent
+  captured bugs and self-removes by flipping red; `skip` covers what `todo`
+  structurally cannot: engine-dependent outcomes and harmful-to-run tests.
+- `todo/README.md` "Blocked by third parties" — the unskip-trigger convention
+  mirrors the **Trigger** requirement of `todo/blocked/` issues.
+- `fs/effects/node/module.f.ts` `TestFn` — the options record extended with
+  `skip` for native framework skipping.

--- a/fs/emergent_testing/todo/todo-property.md
+++ b/fs/emergent_testing/todo/todo-property.md
@@ -250,3 +250,6 @@ out from under `throw`) as part of landing this change.
   structural-key inversion mechanism; this proposal adds a second, *local* flag
   combined with the inherited `throws` flag via XOR (inversion) and OR
   (leaf-ness).
+- [skip-property](./skip-property.md) — `todo` assumes the expectation is
+  uniform across engines and the test is safe to execute; `skip` covers the
+  cases where it is not (engine-dependent outcomes, harmful-to-run tests).


### PR DESCRIPTION
## Summary

This PR adds a specification document for a new `skip` test marker to complement the existing `todo` marker in the emergent testing framework. The `skip` marker addresses test cases that cannot be uniformly handled across engines or are unsafe to execute.

## Changes

- **Added `fs/emergent_testing/todo/skip-property.md`**: A comprehensive specification for the `skip` test marker that:
  - Defines the problem: engine-dependent bugs and harmful-to-run tests that break the `todo` marker's assumptions
  - Proposes `skip` as an inherited region marker (like `throws`) that collects but never executes tests
  - Establishes decision rules for choosing between `todo` and `skip`
  - Details implementation requirements across the test framework (parsing, execution, registration, reporting)
  - Specifies reporting behavior with `# SKIP` annotations and skip tallies
  - Includes a complete task list for implementation
  - Documents the unskip-trigger convention to maintain visibility of skipped tests

- **Updated `fs/emergent_testing/todo/todo-property.md`**: Added cross-reference linking to the new `skip-property` specification, clarifying the relationship between `todo` and `skip` markers.

## Implementation Details

The specification establishes that `skip`:
- Is OR-accumulated along the ancestor path (inherited), unlike `todo` which is local
- Dominates `throw` and `todo` — skipped tests are never executed
- Generators under `skip` are reported as single skipped leaves (not expanded)
- Requires pairing with a `todo/{slug}.md` issue stating the unskip trigger
- Maps natively to framework skip capabilities (Node `--test`, Bun, Playwright)
- Contributes to a separate `skip` counter in test summaries, not affecting pass/fail counts

This is a specification-only change; implementation tasks are enumerated for future work.

https://claude.ai/code/session_01PpBbxBs2nN7sCJNmmy1Gs4