### PR TITLE
Add test case for missing file error handling in proof add

### DIFF
--- a/fs/cas/cli/proof.f.ts
+++ b/fs/cas/cli/proof.f.ts
@@ -47,6 +47,13 @@ export const proof = {
         assertEq(exitCode, 1)
         assert(finalState.stderr.length !== 0)
     },
+    mainAddMissingFile: () => {
+        // The source path doesn't exist, so `streamFile`'s first read comes back as an
+        // error item; `write` fails closed with that error and the handler exits 1
+        // without ever calling `log` — covers the `hashResult[0] === 'error'` branch.
+        const [, exitCode] = virtual(emptyState)(main(makeOptions(['add', 'missing'])))
+        assertEq(exitCode, 1)
+    },
     mainGetFound: () => {
         const content = vec8(0x2An)
         const state = { ...emptyState, root: { myfile: [content] } }


### PR DESCRIPTION
## Summary
Added a new test case to verify error handling when attempting to add a missing file in the proof command.

## Key Changes
- Added `mainAddMissingFile` test function that validates the behavior when the source file doesn't exist
- The test verifies that `streamFile`'s initial read returns an error item, causing `write` to fail and the handler to exit with code 1
- This test case covers the `hashResult[0] === 'error'` branch that was previously untested

## Implementation Details
- The test uses the `virtual` function with `emptyState` to simulate a file system where the 'missing' file doesn't exist
- Asserts that the exit code is 1, confirming proper error handling without requiring `log` to be called
- Follows the existing test pattern used in other test cases in the same file

https://claude.ai/code/session_0195LdoA2zTGUeozo46viLz8