### PR TITLE
Add test cases for padded base64 decode rejection scenarios

### DIFF
--- a/fs/basen/base64/proof.f.ts
+++ b/fs/basen/base64/proof.f.ts
@@ -85,6 +85,20 @@ export const proof = {
         const oversized = 'A'.repeat(174_764)
         assertEq(decode(oversized), null)
     },
+    decodePaddedTailRejections: () => {
+        // These all take the padded branch of `decode` (`padChars > 0`,
+        // i.e. the `head`/`lastChunk` split), unlike `decodeOverflow` above
+        // which takes the unpadded fast path. An invalid character before
+        // the final char must be rejected via the `head` decode...
+        assertEq(decode('!A=='), null)
+        // ...and an invalid final character (the one holding the padding
+        // bits) must be rejected via the last-character decode.
+        assertEq(decode('A!=='), null)
+        // Same as `decodeOverflow`, but with a padded tail so it's the
+        // padded branch that measures the result against `maxLength` and
+        // rejects it.
+        assertEq(decode('A'.repeat(174_764) + '='), null)
+    },
     encodeAtMaxLengthSucceeds: () => {
         // A `maxLength`-sized vector's trailing partial 6-bit chunk is
         // left-padded by `vecToString` itself (see `baseN`), so `encode`


### PR DESCRIPTION
## Summary
Added comprehensive test coverage for base64 decode rejection cases that exercise the padded decoding branch, complementing existing overflow tests.

## Key Changes
- Added `decodePaddedTailRejections` test function with three test cases:
  - Invalid character before padding (`!A==`) - validates rejection via head decode path
  - Invalid final character holding padding bits (`A!==`) - validates rejection via last-character decode path
  - Oversized input with padded tail - validates that padded branch correctly measures result against `maxLength` and rejects overflow

## Implementation Details
These tests specifically target the padded branch of the `decode` function (when `padChars > 0`), which uses a different code path than the unpadded fast path tested in `decodeOverflow`. The tests ensure that invalid characters are properly rejected at different stages of the padded decoding process and that length validation works correctly for padded inputs.

https://claude.ai/code/session_015arff7nAvYnSP755sfMSGo