### PR TITLE
Add fs/cas/evo: revision content format for evolving mutable objects on CAS

### DIFF
--- a/fs/cas/README.md
+++ b/fs/cas/README.md
@@ -1,0 +1,12 @@
+# CAS — content-addressable storage
+
+Hashing, addressing, and path parsing for a filesystem-backed
+content-addressable store: `fileCas` streams content in and out under a
+SHA-256 content hash (cBase32-encoded), with lock-free staging uploads so
+concurrent writers never corrupt each other's blobs.
+
+- [`cli/`](./cli/) — the `cas` command-line front end (`cas add`, `cas get`, ...)
+- [`mcp/`](./mcp/) — an MCP server front end (`cas_add`, `cas_get`, `cas_list`)
+- [`evo/`](./evo/) — the `revision` content format: evolving mutable objects
+  (documents, configs, any stable-named mutable state) on top of the
+  otherwise-immutable store, via a DAG of revision BLOBs

--- a/fs/cas/evo/README.md
+++ b/fs/cas/evo/README.md
@@ -1,0 +1,220 @@
+# `evo` — evolution of mutable objects on top of immutable CAS
+
+CAS blobs are immutable and addressed by content hash, so "the same object,
+but updated" has no address in common with the old version — a new version is
+always a new hash. This module defines a `revision` content format: a BLOB
+representing one step in the evolution of a mutable object, linking back to
+its parent revision(s). Head resolution, materialization, generation-cache
+verification, and a merge-revision constructor live here too, next to the
+schema, keeping [`fs/cas/module.f.ts`](../module.f.ts) focused on
+hashing/addressing.
+
+## The `revision` schema
+
+```ts
+export const revision = {
+    mimeType: 'application/vnd.functionalscript.revision+json',
+    object: ref,
+    parents: array(hash),
+    content: option(ref),
+    changes: option(array(ref)),
+    generation: option(number),
+    archived: option(true),
+} as const
+```
+
+| Field        | Type            | Meaning |
+|--------------|-----------------|---------|
+| `mimeType`   | literal string  | Format tag — see below. |
+| `object`     | `ref`           | Identity of the mutable object being revised. |
+| `parents`    | `hash[]`        | Parent revision BLOBs. Empty ⇒ first revision. |
+| `content`    | `ref?`          | Complete materialized content. Authoritative when present. |
+| `changes`    | `ref[]?`        | Incremental changes against the parent(s). Used only when `content` is absent. |
+| `generation` | `number?`       | Cached generation number — a cache, not a source of truth. |
+| `archived`   | `true?`         | Marks the object archived/inactive. |
+
+## `ref` and `hash`
+
+A `ref` is a URL in content-addressed digital space. Two forms are recognized
+today:
+
+- a **cbase32 hash** — a native CAS address (see [`fs/cbase32`](../../cbase32/)),
+- a standard **`https://` URL** — a bridge to the legacy location-addressed
+  web.
+
+More forms are planned (see "Open design points" below). `hash` is the
+hash-only subset of `ref`: a cbase32 CAS address, never a bridge URL. `parents`
+uses `hash`, not `ref`, because a parent revision is always a CAS blob — a
+bridge URL cannot stand in for it, and **a revision with a non-CAS parent must
+not validate**. `fs/cas/evo/module.f.ts` exports `isHash`/`isRef` for this
+semantic check (the RTTI schema itself only checks that the field is a
+string — RTTI has no "refine" concept) and `parseRevision`, which combines
+structural RTTI validation with these checks.
+
+## Object identity
+
+`object` identity normally comes from the first `content`: the hash of the
+object's initial content is the object's identity. Two objects created from
+identical initial content therefore share an identity — this is by design: it
+is fine to have many changes of the same object from different users. When
+distinct identity is wanted, a ref can carry an additional nonce
+(`{hash}-{nonce}`, not yet implemented). Digital signatures (a separate,
+future spec) will filter changes from unknown users.
+
+`object` is also the fallback base for `parents`: a revision with no parents
+uses `object` as its base, with or without `changes`.
+
+## The `mimeType` tag
+
+`mimeType` is a self-describing format tag: in a generic CAS a blob is just
+bytes under a hash, so without a discriminant a reader can only recognize a
+revision by guessing from its shape, which collides with any other format
+that happens to have `object`/`parents` fields. The tag gives format
+detection (tools can recognize revisions while walking a store) and a cheap
+pre-validation gate; the key doubles as the type discriminant.
+
+The value is a media type in the RFC 6838 vendor tree with the RFC 6839
+`+json` structured-syntax suffix: the part before `+`
+(`vnd.functionalscript.revision`) names the specific format, the suffix tells
+generic tooling the underlying syntax is JSON. No registry entry is required
+for the vendor tree, the string is stable (no mutable URL, no DNS anchoring),
+and it is validated by the schema itself since the literal is part of the
+schema.
+
+The key is spelled `mimeType` — the same field name MCP resource contents
+use — because CAS objects will be exposed as MCP resources and a server can
+surface this value directly as the response `mimeType` (see
+[`../mcp/todo/cas-get-mcp-resource-response.md`](../mcp/todo/cas-get-mcp-resource-response.md)).
+A stored blob is untrusted input, though: a server must never echo a stored
+`mimeType` blindly — only surface it once the blob has been validated against
+the schema that tag names (an allowlist of known
+`application/vnd.functionalscript.*+json` types, each checked with its own
+validator). That MCP-side wiring is tracked separately and not implemented by
+this module.
+
+### Versioning rule
+
+Additive, compatible changes keep the tag — RTTI struct validation accepts
+undeclared keys by design, so a blob with extra fields still validates
+against the v1 schema, and that is the intended forward-compatibility path.
+An **incompatible** change MUST NOT reuse the tag: it introduces a new media
+type (for example `application/vnd.functionalscript.revision2+json`), so
+readers of the old format never validate — and never silently misread — a
+blob of the new one. The tag is therefore the version discriminant for
+breaking changes; no `version` field is needed.
+
+## Head resolution
+
+`object` gives every revision of the same mutable thing a common anchor to
+resolve "current head(s)" against, without requiring a mutable pointer
+anywhere in CAS itself. A head is whatever revision(s) reference `object` and
+are not listed as a parent by another revision *of the same `object`* — a
+revision of a different object referencing the same hash (or an unrelated
+blob imported by sync) must not demote a head.
+
+`heads(object)(entries)` implements this as a reverse index scoped per
+object: it filters `entries` down to those revising `object`, collects every
+hash appearing in one of their `parents` arrays, and returns the ones not
+collected. Heads can be demoted retroactively — simply call `heads` again
+once a newly synced revision extends the entry set with a same-object child.
+
+## Materialization algorithm
+
+`content` has priority; the fields are not mutually exclusive by schema —
+resolution is by precedence. The base of a revision is its materialized
+parent, or `object` itself when `parents` is empty (in all cases, with or
+without `changes`):
+
+1. if `content` is present, use it;
+2. otherwise, apply `changes` on the base;
+3. otherwise (no `changes`), use the base.
+
+Materialization through multiple parents is only defined when every path
+references a single common ancestor, the intermediate revisions have no
+`content`, and all `changes` are CRDTs (so application is order-independent).
+
+**First iteration status:** `materialize` in `module.f.ts` implements steps 1
+and 3 for zero or one parent. `changes` replay (step 2) is not implemented —
+a revision carrying `changes` and no `content` materializes to `undefined`.
+A bare multi-parent revision (no `content`) also materializes to `undefined`;
+a multi-parent (merge) revision must carry `content`.
+
+## Conflicting concurrent heads
+
+Resolved the same way as in Git: a merge tool creates a new revision that
+references the conflicting revisions as `parents`. The format itself does not
+resolve conflicts; it records their resolution. CAS synchronization MUST
+never care about merge conflicts — an object can legitimately have many heads
+in a store at any time. An application can propose a merge revision; sync
+just moves blobs.
+
+`merge(resolve)(object)(parents)(content)` builds such a revision: it
+requires at least two `parents` (resolving one head is not a merge) and fills
+in a `generation` cache from the parents' own cached generations (see below).
+The already-resolved `content` — from a 3-way merge tool, a manual pick,
+whatever produced the answer — is the caller's responsibility; this function
+only records the resolution as CAS data.
+
+`changes` entries will most likely point to an event log, most likely
+CRDT-based, but the refs may point to different (not yet defined) formats.
+
+## Generation cache
+
+`generation` is a cache, not a source of truth — it must always be
+re-derivable from `parents`, and a consumer must not trust a `generation` it
+has not verified against the actual parent chain from an untrusted source.
+Normally `generation = 0` for the first revision, `generation = 1 +
+max(parent.generation)` otherwise.
+
+Two helpers, deliberately asymmetric in what they trust:
+
+- `cachedGeneration(resolve)(parents)` — cheap, for a producer building a
+  *new* revision on top of its own already-trusted history: `1 + max` of each
+  parent's own cached `generation` field (defaulting an unresolved/uncached
+  parent to `0`).
+- `actualGeneration(resolve)(hash)` / `verifyGeneration(resolve)(rev)` —
+  recomputes generation by walking the real parent chain, never trusting a
+  parent's cached field. This is what a consumer of untrusted (e.g. synced)
+  data must run before relying on a cached `generation`.
+
+## `archived`
+
+Marks the mutable object as archived/inactive — for example, a task that is
+done. An archived object's blobs can be deleted from a local CAS after a
+backup. The field follows the existing `option(true)` idiom (a
+presence-only flag) rather than `option(boolean)`, matching the convention
+used elsewhere in the RTTI-typed schemas under `fs/types/rtti`. `isArchived`
+tests the flag; the revision still exists and is just hidden from normal
+active views by whatever consumer implements that view.
+
+## Open design points
+
+- The `changes` event-log/CRDT format(s) still need to be defined (not
+  implemented in the first iteration).
+- Future `ref` forms beyond cbase32 hashes and `https://` bridge URLs
+  (including the optional `{hash}-{nonce}` form for distinct object
+  identity), and which ref positions besides `parents` use the hash-only
+  `hash` type rather than the general `ref` (`object`? `content`? `changes`?).
+- Whether other content formats should share the same `mimeType` tagging
+  convention (including its versioning rule).
+- The exact syntax of a content-addressed revision reference (e.g.
+  `{hash}.{generation}.{hash}` — `hash.generation` alone does not pin a
+  version across branches; undefined for now — only hashes are used).
+- Digital signatures for filtering changes from unknown users — a separate,
+  future spec.
+- Further out: a `{public-key}/{name}.{generation}` form, where the key's
+  owner defines what `{name}` means (see
+  [`../../../todo/plan/vision.md`](../../../todo/plan/vision.md)).
+- Surfacing a validated stored `mimeType` as the MCP `cas_get` response
+  `mimeType` — see
+  [`../mcp/todo/cas-get-mcp-resource-response.md`](../mcp/todo/cas-get-mcp-resource-response.md).
+
+## Related
+
+- [`../todo/revision-content-format.md`](../todo/revision-content-format.md) —
+  the design task this module implements.
+- [`../../../todo/plan/vision.md`](../../../todo/plan/vision.md) — DISOT
+  block types (signature, trust, license, redirect) this format sits
+  alongside.
+- [`../todo/66g-cas-verify-command.md`](../todo/66g-cas-verify-command.md) —
+  integrity checking applies equally to revision BLOBs.

