### PR TITLE
Update CI dependencies and Rust/Deno versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,14 @@
           "run": "sudo apt-get update && sudo apt-get install -y libc6-dev-i386"
         },
         {
-          "uses": "dtolnay/rust-toolchain@1.97.0",
+          "uses": "dtolnay/rust-toolchain@1.97.1",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "i686-unknown-linux-gnu"
           }
         },
         {
-          "uses": "actions/setup-node@v6.4.0",
+          "uses": "actions/setup-node@v7.0.0",
           "with": {
             "node-version": "26.5.0"
           }
@@ -69,13 +69,13 @@
       "runs-on": "ubuntu-26.04-arm",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.97.0",
+          "uses": "dtolnay/rust-toolchain@1.97.1",
           "with": {
             "components": "rustfmt,clippy"
           }
         },
         {
-          "uses": "actions/setup-node@v6.4.0",
+          "uses": "actions/setup-node@v7.0.0",
           "with": {
             "node-version": "26.5.0"
           }
@@ -110,13 +110,13 @@
       "runs-on": "macos-26-intel",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.97.0",
+          "uses": "dtolnay/rust-toolchain@1.97.1",
           "with": {
             "components": "rustfmt,clippy"
           }
         },
         {
-          "uses": "actions/setup-node@v6.4.0",
+          "uses": "actions/setup-node@v7.0.0",
           "with": {
             "node-version": "26.5.0"
           }
@@ -151,13 +151,13 @@
       "runs-on": "macos-26",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.97.0",
+          "uses": "dtolnay/rust-toolchain@1.97.1",
           "with": {
             "components": "rustfmt,clippy"
           }
         },
         {
-          "uses": "actions/setup-node@v6.4.0",
+          "uses": "actions/setup-node@v7.0.0",
           "with": {
             "node-version": "26.5.0"
           }
@@ -192,14 +192,14 @@
       "runs-on": "windows-2025",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.97.0",
+          "uses": "dtolnay/rust-toolchain@1.97.1",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "i686-pc-windows-msvc"
           }
         },
         {
-          "uses": "actions/setup-node@v6.4.0",
+          "uses": "actions/setup-node@v7.0.0",
           "with": {
             "node-version": "26.5.0"
           }
@@ -246,13 +246,13 @@
       "runs-on": "windows-11-arm",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.97.0",
+          "uses": "dtolnay/rust-toolchain@1.97.1",
           "with": {
             "components": "rustfmt,clippy"
           }
         },
         {
-          "uses": "actions/setup-node@v6.4.0",
+          "uses": "actions/setup-node@v7.0.0",
           "with": {
             "node-version": "26.5.0"
           }
@@ -287,7 +287,7 @@
       "runs-on": "ubuntu-26.04-arm",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.97.0",
+          "uses": "dtolnay/rust-toolchain@1.97.1",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "wasm32-wasip1,wasm32-wasip2,wasm32-unknown-unknown,wasm32-wasip1-threads"
@@ -391,7 +391,7 @@
         {
           "uses": "denoland/setup-deno@v2.0.5",
           "with": {
-            "deno-version": "2.9.2"
+            "deno-version": "2.9.3"
           }
         },
         {
@@ -447,7 +447,7 @@
       "runs-on": "ubuntu-26.04-arm",
       "steps": [
         {
-          "uses": "actions/setup-node@v6.4.0",
+          "uses": "actions/setup-node@v7.0.0",
           "with": {
             "node-version": "22.23.1"
           }
@@ -473,7 +473,7 @@
       "runs-on": "ubuntu-26.04-arm",
       "steps": [
         {
-          "uses": "actions/setup-node@v6.4.0",
+          "uses": "actions/setup-node@v7.0.0",
           "with": {
             "node-version": "24.18.0"
           }
@@ -496,7 +496,7 @@
       "runs-on": "ubuntu-26.04-arm",
       "steps": [
         {
-          "uses": "actions/setup-node@v6.4.0",
+          "uses": "actions/setup-node@v7.0.0",
           "with": {
             "node-version": "26.5.0"
           }
@@ -525,7 +525,7 @@
       "runs-on": "ubuntu-26.04-arm",
       "steps": [
         {
-          "uses": "actions/setup-node@v6.4.0",
+          "uses": "actions/setup-node@v7.0.0",
           "with": {
             "node-version": "26.5.0"
           }

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -31,7 +31,7 @@ export const functionalscript = '0.37.0' as const
 export const bun = '1.3.14'
 
 // https://deno.com/
-export const deno = '2.9.2'
+export const deno = '2.9.3'
 
 // https://www.npmjs.com/package/playwright
 export const playwright = '1.61.1'
@@ -57,7 +57,7 @@ export const actions = {
     // https://github.com/marketplace/actions/checkout
     'actions/checkout': 'v7',
     // https://github.com/marketplace/actions/setup-node-js-environment
-    'actions/setup-node': 'v6.4.0',
+    'actions/setup-node': 'v7.0.0',
     // https://github.com/marketplace/actions/cache
     'actions/cache': 'v6.1.0',
     // https://github.com/marketplace/actions/setup-deno
@@ -69,5 +69,5 @@ export const actions = {
     // https://github.com/wasmerio/setup-wasmer
     'wasmerio/setup-wasmer': 'v3.1',
     // https://rust-lang.org/ - value is Rust version, not action version
-    'dtolnay/rust-toolchain': '1.97.0',
+    'dtolnay/rust-toolchain': '1.97.1',
 } as const


### PR DESCRIPTION
## Summary
This PR updates several CI dependencies and tool versions across the GitHub Actions workflow and configuration files.

## Key Changes
- **Rust toolchain**: Updated from `1.97.0` to `1.97.1` across all CI jobs
- **Node.js action**: Upgraded `actions/setup-node` from `v6.4.0` to `v7.0.0` across all CI jobs
- **Deno**: Updated from `2.9.2` to `2.9.3` in both the CI workflow and configuration module

## Implementation Details
- Updated `fs/ci/config/module.f.ts` to reflect the new versions as the source of truth for CI configuration
- All changes propagated consistently across multiple CI job definitions (Linux, macOS, Windows, and ARM runners)
- The updates maintain compatibility with existing CI workflows while bringing in the latest stable versions of these tools

https://claude.ai/code/session_01NTbkESZho2VrYDSLwDF5YG