### PR TITLE
Redesign revision format: remove incremental diffs, rename mimeType to mediaType

### DIFF
--- a/fs/cas/mcp/todo/cas-get-mcp-resource-response.md
+++ b/fs/cas/mcp/todo/cas-get-mcp-resource-response.md
@@ -36,6 +36,11 @@ and the (future) resource view of a blob use the same terminology:
   blob is (or will be) readable via `resources/read`, so a client can move from
   the tool result to the resource without translation.
 - `length` stays — MCP allows additional fields alongside the required ones.
+- Future: an optional `dialect` field may accompany `mimeType` when the blob is a
+  recognized FS dialect of a standard type — e.g. `mimeType: "text/javascript"` with
+  `dialect: "text/vnd.fjs.djs"`. The wire type stays interoperable while the precise
+  format is still reported; see the dialect naming rule in
+  [../../../todo/group-fs-subdirectories-by-concern.md](../../../todo/group-fs-subdirectories-by-concern.md).
 
 ### Tasks
 

--- a/fs/cas/mcp/todo/cas-get-mcp-resource-response.md
+++ b/fs/cas/mcp/todo/cas-get-mcp-resource-response.md
@@ -38,7 +38,7 @@ and the (future) resource view of a blob use the same terminology:
 - `length` stays — MCP allows additional fields alongside the required ones.
 - Future: an optional `dialect` field may accompany `mimeType` when the blob is a
   recognized FS dialect of a standard type — e.g. `mimeType: "text/javascript"` with
-  `dialect: "vnd.fjs.djs"`. The wire type stays interoperable while the precise
+  `dialect: "vnd.fjs.djs+vnd.fjs.fjs"`. The wire type stays interoperable while the precise
   format is still reported; HTTP responses can carry the same value as a `Dialect`
   header. See the dialect naming rule in
   [../../../todo/group-fs-subdirectories-by-concern.md](../../../todo/group-fs-subdirectories-by-concern.md).

--- a/fs/cas/mcp/todo/cas-get-mcp-resource-response.md
+++ b/fs/cas/mcp/todo/cas-get-mcp-resource-response.md
@@ -39,7 +39,8 @@ and the (future) resource view of a blob use the same terminology:
 - Future: an optional `dialect` field may accompany `mimeType` when the blob is a
   recognized FS dialect of a standard type — e.g. `mimeType: "text/javascript"` with
   `dialect: "vnd.fjs.djs"`. The wire type stays interoperable while the precise
-  format is still reported; see the dialect naming rule in
+  format is still reported; HTTP responses can carry the same value as a `Dialect`
+  header. See the dialect naming rule in
   [../../../todo/group-fs-subdirectories-by-concern.md](../../../todo/group-fs-subdirectories-by-concern.md).
 
 ### Tasks

--- a/fs/cas/mcp/todo/cas-get-mcp-resource-response.md
+++ b/fs/cas/mcp/todo/cas-get-mcp-resource-response.md
@@ -38,7 +38,7 @@ and the (future) resource view of a blob use the same terminology:
 - `length` stays — MCP allows additional fields alongside the required ones.
 - Future: an optional `dialect` field may accompany `mimeType` when the blob is a
   recognized FS dialect of a standard type — e.g. `mimeType: "text/javascript"` with
-  `dialect: "text/vnd.fjs.djs"`. The wire type stays interoperable while the precise
+  `dialect: "vnd.fjs.djs"`. The wire type stays interoperable while the precise
   format is still reported; see the dialect naming rule in
   [../../../todo/group-fs-subdirectories-by-concern.md](../../../todo/group-fs-subdirectories-by-concern.md).
 
@@ -57,5 +57,6 @@ and the (future) resource view of a blob use the same terminology:
 
 - [remote-url.md](remote-url.md) — serving URLs as resources
 - [../../todo/revision-content-format.md](../../todo/revision-content-format.md) —
-  the `mediaType` format tag inside revision blobs that the server can surface (after
-  validation) as the response `mimeType`
+  the `dialect` format tag inside revision blobs whose derived media type
+  (`application/{dialect}+json`) the server can surface (after validation) as the
+  response `mimeType`

--- a/fs/cas/mcp/todo/cas-get-mcp-resource-response.md
+++ b/fs/cas/mcp/todo/cas-get-mcp-resource-response.md
@@ -52,5 +52,5 @@ and the (future) resource view of a blob use the same terminology:
 
 - [remote-url.md](remote-url.md) — serving URLs as resources
 - [../../todo/revision-content-format.md](../../todo/revision-content-format.md) —
-  the `mimeType` format tag inside revision blobs that the server can surface (after
+  the `mediaType` format tag inside revision blobs that the server can surface (after
   validation) as the response `mimeType`

--- a/fs/cas/todo/revision-content-format.md
+++ b/fs/cas/todo/revision-content-format.md
@@ -123,9 +123,9 @@ Notes on the shape:
   `snapshot` vs `change` is the standard snapshot/delta dichotomy of event-sourced systems.
 - **Tagged-JSON detection convention** — the tag is not revision-specific, but it is not
   universal either. `fs/media/` hosts formats from different vendors (`text/html`, plain
-  `application/json`, …), and FS's own non-JSON formats (e.g. `application/vnd.fjs.fjs`,
-  possibly with a non-JSON fallback such as `application/vnd.fjs.fjs+javascript`) cannot
-  carry an embedded JSON tag at all — those keep the ordinary `fs/mime` detection path.
+  `application/json`, …), and FS's own JavaScript-subset dialects (tagged
+  `text/vnd.fjs.*+javascript`, e.g. `text/vnd.fjs.fjs+javascript`) cannot carry an
+  embedded JSON tag at all — those keep the ordinary `fs/mime` detection path.
   The convention applies to **new JSON media types designed in FunctionalScript**, and even
   there it is a recommendation (a good default), not a requirement: such a format MAY be a
   JSON object whose **first** key is `mediaType`, so detection matches the byte prefix

--- a/fs/cas/todo/revision-content-format.md
+++ b/fs/cas/todo/revision-content-format.md
@@ -20,14 +20,14 @@ mutable object, linking back to its parent revision(s) (DAG, not just a chain, s
 edits can merge) and carrying the full materialized content. Incremental diffs are
 deliberately **not** part of this format: a reader that did not implement diff replay would
 silently materialize the wrong content, so an optional `changes` field would be a breaking
-change in disguise. Incremental changes will arrive later as their own media type
-(`application/vnd.fjs.change+json`, see the versioning rule below), not as a field of this
-one.
+change in disguise. Incremental changes will arrive later as their own dialect
+(`vnd.fjs.change`, served as `application/vnd.fjs.change+json`; see the versioning rule
+below), not as a field of this one.
 
 The design splits the format from the store operations, to keep the dependency graph
 acyclic:
 
-- **`fs/media/revision/`** — the pure format: the RTTI schema, the `mediaType` constant,
+- **`fs/media/revision/`** — the pure format: the RTTI schema, the `dialect` constant,
   encode/decode/validate, and the README spec. No store access, no effects. It must live
   under `fs/media/` (see
   [fs/todo group-fs-subdirectories-by-concern](../../todo/group-fs-subdirectories-by-concern.md))
