### PR TITLE
Add proof object for pushKey defensive branch coverage

### DIFF
--- a/fs/media/json/parser/module.f.ts
+++ b/fs/media/json/parser/module.f.ts
@@ -10,6 +10,7 @@ import { type JsonToken } from '../tokenizer/module.f.ts'
 import { setReplace, type OrderedMap } from '../../../types/ordered_map/module.f.ts'
 import { type Unknown } from '../module.f.ts'
 import { fromMap } from '../../../types/object/module.f.ts'
+import { assertEq } from '../../../asserts/module.f.ts'
 
 type JsonObject = {
     readonly kind: 'object'
@@ -239,3 +240,17 @@ export const parse
             default: return error('unexpected end')
         }
     }
+
+export const proof = {
+    pushKey: {
+        // `pushKey` is only ever invoked while `state.top` is an object (the
+        // state machine's `'{'`/`'{,'` statuses guarantee it), so its
+        // non-object guard is a defensive branch unreachable through `parse`.
+        // Call it directly to cover that branch.
+        nonObjectTop: () => {
+            const state: StateParse = { status: '[', top: { kind: 'array', values: null }, stack: null }
+            const result = pushKey(state)('key')
+            assertEq(result.status, 'error')
+        },
+    },
+}


### PR DESCRIPTION
## Summary
Added a `proof` export to the JSON parser module that provides test coverage for a defensive, unreachable code branch in the `pushKey` function.

## Key Changes
- Imported `assertEq` from the asserts module
- Added a `proof` object with a `pushKey.nonObjectTop` test case that:
  - Directly invokes `pushKey` with an array as the top-level state (instead of an object)
  - Verifies that the function correctly returns an error status for this defensive branch
  - Documents why this branch is unreachable through normal `parse` execution (the state machine's `'{'`/`'{,'` statuses guarantee `state.top` is always an object when `pushKey` is called)

## Implementation Details
The test creates a minimal `StateParse` state with an array kind at the top, calls `pushKey` with a key string, and asserts that the result has an error status. This ensures complete branch coverage of the `pushKey` function's guard clause.

https://claude.ai/code/session_01WfW1Fgkj5f4R6juHXrvHpA