### PR TITLE
Add test for non-octet-aligned Vec in UTF-8 proof

### DIFF
--- a/fs/text/utf8/proof.f.ts
+++ b/fs/text/utf8/proof.f.ts
@@ -2,7 +2,7 @@ import { toCodePointList, fromCodePointList, fromVec, utf8ByteToCodePointOp } fr
 import { stringify as jsonStringify } from '../../media/json/module.f.ts'
 import { sort } from '../../types/object/module.f.ts'
 import { toArray } from '../../types/list/module.f.ts'
-import { msb, u8ListToVec } from '../../types/bit_vec/module.f.ts'
+import { msb, u8ListToVec, vec } from '../../types/bit_vec/module.f.ts'
 
 const stringify = jsonStringify(sort)
 
@@ -206,6 +206,11 @@ export const proof = {
         () => {
             const v = u8ListToVec(msb)([0xf0, 0x80, 0x80, 0x80])
             if (fromVec(v) !== null) { throw 'expected null for overlong 4-byte encoding' }
+        },
+        // Vec length not a multiple of 8 bits → null
+        () => {
+            const v = vec(4n)(0n)
+            if (fromVec(v) !== null) { throw 'expected null for non-octet-aligned Vec' }
         },
     ]
 }

--- a/fs/text/utf8/proof.f.ts
+++ b/fs/text/utf8/proof.f.ts
@@ -3,6 +3,7 @@ import { stringify as jsonStringify } from '../../media/json/module.f.ts'
 import { sort } from '../../types/object/module.f.ts'
 import { toArray } from '../../types/list/module.f.ts'
 import { msb, u8ListToVec, vec } from '../../types/bit_vec/module.f.ts'
+import { assertEq } from '../../asserts/module.f.ts'
 
 const stringify = jsonStringify(sort)
 
@@ -210,7 +211,7 @@ export const proof = {
         // Vec length not a multiple of 8 bits → null
         () => {
             const v = vec(4n)(0n)
-            if (fromVec(v) !== null) { throw 'expected null for non-octet-aligned Vec' }
+            assertEq(fromVec(v), null)
         },
     ]
 }


### PR DESCRIPTION
## Summary
Added a new test case to the UTF-8 proof module to verify that `fromVec` correctly returns `null` when given a `Vec` with a length that is not a multiple of 8 bits.

## Changes
- Imported `vec` function from `bit_vec/module.f.ts` to enable test vector creation
- Added a new test case that:
  - Creates a 4-bit vector (not octet-aligned)
  - Verifies that `fromVec` returns `null` for this invalid input
  - Documents the expected behavior for non-octet-aligned vectors

## Details
This test ensures that the UTF-8 decoder properly validates that input vectors are aligned to 8-bit boundaries (octets), which is a requirement for valid UTF-8 byte sequences. The test complements existing validation tests for overlong encodings and other UTF-8 edge cases.

https://claude.ai/code/session_01UcnCWWHyDSAnRst2mXPVdF