### PR TITLE
Add test coverage for range-map's default handler

### DIFF
--- a/fs/fsc/module.f.ts
+++ b/fs/fsc/module.f.ts
@@ -102,5 +102,11 @@ export const proof = {
             b(undefined)
             union(a)(b)
         }
+    },
+    // `def` is the range-map's default handler; the public API never calls it directly
+    // (`init` covers every code point), so exercise it here where it's in scope.
+    defHandler: () => {
+        const result = def(undefined)
+        if (result !== unexpectedSymbol) { throw result }
     }
 }


### PR DESCRIPTION
## Summary
Added a test case to exercise the `def` (default handler) function of the range-map, which is not directly called by the public API but should be validated for correctness.

## Key Changes
- Added `defHandler` test function to the `proof` object that:
  - Calls the `def` function with `undefined` as input
  - Verifies it returns the expected `unexpectedSymbol` value
  - Throws if the result is unexpected

## Implementation Details
The test is necessary because the `def` handler is in scope within the module but never invoked through normal public API usage (since `init` covers every code point). This test ensures the default handler behaves correctly when called directly.

https://claude.ai/code/session_0159rLuKRQpUWq9MjQ3Xk2dp