### PR TITLE
Design the fs/media/ bucket for content formats

### DIFF
--- a/fs/cas/todo/revision-content-format.md
+++ b/fs/cas/todo/revision-content-format.md
@@ -20,10 +20,20 @@ mutable object, linking back to its parent revision(s) (DAG, not just a chain, s
 edits can merge) and carrying either the full materialized content or an incremental diff
 against the parent(s).
 
-The format and its supporting functions live in a new `fs/cas/evo/module.f.ts` submodule
-("evo" for evolution), following the existing `fs/cas/cli/` and `fs/cas/mcp/` layout. This
-keeps `fs/cas/module.f.ts` focused on hashing/addressing, and gives head resolution,
-materialization, and the diff format a shared home next to the schema.
+The design splits the format from the store operations, to keep the dependency graph
+acyclic:
+
+- **`fs/media/revision/`** — the pure format: the RTTI schema, the `mimeType` constant,
+  encode/decode/validate, and the README spec. No store access, no effects. It must live
+  under `fs/media/` (see
+  [fs/todo group-fs-subdirectories-by-concern](../../todo/group-fs-subdirectories-by-concern.md))
+  because media-type detection has to import the schema to recognize revision blobs, and
+  `fs/cas/mcp` already depends on the detector — a format inside `fs/cas` would therefore
+  close a `cas` ↔ detector cycle.
+- **`fs/cas/evo/`** ("evo" for evolution, following the existing `fs/cas/cli/` and
+  `fs/cas/mcp/` layout) — the store-touching operations: head resolution, materialization,
+  the per-object reverse index. Depends on `fs/cas` and `fs/media/revision`. This keeps
+  `fs/cas/module.f.ts` focused on hashing/addressing.
 
 ```ts
 export const revision = {
@@ -95,8 +105,8 @@ Notes on the shape:
   suffix tells generic tooling the underlying syntax is JSON. No registry entry is required
   for the vendor tree, the string is stable (no mutable URL, no DNS anchoring), and it is
   validated by the schema itself since the literal is part of the schema. The format spec
-  lives in the `README.md` of the `fs/cas/evo` module (creating it is part of the tasks
-  below; once in the repo it is automatically deployed to functionalscript.com) — the spec
+  lives in the `README.md` of the `fs/media/revision` module (creating it is part of the
+  tasks below; once in the repo it is automatically deployed to functionalscript.com) — the spec
   is referenced by the schema/docs rather than encoded in the tag value. **Versioning rule:**
   additive, compatible changes keep the tag — RTTI struct validation accepts undeclared keys
   by design, so a blob with extra fields still validates against the v1 schema, and that is
@@ -187,13 +197,15 @@ Open design points:
 
 ### Tasks
 
-- [ ] Create `fs/cas/evo/README.md` — the spec of the format tagged
+- [ ] Create `fs/media/revision/README.md` — the spec of the format tagged
       `application/vnd.functionalscript.revision+json`
       (deployed automatically to functionalscript.com once it exists in the repo)
 - [ ] Define `ref` as a URL in CA digital space, recognizing cbase32 hashes and `https://`
       bridge URLs for now, and `hash` as its hash-only subset
-- [ ] Create `fs/cas/evo/module.f.ts` with the RTTI schema for `revision` (`fs/types/rtti`)
-      and its derived TS type
+- [ ] Create `fs/media/revision/module.f.ts` with the RTTI schema for `revision`
+      (`fs/types/rtti`), the `mimeType` constant, and its derived TS type
+- [ ] Create `fs/cas/evo/module.f.ts` for the store-touching operations below, importing the
+      format from `fs/media/revision`
 - [ ] Implement head resolution: given `object`, find revision(s) not listed as a parent
       by any other revision of the same `object` (a reverse index scoped per object; heads
       can be demoted retroactively by sync, but only by same-object children)
@@ -215,6 +227,9 @@ Open design points:
 
 ### Related
 
+- [fs/todo group-fs-subdirectories-by-concern](../../todo/group-fs-subdirectories-by-concern.md)
+  — the `fs/media/` bucket this format's pure part lives in, and the cycle rule that puts it
+  there
 - `todo/plan/vision.md` — DISOT block types (signature, trust, license, redirect) this format
   sits alongside
 - [66g-cas-verify-command](66g-cas-verify-command.md) — integrity checking applies equally to

