### PR TITLE
Add writeBytes validation test for non-append offset

### DIFF
--- a/fs/effects/node/virtual/proof.f.ts
+++ b/fs/effects/node/virtual/proof.f.ts
@@ -1,5 +1,5 @@
 import { assertEq } from '../../../asserts/module.f.ts'
-import { awaitIfPromise, fetch, rm, writeFile, readFile, readdir, import_, rename, readBytes } from '../module.f.ts'
+import { awaitIfPromise, fetch, rm, writeFile, readFile, readdir, import_, rename, readBytes, writeBytes } from '../module.f.ts'
 import { maxLengthBytes, vec, vec8 } from '../../../types/bit_vec/module.f.ts'
 import { emptyState, virtual, type Dir, type JsModule } from './module.f.ts'
 
@@ -157,6 +157,13 @@ export const proof = {
         const root: Dir = { 'big': [chunk0, chunk1] }
         const [, result] = virtual({ ...emptyState, root })(readBytes('big', chunkSize - 1, 2))
         assertEq(result[0], 'ok')
+    },
+    writeBytesWrongOffset: () => {
+        // writeBytes is append-only; an offset that doesn't match the current
+        // file size must fail rather than silently create a hole.
+        const root: Dir = { 'file': [vec8(0x42n)] }
+        const [, result] = virtual({ ...emptyState, root })(writeBytes('file', 5, vec8(0x43n)))
+        assertEq(result[0], 'error')
     },
     largeFileReadBytes: () => {
         // A file stored as two 128 KiB chunks is larger than maxLengthBytes.


### PR DESCRIPTION
## Summary
Added a new proof test to validate that `writeBytes` properly rejects write operations with offsets that don't match the current file size, ensuring append-only semantics are enforced.

## Changes
- Imported `writeBytes` function in the proof test module
- Added `writeBytesWrongOffset` test case that verifies `writeBytes` fails when attempting to write at an offset (5) that doesn't match the current file size (1)
- Test confirms that the virtual filesystem prevents creating "holes" in files by rejecting non-sequential writes

## Implementation Details
The test creates a file with one byte (0x42) and attempts to write another byte (0x43) at offset 5. The expected behavior is that this operation returns an error result, validating that `writeBytes` maintains strict append-only semantics rather than allowing arbitrary offset writes.

https://claude.ai/code/session_01AaRPKHBnBKDrzpejXPaxC7