### PR TITLE
Adapt CI for Wasmtime 47's removal of wasi-threads support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,9 @@
 [target.wasm32-wasip1]
 runner = "wasmtime run --dir . --"
 
-[target.wasm32-wasip1-threads]
-runner = "wasmtime run --wasi threads --wasm shared-memory --dir . --"
+# wasm32-wasip1-threads has no Wasmtime runner: Wasmtime 47 removed wasi-threads
+# support. Run threads tests with `--config .cargo/config.wasmer.toml` instead.
+# See todo/blocked/wasmtime-threads.md.
 
 [target.wasm32-wasip2]
 runner = "wasmtime run --dir . --"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@
         {
           "uses": "bytecodealliance/actions/wasmtime/setup@v1.1.3",
           "with": {
-            "version": "46.0.1"
+            "version": "47.0.1"
           }
         },
         {
@@ -364,12 +364,6 @@
         },
         {
           "run": "cargo test --target wasm32-unknown-unknown --config .cargo/config.wasmer.toml --release"
-        },
-        {
-          "run": "cargo test --target wasm32-wasip1-threads"
-        },
-        {
-          "run": "cargo test --target wasm32-wasip1-threads --release"
         },
         {
           "run": "cargo clippy --target wasm32-wasip1-threads -- -D warnings"

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -44,7 +44,7 @@ export const node = {
 } as const
 
 // https://github.com/bytecodealliance/wasmtime/releases
-export const wasmtime = '46.0.1'
+export const wasmtime = '47.0.1'
 
 // https://github.com/wasmerio/wasmer/releases
 export const wasmer = '7.2.0'

--- a/fs/ci/proof.f.ts
+++ b/fs/ci/proof.f.ts
@@ -16,6 +16,9 @@ const hasRun = (cmd: string) => (gha: GitHubAction): boolean =>
 const hasRunInJob = (jobId: string, cmd: string) => (gha: GitHubAction): boolean =>
     gha.jobs[jobId]?.steps.some(step => step.run?.includes(cmd)) ?? false
 
+const hasExactRunInJob = (jobId: string, cmd: string) => (gha: GitHubAction): boolean =>
+    gha.jobs[jobId]?.steps.some(step => step.run === cmd) ?? false
+
 const makeState = (rust: boolean, packageJson?: string) => ({
     ...emptyState,
     root: {
@@ -63,6 +66,12 @@ export const proof = {
         assert(hasRunInJob('wasm', 'cargo test --target wasm32-wasip1 --release')(gha), 'expected target-specific WASM release check')
         assert(hasRunInJob('wasm', 'cargo clippy --target wasm32-wasip1 -- -D warnings')(gha), 'expected target-specific WASM Rust lint')
         assert(hasRunInJob('wasm', 'cargo clippy --target wasm32-wasip1 --release -- -D warnings')(gha), 'expected target-specific WASM release lint')
+        // Wasmtime 47 removed wasi-threads: the threads target must run under
+        // Wasmer only, while Clippy (no runner) stays.
+        assert(hasRunInJob('wasm', 'cargo test --target wasm32-wasip1-threads --config .cargo/config.wasmer.toml')(gha), 'expected Wasmer WASM threads check')
+        assert(hasRunInJob('wasm', 'cargo clippy --target wasm32-wasip1-threads -- -D warnings')(gha), 'expected WASM threads lint')
+        assert(!hasExactRunInJob('wasm', 'cargo test --target wasm32-wasip1-threads')(gha), 'unexpected Wasmtime WASM threads check')
+        assert(!hasExactRunInJob('wasm', 'cargo test --target wasm32-wasip1-threads --release')(gha), 'unexpected Wasmtime WASM threads release check')
         assert(hasRunInJob('node22', 'fjs t')(gha), 'expected Node 22 FunctionalScript smoke test')
         assert(hasRunInJob('node26', 'npm pack')(gha), 'expected Node 26 package check')
         assert(!hasRun('npm publish --dry-run')(gha), 'unexpected npm publish dry-run')

--- a/fs/ci/rust/module.f.ts
+++ b/fs/ci/rust/module.f.ts
@@ -53,6 +53,15 @@ const wasmTarget = (target: string): readonly MetaStep[] => [
     ...cargoTestPair(target, '.cargo/config.wasmer.toml')
 ]
 
+// Wasmtime 47 removed wasi-threads, so the threads target runs under Wasmer
+// only; Clippy needs no runner and stays. See todo/blocked/wasmtime-threads.md.
+const wasmerOnlyTarget = (target: string): readonly MetaStep[] => [
+    { type: 'rust', target },
+    cargoClippy(target),
+    cargoReleaseClippy(target),
+    ...cargoTestPair(target, '.cargo/config.wasmer.toml')
+]
+
 const i686 = (a: Architecture, v: Os): readonly MetaStep[] => {
     if (a === 'intel') {
         switch (v) {
@@ -79,5 +88,5 @@ export const rustWasmSteps: readonly MetaStep[] = [
     ...wasmTarget('wasm32-wasip1'),
     ...wasmTarget('wasm32-wasip2'),
     ...wasmTarget('wasm32-unknown-unknown'),
-    ...wasmTarget('wasm32-wasip1-threads'),
+    ...wasmerOnlyTarget('wasm32-wasip1-threads'),
 ]

--- a/todo/blocked/wasmtime-threads.md
+++ b/todo/blocked/wasmtime-threads.md
@@ -1,0 +1,41 @@
+# Restore Wasmtime coverage for multi-threaded WASM
+
+**Priority:** P3
+**Status:** blocked
+
+### Problem
+
+Wasmtime 47 removed wasi-threads support (`wasmtime run --wasi threads` is a
+hard error), per the
+[removal RFC](https://github.com/bytecodealliance/rfcs/blob/main/accepted/wasmtime-remove-wasi-threads.md):
+the wasi-threads proposal is architecturally dead-ended, the supporting
+`wasi-common` crate was unmaintained, and Wasmtime's shared-memory
+implementation was unsound. CI therefore runs the `wasm32-wasip1-threads`
+tests under Wasmer only (`.cargo/config.wasmer.toml`); Wasmtime still lints
+the target via Clippy, which needs no runner. The runner×target matrix has
+lost the Wasmtime×threads cell.
+
+### Trigger
+
+Unblocked when Wasmtime ships runnable multi-threaded WASM support again —
+WASIp3 cooperative threading and/or the
+[shared-everything-threads](https://github.com/WebAssembly/shared-everything-threads)
+proposal — and Rust has a corresponding compilation target. Each path that
+ships is a separate runner×target cell; adopt every one that becomes feasible
+for maximum coverage, without waiting for the others. Note the restored
+coverage will likely use a new target, not `wasm32-wasip1-threads`, which
+Wasmtime will not revive.
+
+### Tasks
+
+- [ ] add a Wasmtime runner for the new threads target to `.cargo/config.toml`
+- [ ] extend `fs/ci/rust/module.f.ts` so the threads target runs under
+  Wasmtime again (replace `wasmerOnlyTarget` with the full `wasmTarget`
+  treatment, or add the new target alongside)
+
+### Related
+
+- [fs/ci/rust/module.f.ts](../../fs/ci/rust/module.f.ts) — `wasmerOnlyTarget`
+  is the workaround this issue removes
+- [.cargo/config.toml](../../.cargo/config.toml) — missing
+  `wasm32-wasip1-threads` runner points here


### PR DESCRIPTION
## Summary

This PR updates the CI configuration to accommodate Wasmtime 47's removal of wasi-threads support. The `wasm32-wasip1-threads` target now runs tests exclusively under Wasmer, while Clippy linting (which requires no runtime) continues to work with Wasmtime.

## Key Changes

- **Updated Wasmtime version** from 46.0.1 to 47.0.1 in CI configuration and version tracking
- **Removed Wasmtime runner for threads target** in `.cargo/config.toml` since Wasmtime 47 no longer supports `--wasi threads`
- **Created `wasmerOnlyTarget` helper** in `fs/ci/rust/module.f.ts` to handle targets that require Wasmer for testing but can still use Wasmtime for linting
- **Updated WASM CI steps** to use the new `wasmerOnlyTarget` function for `wasm32-wasip1-threads`
- **Removed Wasmtime test runs** for the threads target from the generated CI workflow (`.github/workflows/ci.yml`)
- **Added comprehensive proof assertions** in `fs/ci/proof.f.ts` to verify:
  - Threads tests run under Wasmer with the correct config
  - Clippy linting still runs for the threads target
  - Wasmtime test runners are not used for threads
- **Added blocking issue documentation** in `todo/blocked/wasmtime-threads.md` explaining the situation and unblocking conditions for future multi-threaded WASM support

## Implementation Details

The solution maintains full CI coverage for the threads target while respecting Wasmtime's architectural decision. The `wasmerOnlyTarget` function mirrors `wasmTarget` but explicitly uses `.cargo/config.wasmer.toml` for test execution, ensuring tests run under Wasmer while Clippy continues to lint without a runtime. This approach allows for easy restoration of Wasmtime coverage once new multi-threaded WASM proposals (WASIp3 or shared-everything-threads) become available in Rust and Wasmtime.

https://claude.ai/code/session_011SHRBv4tJyGp5RktCbzrQc