### PR TITLE
Add step method test for lazy effect composition

### DIFF
--- a/fs/effects/proof.f.ts
+++ b/fs/effects/proof.f.ts
@@ -23,6 +23,10 @@ export const proof = {
             assertPure(e, 7)
             if (!evaluated) { throw 'decode must force the thunk' }
         },
+        step: () => {
+            const e = lazy(() => 5).step(v => pure(v * 2))
+            assertPure(e, 10)
+        },
     },
     foldStep: {
         empty: () => {


### PR DESCRIPTION
## Summary
Added a test case for the `step` method in the proof effects module to verify lazy effect composition behavior.

## Key Changes
- Added `step` test case under the `proof` object that validates the `step` method on lazy effects
- Test verifies that `lazy(() => 5).step(v => pure(v * 2))` correctly evaluates to `10`
- Uses `assertPure` to confirm the lazy effect produces the expected pure value after stepping

## Implementation Details
The test demonstrates that the `step` method properly chains lazy computations with pure value transformations, ensuring that:
1. The lazy thunk is evaluated
2. The step function receives the thunk's result
3. The final pure value reflects the transformation applied

https://claude.ai/code/session_01GrbZnwaUQYAB5a8jNAZBYq