### PR TITLE
Docs: bigint-range comment, djs JSON-bigint proposal, new-PL numbers

### DIFF
--- a/fs/bnf/module.f.ts
+++ b/fs/bnf/module.f.ts
@@ -19,6 +19,21 @@ import { map, toArray, repeat as listRepeat } from '../types/list/module.f.ts'
  * For example: 0xBBBBBB_EEEEEE
  * - 0xBBBBBB is the first symbol (24 bits)
  * - 0xEEEEEE is the last symbol (24 bits)
+ *
+ * 24 bits per half, not 26 (the most `float64`'s 52-bit safe-integer mantissa
+ * could fit two of): 24 is divisible by 4, so each half is exactly 6 hex
+ * digits, and the packed pair reads as a plain `0xYYYYYY_ZZZZZZ` literal with
+ * no partial hex digit at either boundary. 26 bits would still be safe to
+ * store but wouldn't align to hex nibbles, making the packed literal harder
+ * to read and split by eye.
+ *
+ * Not 16 bits (32 bits total) either, even though a 32-bit pair would fit in
+ * a JS bitwise operator's native 32-bit range (JS `|`/`&`/`<<`/etc. operate on
+ * 32-bit ints, whereas the 48-bit pair used here, and even a 52-bit one,
+ * would need converting to `BigInt` for bitwise operations). 16 bits per
+ * symbol can't hold a full Unicode code point: the max scalar value `0x10FFFF`
+ * needs 21 bits, well past `0xFFFF`. So the bitwise-op convenience of 16 loses
+ * to the requirement of representing every Unicode code point in one half.
  */
 export type TerminalRange = number
 

--- a/fs/djs/todo/json-bigint-serialization.md
+++ b/fs/djs/todo/json-bigint-serialization.md
@@ -159,6 +159,12 @@ logic; JS's single `number` type is what makes it necessary here.
 
 ### Related
 
