### PR TITLE
todo: design-first issues for CLI options and CAS command architecture

### DIFF
--- a/fs/cas/todo/66g-cas-get-verify-option.md
+++ b/fs/cas/todo/66g-cas-get-verify-option.md
@@ -1,7 +1,8 @@
 ## 66G-cas-get-verify-option. Option to verify the hash during cas get / read
 
-**Priority:** P3
-**Status:** open
+**Priority:** P4
+**Status:** blocked
+**Blocked by:** [fs/cli options-edsl](../../cli/todo/options-edsl.md), [command-architecture](command-architecture.md)
 
 ### Problem
 
@@ -31,11 +32,24 @@ Keep it opt-in: verification costs a full rehash per read, which is wasteful for
 that already trust the store. Callers that need integrity (untrusted source, security-sensitive
 content, freshly synced data not yet scrubbed) turn it on.
 
+**Blocked** (see the metadata above): the `--verify` flag must be declared through the CLI
+options eDSL ([fs/cli options-edsl](../../cli/todo/options-edsl.md)), not hand-parsed out of
+`args`; and whether/where the option surfaces on other transports is an exposure-matrix
+decision for the CAS command architecture
+([command-architecture](command-architecture.md)). A working prototype exists in the closed
+PR [#1277](https://github.com/functionalscript/functionalscript/pull/1277): a streaming
+`verifyHash` core (folds the read stream into a fresh SHA-2 state, so it is not bound by the
+128 KiB `Vec` cap) plus CLI/MCP wiring and tests. The core function and its tests are worth
+reusing; the transport wiring is what the blockers replace.
+
 Open design points:
 
 - default off vs. on for `cas get`;
-- whether to expose it through the MCP CAS tools as well;
-- error shape on mismatch (treat as not-found vs. a distinct "corrupted" error).
+- whether to expose it through the MCP CAS tools as well — deferred to the
+  [command-architecture](command-architecture.md) exposure matrix;
+- error shape on mismatch (treat as not-found vs. a distinct "corrupted" error; the
+  prototype used a distinct "hash mismatch" error, which keeps a present-but-corrupted
+  blob distinguishable from an absent one).
 
 ### Tasks
 
@@ -48,4 +62,8 @@ Open design points:
 ### Related
 
 - [66g-cas-verify-command](66g-cas-verify-command.md) — batch scrub for the same invariant
+- [command-architecture](command-architecture.md) — decides which transports expose this
+- [fs/cli options-edsl](../../cli/todo/options-edsl.md) — the declarative `--verify` flag
+- PR [#1277](https://github.com/functionalscript/functionalscript/pull/1277) (closed) —
+  prototype implementation kept for reference
 - `issues/plan/vision.md` — protocol-agnostic synchronization / copy-files sync

--- a/fs/cas/todo/66k-cas-cli-mcp-shared-core.md
+++ b/fs/cas/todo/66k-cas-cli-mcp-shared-core.md
@@ -1,7 +1,16 @@
 ## 66K-cas-cli-mcp-shared-core. Share code between CAS CLI and MCP
 
 **Priority:** P3
-**Status:** open
+**Status:** blocked
+**Blocked by:** [command-architecture](command-architecture.md)
+
+> **Re-scoped (2026-07):** this issue is now the *implementation* follow-up
+> of the CAS command architecture design
+> ([command-architecture](command-architecture.md)). The design decides the
+> command set, the typed input/output contracts, the error taxonomy, and the
+> per-transport exposure matrix; the duplication inventory and the unified
+> `add` notes below feed into that design and are then implemented against
+> it, not independently.
 
 ### Problem
 

--- a/fs/cas/todo/command-architecture.md
+++ b/fs/cas/todo/command-architecture.md
@@ -1,0 +1,81 @@
+## command-architecture. Design a transport-agnostic CAS command architecture
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+CAS functionality is exposed through two transports — the CLI
+(`fs/cas/cli/module.f.ts`) and the MCP server (`fs/cas/mcp/module.f.ts`) —
+and each wires its own logic directly onto the store primitives in
+`fs/cas/module.f.ts`. There is no defined notion of a *CAS command*: no
+shared command set, no typed input/output contracts, no common error
+taxonomy, and no stated policy of which transport exposes which operation.
+
+The consequence is that every new feature is pumped into each transport
+separately. PR #1277 (closed) is the motivating example: read-time hash
+verification was added as a hand-parsed `--verify` CLI flag *and* a
+parallel `verify: true` MCP argument — two ad hoc patches around one core
+function, each with its own error wording and flow. A third transport
+(a Web API server, [web-api-server](./web-api-server.md)) would turn the
+duplication into triplication.
+
+[66k-cas-cli-mcp-shared-core](./66k-cas-cli-mcp-shared-core.md) already
+catalogues the existing duplication, but it is written as a mechanical
+dedup refactor of the three current operations. What is missing is the
+design layer above it: what the command set *is*, before any refactoring.
+
+### Proposal
+
+**This is a design task, not an implementation task.** The deliverable is a
+reviewed design document (in `fs/cas/README.md` or a dedicated doc under
+`fs/cas/`); implementation is then re-filed as follow-up issues sized from
+the design.
+
+The design should answer:
+
+1. **What a CAS command is** — a named operation with a typed input, a
+   typed output, and errors drawn from a shared taxonomy (invalid hash /
+   not found / too large / hash mismatch / …), defined independently of any
+   transport and generic in the effect set (`Cas<O>` in, `Effect` out).
+2. **The command set** — today's `add`, `get`, `list`; planned commands
+   such as the batch scrub ([66g-cas-verify-command](./66g-cas-verify-command.md)),
+   read-time verification ([66g-cas-get-verify-option](./66g-cas-get-verify-option.md)),
+   and the Evo operations ([evo](./evo.md)).
+3. **The exposure matrix** — which transports (CLI, MCP,
+   [Web API](./web-api-server.md)) expose which commands, with what
+   restrictions. Known constraint to encode: file-path `add` is CLI-only —
+   the MCP server never opens a client-named path (see the invariant in
+   `fs/cas/mcp/README.md`); the same rule presumably binds a Web API.
+4. **How one declaration drives every adapter.** An idea to evaluate, not
+   prescribe: rtti structs are already the MCP argument schema (deriving
+   both `inputSchema` and `validate`); the same struct could drive CLI
+   option parsing ([fs/cli options-edsl](../../cli/todo/options-edsl.md))
+   and Web API request validation, making the command declaration the
+   single source of truth for names, arguments, help, and error messages.
+5. **Where the shared layer lives** (e.g. `fs/cas/commands/`) and its
+   layering rules: commands depend on the store core and stay
+   effect-generic; transports depend on commands; the store core never
+   depends on a transport.
+
+### Tasks
+
+- [ ] Inventory the current duplication (start from the list in
+      [66k-cas-cli-mcp-shared-core](./66k-cas-cli-mcp-shared-core.md)).
+- [ ] Write and review the design covering points 1–5.
+- [ ] Re-scope [66k-cas-cli-mcp-shared-core](./66k-cas-cli-mcp-shared-core.md)
+      as the implementation of the chosen design, or fold it in and delete it.
+- [ ] File implementation follow-ups; unblock
+      [66g-cas-get-verify-option](./66g-cas-get-verify-option.md) and
+      [web-api-server](./web-api-server.md).
+
+### Related
+
+- [66k-cas-cli-mcp-shared-core](./66k-cas-cli-mcp-shared-core.md) — the
+  implementation follow-up, now blocked on this design.
+- [fs/cli options-edsl](../../cli/todo/options-edsl.md) — the CLI-side
+  declaration mechanism a shared command declaration would plug into.
+- [web-api-server](./web-api-server.md) — the third transport this design
+  must anticipate.
+- [evo](./evo.md) — future commands facing the same CLI/MCP/HTTP question.
+- PR #1277 (closed) — the motivating ad hoc feature patch.

--- a/fs/cas/todo/web-api-server.md
+++ b/fs/cas/todo/web-api-server.md
@@ -1,0 +1,49 @@
+## web-api-server. Web API (HTTP) server as a third CAS transport
+
+**Priority:** P4
+**Status:** blocked
+**Blocked by:** [command-architecture](./command-architecture.md)
+
+### Problem
+
+CAS is reachable only through the CLI and the stdio MCP server. Both are
+per-user, per-process front ends: browsers and remote clients cannot reach
+a store at all, and every stdio MCP instance carries its own process state —
+the Evo proposal ([evo](./evo.md)) already runs into this and floats an
+HTTP(S) server as the way to share one cache across many clients.
+
+Adding an HTTP front end today would mean a third hand-wired copy of the
+command logic — exactly the duplication
+[command-architecture](./command-architecture.md) is being designed to
+eliminate. This issue is therefore blocked on that design.
+
+### Proposal
+
+Once the command architecture exists, expose a subset of the CAS command
+set over HTTP(S):
+
+- the exposed subset and its restrictions come from the architecture's
+  exposure matrix (e.g. no client-named local paths, same as MCP);
+- authentication/authorization is a hard prerequisite for anything
+  non-local (also flagged in [evo](./evo.md)) and needs its own design
+  before the server is reachable beyond localhost;
+- request/response validation should derive from the same command
+  declarations that drive the CLI and MCP adapters;
+- large blobs favour HTTP: streaming request/response bodies avoid the MCP
+  128 KiB inline-content cap, so `add`/`get` of arbitrary-size content is a
+  natural fit for this transport.
+
+### Tasks
+
+- [ ] Wait for the CAS command architecture design
+      ([command-architecture](./command-architecture.md)).
+- [ ] Design authentication and the exposed command subset.
+- [ ] Implement the HTTP adapter over the shared command layer, with proof
+      coverage against the virtual effects runner.
+
+### Related
+
+- [command-architecture](./command-architecture.md) — prerequisite design.
+- [evo](./evo.md) — already floats an HTTP(S) server and its auth question.
+- `fs/effects/node/todo/requestlistener-stateful.md` — HTTP listener
+  effects groundwork.

--- a/fs/cas/todo/web-api-server.md
+++ b/fs/cas/todo/web-api-server.md
@@ -34,9 +34,17 @@ set over HTTP(S):
   before the server is reachable beyond localhost;
 - request/response validation should derive from the same command
   declarations that drive the CLI and MCP adapters;
-- large blobs favour HTTP: streaming request/response bodies avoid the MCP
-  128 KiB inline-content cap, so `add`/`get` of arbitrary-size content is a
-  natural fit for this transport.
+- large blobs favour HTTP *in principle*: the protocol streams
+  request/response bodies, so `add`/`get` of arbitrary-size content is a
+  natural fit for this transport where MCP is capped at 128 KiB of inline
+  content. But the current HTTP effects do not stream:
+  `IncomingMessage.body` / `ServerResponse.body`
+  (`fs/effects/node/module.f.ts`) are single `Vec`s, and the Node runner
+  buffers the whole request (`collect(req)` → `listToVec`) — past the
+  128 KiB `Vec` limit it throws. The CAS store side already streams
+  (`Cas.read`/`Cas.write` deal in chunk lists), so lifting the cap needs
+  **streaming request/response body effects** as a prerequisite; until that
+  design exists, an HTTP adapter inherits the same inline cap as MCP.
 
 **Human-readable HTML pages.** The same server should also serve HTML, so a
 human can browse a CAS in an ordinary browser — one server, two
@@ -62,6 +70,11 @@ HTML form is an exposure-matrix decision for
 
 - [ ] Wait for the CAS command architecture design
       ([command-architecture](./command-architecture.md)).
+- [ ] Design streaming HTTP request/response body effects in
+      `fs/effects/node` (today `IncomingMessage`/`ServerResponse` carry a
+      single `Vec` body, buffered whole by the runner) — prerequisite for
+      arbitrary-size `add`/`get`; without it the adapter keeps the 128 KiB
+      inline cap.
 - [ ] Design authentication and the exposed command subset.
 - [ ] Design the HTML browsing surface: routes / content negotiation, the
       list and blob pages, dialect-aware rendering (revision DAG links).
@@ -80,3 +93,6 @@ HTML form is an exposure-matrix decision for
   navigable DAG.
 - `fs/effects/node/todo/requestlistener-stateful.md` — HTTP listener
   effects groundwork.
+- `fs/effects/node/module.f.ts` (`IncomingMessage`/`ServerResponse`) — the
+  whole-body `Vec` HTTP effects that need a streaming redesign before this
+  transport can carry blobs past 128 KiB.

--- a/fs/cas/todo/web-api-server.md
+++ b/fs/cas/todo/web-api-server.md
@@ -12,6 +12,11 @@ a store at all, and every stdio MCP instance carries its own process state —
 the Evo proposal ([evo](./evo.md)) already runs into this and floats an
 HTTP(S) server as the way to share one cache across many clients.
 
+There is also no way for a *human* to look at a store: every existing front
+end targets a program (shell scripts, MCP agents). Inspecting what a store
+contains — the hash list, a blob's type and size, a revision's parents —
+currently requires driving the CLI or MCP by hand.
+
 Adding an HTTP front end today would mean a third hand-wired copy of the
 command logic — exactly the duplication
 [command-architecture](./command-architecture.md) is being designed to
@@ -33,17 +38,45 @@ set over HTTP(S):
   128 KiB inline-content cap, so `add`/`get` of arbitrary-size content is a
   natural fit for this transport.
 
+**Human-readable HTML pages.** The same server should also serve HTML, so a
+human can browse a CAS in an ordinary browser — one server, two
+representations of the same commands, selected by content negotiation
+(`Accept: text/html` vs `application/json`) or by parallel routes. Browsing
+should cover at least:
+
+- the hash list (`list`) as a page of links;
+- a blob page (`get`): metadata (size, detected media type) plus a rendered
+  view of the content — images inline, text as text, JSON syntax-highlighted
+  ([fs/media/json-html](../../media/html/todo/665-json-html.md) is the
+  building block for that), binaries as a download link;
+- recognized dialects rendered with their structure: a
+  `vnd.fjs.revision` blob (`fs/media/revision/`) should show its `subject`,
+  `snapshot`, and `parents` as clickable links, so a human can walk the
+  revision DAG hash by hash.
+
+The HTML view is read-only browsing; whether any mutating command gets an
+HTML form is an exposure-matrix decision for
+[command-architecture](./command-architecture.md).
+
 ### Tasks
 
 - [ ] Wait for the CAS command architecture design
       ([command-architecture](./command-architecture.md)).
 - [ ] Design authentication and the exposed command subset.
+- [ ] Design the HTML browsing surface: routes / content negotiation, the
+      list and blob pages, dialect-aware rendering (revision DAG links).
 - [ ] Implement the HTTP adapter over the shared command layer, with proof
       coverage against the virtual effects runner.
+- [ ] Implement the HTML pages on the same adapter (JSON and HTML are two
+      renderings of the same command results, not two code paths).
 
 ### Related
 
 - [command-architecture](./command-architecture.md) — prerequisite design.
 - [evo](./evo.md) — already floats an HTTP(S) server and its auth question.
+- [fs/media/json-html](../../media/html/todo/665-json-html.md) — JSON →
+  syntax-highlighted HTML rendering for the blob page.
+- `fs/media/revision/` — dialect whose blobs the browser should render as a
+  navigable DAG.
 - `fs/effects/node/todo/requestlistener-stateful.md` — HTTP listener
   effects groundwork.

--- a/fs/cli/todo/options-edsl.md
+++ b/fs/cli/todo/options-edsl.md
@@ -1,0 +1,73 @@
+## options-edsl. Declarative options in the CLI eDSL
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+`Command` (`fs/cli/module.f.ts`) hands every handler a raw
+`args: readonly string[]` and has no concept of a named option. Any command
+that wants a flag has to hand-parse it:
+
+```ts
+const verify = args.includes('--verify')
+const [hashCBase32, path, ...rest] = args.filter(a => a !== '--verify')
+```
+
+(the `cas get --verify` prototype in PR #1277, closed for exactly this
+reason). Hand-parsing is stringly-typed and wrong in every direction:
+
+- a typo (`--verfy`) is not rejected — it silently becomes a positional
+  argument and surfaces as a misleading arity or invalid-hash error;
+- the option is invisible to the help table `dispatch` renders; the only
+  place to document it is free text in `description`;
+- every next flag copies the same pattern — one divergent parser per
+  command, with no compile-time link between what is parsed and what the
+  handler reads.
+
+### Proposal
+
+Extend the eDSL so a command *declares* its positional parameters and named
+options, and the `fs/cli` layer owns parsing, validation, help rendering,
+and handing the handler a typed record instead of a raw array.
+
+Design first, then migrate. The design should settle:
+
+- the declaration form — e.g. `Command` gaining `params`/`options` fields
+  that `dispatch` validates and folds into the help text;
+- parsing rules: `--flag` booleans, `--key value` and/or `--key=value`,
+  rejection of unknown options, a `--` positional terminator;
+- typing: the handler's input type should be *derived* from the
+  declaration, not asserted. Consider rtti structs as the declaration
+  language — the CAS MCP layer already declares tool args as rtti structs
+  used for both `inputSchema` and `validate`; one declaration could drive
+  CLI parsing and help the same way. Whether that struct should be shared
+  across transports is evaluated in
+  [fs/cas command-architecture](../../cas/todo/command-architecture.md);
+- coordination with [positional-arity-check](./positional-arity-check.md)
+  (arity validation is subsumed by declared positionals) and
+  [fs/fjs 66g-fjs-run-commands](../../fjs/todo/66g-fjs-run-commands.md)
+  (the `Commands` reshaping this should ride along with).
+
+### Tasks
+
+- [ ] Design the declaration shape and parsing rules; record the decision
+      in this file or `fs/cli/README.md`.
+- [ ] Implement parsing, validation, and help rendering in `fs/cli` with
+      proof coverage.
+- [ ] Migrate existing commands; retire the hand-rolled arity checks
+      ([positional-arity-check](./positional-arity-check.md)).
+- [ ] `npx tsc`, `fjs t`.
+
+### Related
+
+- [positional-arity-check](./positional-arity-check.md) — subsumed by
+  declared positional parameters.
+- [dispatch-help-rendering](./dispatch-help-rendering.md) — the help
+  rendering that declared options must plug into.
+- `fs/fjs/todo/66g-fjs-run-commands.md` — the `Commands` reshaping to
+  coordinate with.
+- [fs/cas 66g-cas-get-verify-option](../../cas/todo/66g-cas-get-verify-option.md)
+  — first feature blocked on this.
+- [fs/cas command-architecture](../../cas/todo/command-architecture.md) —
+  the transport-neutral command declaration this may share a language with.

--- a/fs/cli/todo/options-edsl.md
+++ b/fs/cli/todo/options-edsl.md
@@ -23,7 +23,12 @@ reason). Hand-parsing is stringly-typed and wrong in every direction:
   place to document it is free text in `description`;
 - every next flag copies the same pattern — one divergent parser per
   command, with no compile-time link between what is parsed and what the
-  handler reads.
+  handler reads;
+- non-declarative parsing must keep `help` and documentation in sync with
+  the parser by hand: the parsing code, the `description` text, and any
+  README all state the option independently, and nothing detects when they
+  drift apart. With a declarative option, the declaration *is* the single
+  source the help and docs are generated from.
 
 ### Proposal
 


### PR DESCRIPTION
## Summary

Follow-up to #1277 (closed unmerged). That PR wired a `--verify` feature into the CLI by hand-parsing `args` and into MCP as a parallel ad hoc patch — symptoms of two missing designs rather than a missing feature. This PR replaces the implementation with design-first todos:

**New issues**

- `fs/cli/todo/options-edsl.md` (P3) — declarative options/positionals in the CLI `Command` eDSL: parsing, validation, unknown-option rejection, and help rendering owned by `fs/cli`, with the handler input type derived from the declaration. Coordinates with `positional-arity-check`, `dispatch-help-rendering`, and `66g-fjs-run-commands`.
- `fs/cas/todo/command-architecture.md` (P3) — a **design task** (not implementation): define what a CAS command is (typed input/output, shared error taxonomy), the command set, the per-transport exposure matrix (CLI / MCP / Web API), and how one declaration drives every adapter (e.g. rtti structs already drive MCP `inputSchema` + `validate`; evaluate extending that to CLI and HTTP).
- `fs/cas/todo/web-api-server.md` (P4, blocked by the architecture design) — HTTP(S) as a third CAS transport: shares the command layer, needs an auth design, and lifts the MCP 128 KiB inline cap via streaming bodies. Also relevant to `evo.md`, which already floats an HTTP server for shared cache state.

**Updated issues**

- `fs/cas/todo/66g-cas-get-verify-option.md` — P3 → P4, `open` → `blocked` (by the two design issues). References the closed #1277 prototype: the streaming `verifyHash` core there is worth reusing; the transport wiring is what the blockers replace.
- `fs/cas/todo/66k-cas-cli-mcp-shared-core.md` — re-scoped as the implementation follow-up of `command-architecture`, now blocked by it; its duplication inventory feeds the design.

No code changes — todo files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013aiqKbxzmAQ7vMv2xoRY6h

---
_Generated by [Claude Code](https://claude.ai/code/session_013aiqKbxzmAQ7vMv2xoRY6h)_