--- a/fs/todo/group-fs-subdirectories-by-concern.md
+++ b/fs/todo/group-fs-subdirectories-by-concern.md
@@ -22,6 +22,30 @@ Create `fs/common/` for cross-cutting reusable algorithms, starting by moving `m
 - `lang/` for language/format tooling (`json`, `djs`, `fjs`, `fsc`, `bnf`, `js`, `html`) — highest value but highest churn.
 - Storage bucket for `cas` + `sul`; testing bucket for `asserts` + `emergent_testing`.
 
+### Considered: `fs/mime/` as the format bucket
+
+Proposed: move file/blob format modules under `fs/mime/` (e.g. `fs/mime/html`,
+`fs/mime/json`). Rejected as the umbrella name, for three reasons:
+
+1. `fs/mime` already means something else — it is the magic-byte MIME
+   *detection* module consumed by `fs/cas/mcp`, not a namespace. Nesting format
+   implementations under the detection algorithm conflates the two, and the
+   detector itself would then have to move to `fs/mime/detect/`.
+2. MIME is the wrong taxonomy for most candidates: `json`/`html` map cleanly to
+   media types, but `djs`/`fjs` are FS dialects with no registered media type,
+   `base64`/`base_n`/`cbase32`/`base128` are transfer encodings, and
+   `bnf`/`asn.1`/`text` are notations/toolkits. The membership rule would need a
+   judgment call per module — worse than a flat layout.
+3. Directory paths are the public API (no `exports` map), so any move is a
+   breaking change; if one is paid for, `lang/` (above) or `format/` is a more
+   honest bucket name than `mime`.
+
+The part of the idea worth keeping without any move: a **declarative media-type
+registry** in `fs/mime` — entries like `{ mime: 'application/json', parse,
+serialize }` referencing the format modules — so detection refinements (see
+[fs/mime detect-json](../mime/todo/detect-json.md)) and content negotiation can
+dispatch over data instead of hardcoding per-format branches.
+
 ### Tasks
 
 - [ ] Create `fs/basen/` and move `base64`, `base128`, `cbase32` into it.

--- a/fs/todo/group-fs-subdirectories-by-concern.md
+++ b/fs/todo/group-fs-subdirectories-by-concern.md
@@ -19,38 +19,78 @@ Create `fs/common/` for cross-cutting reusable algorithms, starting by moving `m
 
 ### Later candidates
 
-- `lang/` for language/format tooling (`json`, `djs`, `fjs`, `fsc`, `bnf`, `js`, `html`) — highest value but highest churn.
+- Tooling bucket for `bnf`, `fsc`, and possibly `js` (grammar/compiler tooling;
+  the content-facing formats go to `fs/media/`, see below).
 - Storage bucket for `cas` + `sul`; testing bucket for `asserts` + `emergent_testing`.
 
-### Considered: `fs/mime/` as the format bucket
+### 4. `fs/media/` — content formats and media-type detection
 
-Proposed: move file/blob format modules under `fs/mime/` (e.g. `fs/mime/html`,
-`fs/mime/json`). Rejected as the umbrella name, for three reasons:
+The agreed design for the format bucket:
 
-1. `fs/mime` already means something else — it is the magic-byte MIME
-   *detection* module consumed by `fs/cas/mcp`, not a namespace. Nesting format
-   implementations under the detection algorithm conflates the two, and the
-   detector itself would then have to move to `fs/mime/detect/`.
-2. MIME is the wrong taxonomy for most candidates: `json`/`html` map cleanly to
-   media types, but `djs`/`fjs` are FS dialects with no registered media type,
-   `base64`/`base_n`/`cbase32`/`base128` are transfer encodings, and
-   `bnf`/`asn.1`/`text` are notations/toolkits. The membership rule would need a
-   judgment call per module — worse than a flat layout.
-3. Directory paths are the public API (no `exports` map), so any move is a
-   breaking change; if one is paid for, `lang/` (above) or `format/` is a more
-   honest bucket name than `mime`.
+```
+fs/media/
+    html/       text/html
+    json/       application/json
+    djs/        application/vnd.functionalscript.djs
+    fjs/        application/vnd.functionalscript.fjs
+    revision/   application/vnd.functionalscript.revision+json (format only, new code —
+                see fs/cas/todo/revision-content-format.md)
+    type/       media-type detection (today's fs/mime)
+```
 