--- a/fs/cas/evo/module.f.ts
+++ b/fs/cas/evo/module.f.ts
@@ -1,0 +1,230 @@
+/**
+ * Revision content format: evolving mutable objects on top of immutable CAS.
+ *
+ * A `revision` is a BLOB representing one step in the evolution of a mutable
+ * object (a document, a config, any piece of mutable state referenced by a
+ * stable name). Revisions link back to their parent revision(s) — a DAG, not
+ * just a chain, so concurrent edits can merge — and carry either the full
+ * materialized content or an incremental diff against the parent(s).
+ *
+ * See [`README.md`](./README.md) for the full format spec.
+ *
+ * @module
+ */
+import { array, number, option, string } from '../../types/rtti/module.f.ts'
+import type { Ts } from '../../types/rtti/ts/module.f.ts'
+import { validate as rttiValidate } from '../../types/rtti/validate/module.f.ts'
+import { cBase32ToVec } from '../../cbase32/module.f.ts'
+import { ok, error, type Result } from '../../types/result/module.f.ts'
+
+// ── ref / hash ──────────────────────────────────────────────────────────────
+
+/**
+ * A URL in content-addressed digital space. Two forms are recognized today: a
+ * cbase32 hash (a native CAS address, see [`fs/cbase32`](../../cbase32/)) and
+ * a standard `https://` URL as a bridge to the legacy location-addressed web.
+ * More forms are planned — see `README.md`.
+ *
+ * Structurally just a `string` in the RTTI schema (there is no "refine"
+ * concept in `fs/types/rtti`); `isRef` below carries the semantic check that
+ * distinguishes it from an arbitrary string.
+ */
+export const ref = string
+
+/** TypeScript type for {@link ref}. */
+export type Ref = Ts<typeof ref>
+
+/**
+ * The hash-only subset of `ref`: a cbase32 CAS address, never a bridge URL.
+ * Used where a bridge URL must not stand in for the value — `parents`, since
+ * a parent revision is always a CAS blob addressed by its own hash.
+ */
+export const hash = string
+
+/** TypeScript type for {@link hash}. */
+export type Hash = Ts<typeof hash>
+
+/** True when `s` decodes as a cbase32 CAS hash (a native `hash`/`ref`). */
+export const isHash = (s: string): boolean => cBase32ToVec(s) !== null
+
+/** True when `s` is a recognized `ref`: a cbase32 hash or an `https://` bridge URL. */
+export const isRef = (s: string): boolean => isHash(s) || s.startsWith('https://')
+
+// ── revision ──────────────────────────────────────────────────────────────
+
+/**
+ * Format tag for a `revision` BLOB: identifies the BLOB as a revision and
+ * names the media type it should be served with — the same key MCP resource
+ * contents use for the served type. A vendor-tree (RFC 6838) media type with
+ * the `+json` structured-syntax suffix (RFC 6839); see `README.md` for the
+ * versioning rule (additive changes keep the tag, breaking changes mint a
+ * new one).
+ */
+export const mimeType = 'application/vnd.functionalscript.revision+json' as const
+
+/** RTTI schema for a `revision` BLOB. See `README.md` for the field-by-field spec. */
+export const revision = {
+    mimeType,
+    /** Identity of the mutable object being revised. */
+    object: ref,
+    /** Parent revision BLOBs (hash-only — a parent is always a CAS blob). Empty means first revision. */
+    parents: array(hash),
+    /** Complete materialized content. Authoritative when present. */
+    content: option(ref),
+    /** Incremental changes against the parent(s). Used only when `content` is absent. */
+    changes: option(array(ref)),
+    /** Cached generation number — re-derivable from `parents`, never trust it unverified. */
+    generation: option(number),
+    /** Marks the mutable object as archived/inactive. The revision still exists. */
+    archived: option(true),
+} as const
+
+/** TypeScript type for {@link revision}. */
+export type Revision = Ts<typeof revision>
+
+const structValidate = rttiValidate(revision)
+
+/**
+ * Validates an unknown value as a `revision`: structural RTTI validation
+ * (`revision` schema) plus the semantic checks the schema alone cannot
+ * express — every `parents` entry must decode as a cbase32 hash (a bridge URL
+ * must not validate there), and `object`/`content`/`changes` refs must be a
+ * recognized `ref` form. A revision with a non-CAS parent does not validate.
+ */
+export const parseRevision = (value: unknown): Result<Revision, string> => {
+    const r = structValidate(value as any)
+    if (r[0] === 'error') { return error(`${r[1].path.join('.')}: ${r[1].message}`) }
+    const rev = r[1]
+    if (!isRef(rev.object)) { return error('object: not a recognized ref') }
+    for (const p of rev.parents) {
+        if (!isHash(p)) { return error('parents: not a cbase32 hash') }
+    }
+    if (rev.content !== undefined && !isRef(rev.content)) { return error('content: not a recognized ref') }
+    if (rev.changes !== undefined) {
+        for (const c of rev.changes) {
+            if (!isRef(c)) { return error('changes: not a recognized ref') }
+        }
+    }
+    return ok(rev)
+}
+
+// ── head resolution ─────────────────────────────────────────────────────────
+
+/** A stored revision paired with its own content hash. */
+export type Entry = {
+    readonly hash: Hash
+    readonly revision: Revision
+}
+
+/**
+ * Resolves the head(s) of `object`: the revisions of `object` in `entries`
+ * that are not listed as a parent by any *other* revision of the same
+ * `object`. A reverse index scoped per object — a revision of a different
+ * object referencing the same hash (or an unrelated blob) never demotes a
+ * head, and a head can be demoted retroactively simply by re-running this
+ * over a larger `entries` set once a new same-object child is synced in.
+ */
+export const heads = (object: Ref) => (entries: readonly Entry[]): readonly Hash[] => {
+    const sameObject = entries.filter(e => e.revision.object === object)
+    const referencedAsParent = new Set<Hash>()
+    for (const e of sameObject) {
+        for (const p of e.revision.parents) { referencedAsParent.add(p) }
+    }
+    return sameObject.filter(e => !referencedAsParent.has(e.hash)).map(e => e.hash)
+}
+
+// ── materialization ─────────────────────────────────────────────────────────
+
+/** Looks up a stored revision by hash. `undefined` when not present/resolvable. */
+export type Resolve = (hash: Hash) => Revision | undefined
+
+/**
+ * Materializes the content `ref` of `rev`, per the precedence rule: `content`
+ * has priority when present; otherwise the base — the materialization of the
+ * single parent, or `object` itself when there are no parents — is used.
+ *
+ * First iteration only: `changes` replay is not implemented, so a revision
+ * with `changes` and no `content` cannot be materialized here (`undefined`),
+ * and a revision with more than one parent must carry `content` (a merge
+ * revision) — materializing a bare multi-parent revision also returns
+ * `undefined`. An unresolvable parent (`resolve` returns `undefined`) also
+ * yields `undefined` rather than throwing, since a store may legitimately be
+ * missing a blob it hasn't synced yet.
+ */
+export const materialize = (resolve: Resolve) => (object: Ref) => (rev: Revision): Ref | undefined => {
+    if (rev.content !== undefined) { return rev.content }
+    if (rev.changes !== undefined) { return undefined }
+    if (rev.parents.length === 0) { return object }
+    if (rev.parents.length > 1) { return undefined }
+    const parent = resolve(rev.parents[0])
+    return parent === undefined ? undefined : materialize(resolve)(object)(parent)
+}
+
+// ── generation cache ─────────────────────────────────────────────────────────
+
+/**
+ * Cheap generation cache for a *new* revision being constructed locally:
+ * `0` when `parents` is empty, else `1 + max` of each parent's own cached
+ * `generation` (defaulting an uncached/unresolved parent to `0`). This trusts
+ * the parent's cached field, which is fine for a producer building on top of
+ * its own (already-trusted) history — see {@link actualGeneration} for the
+ * untrusted-input counterpart.
+ */
+export const cachedGeneration = (resolve: Resolve) => (parents: readonly Hash[]): number => {
+    if (parents.length === 0) { return 0 }
+    let max = -1
+    for (const p of parents) {
+        const g = resolve(p)?.generation ?? 0
+        if (g > max) { max = g }
+    }
+    return max + 1
+}
+
+/**
+ * Recomputes the generation of the revision at `h` by walking the *actual*
+ * parent chain — it never trusts a parent's own cached `generation` field,
+ * which is exactly the untrusted value this guards against when a revision
+ * arrives from sync. Throws if `h` (or an ancestor) is unresolvable; callers
+ * that need a total function should resolve reachability first.
+ */
+export const actualGeneration = (resolve: Resolve) => (h: Hash): number => {
+    const rev = resolve(h)
+    if (rev === undefined) { throw new Error(`revision-content-format: unresolved revision ${h}`) }
+    return rev.parents.length === 0 ? 0 : 1 + Math.max(...rev.parents.map(actualGeneration(resolve)))
+}
+
+/**
+ * True when `rev.generation` is absent (nothing to verify) or equals the
+ * generation recomputed from the actual parent chain (never the parents' own
+ * cached values) — the check a consumer must run before trusting a cached
+ * `generation` from an untrusted source.
+ */
+export const verifyGeneration = (resolve: Resolve) => (rev: Revision): boolean =>
+    rev.generation === undefined
+    || rev.generation === (rev.parents.length === 0 ? 0 : 1 + Math.max(...rev.parents.map(actualGeneration(resolve))))
+
+// ── archived ─────────────────────────────────────────────────────────────────
+
+/** True when `rev` marks its object as archived/inactive. */
+export const isArchived = (rev: Revision): boolean => rev.archived === true
+
+// ── merge ────────────────────────────────────────────────────────────────────
+
+/**
+ * Builds a merge revision resolving concurrent `parents` (heads) of `object`
+ * into one new revision carrying the already-resolved `content`. Mirrors
+ * Git's model: the format does not resolve the conflict itself, a merge tool
+ * (or a person) does, and this just records that resolution as a new
+ * revision whose `parents` are the merged heads. `parents` must have at
+ * least two entries — resolving one head is not a merge (see `README.md`).
+ */
+export const merge = (resolve: Resolve) => (object: Ref) => (parents: readonly Hash[]) => (content: Ref): Revision => {
+    if (parents.length < 2) { throw new Error('revision-content-format: merge requires at least two parents') }
+    return {
+        mimeType,
+        object,
+        parents,
+        content,
+        generation: cachedGeneration(resolve)(parents),
+    }
+}

