### PR TITLE
Add defensive test case for UTF-8 byte scanning edge case

### DIFF
--- a/fs/text/utf8/proof.f.ts
+++ b/fs/text/utf8/proof.f.ts
@@ -1,4 +1,4 @@
-import { toCodePointList, fromCodePointList, fromVec } from './module.f.ts'
+import { toCodePointList, fromCodePointList, fromVec, utf8ByteToCodePointOp } from './module.f.ts'
 import { stringify as jsonStringify } from '../../media/json/module.f.ts'
 import { sort } from '../../types/object/module.f.ts'
 import { toArray } from '../../types/list/module.f.ts'
@@ -74,6 +74,13 @@ export const proof = {
         () => {
             const result = stringify(toArray(toCodePointList([240, 144, 128, 128])))
             if (result !== '[65536]') { throw result }
+        },
+        // A byte stream never accumulates a 2-byte state whose lead is >= F8
+        // (isLeadByte caps leads at F4), so this defensive fallthrough is
+        // only reachable by calling the scan op directly with such a state.
+        () => {
+            const result = stringify(utf8ByteToCodePointOp(0x80, [0xf8, 0x80]))
+            if (result !== '[[-2147483136,-2147483520],null]') { throw result }
         }
     ],
     fromCodePointList: [


### PR DESCRIPTION
## Summary
Added a test case to the UTF-8 proof module that validates the defensive fallthrough behavior in the byte-to-code-point scanning operation when encountering invalid lead bytes.

## Key Changes
- Imported `utf8ByteToCodePointOp` function from the module to enable direct testing of the scan operation
- Added a new test case that verifies the behavior when calling the scan operation directly with an out-of-range lead byte (0xF8) and a continuation byte sequence
- The test documents that this defensive code path is normally unreachable through the public API since `isLeadByte` caps valid lead bytes at 0xF4

## Implementation Details
- The test calls `utf8ByteToCodePointOp(0x80, [0xf8, 0x80])` directly to exercise the defensive fallthrough
- Validates the expected output format: `[[-2147483136,-2147483520],null]`
- Includes explanatory comments clarifying why this edge case exists and when it can occur

https://claude.ai/code/session_012RV3PBnnE34NoeyF5eHbrL