### PR TITLE
Add proof object with pushKey nonObjectTop branch coverage test

### DIFF
--- a/fs/djs/parser/module.f.ts
+++ b/fs/djs/parser/module.f.ts
@@ -11,6 +11,7 @@ import { setReplace, at, type OrderedMap } from '../../types/ordered_map/module.
 import { fromMap } from '../../types/object/module.f.ts'
 import type { AstArray, AstConst, AstModule, AstModuleRef } from '../ast/module.f.ts'
 import type { TokenMetadata } from '../../js/tokenizer/module.f.ts'
+import { assertEq } from '../../asserts/module.f.ts'
 
 export type ParseError = {
     readonly message: string,
@@ -529,4 +530,24 @@ export const parseFromTokens = (tokenList: List<DjsTokenWithMetadata>): Result<A
         case 'error': return error(state.error)
         default: return error({message: 'unexpected end', metadata: null})
     }
+}
+
+export const proof = {
+    pushKey: {
+        // `pushKey` is only ever invoked while `state.top` is an object (the
+        // `'{'`/`'{,'` value-states guarantee it), so its non-object guard is
+        // a defensive branch unreachable through `parseFromTokens`. Call it
+        // directly to cover that branch.
+        nonObjectTop: () => {
+            const state: ParseValueState = {
+                state: 'exportValue',
+                module: { refs: null, modules: null, consts: null },
+                valueState: '[',
+                top: null,
+                stack: null,
+            }
+            const result = pushKey(state)('key')({ path: 'test', line: 0, column: 0 })
+            assertEq(result.state, 'error')
+        },
+    },
 }


### PR DESCRIPTION
## Summary
Added a `proof` object to the parser module containing a test case that exercises a defensive, unreachable code branch in the `pushKey` function.

## Key Changes
- Imported `assertEq` from the asserts module
- Added a `proof` export object with a `pushKey.nonObjectTop` test function that:
  - Creates a `ParseValueState` with an array value-state (`'['`) and `null` top
  - Invokes `pushKey` directly with this state to trigger the non-object guard branch
  - Asserts that the result is an error state
  - Documents that this branch is unreachable through normal `parseFromTokens` execution

## Implementation Details
The test demonstrates defensive programming by covering a guard clause that should never be reached during normal parsing operations. The state configuration ensures `state.top` is `null` (not an object), which causes `pushKey` to return an error, validating the guard's behavior.

https://claude.ai/code/session_016d8gHECFwRYn6HuS1mNbXQ