--- a/fs/cas/evo/proof.f.ts
+++ b/fs/cas/evo/proof.f.ts
@@ -1,0 +1,291 @@
+import { assert, assertEq } from '../../asserts/module.f.ts'
+import { vec8 } from '../../types/bit_vec/module.f.ts'
+import { vecToCBase32 } from '../../cbase32/module.f.ts'
+import {
+    actualGeneration,
+    cachedGeneration,
+    heads,
+    isArchived,
+    materialize,
+    merge,
+    mimeType,
+    parseRevision,
+    revision,
+    verifyGeneration,
+    type Entry,
+    type Hash,
+    type Ref,
+    type Resolve,
+    type Revision,
+} from './module.f.ts'
+
+// Two distinct real cbase32 hashes for parseRevision tests, which enforce
+// that `object`/`parents` decode as genuine CAS addresses.
+const objectHash = vecToCBase32(vec8(0x01n))
+const parentHash = vecToCBase32(vec8(0x02n))
+const bridgeUrl = 'https://example.com/doc'
+
+const baseRevision = (): Revision => ({
+    mimeType,
+    object: objectHash,
+    parents: [],
+})
+
+// A tiny in-memory resolver, used by the head/materialization/generation
+// tests below: pure functions operating on plain string keys (heads,
+// materialize, and generation checks never call `isHash`/`isRef` themselves
+// — only `parseRevision` enforces the ref grammar, tested separately).
+const storeOf = (entries: readonly Entry[]): Resolve => {
+    const map: { [k: string]: Revision } = {}
+    for (const e of entries) { map[e.hash] = e.revision }
+    return h => map[h]
+}
+
+const entry = (hash: Hash, revision: Revision): Entry => ({ hash, revision })
+
+export const proof = {
+    // ── parseRevision ────────────────────────────────────────────────────────
+
+    parseValidFirstRevision: () => {
+        const r = parseRevision(baseRevision())
+        assertEq(r[0], 'ok')
+    },
+
+    parseRejectsWrongMimeType: () => {
+        const r = parseRevision({ ...baseRevision(), mimeType: 'text/plain' })
+        assertEq(r[0], 'error')
+    },
+
+    // A parent is always a CAS blob: a bridge URL in `parents` must not validate,
+    // even though the same string is a perfectly valid `object`/`content` ref.
+    parseRejectsNonCasParent: () => {
+        const r = parseRevision({ ...baseRevision(), parents: [bridgeUrl] })
+        assertEq(r[0], 'error')
+    },
+
+    parseAcceptsCasHashParent: () => {
+        const r = parseRevision({ ...baseRevision(), parents: [parentHash] })
+        assertEq(r[0], 'ok')
+    },
+
+    parseAcceptsBridgeUrlObjectAndContent: () => {
+        const r = parseRevision({ ...baseRevision(), object: bridgeUrl, content: bridgeUrl })
+        assertEq(r[0], 'ok')
+    },
+
+    parseRejectsMalformedRef: () => {
+        const r = parseRevision({ ...baseRevision(), object: 'not-a-ref-or-hash' })
+        assertEq(r[0], 'error')
+    },
+
+    // ── heads ────────────────────────────────────────────────────────────────
+
+    headsLinearHistory: () => {
+        const obj = 'obj'
+        const r1: Revision = { mimeType, object: obj, parents: [] }
+        const r2: Revision = { mimeType, object: obj, parents: ['r1'] }
+        const entries = [entry('r1', r1), entry('r2', r2)]
+        assertEq(heads(obj)(entries).join(','), 'r2')
+    },
+
+    headsBranchAndMerge: () => {
+        const obj = 'obj'
+        const r1: Revision = { mimeType, object: obj, parents: [] }
+        const r2: Revision = { mimeType, object: obj, parents: ['r1'] }
+        const r3: Revision = { mimeType, object: obj, parents: ['r1'] }
+        let entries = [entry('r1', r1), entry('r2', r2), entry('r3', r3)]
+        // Two concurrent branches from the same root are both heads.
+        assertEq([...heads(obj)(entries)].sort().join(','), 'r2,r3')
+        const r4: Revision = { mimeType, object: obj, parents: ['r2', 'r3'], content: 'content-ref' }
+        entries = [...entries, entry('r4', r4)]
+        // A merge revision referencing both branch heads demotes them.
+        assertEq(heads(obj)(entries).join(','), 'r4')
+    },
+
+    headsManyForOneObject: () => {
+        const obj = 'obj'
+        const entries = [
+            entry('a', { mimeType, object: obj, parents: [] }),
+            entry('b', { mimeType, object: obj, parents: [] }),
+            entry('c', { mimeType, object: obj, parents: [] }),
+        ]
+        assertEq([...heads(obj)(entries)].sort().join(','), 'a,b,c')
+    },
+
+    // A revision of a *different* object referencing the same hash as a parent
+    // must not demote a head of the object under test — the reverse index is
+    // scoped per object.
+    headsScopedPerObject: () => {
+        const obj = 'obj'
+        const other = 'other'
+        const r1: Revision = { mimeType, object: obj, parents: [] }
+        const unrelated: Revision = { mimeType, object: other, parents: ['r1'] }
+        const entries = [entry('r1', r1), entry('u', unrelated)]
+        assertEq(heads(obj)(entries).join(','), 'r1')
+    },
+
+    // A head can be demoted retroactively simply by re-running `heads` over a
+    // larger `entries` set once a same-object child is synced in later.
+    headDemotedRetroactivelyBySync: () => {
+        const obj = 'obj'
+        const r1: Revision = { mimeType, object: obj, parents: [] }
+        const before = [entry('r1', r1)]
+        assertEq(heads(obj)(before).join(','), 'r1')
+        const r2: Revision = { mimeType, object: obj, parents: ['r1'] }
+        const after = [...before, entry('r2', r2)]
+        assertEq(heads(obj)(after).join(','), 'r2')
+    },
+
+    // ── materialize ──────────────────────────────────────────────────────────
+
+    // A first revision with no parents, no content, and no changes materializes
+    // from `object` itself — object identity is the initial content's hash.
+    materializeFirstRevisionFromObject: () => {
+        const obj = 'the-object-ref'
+        const r1: Revision = { mimeType, object: obj, parents: [] }
+        const resolve = storeOf([entry('r1', r1)])
+        assertEq(materialize(resolve)(obj)(r1), obj)
+    },
+
+    // `content` has priority even when a parent is also present.
+    materializeContentTakesPriority: () => {
+        const obj = 'obj'
+        const r1: Revision = { mimeType, object: obj, parents: [] }
+        const r2: Revision = { mimeType, object: obj, parents: ['r1'], content: 'c2' }
+        const resolve = storeOf([entry('r1', r1), entry('r2', r2)])
+        assertEq(materialize(resolve)(obj)(r2), 'c2')
+    },
+
+    // A revision with no `content` materializes through its single parent's
+    // own materialization.
+    materializeThroughParentChain: () => {
+        const obj = 'obj'
+        const r1: Revision = { mimeType, object: obj, parents: [], content: 'c1' }
+        const r2: Revision = { mimeType, object: obj, parents: ['r1'] }
+        const r3: Revision = { mimeType, object: obj, parents: ['r2'] }
+        const resolve = storeOf([entry('r1', r1), entry('r2', r2), entry('r3', r3)])
+        assertEq(materialize(resolve)(obj)(r3), 'c1')
+    },
+
+    // `changes` replay is not implemented in the first iteration: a revision
+    // with `changes` and no `content` cannot be materialized here.
+    materializeUndefinedForChangesOnly: () => {
+        const obj = 'obj'
+        const r1: Revision = { mimeType, object: obj, parents: [], changes: ['diff-ref'] }
+        const resolve = storeOf([entry('r1', r1)])
+        assertEq(materialize(resolve)(obj)(r1), undefined)
+    },
+
+    // A bare multi-parent revision (no `content`) cannot be materialized in the
+    // first iteration — a merge revision must carry `content`.
+    materializeUndefinedForMultiParentNoContent: () => {
+        const obj = 'obj'
+        const r1: Revision = { mimeType, object: obj, parents: [] }
+        const r2: Revision = { mimeType, object: obj, parents: [] }
+        const merged: Revision = { mimeType, object: obj, parents: ['r1', 'r2'] }
+        const resolve = storeOf([entry('r1', r1), entry('r2', r2), entry('merged', merged)])
+        assertEq(materialize(resolve)(obj)(merged), undefined)
+    },
+
+    materializeUndefinedForUnresolvedParent: () => {
+        const obj = 'obj'
+        const r2: Revision = { mimeType, object: obj, parents: ['missing'] }
+        const resolve = storeOf([entry('r2', r2)])
+        assertEq(materialize(resolve)(obj)(r2), undefined)
+    },
+
+    // ── generation ───────────────────────────────────────────────────────────
+
+    generationMatchesActualChain: () => {
+        const obj = 'obj'
+        const r1: Revision = { mimeType, object: obj, parents: [] }
+        const r2: Revision = { mimeType, object: obj, parents: ['r1'], generation: 1 }
+        const resolve = storeOf([entry('r1', r1), entry('r2', r2)])
+        assert(verifyGeneration(resolve)(r2))
+        assertEq(actualGeneration(resolve)('r2'), 1)
+    },
+
+    // A cached `generation` that disagrees with the actual parent chain (as an
+    // untrusted/corrupted-sync revision might carry) must fail verification —
+    // `generation` is a cache, not a source of truth.
+    generationCacheMismatch: () => {
+        const obj = 'obj'
+        const r1: Revision = { mimeType, object: obj, parents: [] }
+        const r2: Revision = { mimeType, object: obj, parents: ['r1'], generation: 5 }
+        const resolve = storeOf([entry('r1', r1), entry('r2', r2)])
+        assert(!verifyGeneration(resolve)(r2))
+    },
+
+    generationAbsentIsTriviallyVerified: () => {
+        const obj = 'obj'
+        const r1: Revision = { mimeType, object: obj, parents: [] }
+        const resolve = storeOf([entry('r1', r1)])
+        assert(verifyGeneration(resolve)(r1))
+    },
+
+    // `actualGeneration` never trusts a parent's own cached field: even if r1's
+    // cache is wrong, r2's actual generation is derived from r1's real (empty)
+    // parent chain, not from r1's lying cache.
+    actualGenerationIgnoresParentsCorruptedCache: () => {
+        const obj = 'obj'
+        const r1: Revision = { mimeType, object: obj, parents: [], generation: 99 }
+        const r2: Revision = { mimeType, object: obj, parents: ['r1'] }
+        const resolve = storeOf([entry('r1', r1), entry('r2', r2)])
+        assertEq(actualGeneration(resolve)('r2'), 1)
+    },
+
+    // ── archived ─────────────────────────────────────────────────────────────
+
+    archivedObjectFlag: () => {
+        const obj = 'obj'
+        const active: Revision = { mimeType, object: obj, parents: [] }
+        const archived: Revision = { mimeType, object: obj, parents: ['r'], archived: true }
+        assert(!isArchived(active))
+        assert(isArchived(archived))
+    },
+
+    // ── merge ────────────────────────────────────────────────────────────────
+
+    mergeBuildsRevisionWithComputedGeneration: () => {
+        const obj = 'obj'
+        const r1: Revision = { mimeType, object: obj, parents: [], generation: 0 }
+        const r2: Revision = { mimeType, object: obj, parents: [], generation: 0 }
+        const resolve = storeOf([entry('r1', r1), entry('r2', r2)])
+        const merged = merge(resolve)(obj)(['r1', 'r2'])('merged-content')
+        assertEq(merged.mimeType, mimeType)
+        assertEq(merged.object, obj)
+        assertEq(merged.parents.join(','), 'r1,r2')
+        assertEq(merged.content, 'merged-content')
+        assertEq(merged.generation, 1)
+    },
+
+    // A merge revision built from real cbase32 hashes/refs validates cleanly
+    // through the full `parseRevision` semantic check, not just the schema shape.
+    mergeOutputValidates: () => {
+        const obj = objectHash
+        const p1 = parentHash
+        const p2 = vecToCBase32(vec8(0x03n))
+        const resolve = storeOf([])
+        const merged = merge(resolve)(obj)([p1, p2])(bridgeUrl)
+        assertEq(parseRevision(merged)[0], 'ok')
+    },
+
+    mergeRequiresAtLeastTwoParents: () => {
+        const obj = 'obj'
+        const resolve = storeOf([])
+        let threw = false
+        try {
+            merge(resolve)(obj)(['only-one'])('c')
+        } catch {
+            threw = true
+        }
+        assert(threw)
+    },
+
+    // The schema itself is a plain RTTI struct — exercised directly so a
+    // regression in the field set shows up here, not only through parseRevision.
+    revisionSchemaShape: () => {
+        assertEq(Object.keys(revision).sort().join(','),
+            'archived,changes,content,generation,mimeType,object,parents')
+    },
+}

