### PR TITLE
Add .js files benefit to types-for-fs todo

### DIFF
--- a/todo/types-for-fs.md
+++ b/todo/types-for-fs.md
@@ -84,4 +84,16 @@ We may have a special version of TypeScript and it should have a run-time descri
 
 ## Benefits
 
-- **Use `.js` files.** Since types are defined as run-time values (RTTI) instead of TypeScript syntax, the code stays plain JavaScript and runs as-is, with no additional compilation step. This could be very attractive for projects which don't accept TypeScript because of the additional compilation step.
+- **Use `.js` files.** Type annotations are written in comments, so the code stays plain JavaScript and runs as-is, with no additional compilation step. This could be very attractive for projects which don't accept TypeScript because of the additional compilation step. The syntax could be similar to JSDoc:
+
+  ```js
+  /** @type {RTTI-TYPE} */
+  const x = ...
+  ```
+
+  or even simpler:
+
+  ```js
+  const x = //: RTTI-TYPE
+      ...
+  ```

--- a/todo/types-for-fs.md
+++ b/todo/types-for-fs.md
@@ -81,3 +81,7 @@ f(ap) // compilation error.
 ```
 
 We may have a special version of TypeScript and it should have a run-time description, similar to [RTTI](../fs/types/rtti/README.md)
+
+## Benefits
+
+- **Use `.js` files.** Since types are defined as run-time values (RTTI) instead of TypeScript syntax, the code stays plain JavaScript and runs as-is, with no additional compilation step. This could be very attractive for projects which don't accept TypeScript because of the additional compilation step.


### PR DESCRIPTION
Note that RTTI-based types keep code as plain JavaScript, avoiding the
compilation step that makes some projects reject TypeScript.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DRQP7f7xeM9XuQcZpifY67