+- [todo/new-pl.md § Numbers](../../../todo/new-pl.md#numbers) — the
+  from-scratch-language version of this same idea (`2` = bigint, `2.0` =
+  number as the *default* literal syntax, no suffix). This proposal is the
+  scoped-down, buildable-today instance of it: same `int`/`float` split,
+  same Python precedent, but as a JSON-compatible serialization convention
+  inside today's `fs/djs` rather than a change to literal syntax.
 - [663-json-djs-tree-type](./663-json-djs-tree-type.md) — generalizes the
   json/djs recursive tree type over its leaf set; this proposal's value type
   is naturally a third instantiation of that generic if the narrower-type

--- a/fs/djs/todo/json-bigint-serialization.md
+++ b/fs/djs/todo/json-bigint-serialization.md
@@ -1,0 +1,175 @@
+## json-bigint-serialization. A bigint-precise parse/serialize pair, in `djs`, staying JSON-compatible
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+Every JSON number in `fs/media/json`'s pipeline collapses to a JS `number`,
+even though the tokenizer computes an exact value first and then throws the
+precision away: `NumberToken.bf: BigFloat` (`fs/js/tokenizer/module.f.ts:81-85`)
+is exact, but `fs/media/json/parser/module.f.ts:121`'s `tokenToValue`
+immediately does `parseFloat(token.value)`. Concretely, parsing
+`{"id": 9007199254740993}` (`2^53 + 1`) silently yields `9007199254740992` —
+no error, just a wrong value.
+
+`fs/media/json` itself should **not** change to fix this: it exists to mirror
+native `JSON.parse`/`JSON.stringify` exactly, and its `Unknown`/`Primitive`
+types are depended on by `fs/mcp`, `fs/cas/mcp`, `fs/mcp/stdio`, `fs/fsm`,
+`fs/dev/package_json`, and others via plain `typeof` switches — widening
+`Primitive` with `bigint` there would be a breaking change to all of them for
+no benefit to callers who just want standard JSON semantics.
+
+`fs/djs` (a JS-superset format transpiled from/to `.f.ts`) already has the
+right leaf type: `Primitive = JsonPrimitive | bigint | undefined`
+(`fs/djs/module.f.ts:22`). But its only bigint encoding today is the JS
+literal suffix — `fs/types/bigint/module.f.ts:90`: `` `${a}n` `` — which is
+not valid JSON. This is not just a theoretical gap: `fs/djs/module.f.ts`'s
+`compile` **already has a live bug** from it. Its `.json`-output branch —
+
+```ts
+// fs/djs/module.f.ts:42-44
+const content = outputFileName.endsWith('.json')
+    ? stringifyAsTree(sort)(result[1])
+    : stringify(sort)(result[1])
+```
+
+— uses `stringifyAsTree`, which is `serializeWithoutConst`
+(`fs/djs/serializer/module.f.ts:133-135`), whose leaf switch has
+`case 'bigint': { return [bigintSerialize(value)] }`
+(`fs/djs/serializer/module.f.ts:120`) — emitting `123n`. So compiling any
+djs module that contains a bigint to an output path ending in `.json`
+**writes invalid JSON to a `.json` file**, silently. `fs/djs/proof.f.ts`'s
+`jsonOutput` test only exercises `export default 42` (a plain number), so
+this is untested and unnoticed today.
+
+### Proposal
+
+Add a second parse/serialize pair to `fs/djs` — alongside the existing
+`123n`-syntax native djs serialization — that encodes the `number`/`bigint`
+distinction using JSON's own number grammar instead of new syntax, so its
+output is valid, standard-JSON-parseable text:
+
+- **Parse.** Reuse `fs/media/json/tokenizer` as-is (it already rejects
+  djs-only tokens like a bigint-suffix literal or a bare identifier, so this
+  new parser only ever accepts plain JSON syntax — no consts, no imports, no
+  `123n`). A JSON `number` token whose literal has no `.` and no exponent
+  (`e`/`E`) — the bare `int` production of RFC 8259 §6 — parses to `bigint`
+  via the token's own `bf[0]` (exact, no re-parsing); everything else parses
+  to `number` as today. Don't duplicate `fs/media/json/parser/module.f.ts`'s
+  state machine to get this: add a new exported `parseWith` (name TBD) that
+  takes the `tokenToValue` mapping as a parameter, with the existing `parse`
+  becoming `parseWith(defaultTokenToValue)` — purely additive, the three
+  existing callers (`fs/dev/package_json`, `fs/mcp/stdio`,
+  `fs/media/revision`) are untouched.
+- **Serialize.** Reuse `fs/media/json/serializer`'s leaf-agnostic atoms
+  (`objectWrap`, `arrayWrap`, `stringSerialize`, `boolSerialize`,
+  `nullSerialize` — already shared with djs's own serializer, see
+  `fs/djs/serializer/module.f.ts:15`). Add a `bigint` case emitting plain
+  digits (no `n` suffix) instead of djs's `bigintSerialize`, and make the
+  `number` case force a `.0` onto whole-number inputs
+  (`Number.isInteger(input)`) so `3` (bigint) and `3.0` (float) stay
+  distinguishable on the wire. JS's own exponential-notation threshold
+  (`JSON.stringify` switches to `e` form exactly at `1e21`) means the
+  plain-digit case and the exponent case never overlap, so no special-casing
+  is needed there — just append `.0` when the output has neither `.` nor
+  `e`.
+- **Fix the live bug.** Once this exists, `fs/djs/module.f.ts`'s `compile`
+  should use the new bigint-JSON-compatible serializer for its `.json`
+  branch instead of `stringifyAsTree`, so a bigint-containing module compiled
+  to `*.json` produces valid JSON instead of `123n`.
+
+### Prior art: Python's `json` module
+
+Python's `int` is arbitrary-precision, and its stdlib `json` module already
+implements exactly this split. CPython's number scanner
+(`Lib/json/scanner.py`, mirrored by the `_json` C accelerator) matches
+`(-?(?:0|[1-9]\d*))(\.\d+)?([eE][-+]?\d+)?` and dispatches:
+
+```python
+if frac or exp:
+    res = parse_float(integer + (frac or '') + (exp or ''))
+else:
+    res = parse_int(integer)
+```
+
+`parse_int` defaults to `int`, `parse_float` to `float` — "no `.`/no
+exponent → integer type, otherwise → float type," confirming `1e2` parses
+as `float(100.0)` (exponent presence alone routes to float, matching the
+strict-grammar reading above, not "no fractional value" more broadly). On
+the write side Python needs no special `.0` convention at all —
+`json.dumps` calls `float.__repr__` directly, which already always emits a
+`.` or exponent (`repr(3.0) == '3.0'`) — so `int`/`float` stay lexically
+distinct for free. The `.0`-forcing step this proposal needs is exactly
+what Python's separate `int`/`float` types already guarantee without extra
+logic; JS's single `number` type is what makes it necessary here.
+
+### Open questions
+
+- **Value type.** djs's own `Primitive` includes `undefined`, which has no
+  JSON encoding — so should this new pair's type be djs's `Unknown` as-is
+  (permissive on the way in, but the serializer must reject/error on
+  `undefined`), or a narrower `JsonPrimitive | bigint` leaf set (no
+  `undefined`, matching what JSON-syntax input can actually produce)? The
+  narrower type is cleaner but is a third leaf-set instantiation alongside
+  json's and djs's — ties this proposal to
+  [663-json-djs-tree-type](./663-json-djs-tree-type.md)'s generic
+  `Tree.Unknown<P>` work, which would make adding a third instantiation
+  trivial instead of a fourth hand-rolled type. Worth sequencing these two
+  together, or at least deciding the order explicitly.
+- **Naming and placement.** Candidates: `parseJson`/`stringifyJson` (reads
+  oddly next to djs's *actual* JSON-incompatible native format),
+  `parseJsonBigint`/`stringifyJsonBigint` (verbose but unambiguous). Home:
+  directly on `fs/djs/module.f.ts`, or a new `fs/djs/json_bigint/module.f.ts`
+  submodule alongside `ast`/`parser`/`serializer`/`tokenizer`/`transpiler`.
+- `-0`: `Number.isInteger(-0)` is `true` — does it need `.0` too (`-0.0`)?
+  `NaN`/`Infinity` are already outside valid JSON, out of scope.
+- Document, wherever this lands, that djs now has **two** bigint encodings
+  (`123n` native, plain-digit-JSON-compatible here) with different
+  tradeoffs, so a future reader doesn't wonder why.
+
+### Tasks
+
+- [ ] Add `parseWith` (name TBD) to `fs/media/json/parser/module.f.ts`,
+      parameterized over `tokenToValue`; reimplement `parse` on top of it
+      with the current `tokenToValue` as the default — no behavior change
+      for existing callers.
+- [ ] Settle the value-type open question above (plain `djs.Unknown` vs. a
+      narrower `JsonPrimitive | bigint`), coordinating with
+      [663-json-djs-tree-type](./663-json-djs-tree-type.md) if the narrower
+      type is chosen.
+- [ ] Implement the new parse function in `fs/djs` using
+      `fs/media/json/tokenizer` + `parseWith` with a `bigint`-for-bare-integers
+      `tokenToValue`.
+- [ ] Implement the new serialize function reusing
+      `fs/media/json/serializer`'s atoms, with a plain-digit `bigint` case
+      and `.0`-forcing on whole `number`s.
+- [ ] Fix `fs/djs/module.f.ts`'s `compile` `.json` branch to use the new
+      serializer instead of `stringifyAsTree`; add a proof case compiling a
+      bigint-containing module to `*.json` and asserting the output is valid
+      JSON (parses back with a JSON-only bigint-aware parser and round-trips).
+- [ ] Add proof coverage: integers beyond `Number.MAX_SAFE_INTEGER`
+      round-trip exactly as `bigint`; a whole-number `number` still
+      round-trips distinctly as `number`; fractional/exponent-form literals
+      stay `number`; djs-only syntax (`123n`, bare identifiers, `undefined`)
+      is rejected by the new parser.
+- [ ] Document the convention (`3` = bigint, `3.0` = float) and its
+      relationship to djs's native `123n` encoding, in `fs/djs/README.md`.
+- [ ] `npx tsc`, `fjs t`.
+
+### Related
+
+- [663-json-djs-tree-type](./663-json-djs-tree-type.md) — generalizes the
+  json/djs recursive tree type over its leaf set; this proposal's value type
+  is naturally a third instantiation of that generic if the narrower-type
+  option is chosen.
+- [parse-text-pipeline.md](../../media/json/todo/parse-text-pipeline.md) —
+  adds a `parseText` (string → `Result`) entry point to `fs/media/json`; the
+  `parseWith` generalization here is the same shape of change (a new
+  parameterized entry point, existing behavior preserved as the default),
+  just on the token-list parser rather than the string-to-tokens pipeline.
+- `fs/media/json/schema/module.f.ts:93-97,106-107` — already documents a
+  `bigint`-as-`Number()` lossy approximation elsewhere (rtti → JSON Schema);
+  a related but separate concern (schema description, not value encoding).
+- `fs/djs/proof.f.ts`'s `jsonOutput` test — the existing (too narrow)
+  coverage of `compile`'s `.json` branch; extend rather than replace.

--- a/todo/new-pl.md
+++ b/todo/new-pl.md
@@ -124,7 +124,28 @@ const a = 2   // typeof(a) === 'bigint'
 const b = 2.0 // typeof(b) === 'number' (IEEE 754 64-bit double)
 ```
 
+**JS compatibility.** The `n` suffix stays valid too, as an accepted-but-redundant alternate spelling: `2n` parses to the same `bigint` value as `2`. This costs nothing in the grammar (`n` is not needed to disambiguate anything once bare integers are already `bigint`) and keeps the parser compatible with existing JS/FunctionalScript/djs source that already spells bigints as `123n` — matching this document's own design constraint that "most existing FunctionalScript modules should be reusable in the new language with little or no modification." `2.0n` (fraction with a bigint suffix) is a syntax error, same as in JS.
+
 Python provides a useful precedent. Python 2 had two integer types: `int` (fixed-width, 32 or 64-bit) and `long` (arbitrary-precision), with `2L` as the bigint literal — mirroring JavaScript's current split between `number` and `bigint`. [Python 3 unified them](https://docs.python.org/3/whatsnew/3.0.html#integers): `int` is now always arbitrary-precision and `long` was removed ([PEP 237](https://peps.python.org/pep-0237/)). The literal `2` is a bigint in Python 3 with no special suffix needed — exactly the behaviour proposed here.
+
+**Mixed arithmetic.** Current JS throws when an operator mixes `bigint` and `number`:
+
+```js
+2n + 2.0 // TypeError: Cannot mix BigInt and other types, use explicit conversions
+```
+
+**Proposal:** keep JS's behavior — an operation that mixes `bigint` and `number` throws a `TypeError` rather than implicitly converting either operand. This matches the [TC39 `proposal-bigint`](https://github.com/tc39/proposal-bigint) design rationale ("Design Goals, Or Why Is This Like This?"): implicit coercion has no single correct answer (`bigint`→`number` risks silent precision loss; `number`→`bigint` breaks on non-integer floats like `1.5`), so the proposal "errs on the side of throwing an exception rather than rely on type coercion and risk giving an imprecise answer." Explicit conversion is required at the boundary instead.
+
+Contrast with Python 3, which goes the other way and promotes `int` to `float` silently:
+
+```python
+2 + 2.0        # 4.0 (float) — int promoted to float, no error
+10**30 + 1.0   # 1e+30 — silent precision loss, everything past ~15-17 significant digits is gone
+```
+
+Python's convenience trades away exactly the precision guarantee that motivates defaulting integer literals to `bigint` in the first place, so JS's stricter behavior is the better fit here despite the extra conversion calls it forces at `bigint`/`number` boundaries.
+
+This `2`/`2.0` split doesn't have to wait for a new PL. [fs/djs/todo/json-bigint-serialization.md](../fs/djs/todo/json-bigint-serialization.md) proposes the same convention — a dot-free numeric literal is `bigint`, a literal with a `.` (or exponent) is `number` — as a JSON-*compatible* serialization inside today's `fs/djs`, and independently lands on the same Python precedent (CPython's `json` scanner uses the identical `frac`/`exp`-presence test to choose `int` vs `float`). It's a concrete, buildable-now instance of this section's idea, scoped to serialization rather than the full language.
 
 ### UTF8 String
 
@@ -332,7 +353,8 @@ Notes and open questions:
 
 ## Tasks
 
-- [ ] Decide on integer literal syntax (`2` = bigint, `2.0` = float)
+- [ ] Decide on integer literal syntax (`2` = bigint, `2.0` = float); accept `2n` as a redundant-but-valid alternate spelling for JS/djs source compatibility
+- [ ] Specify the `TypeError` thrown on mixed `bigint`/`number` arithmetic (matching current JS behavior) and the explicit conversion functions required at the boundary
 - [ ] Define UTF-8 string type and drop UTF-16
 - [ ] Specify `typeof` returning `'array'` for arrays
 - [ ] Define lexicographic key ordering rules


### PR DESCRIPTION
## Summary
- `fs/bnf/module.f.ts`: document why `TerminalRange` packs two 24-bit halves (not 26, not 16) — hex-nibble alignment vs. `float64` capacity vs. native 32-bit bitwise ops vs. full Unicode code-point coverage.
- `fs/djs/todo/json-bigint-serialization.md` (new): proposes a bigint-precise parse/serialize pair for `fs/djs` that stays valid, standard JSON text (dot-free integer literals parse to `bigint`; whole-number floats get a forced `.0`), instead of widening `fs/media/json`'s own `Unknown`/`Primitive` (which would be a breaking change for its many consumers). Documents a live bug found along the way: `fs/djs/module.f.ts`'s `compile` currently writes invalid JSON (`123n`) to `.json`-named output when the source module contains a bigint.
- `todo/new-pl.md`: expands the `### Numbers` section — cross-references the new djs todo as a buildable-today instance of the `2`/`2.0` (bigint/number) literal idea; specifies that mixed `bigint`/`number` arithmetic should keep JS's `TypeError` behavior (verified against the TC39 `proposal-bigint` design rationale, contrasted with Python 3's silent `int`→`float` promotion); and specifies `2n` as an accepted-but-redundant alternate spelling for JS/djs source compatibility.

All changes are documentation/comments only — no behavior change.

## Test plan
- [x] `npx tsc` (after the `fs/bnf/module.f.ts` JSDoc edit)
- [x] Cross-checked all file/line references and relative markdown links in the new/edited docs resolve
- [x] Verified Python 3's `int`/`float` promotion behavior and JS's `bigint`/`number` `TypeError` behavior empirically (`python`, `node`), and the TC39 `proposal-bigint` rationale via its README

🤖 Generated with [Claude Code](https://claude.com/claude-code)