--- a/fs/cas/todo/revision-content-format.md
+++ b/fs/cas/todo/revision-content-format.md
@@ -187,21 +187,21 @@ Open design points:
 
 ### Tasks
 
-- [ ] Create `fs/cas/evo/README.md` — the spec of the format tagged
+- [x] Create `fs/cas/evo/README.md` — the spec of the format tagged
       `application/vnd.functionalscript.revision+json`
       (deployed automatically to functionalscript.com once it exists in the repo)
-- [ ] Define `ref` as a URL in CA digital space, recognizing cbase32 hashes and `https://`
+- [x] Define `ref` as a URL in CA digital space, recognizing cbase32 hashes and `https://`
       bridge URLs for now, and `hash` as its hash-only subset
-- [ ] Create `fs/cas/evo/module.f.ts` with the RTTI schema for `revision` (`fs/types/rtti`)
+- [x] Create `fs/cas/evo/module.f.ts` with the RTTI schema for `revision` (`fs/types/rtti`)
       and its derived TS type
-- [ ] Implement head resolution: given `object`, find revision(s) not listed as a parent
+- [x] Implement head resolution: given `object`, find revision(s) not listed as a parent
       by any other revision of the same `object` (a reverse index scoped per object; heads
       can be demoted retroactively by sync, but only by same-object children)