-The part of the idea worth keeping without any move: a **declarative media-type
-registry** in `fs/mime` — entries like `{ mime: 'application/json', parse,
-serialize }` referencing the format modules — so detection refinements (see
-[fs/mime detect-json](../mime/todo/detect-json.md)) and content negotiation can
-dispatch over data instead of hardcoding per-format branches.
+**Membership rule:** a module goes under `fs/media/` iff it implements content
+whose identity is — or can be, via the RFC 6838 vendor tree — a media type.
+Unregistered FS dialects qualify through `application/vnd.functionalscript.*`
+(only registered structured-syntax suffixes may be appended: `+json` yes,
+`+javascript` is not a registered suffix, so plain
+`application/vnd.functionalscript.fjs`).
+
+**`media/type/`** is the current `fs/mime` detector, renamed: detection is
+about media *types*; the sibling directories are the media themselves. This
+placement enables the declarative step (see
+[fs/mime detect-json](../mime/todo/detect-json.md)): the detector can dispatch
+over its siblings' declared `{ mime, parse, serialize }` instead of hardcoding
+per-format branches.
+
+**Cycle rule** (the reason `revision` is in the list): whatever the detector
+must import to recognize a format — its schema, its `mimeType` constant — must
+be a `media/` sibling, never live inside a store or adapter. Concretely:
+`fs/cas/mcp` depends on the detector, and detecting revision blobs requires the
+revision schema, so a revision format inside `fs/cas` would create a
+`cas` ↔ detector cycle. The revision *format* (schema, tag, encode/decode)
+therefore lives at `fs/media/revision/`, while the store-touching evolution
+operations (head resolution, materialization) stay under `fs/cas` and import
+it — see [fs/cas revision-content-format](../cas/todo/revision-content-format.md).
+
+**Stays out:**
+
+- `text/` — character-encoding infrastructure (`utf8`, `utf16`, `ascii`,
+  `code_point`, `sgr`) with ~39 importers across the tree; the layer *below*
+  media formats, not an implementation of `text/plain`. Remains top-level.
+- `js/` — `identifier` + `tokenizer` only, i.e. language tooling consumed by
+  `djs`/`fsc`, closer in kind to `bnf`; decide with the tooling bucket, not here.
+- `base64`/`base_n`/`cbase32`/`base128` — transfer encodings, not media types
+  (they move under `fs/basen/`, item 1 above).
+
+**Rejected names** for the bucket: `mime/` (collides with the existing detector
+module and reads as detection, not content), `format/`/`lang/` (no crisp
+membership rule — `media` + the vendor tree gives one).
+
+**Migration:** incremental, one move per PR — directory paths are the public
+API (no `exports` map), so every move is a breaking change. `media/revision/`
+is new code (no move) and together with the `fs/mime` → `media/type/` rename
+can establish the bucket first; `json`, `html`, `djs`, `fjs` follow.
 
 ### Tasks
 
 - [ ] Create `fs/basen/` and move `base64`, `base128`, `cbase32` into it.
 - [ ] Create `fs/common/` and move `monoid` from `fs/types/` into it.
 - [ ] Promote the `fjs` bin to `fs/` root; update `package.json`/`deno.json` script paths and fix relative imports.
+- [ ] Rename `fs/mime/` → `fs/media/type/` (establishes the `fs/media/` bucket; `fs/media/revision/` arrives as new code via [fs/cas revision-content-format](../cas/todo/revision-content-format.md)).
+- [ ] Move `fs/json/` → `fs/media/json/` (one PR).
+- [ ] Move `fs/html/` → `fs/media/html/` (one PR).
+- [ ] Move `fs/djs/` → `fs/media/djs/` (one PR).
+- [ ] Move `fs/fjs/` library part → `fs/media/fjs/` (after the bin promotion above).
 - [ ] Update all relative imports referencing the moved modules.
 - [ ] Update `deno.json` `exports` map and run `npm run update`.
 - [ ] Verify `npx tsc` and `fjs t` pass.

--- a/fs/todo/group-fs-subdirectories-by-concern.md
+++ b/fs/todo/group-fs-subdirectories-by-concern.md
@@ -25,25 +25,31 @@ Create `fs/common/` for cross-cutting reusable algorithms, starting by moving `m
 
 ### 4. `fs/media/` — content formats and media-type detection
 
-The agreed design for the format bucket:
+The agreed design for the format bucket. First wave — only these three:
 
 ```
 fs/media/
-    html/       text/html
-    json/       application/json
-    djs/        application/vnd.functionalscript.djs
-    fjs/        application/vnd.functionalscript.fjs
+    html/       text/html (moved from fs/html)
+    json/       application/json (moved from fs/json)
     revision/   application/vnd.functionalscript.revision+json (format only, new code —
                 see fs/cas/todo/revision-content-format.md)