@@ -42,11 +42,13 @@ acyclic:
 ```ts
 export const revision = {
     /**
-     * Format tag: identifies this BLOB as a revision and names the
-     * media type it should be served with. Must be the first key in the
-     * serialized JSON so detection can match the `{"mediaType":"` prefix.
+     * Format tag: names the dialect of this BLOB. Must be the first key
+     * in the serialized JSON so detection can match the `{"dialect":"`
+     * prefix. The media type it is served with is derived:
+     * `application/` + dialect + `+json`, i.e.
+     * `application/vnd.fjs.revision+json`.
      */
-    mediaType: 'application/vnd.fjs.revision+json',
+    dialect: 'vnd.fjs.revision',
 
     /**
      * The subject of this revision: the identity of the mutable object
@@ -96,70 +98,72 @@ Notes on the shape:
   are restricted to hashes only and use the narrower `hash` type in the schema — `parents`
   is one: a parent revision is a CAS blob, so a bridge URL cannot stand in for it, and a
   revision with a non-CAS parent must not validate.
-- `mediaType` is a self-describing format tag. In a generic CAS a blob is just bytes under a
+- `dialect` is a self-describing format tag. In a generic CAS a blob is just bytes under a
   hash, so without a discriminant a reader can only recognize a revision by guessing from its
   shape, which collides with any other format that happens to have `subject`/`parents` fields.
   The tag gives format detection (tools can recognize revisions while walking a store) and a
-  cheap pre-validation gate; the key doubles as the type discriminant. The value is a media
-  type in the RFC 6838 vendor tree with the RFC 6839 `+json` structured-syntax suffix:
-  the part before `+` (`vnd.fjs.revision`) names the specific format, the
-  suffix tells generic tooling the underlying syntax is JSON. No registry entry is required
-  for the vendor tree, the string is stable (no mutable URL, no DNS anchoring), and it is
-  validated by the schema itself since the literal is part of the schema. The format spec
-  lives in the `README.md` of the `fs/media/revision` module (creating it is part of the
-  tasks below; once in the repo it is automatically deployed to functionalscript.com) — the spec
-  is referenced by the schema/docs rather than encoded in the tag value. **Versioning rule:**
-  additive, compatible changes keep the tag — RTTI struct validation accepts undeclared keys
-  by design, so a blob with extra fields still validates against the v1 schema, and that is
-  the intended forward-compatibility path. An **incompatible** change MUST NOT reuse the tag:
-  it introduces a new media type (for example
-  `application/vnd.fjs.revision2+json`), so readers of the old format never
-  validate — and never silently misread — a blob of the new one. The tag is therefore the
-  version discriminant for breaking changes; no `version` field is needed. This rule is why
-  an earlier draft's optional `changes` field (incremental diffs replayed over the base) was
-  dropped: it is *schema*-additive but *semantically* breaking — a v1 reader would still
-  validate such a blob and materialize the base, silently ignoring the changes. Incremental
-  changes are therefore a future separate format, `application/vnd.fjs.change+json` —
+  cheap pre-validation gate; the key doubles as the type discriminant. The value is a
+  **short dialect name** in the RFC 6838 vendor-tree style (`vnd.fjs.revision`); the media
+  type the blob is served with is derived mechanically — `application/` + dialect + `+json`,
+  here `application/vnd.fjs.revision+json` — because the `application/` top level and the
+  RFC 6839 `+json` structured-syntax suffix are already implied by the file being JSON. Any
+  system that does not know the dialect still has the correct generic fallback:
+  `application/json`. No registry entry is required for the vendor tree, the string is
+  stable (no mutable URL, no DNS anchoring), and it is validated by the schema itself since
+  the literal is part of the schema. The format spec lives in the `README.md` of the
+  `fs/media/revision` module (creating it is part of the tasks below; once in the repo it
+  is automatically deployed to functionalscript.com) — the spec is referenced by the
+  schema/docs rather than encoded in the tag value. **Versioning rule:** additive,
+  compatible changes keep the tag — RTTI struct validation accepts undeclared keys by
+  design, so a blob with extra fields still validates against the v1 schema, and that is
+  the intended forward-compatibility path. An **incompatible** change MUST NOT reuse the
+  tag: it introduces a new dialect (for example `vnd.fjs.revision2`), so readers of the old
+  format never validate — and never silently misread — a blob of the new one. The tag is
+  therefore the version discriminant for breaking changes; no `version` field is needed.
+  This rule is why an earlier draft's optional `changes` field (incremental diffs replayed
+  over the base) was dropped: it is *schema*-additive but *semantically* breaking — a v1
+  reader would still validate such a blob and materialize the base, silently ignoring the
+  changes. Incremental changes are therefore a future separate dialect, `vnd.fjs.change` —
   `snapshot` vs `change` is the standard snapshot/delta dichotomy of event-sourced systems.
 - **Tagged-JSON detection convention** — the tag is not revision-specific, but it is not
   universal either. `fs/media/` hosts formats from different vendors (`text/html`, plain
   `application/json`, …), and FS's own JavaScript-subset dialects cannot carry an embedded
   JSON tag at all — those keep the ordinary `fs/mime` detection path, are served as plain
   `text/javascript` (no `+javascript` suffix is registered, and JavaScript MIME types are
-  a closed list nothing recognizes extensions of), and carry their precise format as a
-  **dialect** name (`text/vnd.fjs.fjs`, `text/vnd.fjs.djs`) surfaced out of band — e.g.
-  an additional `dialect` field in MCP responses, which MCP permits.
-  The convention applies to **new JSON media types designed in FunctionalScript**, and even
-  there it is a recommendation (a good default), not a requirement: such a format MAY be a
-  JSON object whose **first** key is `mediaType`, so detection matches the byte prefix
-  `{"mediaType":"application/vnd.fjs.` and then validates against the schema of the named
-  type; anything that does not match falls through to normal media detection. This format
-  adopts the convention. The key is spelled `mediaType`, not `mimeType` or `contentType`:
-  - `mimeType` is the field name MCP JSON uses at top level — resource contents are
+  a closed list nothing recognizes extensions of), and carry the same kind of short
+  dialect name (`vnd.fjs.fjs`, `vnd.fjs.djs`) out of band — e.g. an additional `dialect`
+  field in MCP responses, which MCP permits. The convention applies to **new JSON media
+  types designed in FunctionalScript**, and even there it is a recommendation (a good
+  default), not a requirement: such a format MAY be a JSON object whose **first** key is
+  `dialect`, so detection matches the byte prefix `{"dialect":"vnd.fjs.` and then
+  validates against the schema of the named dialect; anything that does not match falls
+  through to normal media detection. This format adopts the convention. The key is spelled
+  `dialect` — one vocabulary for both the embedded tag and the out-of-band field — and not:
+  - `mimeType` — the field name MCP JSON uses at top level: resource contents are
     `{ uri, mimeType, text | blob }` and our own `cas_get` tool result is
     `{ length, mimeType, type[, uri] }` (see
     [../mcp/todo/cas-get-mcp-resource-response.md](../mcp/todo/cas-get-mcp-resource-response.md)).
     Any such response stored back into CAS would false-positive a `{"mimeType":` prefix
-    sniff; `mediaType` keeps the stored-format tag and the MCP wire vocabulary disjoint.
-  - `contentType` echoes the HTTP header, which carries parameters (`; charset=...`) the
-    tag never has — and `content` is already a colliding term in MCP
-    (`CallToolResult.content`), the very reason `cas_get` renamed its `content` key away.
-  - `mediaType` is the RFC 6838 term ("MIME type" is the legacy name), and it matches the
-    `fs/media/` bucket where the formats live.
-  The MCP server still serves the value under the protocol-mandated response key
-  `mimeType`; the stored-tag → wire-field mapping is one line in the server.
-- **Serving the tag as the response `mimeType`**: the MCP server (`cas_get` and the future
-  resource read) can respond with the blob's own `mediaType` instead of falling back to the
-  generic `text/plain` sniff — but it must never echo the field blindly. A stored blob is
-  untrusted input: anyone can store `{"mediaType": "text/html", ...}` and turn the server
-  into a content-type oracle. The rule: surface the stored `mediaType` only when it matches
-  an allowlist of known `application/vnd.fjs.*+json` types and the blob
-  validates against that type's schema; everything else falls through to the existing
-  `fs/mime` detector. Validation requires materializing and parsing the blob, and the
-  metadata path is deliberately size-independent (`detectStream`, O(1) space, never
-  buffers), so the check is **size-bounded**: it is attempted only for blobs up to the
-  existing 128 KiB inline-content cap; a larger blob always gets the plain `detectStream`
-  result. Revision blobs are small JSON, so the bound costs nothing in practice.
+    sniff, and the value here is not a MIME type anyway.
+  - `contentType` — echoes the HTTP header, and `content` is already a colliding term in
+    MCP (`CallToolResult.content`), the very reason `cas_get` renamed its `content` key away.
+  - `mediaType` — near-synonym of `mimeType`; serving both keys side by side in one
+    response would invite exactly the confusion the vocabulary split is meant to prevent.
+- **Serving the derived media type as the response `mimeType`**: the MCP server (`cas_get`
+  and the future resource read) can respond with the media type derived from the blob's own
+  `dialect` — `application/{dialect}+json` — instead of falling back to the generic
+  `text/plain` sniff. The derivation is structurally safe: whatever the stored value, the
+  result is always an `application/*+json` type, so a hostile blob cannot turn the server
+  into a `text/html` content-type oracle the way echoing a full stored media type could.
+  Still, the server must not surface unknown tags: the rule is to derive the type only when
+  the dialect matches an allowlist of known `vnd.fjs.*` dialects (grammar-checked as an
+  RFC 6838 restricted-name) and the blob validates against that dialect's schema —
+  everything else falls through to the existing `fs/mime` detector. Validation requires
+  materializing and parsing the blob, and the metadata path is deliberately
+  size-independent (`detectStream`, O(1) space, never buffers), so the check is
+  **size-bounded**: it is attempted only for blobs up to the existing 128 KiB
+  inline-content cap; a larger blob always gets the plain `detectStream` result. Revision
+  blobs are small JSON, so the bound costs nothing in practice.
 - `subject` gives every revision of the same mutable thing a common anchor to resolve
   "current head(s)" against, without requiring a mutable pointer anywhere in CAS itself —
   the head is whatever revision(s) reference `subject` and are not listed as a parent by
@@ -197,9 +201,9 @@ Notes on the shape:
 
 Open design points:
 
-- The future incremental-change format `application/vnd.fjs.change+json` (event log,
-  most likely CRDT-based): its shape, and how it links to revisions — as a new media type,
-  not as a field of this format (see the versioning rule above).
+- The future incremental-change dialect `vnd.fjs.change` (event log, most likely
+  CRDT-based): its shape, and how it links to revisions — as a new dialect, not as a field
+  of this format (see the versioning rule above).
 - Future `ref` forms beyond cbase32 hashes and `https://` bridge URLs (including the
   optional `{hash}-{nonce}` form for distinct subject identity), and which ref positions
   besides `parents` use the hash-only `hash` type rather than the general `ref`
@@ -216,13 +220,13 @@ Open design points:
 
 ### Tasks
 
-- [ ] Create `fs/media/revision/README.md` — the spec of the format tagged
-      `application/vnd.fjs.revision+json`
+- [ ] Create `fs/media/revision/README.md` — the spec of the dialect `vnd.fjs.revision`,
+      served as `application/vnd.fjs.revision+json`
       (deployed automatically to functionalscript.com once it exists in the repo)
 - [ ] Define `ref` as a URL in CA digital space, recognizing cbase32 hashes and `https://`
       bridge URLs for now, and `hash` as its hash-only subset
 - [ ] Create `fs/media/revision/module.f.ts` with the RTTI schema for `revision`
-      (`fs/types/rtti`), the `mediaType` constant, and its derived TS type
+      (`fs/types/rtti`), the `dialect` constant, and its derived TS type
 - [ ] Create `fs/cas/evo/module.f.ts` for the store-touching operations below, importing the
       format from `fs/media/revision`
 - [ ] Implement head resolution: given `subject`, find revision(s) not listed as a parent
@@ -236,14 +240,15 @@ Open design points:
 - [ ] Tests: linear history, branch + merge, many heads for one subject, archived object,
       generation cache mismatch, first revision materializing from `subject`, a head demoted
       retroactively by a newly synced revision
-- [ ] Teach the MCP server to surface a stored `mediaType` as the response `mimeType`
-      (allowlisted `application/vnd.fjs.*+json` + schema validation, never a blind echo)
-      instead of the generic text fallback, size-bounded to the 128 KiB inline cap so the
-      metadata path stays O(1)-space for larger blobs — see
+- [ ] Teach the MCP server to surface the media type derived from a stored `dialect` as the
+      response `mimeType` (`application/{dialect}+json`, allowlisted `vnd.fjs.*` dialects +
+      schema validation, never a blind echo) instead of the generic text fallback,
+      size-bounded to the 128 KiB inline cap so the metadata path stays O(1)-space for
+      larger blobs — see
       [../mcp/todo/cas-get-mcp-resource-response.md](../mcp/todo/cas-get-mcp-resource-response.md)
-- [ ] Later, as a separate spec: define the incremental-change format
-      `application/vnd.fjs.change+json` (event log, likely CRDT-based) and how revisions
-      link to it — a new media type, not a new field of this format
+- [ ] Later, as a separate spec: define the incremental-change dialect `vnd.fjs.change`
+      (event log, likely CRDT-based) and how revisions link to it — a new dialect, not a
+      new field of this format
 - [ ] Reference the format from `fs/cas/README.md`
 
 ### Related

--- a/fs/cas/todo/revision-content-format.md
+++ b/fs/cas/todo/revision-content-format.md
@@ -48,8 +48,11 @@ export const revision = {
      */
     mediaType: 'application/vnd.fjs.revision+json',
 
-    /** Identity of the mutable object being revised. */
-    object: ref,
+    /**
+     * The subject of this revision: the identity of the mutable object
+     * being revised ("subject" as in the subject of a certificate).
+     */
+    subject: ref,
 
     /**
      * Parent Revision BLOBs. Empty array means this is the first revision.
@@ -60,15 +63,15 @@ export const revision = {
     parents: array(hash),
 
     /**
-     * Complete materialized content of this revision.
+     * Complete materialized content (snapshot) of this revision.
      *
-     * If absent, the revision's content is its base: the parent's
-     * materialization, or `object` itself for a first revision.
+     * If absent, the revision materializes to its base: the parent's
+     * materialization, or `subject` itself for a first revision.
      */
-    content: option(ref),
+    snapshot: option(ref),
 
     /**
-     * Optional cached generation number within the object's evolution.
+     * Optional cached generation number within the subject's evolution.
      *
      * Normally:
      *   generation = 0 for the first revision
@@ -95,7 +98,7 @@ Notes on the shape:
   revision with a non-CAS parent must not validate.
 - `mediaType` is a self-describing format tag. In a generic CAS a blob is just bytes under a
   hash, so without a discriminant a reader can only recognize a revision by guessing from its
-  shape, which collides with any other format that happens to have `object`/`parents` fields.
+  shape, which collides with any other format that happens to have `subject`/`parents` fields.
   The tag gives format detection (tools can recognize revisions while walking a store) and a
   cheap pre-validation gate; the key doubles as the type discriminant. The value is a media
   type in the RFC 6838 vendor tree with the RFC 6839 `+json` structured-syntax suffix:
@@ -116,7 +119,8 @@ Notes on the shape:
   an earlier draft's optional `changes` field (incremental diffs replayed over the base) was
   dropped: it is *schema*-additive but *semantically* breaking — a v1 reader would still
   validate such a blob and materialize the base, silently ignoring the changes. Incremental
-  changes are therefore a future separate format, `application/vnd.fjs.change+json`.
+  changes are therefore a future separate format, `application/vnd.fjs.change+json` —
+  `snapshot` vs `change` is the standard snapshot/delta dichotomy of event-sourced systems.
 - **Universal detection convention** — the tag is not revision-specific: every FS content
   format is a JSON object whose **first** key is `mediaType`, so detection matches the byte
   prefix `{"mediaType":"application/vnd.fjs.` and then validates against the schema of the
@@ -146,30 +150,31 @@ Notes on the shape:
   buffers), so the check is **size-bounded**: it is attempted only for blobs up to the
   existing 128 KiB inline-content cap; a larger blob always gets the plain `detectStream`
   result. Revision blobs are small JSON, so the bound costs nothing in practice.
-- `object` gives every revision of the same mutable thing a common anchor to resolve
+- `subject` gives every revision of the same mutable thing a common anchor to resolve
   "current head(s)" against, without requiring a mutable pointer anywhere in CAS itself —
-  the head is whatever revision(s) reference `object` and are not listed as a parent by
-  another revision *of the same `object`* — a revision of a different object referencing
-  the same hash (or an unrelated blob imported by sync) must not demote a head. `object` identity normally comes from the first `content`: the hash of
-  the object's initial content is the object's identity. Two objects created from identical
+  the head is whatever revision(s) reference `subject` and are not listed as a parent by
+  another revision *of the same `subject`* — a revision of a different subject referencing
+  the same hash (or an unrelated blob imported by sync) must not demote a head. Subject
+  identity normally comes from the first `snapshot`: the hash of
+  the subject's initial content is the subject's identity. Two subjects created from identical
   initial content therefore share an identity — this is by design: it is fine to have many
   changes of the same object from different users. When distinct identity is wanted, a ref
   can carry an additional nonce (`{hash}-{nonce}`). Digital signatures (a separate, future
-  spec) will filter changes from unknown users. `object` is also the fallback for `parents`:
-  a revision with no parents uses `object` as its base (see the algorithm below).
+  spec) will filter changes from unknown users. `subject` is also the fallback for `parents`:
+  a revision with no parents uses `subject` as its base (see the algorithm below).
 - `parents` is an array to support merges (multiple concurrent lines of history converging),
   matching the "multi-device / multi-user, merge freely" model in
   [vision.md](../../../todo/plan/vision.md).
 - **Materialization algorithm** — the base of a revision is its materialized parent, or
-  `object` itself when `parents` is empty:
-  1. if `content` is present, use it;
+  `subject` itself when `parents` is empty:
+  1. if `snapshot` is present, use it;
   2. otherwise, use the base.
-  A revision with multiple `parents` (a merge) must carry `content`: with more than one
+  A revision with multiple `parents` (a merge) must carry `snapshot`: with more than one
   parent there is no single base to fall back to.
 - **Conflicting concurrent heads** are resolved the same way as in Git: a merge tool creates
   a new revision that references the conflicting revisions as `parents`. The format itself
   does not resolve conflicts; it records their resolution. CAS synchronization MUST never
-  care about merge conflicts — an object can legitimately have many heads in a store at any
+  care about merge conflicts — a subject can legitimately have many heads in a store at any
   time. An application can propose a merge revision; sync just moves blobs.
 - `generation` is a cache, not a source of truth — it must always be re-derivable from
   `parents`, and a consumer must not trust a `generation` it has not verified against the
@@ -186,9 +191,9 @@ Open design points:
   most likely CRDT-based): its shape, and how it links to revisions — as a new media type,
   not as a field of this format (see the versioning rule above).
 - Future `ref` forms beyond cbase32 hashes and `https://` bridge URLs (including the
-  optional `{hash}-{nonce}` form for distinct object identity), and which ref positions
+  optional `{hash}-{nonce}` form for distinct subject identity), and which ref positions
   besides `parents` use the hash-only `hash` type rather than the general `ref`
-  (`object`? `content`?).
+  (`subject`? `snapshot`?).
 - The exact syntax of a content-addressed revision reference (e.g.
   `{hash}.{generation}.{hash}` — `hash.generation` alone does not pin a version across
   branches; undefined for now — only hashes are used).
@@ -210,16 +215,16 @@ Open design points:
       (`fs/types/rtti`), the `mediaType` constant, and its derived TS type
 - [ ] Create `fs/cas/evo/module.f.ts` for the store-touching operations below, importing the
       format from `fs/media/revision`
-- [ ] Implement head resolution: given `object`, find revision(s) not listed as a parent
-      by any other revision of the same `object` (a reverse index scoped per object; heads
-      can be demoted retroactively by sync, but only by same-object children)
-- [ ] Implement content materialization: `content` if present, otherwise the base
-      (parent's materialization, or `object` when `parents` is empty); reject a
-      multi-parent revision without `content`
+- [ ] Implement head resolution: given `subject`, find revision(s) not listed as a parent
+      by any other revision of the same `subject` (a reverse index scoped per subject; heads
+      can be demoted retroactively by sync, but only by same-subject children)
+- [ ] Implement content materialization: `snapshot` if present, otherwise the base
+      (parent's materialization, or `subject` when `parents` is empty); reject a
+      multi-parent revision without `snapshot`
 - [ ] Implement (or specify) a merge tool that resolves concurrent heads into a new revision
-      with multiple `parents` and `content`
-- [ ] Tests: linear history, branch + merge, many heads for one object, archived object,
-      generation cache mismatch, first revision materializing from `object`, a head demoted
+      with multiple `parents` and a `snapshot`
+- [ ] Tests: linear history, branch + merge, many heads for one subject, archived object,
+      generation cache mismatch, first revision materializing from `subject`, a head demoted
       retroactively by a newly synced revision
 - [ ] Teach the MCP server to surface a stored `mediaType` as the response `mimeType`
       (allowlisted `application/vnd.fjs.*+json` + schema validation, never a blind echo)

--- a/fs/cas/todo/revision-content-format.md
+++ b/fs/cas/todo/revision-content-format.md
@@ -123,9 +123,12 @@ Notes on the shape:
   `snapshot` vs `change` is the standard snapshot/delta dichotomy of event-sourced systems.
 - **Tagged-JSON detection convention** — the tag is not revision-specific, but it is not
   universal either. `fs/media/` hosts formats from different vendors (`text/html`, plain
-  `application/json`, …), and FS's own JavaScript-subset dialects (tagged
-  `text/vnd.fjs.*+javascript`, e.g. `text/vnd.fjs.fjs+javascript`) cannot carry an
-  embedded JSON tag at all — those keep the ordinary `fs/mime` detection path.
+  `application/json`, …), and FS's own JavaScript-subset dialects cannot carry an embedded
+  JSON tag at all — those keep the ordinary `fs/mime` detection path, are served as plain
+  `text/javascript` (no `+javascript` suffix is registered, and JavaScript MIME types are
+  a closed list nothing recognizes extensions of), and carry their precise format as a
+  **dialect** name (`text/vnd.fjs.fjs`, `text/vnd.fjs.djs`) surfaced out of band — e.g.
+  an additional `dialect` field in MCP responses, which MCP permits.
   The convention applies to **new JSON media types designed in FunctionalScript**, and even
   there it is a recommendation (a good default), not a requirement: such a format MAY be a
   JSON object whose **first** key is `mediaType`, so detection matches the byte prefix

--- a/fs/cas/todo/revision-content-format.md
+++ b/fs/cas/todo/revision-content-format.md
@@ -121,10 +121,17 @@ Notes on the shape:
   validate such a blob and materialize the base, silently ignoring the changes. Incremental
   changes are therefore a future separate format, `application/vnd.fjs.change+json` —
   `snapshot` vs `change` is the standard snapshot/delta dichotomy of event-sourced systems.
-- **Universal detection convention** — the tag is not revision-specific: every FS content
-  format is a JSON object whose **first** key is `mediaType`, so detection matches the byte
-  prefix `{"mediaType":"application/vnd.fjs.` and then validates against the schema of the
-  named type. The key is spelled `mediaType`, not `mimeType` or `contentType`:
+- **Tagged-JSON detection convention** — the tag is not revision-specific, but it is not
+  universal either. `fs/media/` hosts formats from different vendors (`text/html`, plain
+  `application/json`, …), and FS's own non-JSON formats (e.g. `application/vnd.fjs.fjs`,
+  possibly with a non-JSON fallback such as `application/vnd.fjs.fjs+javascript`) cannot
+  carry an embedded JSON tag at all — those keep the ordinary `fs/mime` detection path.
+  The convention applies to **new JSON media types designed in FunctionalScript**, and even
+  there it is a recommendation (a good default), not a requirement: such a format MAY be a
+  JSON object whose **first** key is `mediaType`, so detection matches the byte prefix
+  `{"mediaType":"application/vnd.fjs.` and then validates against the schema of the named
+  type; anything that does not match falls through to normal media detection. This format
+  adopts the convention. The key is spelled `mediaType`, not `mimeType` or `contentType`:
   - `mimeType` is the field name MCP JSON uses at top level — resource contents are
     `{ uri, mimeType, text | blob }` and our own `cas_get` tool result is
     `{ length, mimeType, type[, uri] }` (see

--- a/fs/cas/todo/revision-content-format.md
+++ b/fs/cas/todo/revision-content-format.md
@@ -131,8 +131,10 @@ Notes on the shape:
   JSON tag at all — those keep the ordinary `fs/mime` detection path, are served as plain
   `text/javascript` (no `+javascript` suffix is registered, and JavaScript MIME types are
   a closed list nothing recognizes extensions of), and carry the same kind of short
-  dialect name (`vnd.fjs.fjs`, `vnd.fjs.djs`) out of band — e.g. an additional `dialect`
-  field in MCP responses, which MCP permits. The convention applies to **new JSON media
+  dialect name (`vnd.fjs.fjs`, `vnd.fjs.djs`) out of band. Out-of-band surfacing is
+  transport-generic: a server that knows the dialect can always attach it — an additional
+  `dialect` field in MCP responses (MCP permits extra fields) or a `Dialect` header in
+  HTTP responses. The convention applies to **new JSON media
   types designed in FunctionalScript**, and even there it is a recommendation (a good
   default), not a requirement: such a format MAY be a JSON object whose **first** key is
   `dialect`, so detection matches the byte prefix `{"dialect":"vnd.fjs.` and then

--- a/fs/cas/todo/revision-content-format.md
+++ b/fs/cas/todo/revision-content-format.md
@@ -17,13 +17,17 @@ collapsed into current content. Without a shared shape for this, every consumer 
 
 Add a `revision` content format: a BLOB that represents one step in the evolution of a
 mutable object, linking back to its parent revision(s) (DAG, not just a chain, so concurrent
-edits can merge) and carrying either the full materialized content or an incremental diff
-against the parent(s).
+edits can merge) and carrying the full materialized content. Incremental diffs are
+deliberately **not** part of this format: a reader that did not implement diff replay would
+silently materialize the wrong content, so an optional `changes` field would be a breaking
+change in disguise. Incremental changes will arrive later as their own media type
+(`application/vnd.fjs.change+json`, see the versioning rule below), not as a field of this
+one.
 
 The design splits the format from the store operations, to keep the dependency graph
 acyclic:
 
-- **`fs/media/revision/`** — the pure format: the RTTI schema, the `mimeType` constant,
+- **`fs/media/revision/`** — the pure format: the RTTI schema, the `mediaType` constant,
   encode/decode/validate, and the README spec. No store access, no effects. It must live
   under `fs/media/` (see
   [fs/todo group-fs-subdirectories-by-concern](../../todo/group-fs-subdirectories-by-concern.md))
@@ -39,10 +43,10 @@ acyclic:
 export const revision = {
     /**
      * Format tag: identifies this BLOB as a revision and names the
-     * media type it should be served with. Same key as MCP resource
-     * contents use for the served type.
+     * media type it should be served with. Must be the first key in the
+     * serialized JSON so detection can match the `{"mediaType":"` prefix.
      */
-    mimeType: 'application/vnd.functionalscript.revision+json',
+    mediaType: 'application/vnd.fjs.revision+json',
 
     /** Identity of the mutable object being revised. */
     object: ref,
@@ -58,16 +62,10 @@ export const revision = {
     /**
      * Complete materialized content of this revision.
      *
-     * If present, this is authoritative and `changes` do not need to be replayed.
+     * If absent, the revision's content is its base: the parent's
+     * materialization, or `object` itself for a first revision.
      */
     content: option(ref),
-
-    /**
-     * Incremental changes introduced by this revision.
-     *
-     * Used only when `content` is absent.
-     */
-    changes: option(array(ref)),
 
     /**
      * Optional cached generation number within the object's evolution.
@@ -95,13 +93,13 @@ Notes on the shape:
   are restricted to hashes only and use the narrower `hash` type in the schema — `parents`
   is one: a parent revision is a CAS blob, so a bridge URL cannot stand in for it, and a
   revision with a non-CAS parent must not validate.
-- `mimeType` is a self-describing format tag. In a generic CAS a blob is just bytes under a
+- `mediaType` is a self-describing format tag. In a generic CAS a blob is just bytes under a
   hash, so without a discriminant a reader can only recognize a revision by guessing from its
   shape, which collides with any other format that happens to have `object`/`parents` fields.
   The tag gives format detection (tools can recognize revisions while walking a store) and a
   cheap pre-validation gate; the key doubles as the type discriminant. The value is a media
   type in the RFC 6838 vendor tree with the RFC 6839 `+json` structured-syntax suffix:
-  the part before `+` (`vnd.functionalscript.revision`) names the specific format, the
+  the part before `+` (`vnd.fjs.revision`) names the specific format, the
   suffix tells generic tooling the underlying syntax is JSON. No registry entry is required
   for the vendor tree, the string is stable (no mutable URL, no DNS anchoring), and it is
   validated by the schema itself since the literal is part of the schema. The format spec
@@ -112,19 +110,36 @@ Notes on the shape:
   by design, so a blob with extra fields still validates against the v1 schema, and that is
   the intended forward-compatibility path. An **incompatible** change MUST NOT reuse the tag:
   it introduces a new media type (for example
-  `application/vnd.functionalscript.revision2+json`), so readers of the old format never
+  `application/vnd.fjs.revision2+json`), so readers of the old format never
   validate — and never silently misread — a blob of the new one. The tag is therefore the
-  version discriminant for breaking changes; no `version` field is needed. The key is
-  spelled `mimeType` — the same field
-  name MCP resource contents use — because CAS objects will be exposed as MCP resources
-  and the server surfaces this value directly (see below and
-  [../mcp/todo/cas-get-mcp-resource-response.md](../mcp/todo/cas-get-mcp-resource-response.md)).
+  version discriminant for breaking changes; no `version` field is needed. This rule is why
+  an earlier draft's optional `changes` field (incremental diffs replayed over the base) was
+  dropped: it is *schema*-additive but *semantically* breaking — a v1 reader would still
+  validate such a blob and materialize the base, silently ignoring the changes. Incremental
+  changes are therefore a future separate format, `application/vnd.fjs.change+json`.
+- **Universal detection convention** — the tag is not revision-specific: every FS content
+  format is a JSON object whose **first** key is `mediaType`, so detection matches the byte
+  prefix `{"mediaType":"application/vnd.fjs.` and then validates against the schema of the
+  named type. The key is spelled `mediaType`, not `mimeType` or `contentType`:
+  - `mimeType` is the field name MCP JSON uses at top level — resource contents are
+    `{ uri, mimeType, text | blob }` and our own `cas_get` tool result is
+    `{ length, mimeType, type[, uri] }` (see
+    [../mcp/todo/cas-get-mcp-resource-response.md](../mcp/todo/cas-get-mcp-resource-response.md)).
+    Any such response stored back into CAS would false-positive a `{"mimeType":` prefix
+    sniff; `mediaType` keeps the stored-format tag and the MCP wire vocabulary disjoint.
+  - `contentType` echoes the HTTP header, which carries parameters (`; charset=...`) the
+    tag never has — and `content` is already a colliding term in MCP
+    (`CallToolResult.content`), the very reason `cas_get` renamed its `content` key away.
+  - `mediaType` is the RFC 6838 term ("MIME type" is the legacy name), and it matches the
+    `fs/media/` bucket where the formats live.
+  The MCP server still serves the value under the protocol-mandated response key
+  `mimeType`; the stored-tag → wire-field mapping is one line in the server.
 - **Serving the tag as the response `mimeType`**: the MCP server (`cas_get` and the future
-  resource read) can respond with the blob's own `mimeType` instead of falling back to the
+  resource read) can respond with the blob's own `mediaType` instead of falling back to the
   generic `text/plain` sniff — but it must never echo the field blindly. A stored blob is
-  untrusted input: anyone can store `{"mimeType": "text/html", ...}` and turn the server
-  into a content-type oracle. The rule: surface the stored `mimeType` only when it matches
-  an allowlist of known `application/vnd.functionalscript.*+json` types and the blob
+  untrusted input: anyone can store `{"mediaType": "text/html", ...}` and turn the server
+  into a content-type oracle. The rule: surface the stored `mediaType` only when it matches
+  an allowlist of known `application/vnd.fjs.*+json` types and the blob
   validates against that type's schema; everything else falls through to the existing
   `fs/mime` detector. Validation requires materializing and parsing the blob, and the
   metadata path is deliberately size-independent (`detectStream`, O(1) space, never
@@ -140,31 +155,22 @@ Notes on the shape:
   initial content therefore share an identity — this is by design: it is fine to have many
   changes of the same object from different users. When distinct identity is wanted, a ref
   can carry an additional nonce (`{hash}-{nonce}`). Digital signatures (a separate, future
-  spec) will filter changes from unknown users. `object` is also the fallback for `parents`
-  in all cases: a revision with no parents uses `object` as its base, with or without
-  `changes` (see the algorithm below).
+  spec) will filter changes from unknown users. `object` is also the fallback for `parents`:
+  a revision with no parents uses `object` as its base (see the algorithm below).
 - `parents` is an array to support merges (multiple concurrent lines of history converging),
   matching the "multi-device / multi-user, merge freely" model in
   [vision.md](../../../todo/plan/vision.md).
-- **Materialization algorithm** — `content` has priority; the fields are not mutually
-  exclusive by schema, resolution is by precedence. The base of a revision is its
-  materialized parent, or `object` itself when `parents` is empty (in all cases, with or
-  without `changes`):
+- **Materialization algorithm** — the base of a revision is its materialized parent, or
+  `object` itself when `parents` is empty:
   1. if `content` is present, use it;
-  2. otherwise, apply `changes` on the base;
-  3. otherwise (no `changes`), use the base.
-  Materialization through multiple parents is only defined when every path references a
-  single common ancestor, the intermediate revisions have no `content`, and all `changes`
-  are CRDTs (so application is order-independent). The first iteration does not implement
-  `changes` at all, so for now the algorithm requires zero or one parent; a multi-parent
-  (merge) revision must carry `content`.
+  2. otherwise, use the base.
+  A revision with multiple `parents` (a merge) must carry `content`: with more than one
+  parent there is no single base to fall back to.
 - **Conflicting concurrent heads** are resolved the same way as in Git: a merge tool creates
   a new revision that references the conflicting revisions as `parents`. The format itself
   does not resolve conflicts; it records their resolution. CAS synchronization MUST never
   care about merge conflicts — an object can legitimately have many heads in a store at any
   time. An application can propose a merge revision; sync just moves blobs.
-- `changes` entries will most likely point to an event log, most likely CRDT-based, but the
-  refs may point to different (not yet defined) formats.
 - `generation` is a cache, not a source of truth — it must always be re-derivable from
   `parents`, and a consumer must not trust a `generation` it has not verified against the
   actual parent chain from an untrusted source.
@@ -176,15 +182,13 @@ Notes on the shape:
 
 Open design points:
 
-- The `changes` event-log/CRDT format(s) still need to be defined (not implemented in the
-  first iteration).
+- The future incremental-change format `application/vnd.fjs.change+json` (event log,
+  most likely CRDT-based): its shape, and how it links to revisions — as a new media type,
+  not as a field of this format (see the versioning rule above).
 - Future `ref` forms beyond cbase32 hashes and `https://` bridge URLs (including the
   optional `{hash}-{nonce}` form for distinct object identity), and which ref positions
   besides `parents` use the hash-only `hash` type rather than the general `ref`
-  (`object`? `content`? `changes`?).
-- Whether other content formats should share the same `mimeType` tagging convention
-  (including its versioning rule: additive changes keep the tag, breaking changes mint a
-  new one).
+  (`object`? `content`?).
 - The exact syntax of a content-addressed revision reference (e.g.
   `{hash}.{generation}.{hash}` — `hash.generation` alone does not pin a version across
   branches; undefined for now — only hashes are used).
@@ -198,31 +202,33 @@ Open design points:
 ### Tasks
 
 - [ ] Create `fs/media/revision/README.md` — the spec of the format tagged
-      `application/vnd.functionalscript.revision+json`
+      `application/vnd.fjs.revision+json`
       (deployed automatically to functionalscript.com once it exists in the repo)
 - [ ] Define `ref` as a URL in CA digital space, recognizing cbase32 hashes and `https://`
       bridge URLs for now, and `hash` as its hash-only subset
 - [ ] Create `fs/media/revision/module.f.ts` with the RTTI schema for `revision`
-      (`fs/types/rtti`), the `mimeType` constant, and its derived TS type
+      (`fs/types/rtti`), the `mediaType` constant, and its derived TS type
 - [ ] Create `fs/cas/evo/module.f.ts` for the store-touching operations below, importing the
       format from `fs/media/revision`
 - [ ] Implement head resolution: given `object`, find revision(s) not listed as a parent
       by any other revision of the same `object` (a reverse index scoped per object; heads
       can be demoted retroactively by sync, but only by same-object children)
-- [ ] Implement content materialization for the first iteration (zero or one parent, no
-      `changes`): `content` → base, where base = parent's materialization or `object`
+- [ ] Implement content materialization: `content` if present, otherwise the base
+      (parent's materialization, or `object` when `parents` is empty); reject a
+      multi-parent revision without `content`
 - [ ] Implement (or specify) a merge tool that resolves concurrent heads into a new revision
       with multiple `parents` and `content`
 - [ ] Tests: linear history, branch + merge, many heads for one object, archived object,
       generation cache mismatch, first revision materializing from `object`, a head demoted
       retroactively by a newly synced revision
-- [ ] Teach the MCP server to surface a stored `mimeType` (allowlisted
-      `application/vnd.functionalscript.*+json` + schema validation, never a blind echo)
+- [ ] Teach the MCP server to surface a stored `mediaType` as the response `mimeType`
+      (allowlisted `application/vnd.fjs.*+json` + schema validation, never a blind echo)
       instead of the generic text fallback, size-bounded to the 128 KiB inline cap so the
       metadata path stays O(1)-space for larger blobs — see
       [../mcp/todo/cas-get-mcp-resource-response.md](../mcp/todo/cas-get-mcp-resource-response.md)
-- [ ] Later iteration: define the `changes` event-log/CRDT format and extend materialization
-      to CRDT changes over a single common ancestor
+- [ ] Later, as a separate spec: define the incremental-change format
+      `application/vnd.fjs.change+json` (event log, likely CRDT-based) and how revisions
+      link to it — a new media type, not a new field of this format
 - [ ] Reference the format from `fs/cas/README.md`
 
 ### Related

--- a/fs/cas/todo/revision-content-format.md
+++ b/fs/cas/todo/revision-content-format.md
@@ -108,7 +108,11 @@ Notes on the shape:
   here `application/vnd.fjs.revision+json` — because the `application/` top level and the
   RFC 6839 `+json` structured-syntax suffix are already implied by the file being JSON. Any
   system that does not know the dialect still has the correct generic fallback:
-  `application/json`. No registry entry is required for the vendor tree, the string is
+  `application/json`. A dialect name may itself be a `+`-separated **fall-back chain**,
+  most specific first (e.g. DJS, a subset of FJS, is `vnd.fjs.djs+vnd.fjs.fjs`); the
+  derivation appends `+json` as the final fall-back, and since only the final suffix of a
+  media type is standardized, the derived type remains a conformant `*+json` type whatever
+  the chain. No registry entry is required for the vendor tree, the string is
   stable (no mutable URL, no DNS anchoring), and it is validated by the schema itself since
   the literal is part of the schema. The format spec lives in the `README.md` of the
   `fs/media/revision` module (creating it is part of the tasks below; once in the repo it
@@ -131,7 +135,7 @@ Notes on the shape:
   JSON tag at all — those keep the ordinary `fs/mime` detection path, are served as plain
   `text/javascript` (no `+javascript` suffix is registered, and JavaScript MIME types are
   a closed list nothing recognizes extensions of), and carry the same kind of short
-  dialect name (`vnd.fjs.fjs`, `vnd.fjs.djs`) out of band. Out-of-band surfacing is
+  dialect name (`vnd.fjs.fjs`, `vnd.fjs.djs+vnd.fjs.fjs`) out of band. Out-of-band surfacing is
   transport-generic: a server that knows the dialect can always attach it — an additional
   `dialect` field in MCP responses (MCP permits extra fields) or a `Dialect` header in
   HTTP responses. The convention applies to **new JSON media
@@ -158,8 +162,9 @@ Notes on the shape:
   result is always an `application/*+json` type, so a hostile blob cannot turn the server
   into a `text/html` content-type oracle the way echoing a full stored media type could.
   Still, the server must not surface unknown tags: the rule is to derive the type only when
-  the dialect matches an allowlist of known `vnd.fjs.*` dialects (grammar-checked as an
-  RFC 6838 restricted-name) and the blob validates against that dialect's schema —
+  the dialect matches an allowlist of known `vnd.fjs.*` dialects (each `+`-separated
+  segment grammar-checked as an RFC 6838 restricted-name) and the blob validates against
+  that dialect's schema —
   everything else falls through to the existing `fs/mime` detector. Validation requires
   materializing and parsing the blob, and the metadata path is deliberately
   size-independent (`detectStream`, O(1) space, never buffers), so the check is

--- a/fs/media/todo/cbor.md
+++ b/fs/media/todo/cbor.md
@@ -1,114 +1,118 @@
-## cbor. Detect CBOR content
+## cbor. A CBOR serializer/parser: `fs/media/cbor`
 
 **Priority:** P3
 **Status:** open
 
+The codec (this todo) and CBOR *detection*
+([detect-cbor.md](detect-cbor.md)) are two different tasks: this one builds the
+pure `fs/media/cbor` module; detection consumes it (tiers 2–3) from the
+`fs/mime` classifier.
+
 ### Problem
 
-CBOR (RFC 8949) is the designated binary counterpart of the FS dialect scheme: it is
-the only binary JSON-family encoding with both a registered media type
-(`application/cbor`) and a registered structured-syntax suffix (`+cbor`, plus
-`+cbor-seq` for sequences, RFC 8742). The dialect naming rule
-(see [fs/todo group-fs-subdirectories-by-concern](../../todo/group-fs-subdirectories-by-concern.md))
-therefore extends mechanically to a binary encoding: the same encoding-neutral
-dialect name is served as `application/{dialect}+json` when the blob is JSON and
-`application/{dialect}+cbor` when the blob is CBOR — the suffix names the
-encoding, the dialect names the format, and a system that does not know the
-dialect still has the correct generic fallback per encoding (`application/json` /
-`application/cbor`).
+CBOR (RFC 8949) is the designated binary counterpart of the FS dialect scheme
+(registered `application/cbor` media type, registered `+cbor` suffix — see
+[fs/todo group-fs-subdirectories-by-concern](../../todo/group-fs-subdirectories-by-concern.md)):
+a dialect-tagged blob is served as `application/{dialect}+cbor` exactly as its
+JSON twin is served as `application/{dialect}+json`. Nothing in the repo can
+read or write CBOR, so binary-encoded FS formats cannot exist: no encoder to
+produce them, no decoder for schema validation, nothing for
+[detect-cbor](detect-cbor.md) tier 2 to decode a dialect entry with, and no
+grammar for a future tier-3 recognizer to share.
 
-The `fs/mime` detector (the future `media/type/`) knows nothing about CBOR. A CBOR
-blob is binary, so today it falls through to `application/octet-stream`, and a
-dialect-tagged CBOR blob cannot be recognized or served with its derived media
-type the way tagged JSON can (see
-[fs/cas revision-content-format](../../cas/todo/revision-content-format.md),
-the tagged-JSON detection convention).
+By the `fs/media/` membership rule the codec belongs here: `media/cbor/`
+implements content whose identity is the media type `application/cbor`, a
+sibling of `media/json/` — same bucket, same reasons, different encoding.
 
 ### Proposal
 
-Recognize CBOR in three tiers, most reliable first. Tiers 1–2 are signature-based
-and cheap; tier 3 is structural and deliberately deferred.
+Create `fs/media/cbor/` following the `fs/media/json/` layout: a root
+`module.f.ts` re-exporting the pieces, `serializer/` (value → bytes) and
+`parser/` (bytes → value) submodules with their `proof.f.ts` tests, and a
+README specifying the data-model mapping. Pure functions only, no store access,
+no effects; errors as result values, not exceptions — matching the sibling
+modules. (No `tokenizer/`: CBOR items are self-delimiting binary, so the
+byte-level item reader plays the tokenizer's role inside `parser/`.)
 
-#### 1. Self-described CBOR — a true magic-byte signature
+#### Data model
 
-RFC 8949 §3.4.6 defines tag 55799 as CBOR's magic number: the encoded tag is the
-byte prefix `0xD9 0xD9 0xF7`, chosen so it is not valid UTF-8 and collides with no
-known format. A blob starting with it is CBOR by declaration → `application/cbor`,
-`type: 'base64'`. This is an ordinary entry in the existing `fs/mime` magic table —
-no new machinery.
+Start with the JSON-compatible subset plus what FS already needs beyond it:
 
-#### 2. Dialect-tagged CBOR — the binary analog of `{"dialect":"` prefix matching
+| CBOR (RFC 8949)                     | FS value                          |
+| ----------------------------------- | --------------------------------- |
+| major 0/1 (int) within safe range   | `number`                          |
+| major 0/1 outside safe range        | `bigint`                          |
+| tags 2/3 (bignum)                   | `bigint`                          |
+| major 7 float                       | `number`                          |
+| `false`/`true`/`null`               | same                              |
+| major 3 (text string, valid UTF-8)  | `string`                          |
+| major 4 (array)                     | array                             |
+| major 5 (map, text keys only)       | object                            |
+| major 2 (byte string)               | later — needs an FS `Vec` mapping |
 
-The tagged-JSON convention carries over: an FS-designed CBOR format is a CBOR map
-whose **first** entry is the text key `"dialect"` with a text-string value. In a
-definite-length encoding the key is the fixed byte sequence
-`0x67 'd' 'i' 'a' 'l' 'e' 'c' 't'` at offset 1 (after the map header
-`0xA0+n`, n < 24), optionally preceded by the tag-55799 prefix from tier 1 — a
-matchable signature, exactly as `{"dialect":"` is in JSON. On a hit: decode the
-dialect value, grammar-check each `+`-separated segment as an RFC 6838
-restricted-name, and apply the same allowlist + schema-validation +
-128 KiB size-bound rules as the JSON path (never a blind echo; the derivation is
-structurally safe — any value yields an `application/*+cbor` type) →
-`application/{dialect}+cbor`; otherwise fall through.
+`bigint` is required from the start: DJS adds `bigint` to JSON, and CBOR
+represents it natively — the pairing is the point of having a binary encoding.
+Everything else CBOR allows (non-text map keys, `undefined`, simple values,
+other tags, indefinite lengths on decode) is **rejected** in the first
+iteration: a small, closed model keeps encode/decode a lossless round trip and
+keeps schema validation meaningful. Extensions widen the table deliberately,
+per dialect (each dialect's README owns what it admits beyond the JSON model).
 
-**Encoding rule for producers** (to be stated in the format specs): FS-produced
-tagged CBOR MUST use definite lengths with the `dialect` entry first. Note that
-RFC 8949 §4.2 core deterministic encoding sorts map keys by the bytewise order of
-their encodings — shorter keys sort first, ties by content. The `revision` schema
-happens to satisfy "dialect first" under that order (no key is shorter than 7
-chars, and `dialect` is bytewise-first among the 7-char keys), but that is luck,
-not a guarantee: any future dialect with a shorter key (or a 7-char key starting
-`a`–`c`) would displace it. The FS canonical form is therefore **dialect-first,
-remaining keys in RFC 8949 deterministic order** — a documented, deliberate
-deviation from pure §4.2 ordering, in exchange for a stable detection prefix.
+#### Serializer: canonical by construction
 
-#### 3. Generic untagged CBOR — deferred
+One encoding, not options:
 
-A bare CBOR item without tier 1/2 markers has no signature, and structural
-detection is false-positive-prone by construction: almost any short byte string
-decodes as *some* valid CBOR item (every byte `0x00`–`0x17` alone is a valid
-unsigned integer). A trustworthy verdict needs a streaming, payload-free CBOR
-recognizer (accept/reject, O(depth), the analog of
-[fs/media/json streaming-recognizer](../json/todo/streaming-recognizer.md)) plus a
-policy gate like detect-json's "object/array top level only" — e.g. accept only a
-single complete map/array item spanning the whole blob. Out of scope for the first
-iteration; without it, untagged CBOR stays `application/octet-stream`, which is
-the honest answer.
+- RFC 8949 §4.2 core deterministic encoding — shortest-form integer heads,
+  definite lengths only, no duplicate keys;
+- the FS canonical tagged form from [detect-cbor.md](detect-cbor.md) §2 on top:
+  when the value carries a `dialect` entry, that entry is encoded **first** and
+  the remaining keys follow in §4.2 bytewise order — the documented deviation
+  from pure §4.2 sorting that buys a stable detection prefix.
+
+A canonical-only serializer makes "same value ⇒ same bytes ⇒ same CAS hash"
+hold by construction — in a content-addressed store the encoder *is* the
+identity function, so encoding options would silently fork identities.
+
+#### Parser: strict, bounded, total
+
+- reject non-well-formed items, trailing bytes after the single top-level item,
+  duplicate map keys, invalid UTF-8 in text strings, and (first iteration)
+  everything outside the data-model table above;
+- a max-depth cap as a DoS guard, like the JSON recognizer's
+  ([fs/media/json streaming-recognizer](../json/todo/streaming-recognizer.md));
+- decoding does **not** require canonical input (a synced blob from elsewhere
+  may be valid CBOR without being FS-canonical); an `isCanonical` check is a
+  separate predicate so consumers that need identity guarantees (CAS dedup,
+  detect-cbor's prefix assumption) can enforce it explicitly.
 
 ### Tasks
 
-- [ ] Add the tag-55799 prefix (`0xD9 0xD9 0xF7`) to the `fs/mime` magic table →
-      `application/cbor`, `type: 'base64'`; proof cases including a tagged blob
-      split across chunks
-- [ ] Specify the FS canonical tagged-CBOR form: definite lengths, `dialect`
-      entry first, remaining keys in RFC 8949 §4.2 order; document the deliberate
-      deviation from pure deterministic ordering and the reason (stable prefix)
-- [ ] Implement tier 2: match the map-header + `"dialect"` key prefix (with and
-      without the tier-1 tag prefix), decode the dialect value, grammar-check
-      `+`-separated segments, allowlist `vnd.fjs.*`, validate against the
-      dialect's schema, size-bounded to the 128 KiB inline cap →
-      `application/{dialect}+cbor`
-- [ ] Surface the derived type in `cas_get` / resource read alongside the JSON
-      path (same rules, different suffix); extend the optional `dialect`
-      field/header to CBOR blobs — see
-      [fs/cas/mcp cas-get-mcp-resource-response](../../cas/mcp/todo/cas-get-mcp-resource-response.md)
-- [ ] Decide per dialect what CBOR-only values (bigint, byte strings, non-string
-      keys) are admitted beyond the JSON data model — each dialect's README owns
-      this; the JSON-compatible subset is the default
-- [ ] Later: the tier-3 streaming CBOR recognizer and its top-level policy gate,
-      as a separate todo when generic CBOR detection is actually needed
+- [ ] Create `fs/media/cbor/README.md` — the data-model mapping table, the
+      canonical-form rules (§4.2 + dialect-first), and the strictness rules
+- [ ] `fs/media/cbor/serializer/module.f.ts` — canonical encoder over the
+      data-model subset, `bigint` included; proof cases against the RFC 8949
+      Appendix A test vectors that fall inside the model
+- [ ] `fs/media/cbor/parser/module.f.ts` — strict decoder (well-formedness,
+      single item, no duplicate keys, UTF-8-valid text, depth cap), result-typed
+      errors; proof cases including truncated items, trailing bytes, duplicate
+      keys, indefinite lengths (rejected), and round trips through the serializer
+- [ ] `isCanonical` predicate (or a decode flag reporting canonicity) for
+      consumers that require byte-identity
+- [ ] Root `fs/media/cbor/module.f.ts` re-exporting serializer/parser and the
+      `application/cbor` constant; reference the module from `fs/media` docs
+- [ ] Unblock [detect-cbor](detect-cbor.md) tier 2: expose a way to decode just
+      the leading `dialect` entry within the 128 KiB bound
+- [ ] Later: byte strings (major 2) once an FS `Vec` mapping is decided; a
+      payload-free O(depth) recognizer sharing this grammar (detect-cbor tier 3)
 
 ### Related
 
+- [detect-cbor.md](detect-cbor.md) — detection; consumes this codec in tiers 2–3
 - [fs/todo group-fs-subdirectories-by-concern](../../todo/group-fs-subdirectories-by-concern.md)
-  — the dialect naming rule and fall-back chain convention this extends to a
-  binary encoding
+  — the dialect naming rule and the `fs/media/` membership rule placing the codec
 - [fs/cas revision-content-format](../../cas/todo/revision-content-format.md) —
-  the tagged-JSON detection convention tier 2 mirrors, and the serving rules
-  (allowlist, schema validation, size bound) it reuses
-- [fs/mime detect-json](../../mime/todo/detect-json.md) — the JSON refinement of
-  the same detector; tier 3 would be its CBOR sibling
+  the tagged-format convention whose binary twin this enables
+- `fs/media/json/` (`serializer/`, `parser/`, `tokenizer/`) — the sibling module
+  whose layout and purity conventions this follows
 - [fs/media/json streaming-recognizer](../json/todo/streaming-recognizer.md) —
-  the payload-free recognizer pattern a tier-3 CBOR recognizer would follow
-- `fs/mime/module.f.ts` — the magic table (tier 1) and `detectStream` (tiers 2–3)
-  this lands in
+  the payload-free recognizer pattern for the future tier-3 sibling

--- a/fs/media/todo/cbor.md
+++ b/fs/media/todo/cbor.md
@@ -55,7 +55,11 @@ represents it natively — the pairing is the point of having a binary encoding.
 Everything else CBOR allows (non-text map keys, `undefined`, simple values,
 other tags, indefinite lengths on decode) is **rejected** in the first
 iteration: a small, closed model keeps encode/decode a lossless round trip and
-keeps schema validation meaningful. Extensions widen the table deliberately,
+keeps schema validation meaningful. One exception: a single leading tag 55799
+(self-described CBOR, [detect-cbor](detect-cbor.md) tier 1) on the top-level
+item is accepted and **transparently unwrapped** — it is an encoding marker,
+not data, and a self-described dialect blob that passes the tier-2 prefix check
+must not then fail schema validation on the wrapper alone. Extensions widen the table deliberately,
 per dialect (each dialect's README owns what it admits beyond the JSON model).
 
 #### Serializer: canonical by construction
@@ -67,7 +71,11 @@ One encoding, not options:
 - the FS canonical tagged form from [detect-cbor.md](detect-cbor.md) §2 on top:
   when the value carries a `dialect` entry, that entry is encoded **first** and
   the remaining keys follow in §4.2 bytewise order — the documented deviation
-  from pure §4.2 sorting that buys a stable detection prefix.
+  from pure §4.2 sorting that buys a stable detection prefix;
+- no tag-55799 wrapper: the canonical form is the bare item (the dialect
+  signature already identifies FS blobs, and canonical bytes must not fork on
+  an optional wrapper — the parser accepts the tag on input, but a wrapped blob
+  is non-canonical).
 
 A canonical-only serializer makes "same value ⇒ same bytes ⇒ same CAS hash"
 hold by construction — in a content-addressed store the encoder *is* the
@@ -77,7 +85,8 @@ identity function, so encoding options would silently fork identities.
 
 - reject non-well-formed items, trailing bytes after the single top-level item,
   duplicate map keys, invalid UTF-8 in text strings, and (first iteration)
-  everything outside the data-model table above;
+  everything outside the data-model table above — after transparently unwrapping
+  an optional single leading tag 55799;
 - a max-depth cap as a DoS guard, like the JSON recognizer's
   ([fs/media/json streaming-recognizer](../json/todo/streaming-recognizer.md));
 - decoding does **not** require canonical input (a synced blob from elsewhere
@@ -95,7 +104,8 @@ identity function, so encoding options would silently fork identities.
 - [ ] `fs/media/cbor/parser/module.f.ts` — strict decoder (well-formedness,
       single item, no duplicate keys, UTF-8-valid text, depth cap), result-typed
       errors; proof cases including truncated items, trailing bytes, duplicate
-      keys, indefinite lengths (rejected), and round trips through the serializer
+      keys, indefinite lengths (rejected), a tag-55799-wrapped item (accepted,
+      unwrapped, reported non-canonical), and round trips through the serializer
 - [ ] `isCanonical` predicate (or a decode flag reporting canonicity) for
       consumers that require byte-identity
 - [ ] Root `fs/media/cbor/module.f.ts` re-exporting serializer/parser and the

--- a/fs/media/todo/cbor.md
+++ b/fs/media/todo/cbor.md
@@ -1,0 +1,114 @@
+## cbor. Detect CBOR content
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+CBOR (RFC 8949) is the designated binary counterpart of the FS dialect scheme: it is
+the only binary JSON-family encoding with both a registered media type
+(`application/cbor`) and a registered structured-syntax suffix (`+cbor`, plus
+`+cbor-seq` for sequences, RFC 8742). The dialect naming rule
+(see [fs/todo group-fs-subdirectories-by-concern](../../todo/group-fs-subdirectories-by-concern.md))
+therefore extends mechanically to a binary encoding: the same encoding-neutral
+dialect name is served as `application/{dialect}+json` when the blob is JSON and
+`application/{dialect}+cbor` when the blob is CBOR — the suffix names the
+encoding, the dialect names the format, and a system that does not know the
+dialect still has the correct generic fallback per encoding (`application/json` /
+`application/cbor`).
+
+The `fs/mime` detector (the future `media/type/`) knows nothing about CBOR. A CBOR
+blob is binary, so today it falls through to `application/octet-stream`, and a
+dialect-tagged CBOR blob cannot be recognized or served with its derived media
+type the way tagged JSON can (see
+[fs/cas revision-content-format](../../cas/todo/revision-content-format.md),
+the tagged-JSON detection convention).
+
+### Proposal
+
+Recognize CBOR in three tiers, most reliable first. Tiers 1–2 are signature-based
+and cheap; tier 3 is structural and deliberately deferred.
+
+#### 1. Self-described CBOR — a true magic-byte signature
+
+RFC 8949 §3.4.6 defines tag 55799 as CBOR's magic number: the encoded tag is the
+byte prefix `0xD9 0xD9 0xF7`, chosen so it is not valid UTF-8 and collides with no
+known format. A blob starting with it is CBOR by declaration → `application/cbor`,
+`type: 'base64'`. This is an ordinary entry in the existing `fs/mime` magic table —
+no new machinery.
+
+#### 2. Dialect-tagged CBOR — the binary analog of `{"dialect":"` prefix matching
+
+The tagged-JSON convention carries over: an FS-designed CBOR format is a CBOR map
+whose **first** entry is the text key `"dialect"` with a text-string value. In a
+definite-length encoding the key is the fixed byte sequence
+`0x67 'd' 'i' 'a' 'l' 'e' 'c' 't'` at offset 1 (after the map header
+`0xA0+n`, n < 24), optionally preceded by the tag-55799 prefix from tier 1 — a
+matchable signature, exactly as `{"dialect":"` is in JSON. On a hit: decode the
+dialect value, grammar-check each `+`-separated segment as an RFC 6838
+restricted-name, and apply the same allowlist + schema-validation +
+128 KiB size-bound rules as the JSON path (never a blind echo; the derivation is
+structurally safe — any value yields an `application/*+cbor` type) →
+`application/{dialect}+cbor`; otherwise fall through.
+
+**Encoding rule for producers** (to be stated in the format specs): FS-produced
+tagged CBOR MUST use definite lengths with the `dialect` entry first. Note that
+RFC 8949 §4.2 core deterministic encoding sorts map keys by the bytewise order of
+their encodings — shorter keys sort first, ties by content. The `revision` schema
+happens to satisfy "dialect first" under that order (no key is shorter than 7
+chars, and `dialect` is bytewise-first among the 7-char keys), but that is luck,
+not a guarantee: any future dialect with a shorter key (or a 7-char key starting
+`a`–`c`) would displace it. The FS canonical form is therefore **dialect-first,
+remaining keys in RFC 8949 deterministic order** — a documented, deliberate
+deviation from pure §4.2 ordering, in exchange for a stable detection prefix.
+
+#### 3. Generic untagged CBOR — deferred
+
+A bare CBOR item without tier 1/2 markers has no signature, and structural
+detection is false-positive-prone by construction: almost any short byte string
+decodes as *some* valid CBOR item (every byte `0x00`–`0x17` alone is a valid
+unsigned integer). A trustworthy verdict needs a streaming, payload-free CBOR
+recognizer (accept/reject, O(depth), the analog of
+[fs/media/json streaming-recognizer](../json/todo/streaming-recognizer.md)) plus a
+policy gate like detect-json's "object/array top level only" — e.g. accept only a
+single complete map/array item spanning the whole blob. Out of scope for the first
+iteration; without it, untagged CBOR stays `application/octet-stream`, which is
+the honest answer.
+
+### Tasks
+
+- [ ] Add the tag-55799 prefix (`0xD9 0xD9 0xF7`) to the `fs/mime` magic table →
+      `application/cbor`, `type: 'base64'`; proof cases including a tagged blob
+      split across chunks
+- [ ] Specify the FS canonical tagged-CBOR form: definite lengths, `dialect`
+      entry first, remaining keys in RFC 8949 §4.2 order; document the deliberate
+      deviation from pure deterministic ordering and the reason (stable prefix)
+- [ ] Implement tier 2: match the map-header + `"dialect"` key prefix (with and
+      without the tier-1 tag prefix), decode the dialect value, grammar-check
+      `+`-separated segments, allowlist `vnd.fjs.*`, validate against the
+      dialect's schema, size-bounded to the 128 KiB inline cap →
+      `application/{dialect}+cbor`
+- [ ] Surface the derived type in `cas_get` / resource read alongside the JSON
+      path (same rules, different suffix); extend the optional `dialect`
+      field/header to CBOR blobs — see
+      [fs/cas/mcp cas-get-mcp-resource-response](../../cas/mcp/todo/cas-get-mcp-resource-response.md)
+- [ ] Decide per dialect what CBOR-only values (bigint, byte strings, non-string
+      keys) are admitted beyond the JSON data model — each dialect's README owns
+      this; the JSON-compatible subset is the default
+- [ ] Later: the tier-3 streaming CBOR recognizer and its top-level policy gate,
+      as a separate todo when generic CBOR detection is actually needed
+
+### Related
+
+- [fs/todo group-fs-subdirectories-by-concern](../../todo/group-fs-subdirectories-by-concern.md)
+  — the dialect naming rule and fall-back chain convention this extends to a
+  binary encoding
+- [fs/cas revision-content-format](../../cas/todo/revision-content-format.md) —
+  the tagged-JSON detection convention tier 2 mirrors, and the serving rules
+  (allowlist, schema validation, size bound) it reuses
+- [fs/mime detect-json](../../mime/todo/detect-json.md) — the JSON refinement of
+  the same detector; tier 3 would be its CBOR sibling
+- [fs/media/json streaming-recognizer](../json/todo/streaming-recognizer.md) —
+  the payload-free recognizer pattern a tier-3 CBOR recognizer would follow
+- `fs/mime/module.f.ts` — the magic table (tier 1) and `detectStream` (tiers 2–3)
+  this lands in

--- a/fs/media/todo/detect-cbor.md
+++ b/fs/media/todo/detect-cbor.md
@@ -1,0 +1,121 @@
+## detect-cbor. Detect CBOR content
+
+**Priority:** P3
+**Status:** open
+
+Detection (this todo) and the CBOR codec itself ([cbor.md](cbor.md), the
+`fs/media/cbor` serializer/parser) are two different tasks: tier 1 below needs no
+CBOR machinery at all, while tiers 2–3 consume the codec once it lands.
+
+### Problem
+
+CBOR (RFC 8949) is the designated binary counterpart of the FS dialect scheme: it is
+the only binary JSON-family encoding with both a registered media type
+(`application/cbor`) and a registered structured-syntax suffix (`+cbor`, plus
+`+cbor-seq` for sequences, RFC 8742). The dialect naming rule
+(see [fs/todo group-fs-subdirectories-by-concern](../../todo/group-fs-subdirectories-by-concern.md))
+therefore extends mechanically to a binary encoding: the same encoding-neutral
+dialect name is served as `application/{dialect}+json` when the blob is JSON and
+`application/{dialect}+cbor` when the blob is CBOR — the suffix names the
+encoding, the dialect names the format, and a system that does not know the
+dialect still has the correct generic fallback per encoding (`application/json` /
+`application/cbor`).
+
+The `fs/mime` detector (the future `media/type/`) knows nothing about CBOR. A CBOR
+blob is binary, so today it falls through to `application/octet-stream`, and a
+dialect-tagged CBOR blob cannot be recognized or served with its derived media
+type the way tagged JSON can (see
+[fs/cas revision-content-format](../../cas/todo/revision-content-format.md),
+the tagged-JSON detection convention).
+
+### Proposal
+
+Recognize CBOR in three tiers, most reliable first. Tiers 1–2 are signature-based
+and cheap; tier 3 is structural and deliberately deferred.
+
+#### 1. Self-described CBOR — a true magic-byte signature
+
+RFC 8949 §3.4.6 defines tag 55799 as CBOR's magic number: the encoded tag is the
+byte prefix `0xD9 0xD9 0xF7`, chosen so it is not valid UTF-8 and collides with no
+known format. A blob starting with it is CBOR by declaration → `application/cbor`,
+`type: 'base64'`. This is an ordinary entry in the existing `fs/mime` magic table —
+no new machinery.
+
+#### 2. Dialect-tagged CBOR — the binary analog of `{"dialect":"` prefix matching
+
+The tagged-JSON convention carries over: an FS-designed CBOR format is a CBOR map
+whose **first** entry is the text key `"dialect"` with a text-string value. In a
+definite-length encoding the key is the fixed byte sequence
+`0x67 'd' 'i' 'a' 'l' 'e' 'c' 't'` at offset 1 (after the map header
+`0xA0+n`, n < 24), optionally preceded by the tag-55799 prefix from tier 1 — a
+matchable signature, exactly as `{"dialect":"` is in JSON. On a hit: decode the
+dialect value, grammar-check each `+`-separated segment as an RFC 6838
+restricted-name, and apply the same allowlist + schema-validation +
+128 KiB size-bound rules as the JSON path (never a blind echo; the derivation is
+structurally safe — any value yields an `application/*+cbor` type) →
+`application/{dialect}+cbor`; otherwise fall through.
+
+**Encoding rule for producers** (to be stated in the format specs): FS-produced
+tagged CBOR MUST use definite lengths with the `dialect` entry first. Note that
+RFC 8949 §4.2 core deterministic encoding sorts map keys by the bytewise order of
+their encodings — shorter keys sort first, ties by content. The `revision` schema
+happens to satisfy "dialect first" under that order (no key is shorter than 7
+chars, and `dialect` is bytewise-first among the 7-char keys), but that is luck,
+not a guarantee: any future dialect with a shorter key (or a 7-char key starting
+`a`–`c`) would displace it. The FS canonical form is therefore **dialect-first,
+remaining keys in RFC 8949 deterministic order** — a documented, deliberate
+deviation from pure §4.2 ordering, in exchange for a stable detection prefix.
+
+#### 3. Generic untagged CBOR — deferred
+
+A bare CBOR item without tier 1/2 markers has no signature, and structural
+detection is false-positive-prone by construction: almost any short byte string
+decodes as *some* valid CBOR item (every byte `0x00`–`0x17` alone is a valid
+unsigned integer). A trustworthy verdict needs a streaming, payload-free CBOR
+recognizer (accept/reject, O(depth), the analog of
+[fs/media/json streaming-recognizer](../json/todo/streaming-recognizer.md)) plus a
+policy gate like detect-json's "object/array top level only" — e.g. accept only a
+single complete map/array item spanning the whole blob. Out of scope for the first
+iteration; without it, untagged CBOR stays `application/octet-stream`, which is
+the honest answer.
+
+### Tasks
+
+- [ ] Add the tag-55799 prefix (`0xD9 0xD9 0xF7`) to the `fs/mime` magic table →
+      `application/cbor`, `type: 'base64'`; proof cases including a tagged blob
+      split across chunks
+- [ ] Specify the FS canonical tagged-CBOR form: definite lengths, `dialect`
+      entry first, remaining keys in RFC 8949 §4.2 order; document the deliberate
+      deviation from pure deterministic ordering and the reason (stable prefix)
+- [ ] Implement tier 2: match the map-header + `"dialect"` key prefix (with and
+      without the tier-1 tag prefix), decode the dialect value, grammar-check
+      `+`-separated segments, allowlist `vnd.fjs.*`, validate against the
+      dialect's schema, size-bounded to the 128 KiB inline cap →
+      `application/{dialect}+cbor`
+- [ ] Surface the derived type in `cas_get` / resource read alongside the JSON
+      path (same rules, different suffix); extend the optional `dialect`
+      field/header to CBOR blobs — see
+      [fs/cas/mcp cas-get-mcp-resource-response](../../cas/mcp/todo/cas-get-mcp-resource-response.md)
+- [ ] Decide per dialect what CBOR-only values (bigint, byte strings, non-string
+      keys) are admitted beyond the JSON data model — each dialect's README owns
+      this; the JSON-compatible subset is the default
+- [ ] Later: the tier-3 streaming CBOR recognizer and its top-level policy gate,
+      as a separate todo when generic CBOR detection is actually needed
+
+### Related
+
+- [cbor.md](cbor.md) — the `fs/media/cbor` serializer/parser this detection
+  consumes (tier 2 decodes the dialect entry and validates the map; tier 3 would
+  share the codec's grammar payload-free)
+- [fs/todo group-fs-subdirectories-by-concern](../../todo/group-fs-subdirectories-by-concern.md)
+  — the dialect naming rule and fall-back chain convention this extends to a
+  binary encoding
+- [fs/cas revision-content-format](../../cas/todo/revision-content-format.md) —
+  the tagged-JSON detection convention tier 2 mirrors, and the serving rules
+  (allowlist, schema validation, size bound) it reuses
+- [fs/mime detect-json](../../mime/todo/detect-json.md) — the JSON refinement of
+  the same detector; tier 3 would be its CBOR sibling
+- [fs/media/json streaming-recognizer](../json/todo/streaming-recognizer.md) —
+  the payload-free recognizer pattern a tier-3 CBOR recognizer would follow
+- `fs/mime/module.f.ts` — the magic table (tier 1) and `detectStream` (tiers 2–3)
+  this lands in

--- a/fs/media/todo/detect-cbor.md
+++ b/fs/media/todo/detect-cbor.md
@@ -44,11 +44,15 @@ no new machinery.
 #### 2. Dialect-tagged CBOR — the binary analog of `{"dialect":"` prefix matching
 
 The tagged-JSON convention carries over: an FS-designed CBOR format is a CBOR map
-whose **first** entry is the text key `"dialect"` with a text-string value. In a
-definite-length encoding the key is the fixed byte sequence
-`0x67 'd' 'i' 'a' 'l' 'e' 'c' 't'` at offset 1 (after the map header
-`0xA0+n`, n < 24), optionally preceded by the tag-55799 prefix from tier 1 — a
-matchable signature, exactly as `{"dialect":"` is in JSON. On a hit: decode the
+whose **first** entry is the text key `"dialect"` with a text-string value. The
+signature is a definite-length map header followed immediately by the fixed key
+bytes `0x67 'd' 'i' 'a' 'l' 'e' 'c' 't'`, optionally preceded by the tag-55799
+prefix from tier 1. The header is not a single fixed byte: it is `0xA0+n` for
+n < 24 entries, or `0xB8`/`0xB9`/`0xBA`/`0xBB` followed by 1/2/4/8 length bytes
+for larger maps — so the detector parses the header (at most 9 bytes, a bounded
+decode, not a fixed-offset compare) and then matches the key. Still a cheap
+prefix check, just header-aware, and it accepts every valid FS-produced map size
+rather than only maps with fewer than 24 entries. On a hit: decode the
 dialect value, grammar-check each `+`-separated segment as an RFC 6838
 restricted-name, and apply the same allowlist + schema-validation +
 128 KiB size-bound rules as the JSON path (never a blind echo; the derivation is
@@ -87,7 +91,9 @@ the honest answer.
 - [ ] Specify the FS canonical tagged-CBOR form: definite lengths, `dialect`
       entry first, remaining keys in RFC 8949 §4.2 order; document the deliberate
       deviation from pure deterministic ordering and the reason (stable prefix)
-- [ ] Implement tier 2: match the map-header + `"dialect"` key prefix (with and
+- [ ] Implement tier 2: parse the definite-length map header (`0xA0`–`0xB7`
+      immediate, `0xB8`–`0xBB` with 1/2/4/8 length bytes — not a fixed-offset
+      compare) and match the `"dialect"` key right after it (with and
       without the tier-1 tag prefix), decode the dialect value, grammar-check
       `+`-separated segments, allowlist `vnd.fjs.*`, validate against the
       dialect's schema, size-bounded to the 128 KiB inline cap →

--- a/fs/media/todo/detect-cbor.md
+++ b/fs/media/todo/detect-cbor.md
@@ -60,7 +60,12 @@ structurally safe — any value yields an `application/*+cbor` type) →
 `application/{dialect}+cbor`; otherwise fall through.
 
 **Encoding rule for producers** (to be stated in the format specs): FS-produced
-tagged CBOR MUST use definite lengths with the `dialect` entry first. Note that
+tagged CBOR MUST use definite lengths with the `dialect` entry first, and no
+tag-55799 wrapper — the dialect signature already identifies the blob, and the
+canonical bytes must not fork on an optional prefix. The wrapper is an
+input-side allowance for externally produced blobs: the
+[`fs/media/cbor` codec](cbor.md) accepts and transparently unwraps it, so a
+self-described dialect blob still schema-validates. Note that
 RFC 8949 §4.2 core deterministic encoding sorts map keys by the bytewise order of
 their encodings — shorter keys sort first, ties by content. The `revision` schema
 happens to satisfy "dialect first" under that order (no key is shorter than 7

--- a/fs/media/todo/detect-cbor.md
+++ b/fs/media/todo/detect-cbor.md
@@ -38,8 +38,19 @@ and cheap; tier 3 is structural and deliberately deferred.
 RFC 8949 §3.4.6 defines tag 55799 as CBOR's magic number: the encoded tag is the
 byte prefix `0xD9 0xD9 0xF7`, chosen so it is not valid UTF-8 and collides with no
 known format. A blob starting with it is CBOR by declaration → `application/cbor`,
-`type: 'base64'`. This is an ordinary entry in the existing `fs/mime` magic table —
-no new machinery.
+`type: 'base64'`.
+
+Unlike the existing magic entries, though, this signature must **not settle** the
+detector: a tag-55799-wrapped dialect map (tier 2) starts with the same three
+bytes, and an early-exit magic hit (`isSettled` treating `matched` as terminal,
+magic-first `finish`) would freeze the verdict at generic `application/cbor`
+before the dialect probe ever sees the map. The rule: tier 2 is checked
+**before** the tier-1 verdict — generic `application/cbor` is the answer only
+when no dialect signature follows the tag, or when the tier-2 validation falls
+through. The cost of keeping the verdict open is bounded: deciding whether a
+dialect map follows takes at most the map header (≤ 9 bytes) plus the 8-byte
+key; the full dialect decode + schema validation is the same 128 KiB
+size-bounded refinement as the tagged-JSON path.
 
 #### 2. Dialect-tagged CBOR — the binary analog of `{"dialect":"` prefix matching
 
@@ -91,8 +102,11 @@ the honest answer.
 ### Tasks
 
 - [ ] Add the tag-55799 prefix (`0xD9 0xD9 0xF7`) to the `fs/mime` magic table →
-      `application/cbor`, `type: 'base64'`; proof cases including a tagged blob
-      split across chunks
+      `application/cbor`, `type: 'base64'` — as a **non-settling** signature:
+      `isSettled` must not treat this match as terminal, and `finish` checks the
+      tier-2 dialect probe before emitting the generic verdict; proof cases
+      including a tagged blob split across chunks and a tag-wrapped dialect map
+      that must report the derived type, not generic `application/cbor`
 - [ ] Specify the FS canonical tagged-CBOR form: definite lengths, `dialect`
       entry first, remaining keys in RFC 8949 §4.2 order; document the deliberate
       deviation from pure deterministic ordering and the reason (stable prefix)

--- a/fs/todo/group-fs-subdirectories-by-concern.md
+++ b/fs/todo/group-fs-subdirectories-by-concern.md
@@ -39,14 +39,15 @@ Later candidates for the same bucket, deliberately deferred to keep each PR
 small:
 
 - `media/type/` — media-type detection (today's `fs/mime`), renamed;
-- `media/djs/` — `application/vnd.functionalscript.djs`.
+- `media/djs/` — `application/vnd.fjs.djs`.
 
 **Membership rule:** a module goes under `fs/media/` iff it implements content
 whose identity is — or can be, via the RFC 6838 vendor tree — a media type.
-Unregistered FS dialects qualify through `application/vnd.functionalscript.*`
+Unregistered FS dialects qualify through `application/vnd.fjs.*`
 (only registered structured-syntax suffixes may be appended: `+json` yes,
 `+javascript` is not a registered suffix, so an FJS type would be plain
-`application/vnd.functionalscript.fjs`). Note there is no `media/fjs/` entry:
+`application/vnd.fjs.fjs` — awkward, may be renamed later, but the `vnd.fjs.*`
+prefix stays consistent). Note there is no `media/fjs/` entry:
 today's `fs/fjs` is only the CLI dispatcher, which item 3 above promotes to
 `fs/` root, leaving nothing to move — a `media/fjs/` module appears only
 if a library-form FJS format module comes to exist.

--- a/fs/todo/group-fs-subdirectories-by-concern.md
+++ b/fs/todo/group-fs-subdirectories-by-concern.md
@@ -39,19 +39,27 @@ Later candidates for the same bucket, deliberately deferred to keep each PR
 small:
 
 - `media/type/` — media-type detection (today's `fs/mime`), renamed;
-- `media/djs/` — `application/vnd.fjs.djs`.
+- `media/djs/` — `text/vnd.fjs.djs+javascript`.
 
 **Membership rule:** a module goes under `fs/media/` iff it implements content
 whose identity is — or can be, via the RFC 6838 vendor tree — a media type.
-Unregistered FS dialects qualify through `application/vnd.fjs.*`
-(only registered structured-syntax suffixes appear in RFC 6839: `+json` yes,
-`+javascript` no — so the registered-safe FJS type is plain
-`application/vnd.fjs.fjs`, with an unregistered non-JSON fallback such as
-`application/vnd.fjs.fjs+javascript` as an option; the doubled name is
-awkward and may be renamed later, but the `vnd.fjs.*` prefix stays
-consistent). The bucket is not FS-only: any media type qualifies, so formats
-from other vendors (`text/html`, `application/json`, …) live here alongside
-the `vnd.fjs.*` ones. Note there is no `media/fjs/` entry:
+Unregistered FS dialects qualify through the `vnd.fjs.*` vendor tree, with
+the top-level type and suffix chosen by what the dialect is a subset of:
+
+- JSON subsets: `application/vnd.fjs.*+json` — matching `application/json`
+  (RFC 8259) and the RFC 6839-registered `+json` suffix;
+- JavaScript subsets: `text/vnd.fjs.*+javascript` — matching `text/javascript`
+  (RFC 9239); `+javascript` is not an RFC 6839-registered suffix, it is our
+  vendor-tree hint that the payload parses as JavaScript, and delivery to an
+  actual JS engine still uses plain `text/javascript` on the wire. So the FJS
+  dialect is `text/vnd.fjs.fjs+javascript` and DJS is
+  `text/vnd.fjs.djs+javascript`.
+
+The `fjs.fjs` doubling is accepted for consistency; if FunctionalScript one
+day gets its own standard MIME type, a short form such as `text/fjs` can
+supersede the vendor name. The bucket is not FS-only: any media type
+qualifies, so formats from other vendors (`text/html`, `application/json`, …)
+live here alongside the `vnd.fjs.*` ones. Note there is no `media/fjs/` entry:
 today's `fs/fjs` is only the CLI dispatcher, which item 3 above promotes to
 `fs/` root, leaving nothing to move — a `media/fjs/` module appears only
 if a library-form FJS format module comes to exist.

--- a/fs/todo/group-fs-subdirectories-by-concern.md
+++ b/fs/todo/group-fs-subdirectories-by-concern.md
@@ -68,11 +68,14 @@ depends on what the format is a subset of:
 
 A dialect name may be a **fall-back chain**: `+` separates dialects, most
 specific first, each segment an RFC 6838 restricted-name (no `+` inside a
-segment). A consumer that does not implement the first segment may process
-the content as the next one; the wire media type is the final fall-back
-after the chain. DJS is a subset of FJS, so its dialect is
-`vnd.fjs.djs+vnd.fjs.fjs`: process as DJS, else as FJS, else as plain
-`text/javascript`. The convention mirrors how MIME suffixes read
+segment). A consumer scans the chain left to right and processes the content
+as the **first segment it implements**, ignoring unknown segments — safe
+because each dialect in the chain guarantees the content is also valid as
+everything to its right, so skipping a more specific dialect loses only its
+extra semantics, never correctness. If no segment is known, the wire media
+type is the final fall-back after the chain. DJS is a subset of FJS, so its
+dialect is `vnd.fjs.djs+vnd.fjs.fjs`: process as DJS, else as FJS, else as
+plain `text/javascript`. The convention mirrors how MIME suffixes read
 (`application/did+ld+json`: most specific first) — and because the standards
 give meaning only to the *final* suffix of a media type, a derived
 `application/{dialect}+json` stays a conformant `*+json` type even when the

--- a/fs/todo/group-fs-subdirectories-by-concern.md
+++ b/fs/todo/group-fs-subdirectories-by-concern.md
@@ -44,10 +44,14 @@ small:
 **Membership rule:** a module goes under `fs/media/` iff it implements content
 whose identity is — or can be, via the RFC 6838 vendor tree — a media type.
 Unregistered FS dialects qualify through `application/vnd.fjs.*`
-(only registered structured-syntax suffixes may be appended: `+json` yes,
-`+javascript` is not a registered suffix, so an FJS type would be plain
-`application/vnd.fjs.fjs` — awkward, may be renamed later, but the `vnd.fjs.*`
-prefix stays consistent). Note there is no `media/fjs/` entry:
+(only registered structured-syntax suffixes appear in RFC 6839: `+json` yes,
+`+javascript` no — so the registered-safe FJS type is plain
+`application/vnd.fjs.fjs`, with an unregistered non-JSON fallback such as
+`application/vnd.fjs.fjs+javascript` as an option; the doubled name is
+awkward and may be renamed later, but the `vnd.fjs.*` prefix stays
+consistent). The bucket is not FS-only: any media type qualifies, so formats
+from other vendors (`text/html`, `application/json`, …) live here alongside
+the `vnd.fjs.*` ones. Note there is no `media/fjs/` entry:
 today's `fs/fjs` is only the CLI dispatcher, which item 3 above promotes to
 `fs/` root, leaving nothing to move — a `media/fjs/` module appears only
 if a library-form FJS format module comes to exist.

--- a/fs/todo/group-fs-subdirectories-by-concern.md
+++ b/fs/todo/group-fs-subdirectories-by-concern.md
@@ -31,7 +31,8 @@ The agreed design for the format bucket. First wave — only these three:
 fs/media/
     html/       text/html (moved from fs/html)
     json/       application/json (moved from fs/json)
-    revision/   application/vnd.fjs.revision+json (format only, new code —
+    revision/   dialect vnd.fjs.revision, served as
+                application/vnd.fjs.revision+json (format only, new code —
                 see fs/cas/todo/revision-content-format.md)
 ```
 
@@ -39,26 +40,30 @@ Later candidates for the same bucket, deliberately deferred to keep each PR
 small:
 
 - `media/type/` — media-type detection (today's `fs/mime`), renamed;
-- `media/djs/` — mimeType `text/javascript`, dialect `text/vnd.fjs.djs`.
+- `media/djs/` — mimeType `text/javascript`, dialect `vnd.fjs.djs`.
 
 **Membership rule:** a module goes under `fs/media/` iff it implements content
 whose identity is a media type — or a named **dialect** of one (see below).
-Unregistered FS formats are named through the `vnd.fjs.*` vendor tree, in two
-different ways depending on what the format is a subset of:
+Unregistered FS formats are named by short **dialect** names in the RFC 6838
+vendor-tree style (`vnd.fjs.*`); how a dialect maps to a wire media type
+depends on what the format is a subset of:
 
-- JSON subsets are **new media types**: `application/vnd.fjs.*+json`. The
-  RFC 6839-registered `+json` suffix makes them recognizable to existing
-  systems (browsers classify any `*+json` as a JSON MIME type — e.g. JSON
-  module imports accept it), so the vendor type itself goes on the wire.
-- JavaScript subsets are **not new media types** — there is no registered
-  `+javascript` suffix, and JavaScript MIME types are a closed list
-  (RFC 9239: `text/javascript` plus obsolete aliases) that nothing extends,
-  so a vendor type would be opaque to every existing consumer. Instead the
-  mimeType stays plain `text/javascript` and the precise format is a
-  **dialect**: a vendor-tree-style name without a suffix, surfaced out of
+- JSON subsets embed their dialect as the first key of the payload
+  (`{"dialect":"vnd.fjs.revision",...}`) and are served with the **derived**
+  media type `application/{dialect}+json` — e.g. `vnd.fjs.revision` →
+  `application/vnd.fjs.revision+json`. The RFC 6839-registered `+json`
+  suffix makes the derived type recognizable to existing systems (browsers
+  classify any `*+json` as a JSON MIME type — e.g. JSON module imports
+  accept it), and any system that does not know the dialect still has the
+  correct generic fallback: `application/json`.
+- JavaScript subsets get **no new media type at all** — there is no
+  registered `+javascript` suffix, and JavaScript MIME types are a closed
+  list (RFC 9239: `text/javascript` plus obsolete aliases) that nothing
+  extends, so a vendor type would be opaque to every existing consumer. The
+  mimeType stays plain `text/javascript` and the dialect is surfaced out of
   band (e.g. an additional `dialect` field in MCP responses — MCP allows
-  extra fields). So FJS is dialect `text/vnd.fjs.fjs` and DJS is dialect
-  `text/vnd.fjs.djs`, both served as `text/javascript`.
+  extra fields). So FJS is dialect `vnd.fjs.fjs` and DJS is dialect
+  `vnd.fjs.djs`, both served as `text/javascript`.
 
 Multiple `fs/media/` directories may therefore share one mimeType and differ
 only by dialect. The `fjs.fjs` doubling is accepted for consistency; if
@@ -79,7 +84,7 @@ over its siblings' declared `{ mime, parse, serialize }` instead of hardcoding
 per-format branches.
 
 **Cycle rule** (the reason `revision` is in the list): whatever the detector
-must import to recognize a format — its schema, its `mimeType` constant — must
+must import to recognize a format — its schema, its `dialect` constant — must
 be a `media/` sibling, never live inside a store or adapter. Concretely:
 `fs/cas/mcp` depends on the detector, and detecting revision blobs requires the
 revision schema, so a revision format inside `fs/cas` would create a

--- a/fs/todo/group-fs-subdirectories-by-concern.md
+++ b/fs/todo/group-fs-subdirectories-by-concern.md
@@ -40,7 +40,7 @@ Later candidates for the same bucket, deliberately deferred to keep each PR
 small:
 
 - `media/type/` — media-type detection (today's `fs/mime`), renamed;
-- `media/djs/` — mimeType `text/javascript`, dialect `vnd.fjs.djs`.
+- `media/djs/` — mimeType `text/javascript`, dialect `vnd.fjs.djs+vnd.fjs.fjs`.
 
 **Membership rule:** a module goes under `fs/media/` iff it implements content
 whose identity is a media type — or a named **dialect** of one (see below).
@@ -63,7 +63,21 @@ depends on what the format is a subset of:
   mimeType stays plain `text/javascript` and the dialect is surfaced out of
   band (e.g. an additional `dialect` field in MCP responses — MCP allows
   extra fields). So FJS is dialect `vnd.fjs.fjs` and DJS is dialect
-  `vnd.fjs.djs`, both served as `text/javascript`.
+  `vnd.fjs.djs+vnd.fjs.fjs` (a fall-back chain, see below), both served as
+  `text/javascript`.
+
+A dialect name may be a **fall-back chain**: `+` separates dialects, most
+specific first, each segment an RFC 6838 restricted-name (no `+` inside a
+segment). A consumer that does not implement the first segment may process
+the content as the next one; the wire media type is the final fall-back
+after the chain. DJS is a subset of FJS, so its dialect is
+`vnd.fjs.djs+vnd.fjs.fjs`: process as DJS, else as FJS, else as plain
+`text/javascript`. The convention mirrors how MIME suffixes read
+(`application/did+ld+json`: most specific first) — and because the standards
+give meaning only to the *final* suffix of a media type, a derived
+`application/{dialect}+json` stays a conformant `*+json` type even when the
+dialect itself contains `+`: to existing systems, everything before the
+final `+json` is an opaque subtype name.
 
 Dialect surfacing is transport-generic: whenever a server knows the dialect,
 it can attach it to the response — an additional `dialect` field in MCP

--- a/fs/todo/group-fs-subdirectories-by-concern.md
+++ b/fs/todo/group-fs-subdirectories-by-concern.md
@@ -65,8 +65,16 @@ depends on what the format is a subset of:
   extra fields). So FJS is dialect `vnd.fjs.fjs` and DJS is dialect
   `vnd.fjs.djs`, both served as `text/javascript`.
 
-Multiple `fs/media/` directories may therefore share one mimeType and differ
-only by dialect. The `fjs.fjs` doubling is accepted for consistency; if
+Dialect surfacing is transport-generic: whenever a server knows the dialect,
+it can attach it to the response — an additional `dialect` field in MCP
+responses (MCP allows extra fields), a `Dialect` header in HTTP responses (a
+Content-Type parameter would not be conformant: media-type parameters must
+be defined by the type's registration, and RFC 9239 defines only `charset`
+for `text/javascript`). For JSON subsets the field is redundant with the
+derived mimeType, but harmless — clients get one uniform lookup order:
+`dialect` field/header, else the embedded `{"dialect":...}` tag, else
+mimeType. Multiple `fs/media/` directories may therefore share one mimeType
+and differ only by dialect. The `fjs.fjs` doubling is accepted for consistency; if
 FunctionalScript one day gets its own standard MIME type, a short form such
 as `text/fjs` can supersede the dialect name. The bucket is not FS-only: any
 media type qualifies, so formats from other vendors (`text/html`,

--- a/fs/todo/group-fs-subdirectories-by-concern.md
+++ b/fs/todo/group-fs-subdirectories-by-concern.md
@@ -31,7 +31,7 @@ The agreed design for the format bucket. First wave — only these three:
 fs/media/
     html/       text/html (moved from fs/html)
     json/       application/json (moved from fs/json)
-    revision/   application/vnd.functionalscript.revision+json (format only, new code —
+    revision/   application/vnd.fjs.revision+json (format only, new code —
                 see fs/cas/todo/revision-content-format.md)
 ```
 

--- a/fs/todo/group-fs-subdirectories-by-concern.md
+++ b/fs/todo/group-fs-subdirectories-by-concern.md
@@ -39,27 +39,34 @@ Later candidates for the same bucket, deliberately deferred to keep each PR
 small:
 
 - `media/type/` — media-type detection (today's `fs/mime`), renamed;
-- `media/djs/` — `text/vnd.fjs.djs+javascript`.
+- `media/djs/` — mimeType `text/javascript`, dialect `text/vnd.fjs.djs`.
 
 **Membership rule:** a module goes under `fs/media/` iff it implements content
-whose identity is — or can be, via the RFC 6838 vendor tree — a media type.
-Unregistered FS dialects qualify through the `vnd.fjs.*` vendor tree, with
-the top-level type and suffix chosen by what the dialect is a subset of:
+whose identity is a media type — or a named **dialect** of one (see below).
+Unregistered FS formats are named through the `vnd.fjs.*` vendor tree, in two
+different ways depending on what the format is a subset of:
 
-- JSON subsets: `application/vnd.fjs.*+json` — matching `application/json`
-  (RFC 8259) and the RFC 6839-registered `+json` suffix;
-- JavaScript subsets: `text/vnd.fjs.*+javascript` — matching `text/javascript`
-  (RFC 9239); `+javascript` is not an RFC 6839-registered suffix, it is our
-  vendor-tree hint that the payload parses as JavaScript, and delivery to an
-  actual JS engine still uses plain `text/javascript` on the wire. So the FJS
-  dialect is `text/vnd.fjs.fjs+javascript` and DJS is
-  `text/vnd.fjs.djs+javascript`.
+- JSON subsets are **new media types**: `application/vnd.fjs.*+json`. The
+  RFC 6839-registered `+json` suffix makes them recognizable to existing
+  systems (browsers classify any `*+json` as a JSON MIME type — e.g. JSON
+  module imports accept it), so the vendor type itself goes on the wire.
+- JavaScript subsets are **not new media types** — there is no registered
+  `+javascript` suffix, and JavaScript MIME types are a closed list
+  (RFC 9239: `text/javascript` plus obsolete aliases) that nothing extends,
+  so a vendor type would be opaque to every existing consumer. Instead the
+  mimeType stays plain `text/javascript` and the precise format is a
+  **dialect**: a vendor-tree-style name without a suffix, surfaced out of
+  band (e.g. an additional `dialect` field in MCP responses — MCP allows
+  extra fields). So FJS is dialect `text/vnd.fjs.fjs` and DJS is dialect
+  `text/vnd.fjs.djs`, both served as `text/javascript`.
 
-The `fjs.fjs` doubling is accepted for consistency; if FunctionalScript one
-day gets its own standard MIME type, a short form such as `text/fjs` can
-supersede the vendor name. The bucket is not FS-only: any media type
-qualifies, so formats from other vendors (`text/html`, `application/json`, …)
-live here alongside the `vnd.fjs.*` ones. Note there is no `media/fjs/` entry:
+Multiple `fs/media/` directories may therefore share one mimeType and differ
+only by dialect. The `fjs.fjs` doubling is accepted for consistency; if
+FunctionalScript one day gets its own standard MIME type, a short form such
+as `text/fjs` can supersede the dialect name. The bucket is not FS-only: any
+media type qualifies, so formats from other vendors (`text/html`,
+`application/json`, …) live here alongside the `vnd.fjs.*` ones. Note there
+is no `media/fjs/` entry:
 today's `fs/fjs` is only the CLI dispatcher, which item 3 above promotes to
 `fs/` root, leaving nothing to move — a `media/fjs/` module appears only
 if a library-form FJS format module comes to exist.


### PR DESCRIPTION
## Summary

This PR redesigns the revision content format to simplify the initial implementation and establish clearer conventions for FS content formats. The key changes are:

1. **Remove incremental diffs from the revision format** — The `changes` field is dropped entirely. Incremental changes will be a separate media type (`application/vnd.fjs.change+json`) in a future iteration, not an optional field of the revision format. This avoids a subtle breaking change where v1 readers would silently ignore the `changes` field and materialize incorrect content.

2. **Rename `mimeType` to `mediaType`** — Establishes a universal detection convention where every FS content format uses `mediaType` as its first JSON key. This:
   - Keeps the stored-format tag disjoint from MCP wire vocabulary (which uses `mimeType`)
   - Avoids false-positive prefix matches when MCP responses are stored back to CAS
   - Aligns with RFC 6838 terminology and the `fs/media/` bucket naming
   - Enables reliable format detection via `{"mediaType":"application/vnd.fjs.` prefix matching

3. **Shorten vendor prefix** — Change from `vnd.functionalscript` to `vnd.fjs` for brevity.

## Key Changes

- **Materialization algorithm simplified**: Remove the three-step precedence logic. Now: use `content` if present, otherwise use the base (parent's materialization or `object` itself). Multi-parent revisions must carry `content`.

- **Schema field changes**:
  - Remove `changes: option(array(ref))` field entirely
  - Rename `mimeType` to `mediaType`
  - Update `content` field documentation to clarify it's optional and the base is used when absent

- **Versioning rule clarified**: Breaking changes introduce a new media type (e.g., `vnd.fjs.revision2+json`), not a version field. This ensures old readers never silently misread new blobs.

- **Detection convention documented**: All FS content formats use `mediaType` as the first key, enabling O(1) format detection by byte-prefix matching before schema validation.

- **MCP server integration**: The server maps the stored `mediaType` value to the response `mimeType` field (after allowlist validation), keeping the two vocabularies separate.

## Implementation Impact

- First iteration focuses on linear history and explicit content; multi-parent merges require `content` to be present
- Incremental changes deferred to a separate format and spec
- Detection and validation can now be unified across all FS content formats using the `mediaType` convention

https://claude.ai/code/session_01RVkyUskKCP5FtEdWqHu9ij