-- [ ] Implement content materialization for the first iteration (zero or one parent, no
+- [x] Implement content materialization for the first iteration (zero or one parent, no
       `changes`): `content` → base, where base = parent's materialization or `object`
-- [ ] Implement (or specify) a merge tool that resolves concurrent heads into a new revision
+- [x] Implement (or specify) a merge tool that resolves concurrent heads into a new revision
       with multiple `parents` and `content`
-- [ ] Tests: linear history, branch + merge, many heads for one object, archived object,
+- [x] Tests: linear history, branch + merge, many heads for one object, archived object,
       generation cache mismatch, first revision materializing from `object`, a head demoted
       retroactively by a newly synced revision
 - [ ] Teach the MCP server to surface a stored `mimeType` (allowlisted
@@ -211,7 +211,7 @@ Open design points:
       [../mcp/todo/cas-get-mcp-resource-response.md](../mcp/todo/cas-get-mcp-resource-response.md)
 - [ ] Later iteration: define the `changes` event-log/CRDT format and extend materialization
       to CRDT changes over a single common ancestor
-- [ ] Reference the format from `fs/cas/README.md`
+- [x] Reference the format from `fs/cas/README.md`
 
 ### Related
 


### PR DESCRIPTION
Implements the first-iteration scope of fs/cas/todo/revision-content-format.md:
the `revision` RTTI schema (ref/hash types, mimeType tag, parseRevision with
the semantic hash/ref checks the schema alone can't express), head resolution
scoped per object, content materialization (zero/one parent, no `changes`
replay yet), generation-cache computation/verification, a merge-revision
constructor, and tests covering linear history, branch+merge, many heads,
retroactive head demotion, archived objects, and generation mismatch.

Deferred (tracked as open items in the todo): the `changes` event-log/CRDT
format, and teaching the MCP server to surface a validated stored `mimeType`
as the `cas_get` response mimeType.