### PR TITLE
Add test for non-ENOENT access errors in fileCas.list()

### DIFF
--- a/fs/cas/proof.f.ts
+++ b/fs/cas/proof.f.ts
@@ -2,7 +2,7 @@ import { length, maxLength, msb, vec, vec8, type Vec } from '../types/bit_vec/mo
 import { cBase32ToVec, vecToCBase32 } from '../basen/cbase32/module.f.ts'
 import { computeSync, sha256 } from '../crypto/sha2/module.f.ts'
 import { fileCas, casAddFile, type FileCasOperation, casUpload } from './module.f.ts'
-import { pure, type Effect } from '../effects/module.f.ts'
+import { decode, pure, type Effect } from '../effects/module.f.ts'
 import { mkdir, writeFile, rm, readFile, type ReadFile, type WriteFile, type Rm, type Mkdir, type IoResult, access } from '../effects/node/module.f.ts'
 import { error, ok, type Ok } from '../types/result/module.f.ts'
 import { emptyState, virtual } from '../effects/node/virtual/module.f.ts'
@@ -260,5 +260,22 @@ export const proof = {
         const c = fileCas(sha256)('.')
         const [, hashes] = virtual(state1)(c.list())
         assertEq(hashes.length, 0, ['expected nothing published on failed upload', hashes])
+    },
+    casListPropagatesNonNotFoundAccessError: () => {
+        // A non-ENOENT `access` failure (permissions, corruption) is a genuine storage
+        // error and must propagate out of `list`, not be swallowed as an empty store.
+        const c = fileCas(sha256)('.')
+        const boom = { code: 'EACCES' }
+        const d = decode(c.list())
+        assert(!d.done, 'expected list() to issue an access command first')
+        assertEq(d.command, 'access')
+        const continuation = d.continuation as (r: IoResult<void>) => Effect<FileCasOperation, readonly Vec[]>
+        let threw: unknown
+        try {
+            continuation(error(boom))
+        } catch (e) {
+            threw = e
+        }
+        assertEq(threw, boom)
     },
 }


### PR DESCRIPTION
## Summary
Added a new test case to verify that non-ENOENT access errors (such as permission denied) properly propagate from the `fileCas.list()` operation instead of being silently swallowed as an empty store.

## Changes
- Imported `decode` utility from effects module to enable effect introspection in tests
- Added `casListPropagatesNonNotFoundAccessError` test that:
  - Creates a file CAS instance and decodes its `list()` effect
  - Verifies that `list()` first issues an `access` command
  - Confirms that non-ENOENT errors (e.g., EACCES permission errors) thrown by the continuation are properly propagated rather than handled as empty results
  - Ensures genuine storage errors don't get masked as missing directories

## Implementation Details
The test uses effect decoding to inspect the internal structure of the `list()` operation, allowing it to manually invoke the continuation with an error result and verify the error handling behavior. This ensures that only "not found" errors are treated as empty stores, while other access failures are treated as genuine errors that should propagate to the caller.

https://claude.ai/code/session_01T8cH8LtUy5Gg2Nk6p18emM