### PR TITLE
Add test case for empty variant rule parsing

### DIFF
--- a/fs/bnf/descent/proof.f.ts
+++ b/fs/bnf/descent/proof.f.ts
@@ -126,6 +126,13 @@ export const proof = {
             if (result !== '[{"tag":"e","sequence":[]},true,0]') { throw result }
         },
         () => {
+            const emptyVariantRule = {}
+            const m = descentParser(emptyVariantRule)
+            const mr = m("", [])
+            const result = JSON.stringify(mr)
+            if (result !== '[{"sequence":[]},false,0]') { throw result }
+        },
+        () => {
             const stringRule = 'AB'
             const m = descentParser(stringRule)
             const mr = descentParserCpOnly(m, "", [65,66])


### PR DESCRIPTION
## Summary
Added a new test case to verify the descent parser correctly handles empty variant rules (empty object literals).

## Key Changes
- Added a proof test that validates parsing behavior when an empty object `{}` is used as a rule
- The test verifies that the parser returns the expected result structure `[{"sequence":[]},false,0]` when parsing an empty string with an empty variant rule
- This test ensures the parser gracefully handles edge cases with minimal rule definitions

## Implementation Details
The new test follows the existing pattern in the proof suite:
- Creates an empty variant rule as an empty object
- Instantiates the descent parser with this rule
- Invokes the parser with empty input and empty array
- Validates the JSON stringified result matches the expected output format

https://claude.ai/code/session_016M7WfcDNcxQ1cX4BKv6M8s