### PR TITLE
Scope revision format todo to media detection and require hash-only refs

### DIFF
--- a/fs/cas/todo/revision-content-format.md
+++ b/fs/cas/todo/revision-content-format.md
@@ -163,10 +163,12 @@ Notes on the shape:
   identity normally comes from the first `snapshot`: the hash of
   the subject's initial content is the subject's identity. Two subjects created from identical
   initial content therefore share an identity — this is by design: it is fine to have many
-  changes of the same object from different users. When distinct identity is wanted, a
-  future reference form can carry an additional nonce (`{hash}-{nonce}`). Digital signatures
-  (a separate, future spec) will filter changes from unknown users. `subject` is also the
-  fallback for `parents`: a revision with no parents uses `subject` as its base.
+  changes of the same object from different users. This hash-only dialect does not support
+  distinct identities for identical initial content. A nonce-bearing reference form such as
+  `{hash}-{nonce}` would not be a cbase32 hash, so it is explicitly future/out-of-scope and
+  would require a later dialect or separate design. Digital signatures (a separate, future
+  spec) will filter changes from unknown users. `subject` is also the fallback for `parents`:
+  a revision with no parents uses `subject` as its base.
 - `parents` is an array to support merges (multiple concurrent lines of history converging),
   matching the "multi-device / multi-user, merge freely" model in
   [vision.md](../../../todo/plan/vision.md).
@@ -189,8 +191,8 @@ Open design points:
 - The future incremental-change dialect `vnd.fjs.change` (event log, most likely
   CRDT-based): its shape, and how it links to revisions — as a new dialect, not as a field
   of this format (see the versioning rule above).
-- Future reference forms beyond cbase32 hashes (including the optional `{hash}-{nonce}`
-  form for distinct subject identity), if a later dialect needs them.
+- Future reference forms beyond cbase32 hashes, including a possible nonce-bearing form for
+  distinct subject identity. Such forms are out of scope for this hash-only dialect.
 - The exact syntax of a content-addressed revision reference (e.g.
   `{hash}.{generation}.{hash}` — `hash.generation` alone does not pin a version across
   branches; undefined for now — only hashes are used).

--- a/fs/cas/todo/revision-content-format.md
+++ b/fs/cas/todo/revision-content-format.md
@@ -35,10 +35,10 @@ recognition:
   `fs/media` detector should be able to identify a valid revision blob and return the
   derived media type `application/vnd.fjs.revision+json`.
 
