### PR TITLE
Upgrade Wasmtime to version 47.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@
         {
           "uses": "bytecodealliance/actions/wasmtime/setup@v1.1.3",
           "with": {
-            "version": "47.0.1"
+            "version": "47.0.2"
           }
         },
         {

--- a/fs/ci/config/module.f.ts
+++ b/fs/ci/config/module.f.ts
@@ -44,7 +44,7 @@ export const node = {
 } as const
 
 // https://github.com/bytecodealliance/wasmtime/releases
-export const wasmtime = '47.0.1'
+export const wasmtime = '47.0.2'
 
 // https://github.com/wasmerio/wasmer/releases
 export const wasmer = '7.2.0'


### PR DESCRIPTION
## Summary
This pull request updates the Wasmtime runtime dependency from version 47.0.1 to 47.0.2 across the project configuration.

## Changes
- Updated Wasmtime version in GitHub Actions CI workflow configuration
- Updated Wasmtime version in the module configuration file

## Details
The Wasmtime version has been bumped to 47.0.2 in two locations:
- `.github/workflows/ci.yml`: Updated the `bytecodealliance/actions/wasmtime/setup` action to use the latest patch version
- `fs/ci/config/module.f.ts`: Updated the exported `wasmtime` constant to reflect the new version

This is a patch-level update that includes bug fixes and improvements from the Wasmtime project.

https://claude.ai/code/session_01J5SDueYdzAmGbVHqd28wNa