-    type/       media-type detection (today's fs/mime)
 ```
+
+Later candidates for the same bucket, deliberately deferred to keep each PR
+small:
+
+- `media/type/` — media-type detection (today's `fs/mime`), renamed;
+- `media/djs/` — `application/vnd.functionalscript.djs`.
 
 **Membership rule:** a module goes under `fs/media/` iff it implements content
 whose identity is — or can be, via the RFC 6838 vendor tree — a media type.
 Unregistered FS dialects qualify through `application/vnd.functionalscript.*`
 (only registered structured-syntax suffixes may be appended: `+json` yes,
-`+javascript` is not a registered suffix, so plain
-`application/vnd.functionalscript.fjs`).
+`+javascript` is not a registered suffix, so an FJS type would be plain
+`application/vnd.functionalscript.fjs`). Note there is no `media/fjs/` entry:
+today's `fs/fjs` is only the CLI dispatcher, which item 3 above promotes to
+`fs/` root, leaving nothing to move — a `media/fjs/` module appears only
+if a library-form FJS format module comes to exist.
 
 **`media/type/`** is the current `fs/mime` detector, renamed: detection is
 about media *types*; the sibling directories are the media themselves. This
@@ -77,20 +83,20 @@ module and reads as detection, not content), `format/`/`lang/` (no crisp
 membership rule — `media` + the vendor tree gives one).
 
 **Migration:** incremental, one move per PR — directory paths are the public
-API (no `exports` map), so every move is a breaking change. `media/revision/`
-is new code (no move) and together with the `fs/mime` → `media/type/` rename
-can establish the bucket first; `json`, `html`, `djs`, `fjs` follow.
+API (no `exports` map), so every move is a breaking change. The first wave is
+`json` and `html` (moves) plus `revision` (new code, no move); the
+`fs/mime` → `media/type/` rename and `djs` follow later.
 
 ### Tasks
 
 - [ ] Create `fs/basen/` and move `base64`, `base128`, `cbase32` into it.
 - [ ] Create `fs/common/` and move `monoid` from `fs/types/` into it.
 - [ ] Promote the `fjs` bin to `fs/` root; update `package.json`/`deno.json` script paths and fix relative imports.
-- [ ] Rename `fs/mime/` → `fs/media/type/` (establishes the `fs/media/` bucket; `fs/media/revision/` arrives as new code via [fs/cas revision-content-format](../cas/todo/revision-content-format.md)).
-- [ ] Move `fs/json/` → `fs/media/json/` (one PR).
+- [ ] Move `fs/json/` → `fs/media/json/` (one PR; establishes the `fs/media/` bucket).
 - [ ] Move `fs/html/` → `fs/media/html/` (one PR).
-- [ ] Move `fs/djs/` → `fs/media/djs/` (one PR).
-- [ ] Move `fs/fjs/` library part → `fs/media/fjs/` (after the bin promotion above).
+- [ ] `fs/media/revision/` arrives as new code via [fs/cas revision-content-format](../cas/todo/revision-content-format.md) — no move needed.
+- [ ] Later: rename `fs/mime/` → `fs/media/type/`.
+- [ ] Later: move `fs/djs/` → `fs/media/djs/`.
 - [ ] Update all relative imports referencing the moved modules.
 - [ ] Update `deno.json` `exports` map and run `npm run update`.
 - [ ] Verify `npx tsc` and `fjs t` pass.


### PR DESCRIPTION
Design-doc-only change (no code): records the agreed `fs/media/` design in the grouping todo and aligns the revision-content-format todo with it.

- `fs/todo/group-fs-subdirectories-by-concern.md`: adds item 4, the `fs/media/` bucket for content formats identified by media types (RFC 6838 vendor tree for FS dialects). First wave is `media/json`, `media/html` (moves) and `media/revision` (new code); the `fs/mime` → `media/type` rename and `djs` are deferred. Documents the membership rule, the cycle rule (whatever the detector imports must be a `media/` sibling), what stays out (`text/`, `js/`, `base*`), and the rejected names (`mime/`, `format/`, `lang/`).
- `fs/cas/todo/revision-content-format.md`: splits the revision *format* (RTTI schema, `mimeType` constant, spec README → `fs/media/revision/`) from the store-touching operations (head resolution, materialization → `fs/cas/evo/`), so `cas` and media-type detection never depend on each other.

Review feedback addressed: the `media/fjs` move task was dropped — `fs/fjs` is only the CLI dispatcher, already promoted to `fs/` root by item 3, so there is no library part to move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B73jxY35us2PD1BA8W8zrt