### PR TITLE
Add test3 to exercise branch-merge-into-Branch5-sibling path

### DIFF
--- a/fs/types/btree/remove/proof.f.ts
+++ b/fs/types/btree/remove/proof.f.ts
@@ -485,7 +485,32 @@ const test2 = () => {
     }
 }
 
+// Exercises the branch-merge-into-Branch5-sibling path in reduceValue0
+// (removing an underflowed left leaf merges into a 5-wide right branch).
+const test3 = () => {
+    let _map: TNode<string> | null = ['1']
+    for (let i = 2; i <= 50; i++)
+        _map = set(_map)(i.toString())
+
+    _map = remove(_map)('40')
+    if (_map === null) { throw _map }
+
+    _map = remove(_map)('10')
+    if (_map === null) { throw _map }
+    const r = jsonStr(_map)
+    if (r !==
+        '[[[[["1","11"],"12",["13"],"14",["15"]],"16",[["17"],"18",["19"]],"2",[["20"],"21",["22"]]],' +
+        '"23",' +
+        '[[["24"],"25",["26"]],"27",[["28"],"29",["3"]]]],' +
+        '"30",' +
+        '[[[["31"],"32",["33"]],"34",[["35"],"36",["37"],"38",["39"]]],' +
+        '"4",' +
+        '[[["41","42"],"43",["44"],"45",["46"]],"47",[["48"],"49",["5","50"]],"6",[["7"],"8",["9"]]]]]'
+    ) { throw r }
+}
+
 export const proof = {
     test,
     test2,
+    test3,
 }


### PR DESCRIPTION
## Summary
Added a new test case (`test3`) to the B-tree removal proof module to exercise the branch-merge-into-Branch5-sibling code path in `reduceValue0`.

## Key Changes
- Added `test3` function that builds a B-tree with 50 entries and performs two removal operations
- Tests the specific scenario where removing an underflowed left leaf causes it to merge into a 5-wide right branch
- Validates the resulting tree structure against an expected JSON representation
- Exported `test3` in the proof object alongside existing `test` and `test2`

## Implementation Details
The test:
1. Constructs a B-tree by inserting keys '1' through '50'
2. Removes key '40' to trigger structural changes
3. Removes key '10' to trigger the branch-merge-into-Branch5-sibling path
4. Verifies the final tree structure matches the expected nested array representation

This test case improves code coverage for the B-tree removal algorithm's edge cases.

https://claude.ai/code/session_01Kcp5hdbdNv9LQ4jiaz6xEb