### PR TITLE
Update Rust toolchain to 1.97.0 and FunctionalScript to 0.37.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@
           "run": "sudo apt-get update && sudo apt-get install -y libc6-dev-i386"
         },
         {
-          "uses": "dtolnay/rust-toolchain@1.96.1",
+          "uses": "dtolnay/rust-toolchain@1.97.0",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "i686-unknown-linux-gnu"
@@ -28,7 +28,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.36.0"
+          "run": "npm install -g functionalscript@0.37.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -69,7 +69,7 @@
       "runs-on": "ubuntu-26.04-arm",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.96.1",
+          "uses": "dtolnay/rust-toolchain@1.97.0",
           "with": {
             "components": "rustfmt,clippy"
           }
@@ -81,7 +81,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.36.0"
+          "run": "npm install -g functionalscript@0.37.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -110,7 +110,7 @@
       "runs-on": "macos-26-intel",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.96.1",
+          "uses": "dtolnay/rust-toolchain@1.97.0",
           "with": {
             "components": "rustfmt,clippy"
           }
@@ -122,7 +122,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.36.0"
+          "run": "npm install -g functionalscript@0.37.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -151,7 +151,7 @@
       "runs-on": "macos-26",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.96.1",
+          "uses": "dtolnay/rust-toolchain@1.97.0",
           "with": {
             "components": "rustfmt,clippy"
           }
@@ -163,7 +163,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.36.0"
+          "run": "npm install -g functionalscript@0.37.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -192,7 +192,7 @@
       "runs-on": "windows-2025",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.96.1",
+          "uses": "dtolnay/rust-toolchain@1.97.0",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "i686-pc-windows-msvc"
@@ -205,7 +205,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.36.0"
+          "run": "npm install -g functionalscript@0.37.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -246,7 +246,7 @@
       "runs-on": "windows-11-arm",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.96.1",
+          "uses": "dtolnay/rust-toolchain@1.97.0",
           "with": {
             "components": "rustfmt,clippy"
           }
@@ -258,7 +258,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.36.0"
+          "run": "npm install -g functionalscript@0.37.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -287,7 +287,7 @@
       "runs-on": "ubuntu-26.04-arm",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.96.1",
+          "uses": "dtolnay/rust-toolchain@1.97.0",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads"
@@ -395,13 +395,13 @@
           }
         },
         {
-          "run": "deno install -g -A --minimum-dependency-age=0 npm:functionalscript@0.36.0"
+          "run": "deno install -g -A --minimum-dependency-age=0 npm:functionalscript@0.37.0"
         },
         {
           "uses": "actions/checkout@v7"
         },
         {
-          "run": "deno run -A --minimum-dependency-age=0 npm:functionalscript@0.36.0 t"
+          "run": "deno run -A --minimum-dependency-age=0 npm:functionalscript@0.37.0 t"
         },
         {
           "run": "deno install --frozen"
@@ -424,7 +424,7 @@
           }
         },
         {
-          "run": "bun install -g functionalscript@0.36.0"
+          "run": "bun install -g functionalscript@0.37.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -433,7 +433,7 @@
           "run": "bun install --frozen-lockfile"
         },
         {
-          "run": "bunx functionalscript@0.36.0 t"
+          "run": "bunx functionalscript@0.37.0 t"
         },
         {
           "run": "bun test --coverage"
@@ -453,7 +453,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.36.0"
+          "run": "npm install -g functionalscript@0.37.0"
         },
         {
           "uses": "actions/checkout@v7"

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -25,7 +25,7 @@ export const images = {
 // published FunctionalScript release; do not tie it to package.json's current
 // in-repo version.
 // https://www.npmjs.com/package/functionalscript
-export const functionalscript = '0.36.0' as const
+export const functionalscript = '0.37.0' as const
 
 // https://bun.sh/
 export const bun = '1.3.14'
@@ -69,5 +69,5 @@ export const actions = {
     // https://github.com/wasmerio/setup-wasmer
     'wasmerio/setup-wasmer': 'v3.1',
     // https://rust-lang.org/ - value is Rust version, not action version
-    'dtolnay/rust-toolchain': '1.96.1',
+    'dtolnay/rust-toolchain': '1.97.0',
 } as const


### PR DESCRIPTION
## Summary
This PR updates the CI configuration and build tool versions to use newer releases of Rust and FunctionalScript across all build environments.

## Key Changes
- **Rust toolchain**: Updated from 1.96.1 to 1.97.0 across all CI jobs (Linux x86_64, Linux ARM, macOS Intel, macOS ARM, Windows, and WebAssembly)
- **FunctionalScript**: Updated from 0.36.0 to 0.37.0 across all package managers (npm, deno, bun)
- Updated both `.github/workflows/ci.yml` and `fs/ci/config/module.f.ts` to maintain consistency

## Implementation Details
- Changes applied consistently across 6 different CI job configurations (ubuntu-26.04, ubuntu-26.04-arm, macos-26-intel, macos-26, windows-2025, windows-11-arm)
- FunctionalScript version updated in all installation methods: npm install, deno install, and bun install
- Configuration centralized in `fs/ci/config/module.f.ts` with corresponding updates to the generated CI workflow file

https://claude.ai/code/session_01FgMqDfxvZo4S5q9HRvevFD