### PR TITLE
Design and document subject revision history API

### DIFF
--- a/fs/cas/evo/todo/evo-revision.md
+++ b/fs/cas/evo/todo/evo-revision.md
@@ -99,7 +99,7 @@ export type RevisionData = {
 
 Decided together with this tool (the format is still being designed and no
 stored records exist yet, so this is free). The format-level change itself
-is tracked — with P0 priority, together with requiring `snapshot` — in
+is tracked — with P1 priority, together with requiring `snapshot` — in
 [`fs/media/revision/todo/required-fields.md`](../../../media/revision/todo/required-fields.md);
 what follows is the semantics and the evo layer's part:
 
@@ -156,10 +156,18 @@ recorded so the decision is made deliberately, not by accident.
 ### Implementation notes
 
 - **Errors.** Three distinct failures, each a proper message rather than
-  `null`: hash not present in the store; blob present but not a valid
-  revision (wrong dialect, failed schema, failed reference check); decode
-  failure. `resolveParent` (`fs/cas/evo/module.f.ts`) already implements
-  the shape of this check for `add`'s parents.
+  `null`: `hash` is not a cbase32 string; the hash is not present in the
+  store; the blob is present but not a valid revision (bad UTF-8/JSON,
+  wrong dialect, failed schema or reference check). `decodeRevisionBlob`
+  (`fs/cas/evo/module.f.ts`) cannot serve this contract as-is — it
+  deliberately collapses the read error and every decode failure into one
+  `null`, because it exists for scanning stores containing arbitrary
+  content, and `resolveParent` built on it likewise folds "missing" and
+  "not a revision" into a single message. `revision(hash)` therefore
+  performs the two stages itself — the read (a miss → "not present")
+  separately from the decode (a failure → "not a revision") — the same
+  split `decodeRevisionBlob` composes internally, just without discarding
+  which stage failed.
 - **Serving.** v1 reads through `decodeRevisionBlob` like `resolveParent`
   does. The per-revision cache planned in
   [`todo/subject-history.md`](subject-history.md) (`hash → ordered
@@ -174,7 +182,7 @@ recorded so the decision is made deliberately, not by accident.
 - [ ] Format change — `generation` (and `snapshot`) required, schema +
       `validate` + README: tracked in
       [`fs/media/revision/todo/required-fields.md`](../../../media/revision/todo/required-fields.md)
-      (P0). The `add` task below must land in the same change — a schema
+      (P1). The `add` task below must land in the same change — a schema
       that requires fields `add` doesn't yet write rejects its own
       writer's output.
 - [ ] Rename `AddRevision` → `RevisionData` (adding the optional
@@ -201,7 +209,7 @@ recorded so the decision is made deliberately, not by accident.
 - [`todo/subject-history.md`](subject-history.md) — the mainline walk this
   tool is the node-detail companion to.
 - [`fs/media/revision/todo/required-fields.md`](../../../media/revision/todo/required-fields.md)
-  — the P0 format change (require `generation` and `snapshot`) this
+  — the P1 format change (require `generation` and `snapshot`) this
   design's `generation` semantics land through.
 - `fs/media/revision/README.md` — the `vnd.fjs.revision` format whose
   `generation` field this makes required.

--- a/fs/cas/evo/todo/evo-revision.md
+++ b/fs/cas/evo/todo/evo-revision.md
@@ -82,9 +82,13 @@ export type RevisionData = {
 - Optionality means different things per direction, documented per field:
   - `subject` — input: absent means "infer from my single parent"; output:
     always present.
-  - `snapshot` — input: absent means "inherit per the format rules";
-    output: passed through as stored (absent = inherited — server-side
-    resolution can be a later option).
+  - `snapshot` — input: absent is a write-boundary convenience, resolved
+    at `add` (zero parents → `subject` as the reference, one parent → the
+    parent's snapshot) and written explicitly; output: **always present**
+    — the canonical stored snapshot. The required-fields change
+    ([`fs/media/revision/todo/required-fields.md`](../../../media/revision/todo/required-fields.md))
+    makes every stored blob carry it, so clients never handle
+    inheritance.
   - `generation` — input: **ignored**; the server computes the
     authoritative value (see below), so a value read from `evo_revision`
     can be fed back into `evo_add` unchanged without stripping fields —
@@ -175,7 +179,8 @@ recorded so the decision is made deliberately, not by accident.
   neither can go stale — but that is an optimization, not a requirement:
   the cache holds only part of what `evo_revision` returns.
 - **MCP output** is the JSON of `RevisionData` with the output guarantees
-  above: `{ subject, parents, snapshot?, archived?, generation }`.
+  above: `{ subject, parents, snapshot, archived?, generation }` — only
+  `archived` is genuinely optional on output.
 
 ### Tasks
 

--- a/fs/cas/evo/todo/evo-revision.md
+++ b/fs/cas/evo/todo/evo-revision.md
@@ -106,6 +106,18 @@ stored records exist yet, so this is free):
   structural schema, the same layering as `isHash`. Existence and
   integer-ness are the *correctness* check — a blob failing it is not a
   revision.
+- **Why this keeps the dialect tag.** The README's versioning rule —
+  an incompatible change must take a new dialect — exists to protect
+  *stored* blobs from silently falling out of detection, and no
+  `vnd.fjs.revision` records have ever been stored: the format is still
+  being designed, so this lands in-place as a pre-release design revision,
+  not a versioned format change. Two consequences the implementation must
+  respect: the schema change and `add` writing `generation` must land in
+  the **same change** (a writer that trails the schema produces blobs its
+  own reader rejects — including today's `add`, which writes
+  generation-less blobs); and this move is available only while no records
+  exist — once they do, any further requirement change takes a new dialect,
+  exactly as the rule says.
 - **Continuity is observed, not enforced.** The normative value — `0` for a
   root (`parents: []`), else `1 + max(parents' generations)` — is what
   evo's `add` always writes. But equality with that formula is *not* a
@@ -166,7 +178,9 @@ recorded so the decision is made deliberately, not by accident.
 - [ ] Make `generation` required in code: `revisionSchema`
       `option(number)` → `number`, non-negative-integer check in
       `validate`, with proof coverage for a missing, non-integer, and
-      negative `generation`.
+      negative `generation`. Must land in the same change as the `add`
+      task below — a schema that requires `generation` while `add` still
+      writes blobs without it rejects its own writer's output.
 - [ ] Rename `AddRevision` → `RevisionData` (adding the optional
       `generation` field), update the `fs/cas/evo/mcp` doc table.
 - [ ] Compute and write `generation` in `add` (base case `0`, else

--- a/fs/cas/evo/todo/evo-revision.md
+++ b/fs/cas/evo/todo/evo-revision.md
@@ -172,8 +172,10 @@ recorded so the decision is made deliberately, not by accident.
   separately from the decode (a failure → "not a revision") — the same
   split `decodeRevisionBlob` composes internally, just without discarding
   which stage failed.
-- **Serving.** v1 reads through `decodeRevisionBlob` like `resolveParent`
-  does. The per-revision cache planned in
+- **Serving.** v1 serves each call with a store round trip, but per the
+  error contract above it is a separate `cas.read` followed by a decode
+  step — not a `decodeRevisionBlob` call, which cannot tell "not present"
+  from "not a revision". The per-revision cache planned in
   [`todo/subject-history.md`](subject-history.md) (`hash → ordered
   parents`) can memoize `generation` alongside — both are immutable, so
   neither can go stale — but that is an optimization, not a requirement:

--- a/fs/cas/evo/todo/evo-revision.md
+++ b/fs/cas/evo/todo/evo-revision.md
@@ -98,7 +98,10 @@ export type RevisionData = {
 ### `generation`: required in the format, computed at `add`
 
 Decided together with this tool (the format is still being designed and no
-stored records exist yet, so this is free):
+stored records exist yet, so this is free). The format-level change itself
+is tracked — with P0 priority, together with requiring `snapshot` — in
+[`fs/media/revision/todo/required-fields.md`](../../../media/revision/todo/required-fields.md);
+what follows is the semantics and the evo layer's part:
 
 - **The format requires `generation`**: `revisionSchema`
   (`fs/media/revision/module.f.ts`) changes `option(number)` → `number`,
@@ -168,25 +171,23 @@ recorded so the decision is made deliberately, not by accident.
 
 ### Tasks
 
-- [ ] Describe `generation` as a required field in the revision format
-      documentation (`fs/media/revision/README.md`): schema snippet and
-      field table say `number`, required; the "cache, not a source of
-      truth" paragraph is reframed as existence/integer-ness being the
-      correctness check, the `1 + max` formula being what conforming
-      writers produce, and a deviation being an epoch-reset signal, not a
-      validity failure.
-- [ ] Make `generation` required in code: `revisionSchema`
-      `option(number)` → `number`, non-negative-integer check in
-      `validate`, with proof coverage for a missing, non-integer, and
-      negative `generation`. Must land in the same change as the `add`
-      task below — a schema that requires `generation` while `add` still
-      writes blobs without it rejects its own writer's output.
+- [ ] Format change — `generation` (and `snapshot`) required, schema +
+      `validate` + README: tracked in
+      [`fs/media/revision/todo/required-fields.md`](../../../media/revision/todo/required-fields.md)
+      (P0). The `add` task below must land in the same change — a schema
+      that requires fields `add` doesn't yet write rejects its own
+      writer's output.
 - [ ] Rename `AddRevision` → `RevisionData` (adding the optional
       `generation` field), update the `fs/cas/evo/mcp` doc table.
 - [ ] Compute and write `generation` in `add` (base case `0`, else
-      `1 + max`; a caller-supplied `generation` is ignored), with proof
-      coverage including a merge of parents with differing generations and
-      an input whose supplied `generation` differs from the computed one.
+      `1 + max`; a caller-supplied `generation` is ignored), and resolve
+      an absent input `snapshot` at `add` by the rules the format used to
+      carry (zero parents → `subject` as the reference, which must then be
+      a hash; one parent → the parent's snapshot; more than one parent →
+      error, an explicit `snapshot` is required), writing the resolved
+      hash explicitly. Proof coverage includes a merge of parents with
+      differing generations, an input whose supplied `generation` differs
+      from the computed one, and each snapshot-resolution case.
 - [ ] Implement `revision(hash)` on `Evo<O>` with proof coverage for all
       three error cases and for canonicalized output (a parent stored under
       an alias spelling comes back canonical).
@@ -199,5 +200,8 @@ recorded so the decision is made deliberately, not by accident.
 
 - [`todo/subject-history.md`](subject-history.md) — the mainline walk this
   tool is the node-detail companion to.
+- [`fs/media/revision/todo/required-fields.md`](../../../media/revision/todo/required-fields.md)
+  — the P0 format change (require `generation` and `snapshot`) this
+  design's `generation` semantics land through.
 - `fs/media/revision/README.md` — the `vnd.fjs.revision` format whose
   `generation` field this makes required.

--- a/fs/cas/evo/todo/evo-revision.md
+++ b/fs/cas/evo/todo/evo-revision.md
@@ -35,7 +35,7 @@ A typed read, alongside the existing operations:
 
 ```ts
 /** The revision at `hash`, decoded, validated, and canonicalized. */
-readonly revision: (hash: Hash) => Effect<O | MemOp, Result<RevisionView, string>>
+readonly revision: (hash: Hash) => Effect<O | MemOp, Result<RevisionData, string>>
 ```
 
 exposed over MCP as **`evo_revision`**, args `{ hash }`. The name follows
@@ -59,9 +59,11 @@ expands a branch — without the client ever touching raw bytes.
 ### One shared structure: `AddRevision` → `RevisionData`
 
 `AddRevision` (`fs/cas/evo/module.f.ts`) is renamed **`RevisionData`** and
-becomes the shared vocabulary of both directions — `evo_add` takes it,
-`evo_revision` returns it (refined), and "what you add is what you get
-back":
+becomes the *single* vocabulary of both directions — `evo_add` takes it,
+`evo_revision` returns it, and "what you add is what you get back". No
+extension or intersection types: one structure, every direction-specific
+field optional, with the per-direction guarantees documented rather than
+typed:
 
 ```ts
 export type RevisionData = {
@@ -69,25 +71,25 @@ export type RevisionData = {
     readonly snapshot?: Hash | undefined
     readonly subject?: Subject | undefined
     readonly archived?: true | undefined
-}
-
-/** What `revision(hash)` returns: the data plus what the server always knows. */
-export type RevisionView = RevisionData & {
-    readonly subject: Subject
-    readonly generation: number
+    readonly generation?: number | undefined
 }
 ```
 
-- `RevisionData` is exactly the media-level `Revision` minus `dialect` and
-  `generation` — and dropping `dialect` on output is a feature: it is a
-  serialization tag with no information once past validation. The evo layer
-  speaks the semantic content of a revision, the same in both directions.
-- Optionality means different things per direction, which the refinement
-  captures: on input, absent `subject` means "infer from my single parent"
-  and absent `snapshot` means "inherit per the format rules"; on output,
-  `subject` is always known (the intersection makes the compiler know it
-  too) while `snapshot` passes through as stored (absent = inherited —
-  server-side resolution can be a later option).
+- `RevisionData` is the media-level `Revision` minus `dialect` — and
+  dropping `dialect` on output is a feature: it is a serialization tag with
+  no information once past validation. The evo layer speaks the semantic
+  content of a revision, the same in both directions.
+- Optionality means different things per direction, documented per field:
+  - `subject` — input: absent means "infer from my single parent"; output:
+    always present.
+  - `snapshot` — input: absent means "inherit per the format rules";
+    output: passed through as stored (absent = inherited — server-side
+    resolution can be a later option).
+  - `generation` — input: **ignored**; the server computes the
+    authoritative value (see below), so a value read from `evo_revision`
+    can be fed back into `evo_add` unchanged without stripping fields —
+    the round trip is the point of the shared type. Output: always
+    present.
 - The returned `parents`/`snapshot` are canonical cbase32 spellings, so
   they compare directly against `evo_head`/`evo_history` output.
 - The rename touches the `fs/cas/evo/mcp` doc table but not `evo_add`'s
@@ -114,11 +116,14 @@ stored records exist yet, so this is free):
   epoch-reset indicator); they must not reject the blob for it. Ordering by
   `generation` is therefore reliable within an epoch, and the one-level
   comparison against parents is the cheap epoch-boundary detector.
-- **`evo_add` computes it.** `RevisionData` has no `generation` field —
-  callers never supply it. `resolveParents` already fetches and decodes
-  every parent during `add`, so the computation is a `max` over values
-  already in hand, plus the base case `0` for zero parents. Everything evo
-  writes follows the formula by construction.
+- **`evo_add` computes it.** A `generation` supplied in the input
+  `RevisionData` is ignored — the server writes its own computed value, so
+  the round trip (read via `evo_revision`, add via `evo_add`) needs no
+  field-stripping and can never smuggle a wrong generation into a blob.
+  `resolveParents` already fetches and decodes every parent during `add`,
+  so the computation is a `max` over values already in hand, plus the base
+  case `0` for zero parents. Everything evo writes follows the formula by
+  construction.
 - **`evo_revision` returns the stored value** — always present by format.
 
 ### Open question: cross-subject parents
@@ -146,21 +151,28 @@ recorded so the decision is made deliberately, not by accident.
   parents`) can memoize `generation` alongside — both are immutable, so
   neither can go stale — but that is an optimization, not a requirement:
   the cache holds only part of what `evo_revision` returns.
-- **MCP output** is the JSON of `RevisionView`:
-  `{ subject, parents, snapshot?, archived?, generation }`.
+- **MCP output** is the JSON of `RevisionData` with the output guarantees
+  above: `{ subject, parents, snapshot?, archived?, generation }`.
 
 ### Tasks
 
-- [ ] Make `generation` required: `revisionSchema` `option(number)` →
-      `number`, non-negative-integer check in `validate`, README update
-      (`fs/media/revision/README.md`) including the epoch-reset semantics
-      and the continuity-is-not-validity rule, with proof coverage for a
-      missing, non-integer, and negative `generation`.
-- [ ] Rename `AddRevision` → `RevisionData`, add `RevisionView`, update the
-      `fs/cas/evo/mcp` doc table.
+- [ ] Describe `generation` as a required field in the revision format
+      documentation (`fs/media/revision/README.md`): schema snippet and
+      field table say `number`, required; the "cache, not a source of
+      truth" paragraph is reframed as existence/integer-ness being the
+      correctness check, the `1 + max` formula being what conforming
+      writers produce, and a deviation being an epoch-reset signal, not a
+      validity failure.
+- [ ] Make `generation` required in code: `revisionSchema`
+      `option(number)` → `number`, non-negative-integer check in
+      `validate`, with proof coverage for a missing, non-integer, and
+      negative `generation`.
+- [ ] Rename `AddRevision` → `RevisionData` (adding the optional
+      `generation` field), update the `fs/cas/evo/mcp` doc table.
 - [ ] Compute and write `generation` in `add` (base case `0`, else
-      `1 + max`), with proof coverage including a merge of parents with
-      differing generations.
+      `1 + max`; a caller-supplied `generation` is ignored), with proof
+      coverage including a merge of parents with differing generations and
+      an input whose supplied `generation` differs from the computed one.
 - [ ] Implement `revision(hash)` on `Evo<O>` with proof coverage for all
       three error cases and for canonicalized output (a parent stored under
       an alias spelling comes back canonical).

--- a/fs/cas/evo/todo/evo-revision.md
+++ b/fs/cas/evo/todo/evo-revision.md
@@ -1,0 +1,177 @@
+## `evo_revision`: typed read of a single revision
+
+**Priority:** P3
+**Status:** open — design chosen, not yet implemented
+
+### Problem
+
+The mainline history design
+([`todo/subject-history.md`](subject-history.md)) deliberately returns bare
+hashes and leaves node detail — merge parents, the snapshot pointer, the
+`archived` flag — to the client. The only path to that detail today is
+`cas_get` + client-side decoding, which has three problems:
+
+1. **Canonicalization.** cbase32 hashes have alias spellings (case,
+   `i`/`l`/`o`), and `Evo` normalizes everything through `canonicalHash`
+   (`fs/cas/evo/module.f.ts`): `evo_head` — and the planned `evo_history` —
+   return canonical spellings. A raw blob's `parents` carry whatever
+   spellings its writer used, so the history design's client-side rules
+   ("expand `parents[i]` with `history(...)`", "stop at the first hash
+   you've seen") compare raw-blob strings against canonical API output — an
+   alias spelling breaks the comparison silently. Every client would need
+   to know about cbase32 aliasing; that does not scale.
+2. **Validation duplication.** With bare `cas_get`, each client
+   re-implements JSON parsing, schema validation, the `dialect` check, and
+   `isHash` on every reference. `decodeRevisionBlob`
+   (`fs/cas/evo/module.f.ts`) already does all of it, server-side, and is
+   already exported.
+3. **Consumer profile.** The MCP tools are consumed by agents; leaving the
+   *interpretation* of raw bytes to the least reliable layer is the wrong
+   default.
+
+### Chosen design
+
+A typed read, alongside the existing operations:
+
+```ts
+/** The revision at `hash`, decoded, validated, and canonicalized. */
+readonly revision: (hash: Hash) => Effect<O | MemOp, Result<RevisionView, string>>
+```
+
+exposed over MCP as **`evo_revision`**, args `{ hash }`. The name follows
+the house pattern — one noun per read tool, namespace as scope: `evo_head`
+is "the heads of this subject", `evo_revision` is "the revision at this
+hash". (`evo_get` was rejected: it implies `cas_get`-scoped-to-evo, i.e.
+raw bytes, which is exactly what this tool is not — the `get` verb stays
+reserved for "raw bytes by hash". `evo_get_revision` says nothing
+`evo_revision` doesn't and breaks the one-token-per-tool style.)
+
+`cas_get` remains the generic raw-bytes tool for arbitrary blobs
+(snapshots, non-revision content); `evo_revision` is the typed view for
+revisions specifically. Layering, not duplication — `evo_add` validates on
+the way in, `evo_revision` validates on the way out.
+
+Together with `evo_history` the merge-expansion loop becomes mechanical:
+`evo_history` gives the chain, `evo_revision` gives node detail (every
+`parents` entry past index 0 is a merged-in branch), `evo_history(parent)`
+expands a branch — without the client ever touching raw bytes.
+
+### One shared structure: `AddRevision` → `RevisionData`
+
+`AddRevision` (`fs/cas/evo/module.f.ts`) is renamed **`RevisionData`** and
+becomes the shared vocabulary of both directions — `evo_add` takes it,
+`evo_revision` returns it (refined), and "what you add is what you get
+back":
+
+```ts
+export type RevisionData = {
+    readonly parents: readonly Hash[]
+    readonly snapshot?: Hash | undefined
+    readonly subject?: Subject | undefined
+    readonly archived?: true | undefined
+}
+
+/** What `revision(hash)` returns: the data plus what the server always knows. */
+export type RevisionView = RevisionData & {
+    readonly subject: Subject
+    readonly generation: number
+}
+```
+
+- `RevisionData` is exactly the media-level `Revision` minus `dialect` and
+  `generation` — and dropping `dialect` on output is a feature: it is a
+  serialization tag with no information once past validation. The evo layer
+  speaks the semantic content of a revision, the same in both directions.
+- Optionality means different things per direction, which the refinement
+  captures: on input, absent `subject` means "infer from my single parent"
+  and absent `snapshot` means "inherit per the format rules"; on output,
+  `subject` is always known (the intersection makes the compiler know it
+  too) while `snapshot` passes through as stored (absent = inherited —
+  server-side resolution can be a later option).
+- The returned `parents`/`snapshot` are canonical cbase32 spellings, so
+  they compare directly against `evo_head`/`evo_history` output.
+- The rename touches the `fs/cas/evo/mcp` doc table but not `evo_add`'s
+  wire shape.
+
+### `generation`: required in the format, computed at `add`
+
+Decided together with this tool (the format is still being designed and no
+stored records exist yet, so this is free):
+
+- **The format requires `generation`**: `revisionSchema`
+  (`fs/media/revision/module.f.ts`) changes `option(number)` → `number`,
+  with "is a non-negative integer" enforced by `validate` on top of the
+  structural schema, the same layering as `isHash`. Existence and
+  integer-ness are the *correctness* check — a blob failing it is not a
+  revision.
+- **Continuity is observed, not enforced.** The normative value — `0` for a
+  root (`parents: []`), else `1 + max(parents' generations)` — is what
+  evo's `add` always writes. But equality with that formula is *not* a
+  validity condition for blobs from elsewhere: a deviation is a **signal**
+  that someone reset the history/clock — e.g. a revision starting a new
+  epoch, such as a new subject that still lists its origin as `parents` to
+  show how it was formed. Consumers may surface the discontinuity (an
+  epoch-reset indicator); they must not reject the blob for it. Ordering by
+  `generation` is therefore reliable within an epoch, and the one-level
+  comparison against parents is the cheap epoch-boundary detector.
+- **`evo_add` computes it.** `RevisionData` has no `generation` field —
+  callers never supply it. `resolveParents` already fetches and decodes
+  every parent during `add`, so the computation is a `max` over values
+  already in hand, plus the base case `0` for zero parents. Everything evo
+  writes follows the formula by construction.
+- **`evo_revision` returns the stored value** — always present by format.
+
+### Open question: cross-subject parents
+
+The epoch-reset scenario above ("new subject formed from an old one") is
+currently rejected at the *evo* layer: `validateParentSubjects`
+(`fs/cas/evo/module.f.ts`) requires every parent to share the revision's
+`subject`. The format itself never forbade cross-subject parents, so
+allowing that scenario is an evo-layer relaxation — one that would also
+touch the closure assumption behind the subject-history design (a mainline
+walk could then cross into another subject's revisions, which is arguably
+the point: the history *shows how it was formed*). Not decided here;
+recorded so the decision is made deliberately, not by accident.
+
+### Implementation notes
+
+- **Errors.** Three distinct failures, each a proper message rather than
+  `null`: hash not present in the store; blob present but not a valid
+  revision (wrong dialect, failed schema, failed reference check); decode
+  failure. `resolveParent` (`fs/cas/evo/module.f.ts`) already implements
+  the shape of this check for `add`'s parents.
+- **Serving.** v1 reads through `decodeRevisionBlob` like `resolveParent`
+  does. The per-revision cache planned in
+  [`todo/subject-history.md`](subject-history.md) (`hash → ordered
+  parents`) can memoize `generation` alongside — both are immutable, so
+  neither can go stale — but that is an optimization, not a requirement:
+  the cache holds only part of what `evo_revision` returns.
+- **MCP output** is the JSON of `RevisionView`:
+  `{ subject, parents, snapshot?, archived?, generation }`.
+
+### Tasks
+
+- [ ] Make `generation` required: `revisionSchema` `option(number)` →
+      `number`, non-negative-integer check in `validate`, README update
+      (`fs/media/revision/README.md`) including the epoch-reset semantics
+      and the continuity-is-not-validity rule, with proof coverage for a
+      missing, non-integer, and negative `generation`.
+- [ ] Rename `AddRevision` → `RevisionData`, add `RevisionView`, update the
+      `fs/cas/evo/mcp` doc table.
+- [ ] Compute and write `generation` in `add` (base case `0`, else
+      `1 + max`), with proof coverage including a merge of parents with
+      differing generations.
+- [ ] Implement `revision(hash)` on `Evo<O>` with proof coverage for all
+      three error cases and for canonicalized output (a parent stored under
+      an alias spelling comes back canonical).
+- [ ] Expose `evo_revision` through MCP (`fs/cas/evo/mcp`) and document it
+      in `fs/cas/evo/README.md` / `fs/cas/evo/mcp/README.md`.
+- [ ] Decide the cross-subject-parents question (separate todo if
+      accepted).
+
+### Related
+
+- [`todo/subject-history.md`](subject-history.md) — the mainline walk this
+  tool is the node-detail companion to.
+- `fs/media/revision/README.md` — the `vnd.fjs.revision` format whose
+  `generation` field this makes required.

--- a/fs/cas/evo/todo/subject-history.md
+++ b/fs/cas/evo/todo/subject-history.md
@@ -51,9 +51,14 @@ readonly history: (start: Hash, limit?: number) => Effect<O | MemOp, Result<read
   starting *revision*, not a subject: the client calls `head(subject)`
   (`readonly Hash[]`) and then `history(h)` per head. One operation covers
   heads, merged-in branches, and pagination resumption alike.
-- **Pagination** is the optional `limit`. To continue, re-call `history`
-  with the last returned hash — the first element of the continuation
-  repeats it, which the client drops. No cursor machinery.
+- **Pagination** is the optional `limit`, and a supplied `limit` must be
+  at least 2 — rejected as an error, not clamped, when smaller. The last
+  element of a page doubles as the resume anchor, so every page must carry
+  at least one element *beyond* it; with `limit = 1` a caller could never
+  advance (`history(h, 1)` returns `[h]`, and resuming from `h` returns
+  `[h]` again, forever). To continue, re-call `history` with the last
+  returned hash — the first element of the continuation repeats it, which
+  the client drops. No cursor machinery.
 - **Convergence rule.** Expanding a merged-in branch eventually rejoins
   ancestry the client already holds (at the common ancestor, then all the
   way to the root). The client-side rule is: stop at the first hash you
@@ -134,8 +139,8 @@ the rare consumer, still reachable in O(branches) calls.
       map (immutable, never stale).
 - [ ] Implement `history(start, limit?)` on `Evo<O>` with proof coverage,
       including a subject with a merge (multiple parents), a subject with
-      multiple concurrent heads, `limit`/resume, and an unknown or
-      non-revision `start`.
+      multiple concurrent heads, `limit`/resume, rejection of `limit < 2`,
+      and an unknown or non-revision `start`.
 - [ ] Expose it through MCP (`fs/cas/evo/mcp`) and document it in
       `fs/cas/evo/README.md` / `fs/cas/evo/mcp/README.md`.
 

--- a/fs/cas/evo/todo/subject-history.md
+++ b/fs/cas/evo/todo/subject-history.md
@@ -35,8 +35,12 @@ readonly history: (start: Hash) => Effect<O | MemOp, Result<readonly Hash[], str
 ```
 
 - **Return shape is just `readonly Hash[]`** — the same primitive
-  `head(subject)` already returns. Element 0 is `start`; each next element
-  is the previous element's `parents[0]`; the array ends at a root
+  `head(subject)` already returns. Element 0 is `start` in its *canonical*
+  cbase32 spelling — decoded and re-encoded, never echoed: cbase32 accepts
+  alias spellings (case, `i`/`l`/`o`), and an input alias leaking into the
+  result would be the one non-canonical hash in an otherwise canonical
+  API, breaking the client-side seen-hash comparison. Each next element is
+  the previous element's `parents[0]`; the array ends at a root
   (`parents: []`). Adjacency *is* the mainline edge; there is no other
   structure in the value.
 - **Merges are discovered by the client, not encoded here.** A v1 item is a
@@ -139,7 +143,8 @@ the rare consumer, still reachable in O(branches) calls.
       map (immutable, never stale).
 - [ ] Implement `history(start)` on `Evo<O>` with proof coverage,
       including a subject with a merge (multiple parents), a subject with
-      multiple concurrent heads, and an unknown or non-revision `start`.
+      multiple concurrent heads, an unknown or non-revision `start`, and a
+      `start` given in an alias spelling (element 0 comes back canonical).
 - [ ] Expose it through MCP (`fs/cas/evo/mcp`) and document it in
       `fs/cas/evo/README.md` / `fs/cas/evo/mcp/README.md`.
 

--- a/fs/cas/evo/todo/subject-history.md
+++ b/fs/cas/evo/todo/subject-history.md
@@ -41,11 +41,12 @@ readonly history: (start: Hash, limit?: number) => Effect<O | MemOp, Result<read
   there is no other structure in the value.
 - **Merges are discovered by the client, not encoded here.** A v1 item is a
   bare hash. A client that wants merge markers (or the merged-in branches)
-  fetches the revision blob via the existing `cas_get` +
-  `decodeRevisionBlob` and reads its full `parents`; every parent beyond
-  index 0 is a merged-in branch, and its own history is one more
-  `history(parent)` call. The API adds no data a client couldn't already
-  reach — it adds the walk.
+  fetches the revision via the typed companion read
+  [`todo/evo-revision.md`](evo-revision.md) (`evo_revision`, which decodes,
+  validates, and canonicalizes server-side) and reads its full `parents`;
+  every parent beyond index 0 is a merged-in branch, and its own history is
+  one more `history(parent)` call. The API adds no data a client couldn't
+  already reach — it adds the walk.
 - **Multiple concurrent heads need no special encoding.** `history` takes a
   starting *revision*, not a subject: the client calls `head(subject)`
   (`readonly Hash[]`) and then `history(h)` per head. One operation covers
@@ -140,6 +141,9 @@ the rare consumer, still reachable in O(branches) calls.
 
 ### Related
 
+- [`todo/evo-revision.md`](evo-revision.md) — the typed single-revision
+  read (`evo_revision`) that serves the node detail this walk deliberately
+  omits, and the required-`generation` format decision.
 - [`todo/cache-staleness.md`](cache-staleness.md) — history is read from the
   same in-memory cache, so it inherits that staleness question.
 - `fs/media/revision/README.md` — the `vnd.fjs.revision` DAG shape

--- a/fs/cas/evo/todo/subject-history.md
+++ b/fs/cas/evo/todo/subject-history.md
@@ -31,14 +31,14 @@ The history operation walks exactly that link:
 
 ```ts
 /** First-parent chain starting at (and including) `start`. */
-readonly history: (start: Hash, limit?: number) => Effect<O | MemOp, Result<readonly Hash[], string>>
+readonly history: (start: Hash) => Effect<O | MemOp, Result<readonly Hash[], string>>
 ```
 
 - **Return shape is just `readonly Hash[]`** — the same primitive
   `head(subject)` already returns. Element 0 is `start`; each next element
   is the previous element's `parents[0]`; the array ends at a root
-  (`parents: []`) or at `limit` elements. Adjacency *is* the mainline edge;
-  there is no other structure in the value.
+  (`parents: []`). Adjacency *is* the mainline edge; there is no other
+  structure in the value.
 - **Merges are discovered by the client, not encoded here.** A v1 item is a
   bare hash. A client that wants merge markers (or the merged-in branches)
   fetches the revision via the typed companion read
@@ -50,15 +50,15 @@ readonly history: (start: Hash, limit?: number) => Effect<O | MemOp, Result<read
 - **Multiple concurrent heads need no special encoding.** `history` takes a
   starting *revision*, not a subject: the client calls `head(subject)`
   (`readonly Hash[]`) and then `history(h)` per head. One operation covers
-  heads, merged-in branches, and pagination resumption alike.
-- **Pagination** is the optional `limit`, and a supplied `limit` must be
-  at least 2 — rejected as an error, not clamped, when smaller. The last
-  element of a page doubles as the resume anchor, so every page must carry
-  at least one element *beyond* it; with `limit = 1` a caller could never
-  advance (`history(h, 1)` returns `[h]`, and resuming from `h` returns
-  `[h]` again, forever). To continue, re-call `history` with the last
-  returned hash — the first element of the continuation repeats it, which
-  the client drops. No cursor machinery.
+  heads and merged-in branches alike.
+- **No pagination in v1** — `history` returns the full chain to the root.
+  A `limit` parameter can be added compatibly in a future release (an
+  optional parameter is a non-breaking addition). When it is, the designed
+  semantics are: the last element of a page doubles as the resume anchor
+  (re-call `history` with it and drop the repeated first element), so a
+  supplied `limit` must be at least 2 — rejected, not clamped, when
+  smaller, since with `limit = 1` a caller could never advance
+  (`history(h, 1)` would return `[h]` forever).
 - **Convergence rule.** Expanding a merged-in branch eventually rejoins
   ancestry the client already holds (at the common ancestor, then all the
   way to the root). The client-side rule is: stop at the first hash you
@@ -96,9 +96,8 @@ readonly history: (start: Hash, limit?: number) => Effect<O | MemOp, Result<read
   the in-memory cache like everything else in `Evo<O>`.
 - **MCP surface.** A new `evo_history` tool (`fs/cas/evo/mcp/module.f.ts`)
   alongside `evo_list`/`evo_head`/`evo_add`, taking `start` (hash) and
-  optional `limit`, returning the hash array. Evo-specific, so a dedicated
-  tool name is fine (unlike the generic refresh tool in
-  `cache-staleness.md`).
+  returning the hash array. Evo-specific, so a dedicated tool name is fine
+  (unlike the generic refresh tool in `cache-staleness.md`).
 
 ### Discarded alternatives
 
@@ -130,17 +129,17 @@ the rare consumer, still reachable in O(branches) calls.
 
 - [x] Pick a history representation and write out its exact shape and
       reconstruction algorithm (this document).
-- [x] Decide the open questions (archived revisions: included; size: `limit`
-      + resume-by-last-hash; staleness: inherited from
+- [x] Decide the open questions (archived revisions: included; size: full
+      chain in v1, `limit` deferred to a future release with
+      resume-by-last-hash semantics; staleness: inherited from
       `cache-staleness.md`; MCP tool: `evo_history`).
 - [x] Document the `parents[0]`-is-mainline commitment in
       `fs/media/revision/README.md`.
 - [ ] Extend the Evo cache with the per-revision `hash → ordered parents`
       map (immutable, never stale).
-- [ ] Implement `history(start, limit?)` on `Evo<O>` with proof coverage,
+- [ ] Implement `history(start)` on `Evo<O>` with proof coverage,
       including a subject with a merge (multiple parents), a subject with
-      multiple concurrent heads, `limit`/resume, rejection of `limit < 2`,
-      and an unknown or non-revision `start`.
+      multiple concurrent heads, and an unknown or non-revision `start`.
 - [ ] Expose it through MCP (`fs/cas/evo/mcp`) and document it in
       `fs/cas/evo/README.md` / `fs/cas/evo/mcp/README.md`.
 

--- a/fs/cas/evo/todo/subject-history.md
+++ b/fs/cas/evo/todo/subject-history.md
@@ -1,7 +1,7 @@
-## Return a subject's full revision history
+## Return a subject's revision history
 
 **Priority:** P3
-**Status:** open
+**Status:** open — design chosen, not yet implemented
 
 ### Problem
 
@@ -18,122 +18,123 @@ is a DAG (multiple parents on a merge, and a subject can have multiple
 concurrent heads), so whatever shape this returns has to represent branching
 and merging, not just a linear list.
 
-### Proposal
+### Chosen design: the mainline walk
 
-No design has been chosen yet. Candidate shapes, roughly in order of how
-much new format they invent:
+`parents[0]` of a revision is its **mainline** parent — the branch the
+revision landed on, in the sense of Git's first-parent link. This is now a
+documented commitment of the `vnd.fjs.revision` format itself
+(`fs/media/revision/README.md`), not just of this API: merge-creating
+clients list the branch they merged *into* first, and the parent order is
+load-bearing from here on.
 
-1. **Just the node set.** `Evo<O>` already tracks, per subject,
-   `SubjectState.hashes` — every revision hash ever added for that subject
-   (`fs/cas/evo/module.f.ts`). With the cross-subject-parent check
-   (`validateParentSubjects`) now in place, every parent of a subject's
-   revision is guaranteed to belong to the same subject, so this set is
-   already exactly the DAG's node set — closed under "is a parent of". A
-   `history(subject)` that just returns this array (already-cached, free to
-   compute) needs no new serialization: each revision blob already embeds
-   its own `parents`, so a client that wants edges fetches each hash via the
-   existing `cas_get`/`decodeRevisionBlob` and reconstructs the DAG itself.
-   Cheapest to implement and to reason about; costs the client N additional
-   fetches to see any structure.
-2. **Edge list.** `readonly (readonly [hash: Hash, parents: readonly Hash[]])[]`
-   — one entry per revision, pairing its hash with its parent hashes,
-   embedding the edges without inventing an object-keyed format. Order
-   independent, trivial to fold into a client-side adjacency map, and (unlike
-   option 3) never uses a hash as an object *key*, so it can't run into the
-   own-property-lookup class of bug the Evo cache itself had to fix
-   (`fs/cas/evo/module.f.ts` `at`) — a hash colliding with `toString`/
-   `constructor` is astronomically unlikely but not the kind of thing worth
-   relying on when a plain array sidesteps it entirely.
-3. **Adjacency map keyed by hash**, as originally sketched:
-   ```json
-   {
-     "headRevisionHash": ["parent0Hash", "parent1Hash"],
-     "parent0Hash": ["..."]
-   }
-   ```
-   Reads naturally as "the DAG", but every key is a hash used as a plain
-   object property — the same shape of risk `at` (own-property lookup) was
-   added to guard against for subjects; hashes aren't attacker-controlled
-   arbitrary strings the way subjects are, so this is a much smaller concern
-   here, but a consumer indexing this object should still look up by own
-   property, not bare `obj[hash]`.
-4. **Flattened left-branch sequence**, modeled on Git: the *left* (first-
-   listed) parent is the mainline — the branch this history is "of" — and
-   any further (*right*) parents are other branches that merged into it, the
-   way Git's first-parent link marks the branch a merge commit landed on.
-   Rendered history tools (`git log --first-parent`) walk exactly this link
-   and treat the rest as detail; this format encodes that same asymmetry
-   instead of treating all parents as interchangeable.
+The history operation walks exactly that link:
 
-   A flat array is the mainline: each element is normally a bare hash,
-   continuing to that hash's own mainline parent as the next element. A
-   node that is *also* a merge (has more than one parent) replaces its bare
-   entry with a binary bracket `[node, mergedParent]`, where `mergedParent`
-   is the (recursively encoded) branch that merged in. The mainline then
-   continues as usual: if this node has a predecessor already extending a
-   flat array, its own mainline parent becomes the *next* element of that
-   same array; if the node is the value's own starting point (no
-   predecessor to continue from), its mainline parent has nowhere else to
-   go and is wrapped in too, as the outermost element of the same bracket.
+```ts
+/** First-parent chain starting at (and including) `start`. */
+readonly history: (start: Hash, limit?: number) => Effect<O | MemOp, Result<readonly Hash[], string>>
+```
 
-   Worked examples:
-   - `['a', 'b', 'c']` — no merges, pure mainline: `a`'s parent is `b`,
-     `b`'s parent is `c`.
-   - `['a', ['b', 'd'], 'c', 'd']` — `a`'s mainline parent is `b`; `b` is a
-     merge (bracket `['b', 'd']`: `b`'s merged-in parent is `d`); `b`'s own
-     mainline parent, `c`, continues the *outer* array (there was already
-     one to continue, from `a`); `c`'s parent is `d`. Edges: `a→b`, `b→d`,
-     `b→c`, `c→d`.
-   - `[[[a, d], c], b]` — `a` is a three-way merge (`a → b, c, d`) and is
-     itself the sequence's starting point, so *all three* parents end up
-     wrapped: innermost `[a, d]` pairs `a` with its last-listed parent `d`;
-     wrapping with `c` adds the next; wrapping with `b` (outermost) adds the
-     mainline parent last, because there's no enclosing array for `b` to
-     continue instead. Edges: `a→b`, `a→c`, `a→d`.
+- **Return shape is just `readonly Hash[]`** — the same primitive
+  `head(subject)` already returns. Element 0 is `start`; each next element
+  is the previous element's `parents[0]`; the array ends at a root
+  (`parents: []`) or at `limit` elements. Adjacency *is* the mainline edge;
+  there is no other structure in the value.
+- **Merges are discovered by the client, not encoded here.** A v1 item is a
+  bare hash. A client that wants merge markers (or the merged-in branches)
+  fetches the revision blob via the existing `cas_get` +
+  `decodeRevisionBlob` and reads its full `parents`; every parent beyond
+  index 0 is a merged-in branch, and its own history is one more
+  `history(parent)` call. The API adds no data a client couldn't already
+  reach — it adds the walk.
+- **Multiple concurrent heads need no special encoding.** `history` takes a
+  starting *revision*, not a subject: the client calls `head(subject)`
+  (`readonly Hash[]`) and then `history(h)` per head. One operation covers
+  heads, merged-in branches, and pagination resumption alike.
+- **Pagination** is the optional `limit`. To continue, re-call `history`
+  with the last returned hash — the first element of the continuation
+  repeats it, which the client drops. No cursor machinery.
+- **Convergence rule.** Expanding a merged-in branch eventually rejoins
+  ancestry the client already holds (at the common ancestor, then all the
+  way to the root). The client-side rule is: stop at the first hash you
+  have already seen. A server-side `until` parameter is possible later but
+  not part of v1.
+- **Archived revisions are included.** The walk follows parent links, and a
+  parent doesn't stop being a parent by being `archived`.
+- **Upgrade path (decided now, taken never or later).** If a client ever
+  needs merge parents inline, the chosen path is an options flag — e.g.
+  `history(start, { parents: true })` returning
+  `readonly (readonly [Hash, ...Hash[]])[]` (item 0 = the revision, rest =
+  its non-mainline parents) — not a change to the default `readonly Hash[]`
+  shape, and not a second tool. The v1 contract never changes.
 
-   Three-or-more-parent merges are expected to be extremely rare (as in
-   Git), so the format doesn't need a flat "list of siblings" shape for
-   them — nesting one binary bracket per extra parent, as above, is an
-   acceptable fallback for a case this uncommon, in exchange for keeping the
-   common one-merged-parent case (`[node, mergedParent]`) simple.
+### Implementation notes
 
-   More compact than option 3 for a mostly-linear history (no hash is
-   repeated as a key), and the grammar is recursive (a merged parent is
-   itself encoded the same way, so it can carry its own further history)
-   rather than limited to one level of branching.
-
-   Still open: a subject can have more than one *current* head at once (see
-   `head(subject)`'s return type, `readonly Hash[]`), but every worked
-   example above starts from a single head. Does `history` take/return one
-   sequence per head, or does the grammar need a way to start several
-   left-branch chains in one value?
-
-Whatever is chosen should also settle:
-
-- **Archived revisions** (`archived: true`) — included in history or not?
-  History is presumably meant to include them (that's what "history" means),
-  but worth stating explicitly.
-- **Size.** A long-lived subject's history can be arbitrarily large; does
-  `history` need pagination, a depth limit, or a "since generation X" cursor,
-  or is returning everything acceptable for a first version?
+- **The cache can't serve the walk yet.** `SubjectState`
+  (`fs/cas/evo/module.f.ts`) deliberately stores `hashes` and `parents` as
+  flat, order-independent sets — enough for `headsOf`, not enough to follow
+  a first-parent chain. Preferred fix: extend the cache with a per-revision
+  `hash → ordered parents` map. Revision blobs are immutable, so that
+  mapping can never go stale (unlike heads), and the walk becomes pure
+  in-memory. It also doesn't threaten the fold-order-independence invariant
+  documented at the top of the module — the per-revision parent list is
+  fixed data carried by each blob, not something accumulated across fold
+  order. (The alternative — `cas_get` + decode per step at call time —
+  works but costs O(chain) I/O per call.)
+- **Errors.** `start` must resolve and decode as a revision
+  (`resolveParent` already implements exactly this check for `add`);
+  otherwise `history` returns the error. A decode failure *mid-walk*
+  (corrupt or missing parent blob) is also an error, not a silent
+  truncation.
 - **Staleness.** Same cache-staleness concern as
   [`todo/cache-staleness.md`](cache-staleness.md) — history is served from
   the in-memory cache like everything else in `Evo<O>`.
-- **MCP surface.** Presumably a new `evo_history` tool
-  (`fs/cas/evo/mcp/module.f.ts`) alongside `evo_list`/`evo_head`/`evo_add` —
-  unlike the generic refresh tool in `cache-staleness.md`, this one is
-  Evo-specific (a subject's revision history isn't a concept any other
-  planned cache would share), so a dedicated tool name is fine here.
+- **MCP surface.** A new `evo_history` tool (`fs/cas/evo/mcp/module.f.ts`)
+  alongside `evo_list`/`evo_head`/`evo_add`, taking `start` (hash) and
+  optional `limit`, returning the hash array. Evo-specific, so a dedicated
+  tool name is fine (unlike the generic refresh tool in
+  `cache-staleness.md`).
+
+### Discarded alternatives
+
+Earlier candidates, kept for the record:
+
+1. **Just the node set** — return `SubjectState.hashes`. Free to compute
+   and closed under "is a parent of" (thanks to `validateParentSubjects`),
+   but unordered: N extra fetches for the client to see *any* structure,
+   including plain display order.
+2. **Edge list** — `readonly (readonly [Hash, readonly Hash[]])[]`. Whole
+   DAG in one response, no hash-as-object-key risk, but response size is
+   the whole history and the client still reconstructs everything itself.
+3. **Adjacency map keyed by hash** — reads naturally as "the DAG" but uses
+   hashes as object keys, the own-property-lookup class of risk the Evo
+   cache's `at` was added to guard against.
+4. **Recursive first-parent grammar** — a flat mainline array where a merge
+   becomes a nested bracket `[node, mergedParent]`, recursively. Had the
+   right asymmetry (first-parent vs merged-in) but paid for it with a
+   recursive encoding, special cases for merges at the sequence start and
+   three-plus-parent merges, and an unresolved question for multiple
+   concurrent heads.
+
+The chosen design keeps option 4's first-parent asymmetry and drops its
+grammar: laziness (per-branch `history` calls) replaces recursion, and the
+one thing options 1–2 did better — the *entire* DAG in a single call — is
+the rare consumer, still reachable in O(branches) calls.
 
 ### Tasks
 
-- [ ] Pick a history representation (one of the above, or something else)
-      and write out its exact shape and reconstruction algorithm.
-- [ ] Decide the open questions above (archived revisions, size/pagination,
-      staleness, MCP tool name/shape).
-- [ ] Implement `history(subject)` on `Evo<O>` with proof coverage,
-      including a subject with a merge (multiple parents) and one with
-      multiple concurrent heads.
+- [x] Pick a history representation and write out its exact shape and
+      reconstruction algorithm (this document).
+- [x] Decide the open questions (archived revisions: included; size: `limit`
+      + resume-by-last-hash; staleness: inherited from
+      `cache-staleness.md`; MCP tool: `evo_history`).
+- [x] Document the `parents[0]`-is-mainline commitment in
+      `fs/media/revision/README.md`.
+- [ ] Extend the Evo cache with the per-revision `hash → ordered parents`
+      map (immutable, never stale).
+- [ ] Implement `history(start, limit?)` on `Evo<O>` with proof coverage,
+      including a subject with a merge (multiple parents), a subject with
+      multiple concurrent heads, `limit`/resume, and an unknown or
+      non-revision `start`.
 - [ ] Expose it through MCP (`fs/cas/evo/mcp`) and document it in
       `fs/cas/evo/README.md` / `fs/cas/evo/mcp/README.md`.
 
@@ -142,4 +143,5 @@ Whatever is chosen should also settle:
 - [`todo/cache-staleness.md`](cache-staleness.md) — history is read from the
   same in-memory cache, so it inherits that staleness question.
 - `fs/media/revision/README.md` — the `vnd.fjs.revision` DAG shape
-  (`parents`, merges, concurrent heads) this history has to represent.
+  (`parents`, merges, concurrent heads) this history walks, including the
+  first-parent (mainline) ordering commitment.

--- a/fs/media/revision/README.md
+++ b/fs/media/revision/README.md
@@ -29,7 +29,7 @@ export const revisionSchema = {
 |--------------|-------------------------|------------------------------------------------------------------------|
 | `dialect`    | `'vnd.fjs.revision'`    | Format tag — see [Media type](#media-type-and-dialect-tag) below.      |
 | `subject`    | `string`                | Identity of the mutable object this revision revises.                  |
-| `parents`    | `hash[]`                | Parent revision BLOBs. `[]` means this is the first revision.          |
+| `parents`    | `hash[]`                | Parent revision BLOBs, mainline (first-parent) first — see below. `[]` means this is the first revision. |
 | `snapshot`   | `hash` (optional)       | Complete materialized content of this revision.                        |
 | `generation` | `number` (optional)     | Cached generation number — `0` for the first revision, else `1 + max(parent.generation)`. |
 | `archived`   | `true` (optional)       | Marks the mutable object as archived/inactive.                         |
@@ -121,6 +121,16 @@ creates a new revision listing the conflicting revisions as `parents`. The
 format only records conflict resolution; it never resolves conflicts itself,
 and CAS synchronization never needs to care — a subject can legitimately have
 many heads in a store at any time.
+
+Parent *order* is significant: `parents[0]` is the **mainline** parent — the
+branch this revision landed on, in the sense of Git's first-parent link. A
+merge tool merging branch B into branch A lists A's head first, then B's.
+Walking only first parents from a head therefore yields that head's mainline
+history, with every later `parents` entry marking a branch that merged in —
+this is the walk the planned history API performs
+([`fs/cas/evo/todo/subject-history.md`](../../cas/evo/todo/subject-history.md)).
+Reordering `parents` changes the meaning of a revision (which branch the
+merge landed on), not just its serialization.
 
 `generation` is a cache, not a source of truth: it must always be
 re-derivable from `parents`, and a consumer must not trust a `generation` it

--- a/fs/media/revision/todo/required-fields.md
+++ b/fs/media/revision/todo/required-fields.md
@@ -1,0 +1,111 @@
+## Require all fields whose absence forces inference
+
+**Priority:** P0
+**Status:** open
+
+### Problem
+
+While the `vnd.fjs.revision` format is still being designed and **no
+revision records exist anywhere**, requirement changes are free: they land
+in-place, under the same dialect tag, with nothing stored to migrate. That
+window closes the moment the first revision is written — after that, any
+requirement change takes a new dialect (see the versioning rule in
+[`README.md`](../README.md), and the rationale recorded in
+[`fs/cas/evo/todo/evo-revision.md`](../../../cas/evo/todo/evo-revision.md)).
+Hence P0: this must land before the API is used to create revisions.
+
+The rule: **a field whose absent value must be *derived from other data*
+is required.** Optional stays reserved for fields whose absent value is a
+constant default. Today two fields violate the rule:
+
+- **`snapshot`** — the most inference-heavy field in the format. Its
+  absence triggers the three-case resolution algorithm
+  ([`README.md`](../README.md), "Snapshot resolution"): zero parents →
+  fall back to `subject`, one parent → inherit the parent's snapshot,
+  multiple parents → invalid. The inheritance case is *non-local*
+  inference: resolving it means fetching the parent blob — and if that one
+  also omitted `snapshot`, an ancestry walk to the nearest explicit one.
+  The revision's actual content is unknowable without I/O.
+- **`generation`** — absent means "re-derive from the ancestry", an
+  ancestry walk for one integer. (Decided in
+  [`fs/cas/evo/todo/evo-revision.md`](../../../cas/evo/todo/evo-revision.md);
+  the format-level change is tracked here.)
+
+### Change
+
+Both become required in `revisionSchema` (`module.f.ts`):
+
+- `snapshot`: `option(hash)` → `hash`. Every revision states its content
+  explicitly — even when unchanged from a parent (an archive-only
+  revision, a merge taking one side wholesale). The cost is one hash per
+  blob; the payoff is that the whole resolution algorithm is deleted, and
+  with it:
+  - the `subject`-as-fallback special case — `subject` becomes purely an
+    identity string, always, never conditionally validated as a hash;
+  - the "absent with multiple parents" error case — there is no absent.
+- `generation`: `option(number)` → `number`, "is a non-negative integer"
+  enforced by `validate` on top of the structural schema (the same
+  layering as `isHash`). Existence and integer-ness are the correctness
+  check; equality with `1 + max(parents' generations)` is observed, not
+  enforced — a deviation signals an epoch reset (see
+  [`evo-revision.md`](../../../cas/evo/todo/evo-revision.md)), not an
+  invalid blob.
+
+**Not required — `archived`.** Its absence is not inference: the default
+is the constant `false`, derivable from nothing. Forcing
+`archived: false` onto every blob is pure noise, and `option(true)` is the
+established presence-flag idiom. It stays optional, and this is the
+documented boundary of the rule.
+
+### The property this buys
+
+With `snapshot` and `generation` required, **a revision blob is fully
+interpretable in isolation**: no field's meaning ever requires fetching
+another blob. Cross-blob *checks* remain — generation continuity,
+same-subject parents — but those are signals and layer rules, not "what
+does this blob say". The README should state this property explicitly; it
+is the invariant future field proposals are measured against.
+
+Inference doesn't disappear — it moves to the write boundary, where it
+runs once, server-side, with the parents already resolved: `evo_add`
+(`fs/cas/evo`) keeps its input conveniences (infer `subject` from the
+single parent, compute `generation`, resolve an absent input `snapshot`
+by the same rules the format used to carry) and writes every field
+explicitly. APIs infer; the stored record never does.
+
+### Future relaxation
+
+A future format version may make a required field optional again — but
+only together with a *specified inference algorithm* for the absent value,
+and (per the versioning rule) under a new dialect, since readers of this
+dialect reject blobs missing a required field. The relaxation and its
+algorithm are one decision; this todo just keeps the door open.
+
+### Tasks
+
+- [ ] `revisionSchema`: `snapshot` `option(hash)` → `hash`, `generation`
+      `option(number)` → `number`; non-negative-integer check for
+      `generation` in `validate`; remove the snapshot-resolution logic and
+      the `subject`-as-hash fallback from `validate`/`decodeText`.
+- [ ] Proof coverage: missing/non-integer/negative `generation`, missing
+      `snapshot`, and a zero-parent revision whose `subject` is not a hash
+      (now valid — `subject` is never a snapshot reference).
+- [ ] `README.md`: update the schema snippet and field table (`snapshot`
+      and `generation` required); delete the "Snapshot resolution"
+      section; reframe the `generation` paragraph (correctness =
+      existence + integer-ness, `1 + max` is what conforming writers
+      produce, deviation = epoch-reset signal); state the
+      interpretable-in-isolation property and the required-fields rule
+      with the `archived` boundary; note the future-relaxation rule.
+- [ ] Land before any revision records are created (and in the same change
+      as `evo_add` writing the required fields — see the sequencing note
+      in [`evo-revision.md`](../../../cas/evo/todo/evo-revision.md)).
+
+### Related
+
+- [`fs/cas/evo/todo/evo-revision.md`](../../../cas/evo/todo/evo-revision.md)
+  — the `generation` semantics (computed at `add`, epoch-reset signal) and
+  the why-no-dialect-bump rationale this change relies on.
+- [`fs/cas/evo/todo/subject-history.md`](../../../cas/evo/todo/subject-history.md)
+  — the mainline walk whose `evo_revision` companion motivated requiring
+  `generation`.

--- a/fs/media/revision/todo/required-fields.md
+++ b/fs/media/revision/todo/required-fields.md
@@ -1,6 +1,6 @@
 ## Require all fields whose absence forces inference
 
-**Priority:** P0
+**Priority:** P1
 **Status:** open
 
 ### Problem
@@ -12,7 +12,8 @@ window closes the moment the first revision is written — after that, any
 requirement change takes a new dialect (see the versioning rule in
 [`README.md`](../README.md), and the rationale recorded in
 [`fs/cas/evo/todo/evo-revision.md`](../../../cas/evo/todo/evo-revision.md)).
-Hence P0: this must land before the API is used to create revisions.
+Hence P1, blocking: this must land before the API is used to create
+revisions.
 
 The rule: **a field whose absent value must be *derived from other data*
 is required.** Optional stays reserved for fields whose absent value is a

--- a/fs/media/revision/todo/required-fields.md
+++ b/fs/media/revision/todo/required-fields.md
@@ -7,7 +7,15 @@
 
 While the `vnd.fjs.revision` format is still being designed and **no
 revision records exist anywhere**, requirement changes are free: they land
-in-place, under the same dialect tag, with nothing stored to migrate. That
+in-place, under the same dialect tag, with nothing stored to migrate.
+This is a matter of record, not an assumption: the format was introduced
+a few weeks ago, no released version of FunctionalScript has ever
+included the evo API, and the only writers that have ever run are this
+repository's own proofs against in-memory stores — no persistent store
+has ever been populated with revision blobs. The same applies to every
+semantic commitment made while designing the format (e.g. the
+first-parent ordering in [`README.md`](../README.md)): there are no
+pre-existing blobs whose meaning could shift. That
 window closes the moment the first revision is written — after that, any
 requirement change takes a new dialect (see the versioning rule in
 [`README.md`](../README.md), and the rationale recorded in


### PR DESCRIPTION
## Summary

This PR finalizes the design for a subject revision history API and documents the first-parent ordering commitment in the revision format. The history operation walks the mainline (first-parent) chain from a given revision, enabling clients to efficiently traverse a subject's revision DAG.

## Changes

- **`fs/cas/evo/todo/subject-history.md`**: Replaced the open design proposal section with a concrete chosen design:
  - History operation returns `readonly Hash[]` — a simple array of revision hashes following the first-parent chain
  - Clients discover merges by fetching full revision blobs and reading non-mainline parents
  - Supports pagination via optional `limit` parameter; resumption by re-calling with the last hash
  - Archived revisions are included in the walk
  - Documented implementation notes: cache extension needed for per-revision parent maps, error handling for invalid/corrupt revisions, MCP surface as `evo_history` tool
  - Moved earlier candidate designs (node set, edge list, adjacency map, recursive grammar) to a "Discarded alternatives" section with rationale
  - Updated task list to reflect completed design decisions and remaining implementation work

- **`fs/media/revision/README.md`**: Documented the first-parent ordering commitment:
  - Updated `parents` field description to clarify that mainline parent comes first
  - Added new section explaining parent order significance: `parents[0]` is the mainline parent (Git's first-parent link semantics)
  - Noted that merge tools must list the target branch first when merging
  - Explained that reordering `parents` changes revision meaning, not just serialization
  - Linked to the history API design document

## Implementation Notes

The chosen design prioritizes simplicity and laziness:
- Returns only the mainline chain, not the entire DAG
- Clients make additional `history()` calls per branch to explore merges
- No new serialization format invented; uses existing revision blob structure
- Avoids hash-as-object-key risks by using plain arrays
- Pagination and convergence detection are client-side responsibilities
- Cache extension (per-revision parent map) is needed for efficient in-memory walks

https://claude.ai/code/session_01XcbFaUhAGNomb3EYDUnZML