-Store-touching evolution operations (head resolution, materialization, per-object reverse
-indexes, MCP resource behavior) are intentionally deferred. This issue only defines the
-revision type and teaches media detection to recognize it; it does not add an `fs/cas/evo`
-module and does not materialize revisions.
+Store-touching evolution operations (head resolution, materialization, and per-object
+reverse indexes) are intentionally deferred. This issue only defines the revision type and
+teaches media detection to recognize it; it does not add store-side evolution code and does
+not materialize revisions.
 
 ```ts
 export const revision = {
@@ -136,29 +136,25 @@ Notes on the shape:
   `text/javascript` (no `+javascript` suffix is registered, and JavaScript MIME types are
   a closed list nothing recognizes extensions of), and carry the same kind of short
   dialect name (`vnd.fjs.fjs`, `vnd.fjs.djs+vnd.fjs.fjs`) out of band. Out-of-band surfacing is
-  transport-generic: a server that knows the dialect can always attach it — an additional
-  `dialect` field in MCP responses (MCP permits extra fields) or a `Dialect` header in
-  HTTP responses. The convention applies to **new JSON media
+  transport-generic: a server that knows the dialect can always attach it alongside the
+  payload, for example with a response field or header. The convention applies to **new JSON media
   types designed in FunctionalScript**, and even there it is a recommendation (a good
   default), not a requirement: such a format MAY be a JSON object whose **first** key is
   `dialect`, so detection matches the byte prefix `{"dialect":"vnd.fjs.` and then
   validates against the schema of the named dialect; anything that does not match falls
   through to normal media detection. This format adopts the convention. The key is spelled
   `dialect` — one vocabulary for both the embedded tag and the out-of-band field — and not:
-  - `mimeType` — the field name MCP JSON uses at top level: resource contents are
-    `{ uri, mimeType, text | blob }` and our own `cas_get` tool result is
-    `{ length, mimeType, type[, uri] }` (see
-    [../mcp/todo/cas-get-mcp-resource-response.md](../mcp/todo/cas-get-mcp-resource-response.md)).
-    Any such response stored back into CAS would false-positive a `{"mimeType":` prefix
-    sniff, and the value here is not a MIME type anyway.
+  - `mimeType` — a common response field name. Any response envelope stored back into CAS
+    would false-positive a `{"mimeType":` prefix sniff, and the value here is not a MIME
+    type anyway.
   - `contentType` — echoes the HTTP header, and `content` is already a colliding term in
-    MCP (`CallToolResult.content`), the very reason `cas_get` renamed its `content` key away.
+    many response envelopes.
   - `mediaType` — near-synonym of `mimeType`; serving both keys side by side in one
     response would invite exactly the confusion the vocabulary split is meant to prevent.
 - **Media detection**: `fs/media` should detect revision blobs by the embedded dialect tag and
   schema validation, then report the derived media type `application/vnd.fjs.revision+json`.
-  This recognition is local to media detection; CAS/MCP response shaping is out of scope
-  for this issue and can be designed later once the pure detector exists.
+  This recognition is local to media detection; response shaping is out of scope for this
+  issue and can be designed later once the pure detector exists.
 - `subject` gives every revision of the same mutable thing a common anchor to resolve
   "current head(s)" against, without requiring a mutable pointer anywhere in CAS itself —
   the head is whatever revision(s) reference `subject` and are not listed as a parent by
@@ -167,18 +163,13 @@ Notes on the shape:
   identity normally comes from the first `snapshot`: the hash of
   the subject's initial content is the subject's identity. Two subjects created from identical
   initial content therefore share an identity — this is by design: it is fine to have many
-  changes of the same object from different users. When distinct identity is wanted, a ref
-  can carry an additional nonce (`{hash}-{nonce}`). Digital signatures (a separate, future
-  spec) will filter changes from unknown users. `subject` is also the fallback for `parents`:
-  a revision with no parents uses `subject` as its base (see the algorithm below).
+  changes of the same object from different users. When distinct identity is wanted, a
+  future reference form can carry an additional nonce (`{hash}-{nonce}`). Digital signatures
+  (a separate, future spec) will filter changes from unknown users. `subject` is also the
+  fallback for `parents`: a revision with no parents uses `subject` as its base.
 - `parents` is an array to support merges (multiple concurrent lines of history converging),
   matching the "multi-device / multi-user, merge freely" model in
   [vision.md](../../../todo/plan/vision.md).
-- **Future materialization algorithm** — out of scope for the first detector-only change.
-  The intended rule is that the base of a revision is its materialized parent, or `subject`
-  itself when `parents` is empty: if `snapshot` is present, use it; otherwise, use the base.
-  A revision with multiple `parents` (a merge) must carry `snapshot`: with more than one
-  parent there is no single base to fall back to.
 - **Conflicting concurrent heads** are resolved the same way as in Git: a merge tool creates
   a new revision that references the conflicting revisions as `parents`. The format itself
   does not resolve conflicts; it records their resolution. CAS synchronization MUST never

--- a/fs/cas/todo/revision-content-format.md
+++ b/fs/cas/todo/revision-content-format.md
@@ -55,7 +55,7 @@ export const revision = {
      * The subject of this revision: the identity of the mutable object
      * being revised ("subject" as in the subject of a certificate).
      * Usually any string; it must be a hash only when it is used as
-     * the fallback content reference.
+     * the fallback snapshot reference.
      */
     subject: string,
 
@@ -67,12 +67,14 @@ export const revision = {
     parents: array(hash),
 
     /**
-     * Complete materialized content of this revision.
+     * Complete materialized content (snapshot) of this revision.
      *
-     * If absent and there is not exactly one parent, `subject` is used
-     * as the fallback content reference and must validate as a hash.
+     * If absent and there are zero parents, `subject` is used
+     * as the fallback snapshot reference and must validate as a hash.
+     * If absent with exactly one parent, the parent is inherited.
+     * If absent with multiple parents, validation fails.
      */
-    content: option(hash),
+    snapshot: option(hash),
 
     /**
      * Optional cached generation number within the subject's evolution.
@@ -94,13 +96,16 @@ export const revision = {
 
 Notes on the shape:
 
-- `hash` is the only content-reference type in this first revision format. It is a cbase32
+- `hash` is the only snapshot-reference type in this first revision format. It is a cbase32
   native CAS address (see `fs/basen/cbase32/`). Revision blobs do not accept `https://`
-  bridge URLs or any other location-addressed reference form for CAS content references:
-  `parents` and `content` always validate as hashes. `subject` is an identity string, not
-  necessarily a content reference; it validates as a hash only in the fallback case where
-  `content === undefined` and `parents.length !== 1`, because then the revision uses
-  `subject` as the content reference.
+  bridge URLs or any other location-addressed reference form for CAS snapshot references:
+  `parents` and `snapshot` always validate as hashes. `subject` is an identity string, not
+  necessarily a snapshot reference; it validates as a hash only when `snapshot === undefined`
+  and `parents.length === 0`, because then the revision uses `subject` as the snapshot
+  reference. A revision with `snapshot === undefined` and `parents.length === 1` inherits
+  the single parent snapshot. A revision with `snapshot === undefined` and
+  `parents.length > 1` is invalid because there is no single parent snapshot to inherit, and
+  falling back to `subject` would silently lose the merge result.
 - `dialect` is a self-describing format tag. In a generic CAS a blob is just bytes under a
   hash, so without a discriminant a reader can only recognize a revision by guessing from its
   shape, which collides with any other format that happens to have `subject`/`parents` fields.
@@ -131,7 +136,7 @@ Notes on the shape:
   over the base) was dropped: it is *schema*-additive but *semantically* breaking — a v1
   reader would still validate such a blob and materialize the base, silently ignoring the
   changes. Incremental changes are therefore a future separate dialect, `vnd.fjs.change` —
-  `content` vs `change` is the standard snapshot/delta dichotomy of event-sourced systems.
+  `snapshot` vs `change` is the standard snapshot/delta dichotomy of event-sourced systems.
 - **Tagged-JSON detection convention** — the tag is not revision-specific, but it is not
   universal either. `fs/media/` hosts formats from different vendors (`text/html`, plain
   `application/json`, …), and FS's own JavaScript-subset dialects cannot carry an embedded
@@ -156,6 +161,10 @@ Notes on the shape:
     response would invite exactly the confusion the vocabulary split is meant to prevent.
 - **Media detection**: `fs/media` should detect revision blobs by the embedded dialect tag and
   schema validation, then report the derived media type `application/vnd.fjs.revision+json`.
+  Prefix matching can stay streaming, but schema validation requires buffering and parsing
+  JSON, so it must be attempted only when the blob is already buffered or within a
+  size-bounded path such as the existing 128 KiB inline-content cap. Larger blobs must fall
+  back to the existing streaming detector so metadata-only reads remain size-independent.
   This recognition is local to media detection; response shaping is out of scope for this
   issue and can be designed later once the pure detector exists.
 - `subject` gives every revision of the same mutable thing a common anchor to resolve
@@ -163,10 +172,10 @@ Notes on the shape:
   the head is whatever revision(s) reference `subject` and are not listed as a parent by
   another revision *of the same `subject`* — a revision of a different subject referencing
   the same hash (or an unrelated blob imported by sync) must not demote a head. Subject
-  identity can be any string when `content` or exactly one parent supplies the content
-  reference. When neither is available, `subject` doubles as the fallback content reference
-  and must be a hash. A nonce-bearing subject such as `{hash}-{nonce}` is therefore valid
-  only when `subject` is not being used as that fallback content reference. Digital
+  identity can be any string when `snapshot` or exactly one parent supplies the snapshot
+  reference. With zero parents and no `snapshot`, `subject` doubles as the fallback snapshot
+  reference and must be a hash. A nonce-bearing subject such as `{hash}-{nonce}` is therefore valid
+  only when `subject` is not being used as that fallback snapshot reference. Digital
   signatures (a separate, future spec) will filter changes from unknown users.
 - `parents` is an array to support merges (multiple concurrent lines of history converging),
   matching the "multi-device / multi-user, merge freely" model in
@@ -190,8 +199,8 @@ Open design points:
 - The future incremental-change dialect `vnd.fjs.change` (event log, most likely
   CRDT-based): its shape, and how it links to revisions — as a new dialect, not as a field
   of this format (see the versioning rule above).
-- Future content-reference forms beyond cbase32 hashes. Subject identity strings can already
-  use non-hash forms when `content` or exactly one parent supplies the content reference.
+- Future snapshot-reference forms beyond cbase32 hashes. Subject identity strings can already
+  use non-hash forms when `snapshot` or exactly one parent supplies the snapshot reference.
 - The exact syntax of a content-addressed revision reference (e.g.
   `{hash}.{generation}.{hash}` — `hash.generation` alone does not pin a version across
   branches; undefined for now — only hashes are used).
@@ -207,18 +216,20 @@ Open design points:
 - [ ] Create `fs/media/revision/README.md` — the spec of the dialect `vnd.fjs.revision`,
       served as `application/vnd.fjs.revision+json`
       (deployed automatically to functionalscript.com once it exists in the repo)
-- [ ] Define `hash` as the only content-reference type accepted by this dialect, recognizing
+- [ ] Define `hash` as the only snapshot-reference type accepted by this dialect, recognizing
       cbase32 native CAS addresses and rejecting `https://` bridge URLs for `parents`,
-      `content`, and fallback `subject` references
+      `snapshot`, and zero-parent fallback `subject` references
 - [ ] Create `fs/media/revision/module.f.ts` with the RTTI schema for `revision`
       (`fs/types/rtti`), the `dialect` constant, and its derived TS type
 - [ ] Teach `fs/media` detection to recognize valid revision JSON and return the derived
       media type `application/vnd.fjs.revision+json`, falling through to the existing
       detector for unknown dialects or invalid revision blobs
 - [ ] Tests: valid revision detection, invalid revision fallthrough, `https://` bridge URL
-      rejection in `parents`, `content`, and fallback `subject`, arbitrary string `subject`
-      acceptance when `content` is present or `parents.length === 1`, first-key `dialect`
-      prefix matching, and ordinary JSON fallback behavior
+      rejection in `parents`, `snapshot`, and zero-parent fallback `subject`, arbitrary string
+      `subject` acceptance when `snapshot` is present or `parents.length === 1`, invalid
+      multi-parent revisions without `snapshot`, size-bounded schema validation with large
+      blobs falling through to the streaming detector, first-key `dialect` prefix matching,
+      and ordinary JSON fallback behavior
 - [ ] Later, as a separate spec: define the incremental-change dialect `vnd.fjs.change`
       (event log, likely CRDT-based) and how revisions link to it — a new dialect, not a
       new field of this format

--- a/fs/cas/todo/revision-content-format.md
+++ b/fs/cas/todo/revision-content-format.md
@@ -54,8 +54,10 @@ export const revision = {
     /**
      * The subject of this revision: the identity of the mutable object
      * being revised ("subject" as in the subject of a certificate).
+     * Usually any string; it must be a hash only when it is used as
+     * the fallback content reference.
      */
-    subject: hash,
+    subject: string,
 
     /**
      * Parent Revision BLOBs. Empty array means this is the first revision.
@@ -65,12 +67,12 @@ export const revision = {
     parents: array(hash),
 
     /**
-     * Complete materialized content (snapshot) of this revision.
+     * Complete materialized content of this revision.
      *
-     * If absent, the revision materializes to its base: the parent's
-     * materialization, or `subject` itself for a first revision.
+     * If absent and there is not exactly one parent, `subject` is used
+     * as the fallback content reference and must validate as a hash.
      */
-    snapshot: option(hash),
+    content: option(hash),
 
     /**
      * Optional cached generation number within the subject's evolution.
@@ -92,12 +94,13 @@ export const revision = {
 
 Notes on the shape:
 
-- `hash` is the only reference type in this first revision format. It is a cbase32 native
-  CAS address (see `fs/basen/cbase32/`). Revision blobs do not accept `https://` bridge
-  URLs or any other location-addressed reference form: `subject`, `parents`, and `snapshot`
-  all validate as hashes. Future non-hash reference forms, if needed, belong in a later
-  dialect or a separate design so v1 readers never silently accept references they cannot
-  resolve as CAS blobs.
+- `hash` is the only content-reference type in this first revision format. It is a cbase32
+  native CAS address (see `fs/basen/cbase32/`). Revision blobs do not accept `https://`
+  bridge URLs or any other location-addressed reference form for CAS content references:
+  `parents` and `content` always validate as hashes. `subject` is an identity string, not
+  necessarily a content reference; it validates as a hash only in the fallback case where
+  `content === undefined` and `parents.length !== 1`, because then the revision uses
+  `subject` as the content reference.
 - `dialect` is a self-describing format tag. In a generic CAS a blob is just bytes under a
   hash, so without a discriminant a reader can only recognize a revision by guessing from its
   shape, which collides with any other format that happens to have `subject`/`parents` fields.
@@ -128,7 +131,7 @@ Notes on the shape:
   over the base) was dropped: it is *schema*-additive but *semantically* breaking — a v1
   reader would still validate such a blob and materialize the base, silently ignoring the
   changes. Incremental changes are therefore a future separate dialect, `vnd.fjs.change` —
-  `snapshot` vs `change` is the standard snapshot/delta dichotomy of event-sourced systems.
+  `content` vs `change` is the standard snapshot/delta dichotomy of event-sourced systems.
 - **Tagged-JSON detection convention** — the tag is not revision-specific, but it is not
   universal either. `fs/media/` hosts formats from different vendors (`text/html`, plain
   `application/json`, …), and FS's own JavaScript-subset dialects cannot carry an embedded
@@ -160,15 +163,11 @@ Notes on the shape:
   the head is whatever revision(s) reference `subject` and are not listed as a parent by
   another revision *of the same `subject`* — a revision of a different subject referencing
   the same hash (or an unrelated blob imported by sync) must not demote a head. Subject
-  identity normally comes from the first `snapshot`: the hash of
-  the subject's initial content is the subject's identity. Two subjects created from identical
-  initial content therefore share an identity — this is by design: it is fine to have many
-  changes of the same object from different users. This hash-only dialect does not support
-  distinct identities for identical initial content. A nonce-bearing reference form such as
-  `{hash}-{nonce}` would not be a cbase32 hash, so it is explicitly future/out-of-scope and
-  would require a later dialect or separate design. Digital signatures (a separate, future
-  spec) will filter changes from unknown users. `subject` is also the fallback for `parents`:
-  a revision with no parents uses `subject` as its base.
+  identity can be any string when `content` or exactly one parent supplies the content
+  reference. When neither is available, `subject` doubles as the fallback content reference
+  and must be a hash. A nonce-bearing subject such as `{hash}-{nonce}` is therefore valid
+  only when `subject` is not being used as that fallback content reference. Digital
+  signatures (a separate, future spec) will filter changes from unknown users.
 - `parents` is an array to support merges (multiple concurrent lines of history converging),
   matching the "multi-device / multi-user, merge freely" model in
   [vision.md](../../../todo/plan/vision.md).
@@ -191,8 +190,8 @@ Open design points:
 - The future incremental-change dialect `vnd.fjs.change` (event log, most likely
   CRDT-based): its shape, and how it links to revisions — as a new dialect, not as a field
   of this format (see the versioning rule above).
-- Future reference forms beyond cbase32 hashes, including a possible nonce-bearing form for
-  distinct subject identity. Such forms are out of scope for this hash-only dialect.
+- Future content-reference forms beyond cbase32 hashes. Subject identity strings can already
+  use non-hash forms when `content` or exactly one parent supplies the content reference.
 - The exact syntax of a content-addressed revision reference (e.g.
   `{hash}.{generation}.{hash}` — `hash.generation` alone does not pin a version across
   branches; undefined for now — only hashes are used).
@@ -208,16 +207,18 @@ Open design points:
 - [ ] Create `fs/media/revision/README.md` — the spec of the dialect `vnd.fjs.revision`,
       served as `application/vnd.fjs.revision+json`
       (deployed automatically to functionalscript.com once it exists in the repo)
-- [ ] Define `hash` as the only reference type accepted by this dialect, recognizing
-      cbase32 native CAS addresses and rejecting `https://` bridge URLs
+- [ ] Define `hash` as the only content-reference type accepted by this dialect, recognizing
+      cbase32 native CAS addresses and rejecting `https://` bridge URLs for `parents`,
+      `content`, and fallback `subject` references
 - [ ] Create `fs/media/revision/module.f.ts` with the RTTI schema for `revision`
       (`fs/types/rtti`), the `dialect` constant, and its derived TS type
 - [ ] Teach `fs/media` detection to recognize valid revision JSON and return the derived
       media type `application/vnd.fjs.revision+json`, falling through to the existing
       detector for unknown dialects or invalid revision blobs
 - [ ] Tests: valid revision detection, invalid revision fallthrough, `https://` bridge URL
-      rejection in `subject`, `parents`, and `snapshot`, first-key `dialect` prefix matching,
-      and ordinary JSON fallback behavior
+      rejection in `parents`, `content`, and fallback `subject`, arbitrary string `subject`
+      acceptance when `content` is present or `parents.length === 1`, first-key `dialect`
+      prefix matching, and ordinary JSON fallback behavior
 - [ ] Later, as a separate spec: define the incremental-change dialect `vnd.fjs.change`
       (event log, likely CRDT-based) and how revisions link to it — a new dialect, not a
       new field of this format

--- a/fs/cas/todo/revision-content-format.md
+++ b/fs/cas/todo/revision-content-format.md
@@ -24,20 +24,21 @@ change in disguise. Incremental changes will arrive later as their own dialect
 (`vnd.fjs.change`, served as `application/vnd.fjs.change+json`; see the versioning rule
 below), not as a field of this one.
 
-The design splits the format from the store operations, to keep the dependency graph
-acyclic:
+The first implementation step is deliberately limited to the pure format and media
+recognition:
 
 - **`fs/media/revision/`** — the pure format: the RTTI schema, the `dialect` constant,
   encode/decode/validate, and the README spec. No store access, no effects. It must live
   under `fs/media/` (see
   [fs/todo group-fs-subdirectories-by-concern](../../todo/group-fs-subdirectories-by-concern.md))
-  because media-type detection has to import the schema to recognize revision blobs, and
-  `fs/cas/mcp` already depends on the detector — a format inside `fs/cas` would therefore
-  close a `cas` ↔ detector cycle.
-- **`fs/cas/evo/`** ("evo" for evolution, following the existing `fs/cas/cli/` and
-  `fs/cas/mcp/` layout) — the store-touching operations: head resolution, materialization,
-  the per-object reverse index. Depends on `fs/cas` and `fs/media/revision`. This keeps
-  `fs/cas/module.f.ts` focused on hashing/addressing.
+  because media-type detection has to import the schema to recognize revision blobs. The
+  `fs/media` detector should be able to identify a valid revision blob and return the
+  derived media type `application/vnd.fjs.revision+json`.
+
+Store-touching evolution operations (head resolution, materialization, per-object reverse
+indexes, MCP resource behavior) are intentionally deferred. This issue only defines the
+revision type and teaches media detection to recognize it; it does not add an `fs/cas/evo`
+module and does not materialize revisions.
 
 ```ts
 export const revision = {
@@ -54,13 +55,12 @@ export const revision = {
      * The subject of this revision: the identity of the mutable object
      * being revised ("subject" as in the subject of a certificate).
      */
-    subject: ref,
+    subject: hash,
 
     /**
      * Parent Revision BLOBs. Empty array means this is the first revision.
      *
-     * `hash` is the hash-only subset of `ref`: a parent is a CAS blob,
-     * so a bridge URL cannot stand in for it.
+     * Parent revisions are CAS blobs, so each parent is a hash.
      */
     parents: array(hash),
 
@@ -70,7 +70,7 @@ export const revision = {
      * If absent, the revision materializes to its base: the parent's
      * materialization, or `subject` itself for a first revision.
      */
-    snapshot: option(ref),
+    snapshot: option(hash),
 
     /**
      * Optional cached generation number within the subject's evolution.
@@ -92,12 +92,12 @@ export const revision = {
 
 Notes on the shape:
 
-- `ref` is a URL in content-addressed digital space. For now two forms are recognized: a
-  cbase32 hash (a native CAS address, see `fs/basen/cbase32/`), and a standard `https://` URL as a
-  bridge to the legacy location-addressed web. More forms are planned. Some ref positions
-  are restricted to hashes only and use the narrower `hash` type in the schema — `parents`
-  is one: a parent revision is a CAS blob, so a bridge URL cannot stand in for it, and a
-  revision with a non-CAS parent must not validate.
+- `hash` is the only reference type in this first revision format. It is a cbase32 native
+  CAS address (see `fs/basen/cbase32/`). Revision blobs do not accept `https://` bridge
+  URLs or any other location-addressed reference form: `subject`, `parents`, and `snapshot`
+  all validate as hashes. Future non-hash reference forms, if needed, belong in a later
+  dialect or a separate design so v1 readers never silently accept references they cannot
+  resolve as CAS blobs.
 - `dialect` is a self-describing format tag. In a generic CAS a blob is just bytes under a
   hash, so without a discriminant a reader can only recognize a revision by guessing from its
   shape, which collides with any other format that happens to have `subject`/`parents` fields.
@@ -155,22 +155,10 @@ Notes on the shape:
     MCP (`CallToolResult.content`), the very reason `cas_get` renamed its `content` key away.
   - `mediaType` — near-synonym of `mimeType`; serving both keys side by side in one
     response would invite exactly the confusion the vocabulary split is meant to prevent.
-- **Serving the derived media type as the response `mimeType`**: the MCP server (`cas_get`
-  and the future resource read) can respond with the media type derived from the blob's own
-  `dialect` — `application/{dialect}+json` — instead of falling back to the generic
-  `text/plain` sniff. The derivation is structurally safe: whatever the stored value, the
-  result is always an `application/*+json` type, so a hostile blob cannot turn the server
-  into a `text/html` content-type oracle the way echoing a full stored media type could.
-  Still, the server must not surface unknown tags: the rule is to derive the type only when
-  the dialect matches an allowlist of known `vnd.fjs.*` dialects (each `+`-separated
-  segment grammar-checked as an RFC 6838 restricted-name) and the blob validates against
-  that dialect's schema —
-  everything else falls through to the existing `fs/mime` detector. Validation requires
-  materializing and parsing the blob, and the metadata path is deliberately
-  size-independent (`detectStream`, O(1) space, never buffers), so the check is
-  **size-bounded**: it is attempted only for blobs up to the existing 128 KiB
-  inline-content cap; a larger blob always gets the plain `detectStream` result. Revision
-  blobs are small JSON, so the bound costs nothing in practice.
+- **Media detection**: `fs/media` should detect revision blobs by the embedded dialect tag and
+  schema validation, then report the derived media type `application/vnd.fjs.revision+json`.
+  This recognition is local to media detection; CAS/MCP response shaping is out of scope
+  for this issue and can be designed later once the pure detector exists.
 - `subject` gives every revision of the same mutable thing a common anchor to resolve
   "current head(s)" against, without requiring a mutable pointer anywhere in CAS itself —
   the head is whatever revision(s) reference `subject` and are not listed as a parent by
@@ -186,10 +174,9 @@ Notes on the shape:
 - `parents` is an array to support merges (multiple concurrent lines of history converging),
   matching the "multi-device / multi-user, merge freely" model in
   [vision.md](../../../todo/plan/vision.md).
-- **Materialization algorithm** — the base of a revision is its materialized parent, or
-  `subject` itself when `parents` is empty:
-  1. if `snapshot` is present, use it;
-  2. otherwise, use the base.
+- **Future materialization algorithm** — out of scope for the first detector-only change.
+  The intended rule is that the base of a revision is its materialized parent, or `subject`
+  itself when `parents` is empty: if `snapshot` is present, use it; otherwise, use the base.
   A revision with multiple `parents` (a merge) must carry `snapshot`: with more than one
   parent there is no single base to fall back to.
 - **Conflicting concurrent heads** are resolved the same way as in Git: a merge tool creates
@@ -211,10 +198,8 @@ Open design points:
 - The future incremental-change dialect `vnd.fjs.change` (event log, most likely
   CRDT-based): its shape, and how it links to revisions — as a new dialect, not as a field
   of this format (see the versioning rule above).
-- Future `ref` forms beyond cbase32 hashes and `https://` bridge URLs (including the
-  optional `{hash}-{nonce}` form for distinct subject identity), and which ref positions
-  besides `parents` use the hash-only `hash` type rather than the general `ref`
-  (`subject`? `snapshot`?).
+- Future reference forms beyond cbase32 hashes (including the optional `{hash}-{nonce}`
+  form for distinct subject identity), if a later dialect needs them.
 - The exact syntax of a content-addressed revision reference (e.g.
   `{hash}.{generation}.{hash}` — `hash.generation` alone does not pin a version across
   branches; undefined for now — only hashes are used).
@@ -230,29 +215,16 @@ Open design points:
 - [ ] Create `fs/media/revision/README.md` — the spec of the dialect `vnd.fjs.revision`,
       served as `application/vnd.fjs.revision+json`
       (deployed automatically to functionalscript.com once it exists in the repo)
-- [ ] Define `ref` as a URL in CA digital space, recognizing cbase32 hashes and `https://`
-      bridge URLs for now, and `hash` as its hash-only subset
+- [ ] Define `hash` as the only reference type accepted by this dialect, recognizing
+      cbase32 native CAS addresses and rejecting `https://` bridge URLs
 - [ ] Create `fs/media/revision/module.f.ts` with the RTTI schema for `revision`
       (`fs/types/rtti`), the `dialect` constant, and its derived TS type
-- [ ] Create `fs/cas/evo/module.f.ts` for the store-touching operations below, importing the
-      format from `fs/media/revision`
-- [ ] Implement head resolution: given `subject`, find revision(s) not listed as a parent
-      by any other revision of the same `subject` (a reverse index scoped per subject; heads
-      can be demoted retroactively by sync, but only by same-subject children)
-- [ ] Implement content materialization: `snapshot` if present, otherwise the base
-      (parent's materialization, or `subject` when `parents` is empty); reject a
-      multi-parent revision without `snapshot`
-- [ ] Implement (or specify) a merge tool that resolves concurrent heads into a new revision
-      with multiple `parents` and a `snapshot`
-- [ ] Tests: linear history, branch + merge, many heads for one subject, archived object,
-      generation cache mismatch, first revision materializing from `subject`, a head demoted
-      retroactively by a newly synced revision
-- [ ] Teach the MCP server to surface the media type derived from a stored `dialect` as the
-      response `mimeType` (`application/{dialect}+json`, allowlisted `vnd.fjs.*` dialects +
-      schema validation, never a blind echo) instead of the generic text fallback,
-      size-bounded to the 128 KiB inline cap so the metadata path stays O(1)-space for
-      larger blobs — see
-      [../mcp/todo/cas-get-mcp-resource-response.md](../mcp/todo/cas-get-mcp-resource-response.md)
+- [ ] Teach `fs/media` detection to recognize valid revision JSON and return the derived
+      media type `application/vnd.fjs.revision+json`, falling through to the existing
+      detector for unknown dialects or invalid revision blobs
+- [ ] Tests: valid revision detection, invalid revision fallthrough, `https://` bridge URL
+      rejection in `subject`, `parents`, and `snapshot`, first-key `dialect` prefix matching,
+      and ordinary JSON fallback behavior
 - [ ] Later, as a separate spec: define the incremental-change dialect `vnd.fjs.change`
       (event log, likely CRDT-based) and how revisions link to it — a new dialect, not a
       new field of this format


### PR DESCRIPTION
### Motivation

- Limit the initial work to pure media detection so `fs/media` can identify revision blobs without introducing store-side evolution or MCP response behavior. 
- Ensure the v1 dialect uses content-addressed (hash) references only so readers never accept location-style URLs accidentally. 
- Remove the planned `fs/cas/evo` materialization/mcp subtasks from this change so the first step is only schema + detector.

### Description

- Updated `fs/cas/todo/revision-content-format.md` to scope the first implementation to `fs/media` detection and to explicitly defer store-touching evolution work. 
- Changed the proposed schema to use `hash` for `subject`, `parents`, and `snapshot` and documented that `https://` bridge URLs and other location-addressed refs are rejected for this dialect. 
- Replaced the MCP response-shaping / server mime-type section with a local `fs/media` detection requirement and marked the materialization algorithm as future/out-of-scope for the detector-only change. 
- Simplified the tasks list to focus on creating `fs/media/revision/README.md`, adding the RTTI schema/module, teaching `fs/media` detection to return `application/vnd.fjs.revision+json`, and tests for detection/fallback and hash-only validation.

### Testing

- Ran `git diff --check` to validate there are no whitespace or diff-check errors and it succeeded. 
- Performed local file inspections of `fs/cas/todo/revision-content-format.md` to verify the intended text replacements and task updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50e0e02ee0832bb3d2d799ce1d491a)