### PR TITLE
Add test for invalid buffer size in writeFromStream

### DIFF
--- a/fs/effects/node/proof.f.ts
+++ b/fs/effects/node/proof.f.ts
@@ -1,9 +1,9 @@
-import { empty, isVec, uint, vec8, type Vec } from "../../types/bit_vec/module.f.ts"
+import { empty, isVec, uint, vec, vec8, type Vec } from "../../types/bit_vec/module.f.ts"
 import { utf8, utf8ToString } from "../../text/module.f.ts"
 import { decode, pure } from "../module.f.ts"
 import { both, fetch, mkdir, now, readdir, readFile, readUtf8File, rm, sandbox, writeFile, writeUtf8File, rename, readBytes, randomInt, writeFromStream, type IoResult } from "./module.f.ts"
 import { create as memCreate, read as memRead, write as memWrite } from "../memory/module.f.ts"
-import { empty as listEmpty } from "../list/module.f.ts"
+import { empty as listEmpty, nonEmpty as listNonEmpty } from "../list/module.f.ts"
 import { emptyState, virtual, type Dir } from "./virtual/module.f.ts"
 import { assert, assertEq, assertNotNullish } from '../../asserts/module.f.ts'
 
@@ -389,6 +389,15 @@ export const proof = {
             assert(t === 'error', result)
             const file = state.root.hello
             assert(!(!Array.isArray(file) || uint(file[0]) !== 0x2An), file)
+        },
+        invalidBufferSize: () => {
+            // A chunk whose bit length isn't a multiple of 8 trips the
+            // byte-alignment guard before `writeBytes` is ever called.
+            const [_, [t, result]] = virtual(emptyState)(
+                writeFromStream('hello', listNonEmpty<never, IoResult<Vec>>(['ok', vec(4n)(0b1010n)], listEmpty()))
+            )
+            assert(t === 'error', result)
+            assertEq(result, 'invalid buffer size')
         },
     },
 }


### PR DESCRIPTION
## Summary
Added a new test case to validate that `writeFromStream` properly rejects chunks with bit lengths that aren't byte-aligned (not a multiple of 8).

## Changes
- Imported `vec` function from bit_vec module for creating test vectors
- Imported `listNonEmpty` from list module for constructing non-empty lists
- Added `invalidBufferSize` test case that:
  - Creates a stream with a 4-bit vector (0b1010) which violates byte-alignment requirements
  - Verifies that the operation returns an error with message 'invalid buffer size'
  - Confirms the byte-alignment guard is enforced before `writeBytes` is called

## Implementation Details
The test uses the virtual file system to simulate the error condition, passing a non-byte-aligned chunk through `writeFromStream` and asserting that the appropriate validation error is caught.

https://claude.ai/code/session_019wGEM2DzCMNdXY5iMpCbiq