### PR TITLE
Reject oversized cas_add inline content gracefully

### DIFF
--- a/fs/asn.1/module.f.ts
+++ b/fs/asn.1/module.f.ts
@@ -20,6 +20,7 @@ import {
 import { identity } from "../types/function/module.f.ts"
 import { max } from "../types/function/compare/module.f.ts"
 import { encode as b128encode, decode as b128decode } from "../base128/module.f.ts"
+import { unwrap, type Nullable } from "../types/nullable/module.f.ts"
 
 const { popFront: pop, listToVec } = msb
 
@@ -48,7 +49,9 @@ type ParsedTag = readonly[ClassPc, bigint]
 /** ASN.1 tag number. */
 type Tag = bigint
 
-const parsedTagEncode = ([classPc, number]: ParsedTag): Vec => {
+// Builds from a caller-supplied tag number (b128-encoded), so its length is
+// data-derived — it propagates the over-cap `null`.
+const parsedTagEncode = ([classPc, number]: ParsedTag): Nullable<Vec> => {
     const [firstByteNumber, rest] = number < tagNumberMask
         ? [number, empty]
         : [tagNumberMask, b128encode(number)]
@@ -70,7 +73,9 @@ const tagEncode = (tag: Tag): Vec =>
 
 const tagDecode = (v: Vec): readonly[Tag, Vec] => {
     const [parsedTag, rest] = parsedTagDecode(v)
-    return [uint(parsedTagEncode(parsedTag)), rest]
+    // Re-encoding a tag parsed from already-bounded input (`v` is itself a
+    // `Vec`, so ≤ `maxLength`); the over-cap `null` branch is dead.
+    return [uint(unwrap(parsedTagEncode(parsedTag))), rest]
 }
 
 //
@@ -133,7 +138,7 @@ const round8 = ({ length, uint }: Unpacked): Round8 => {
     return { byteLen, v: vec(byteLen << 3n)(uint) }
 }
 
-const lenEncode = (uint: bigint): Vec => {
+const lenEncode = (uint: bigint): Nullable<Vec> => {
     if (uint < 0x80n) {
         return vec8(uint)
     }
@@ -159,11 +164,15 @@ const lenDecode = (v: Vec): readonly[bigint, Vec] => {
 /** Raw ASN.1 TLV tuple. */
 export type Raw = readonly [Tag, Vec]
 
-/** Encodes a raw ASN.1 TLV tuple into a bit vector. */
-export const encodeRaw = ([tag, value]: Raw): Vec => {
+/**
+ * Encodes a raw ASN.1 TLV tuple into a bit vector. Wraps a caller-supplied
+ * `value` whose length is data-derived, so it propagates the over-cap `null`.
+ */
+export const encodeRaw = ([tag, value]: Raw): Nullable<Vec> => {
     const tagVec = tagEncode(tag)
     const { byteLen, v } = round8(unpack(value))
-    return listToVec([tagVec, lenEncode(byteLen), v])
+    const len = lenEncode(byteLen)
+    return len === null ? null : listToVec([tagVec, len, v])
 }
 
 /** Decodes a raw ASN.1 TLV tuple and returns the remaining input. */
@@ -210,8 +219,8 @@ export const decodeOctetString = (v: Vec): Vec => v
 /** ASN.1 OBJECT IDENTIFIER components. */
 export type ObjectIdentifier = readonly bigint[]
 
-/** Encodes an OBJECT IDENTIFIER value. */
-export const encodeObjectIdentifier = (oid: ObjectIdentifier): Vec => {
+/** Encodes an OBJECT IDENTIFIER value. Propagates the over-cap `null`. */
+export const encodeObjectIdentifier = (oid: ObjectIdentifier): Nullable<Vec> => {
     const [first, second, ...rest] = oid
     const firstByte = first * 40n + second
     return listToVec([vec8(firstByte), ...rest.map(b128encode)])
@@ -242,11 +251,23 @@ export const decodeObjectIdentifier = (v: Vec): ObjectIdentifier => {
 /** ASN.1 ordered collection of records. */
 export type Sequence = readonly Record[]
 
-const genericEncodeSequence = (map: (vec: readonly Vec[]) => readonly Vec[]) => (...records: Sequence): Vec =>
-    listToVec(map(records.map(encode)))
+/** Sequences an array of `Nullable<Vec>`, returning `null` if any element is `null`. */
+const allOrNull = (xs: readonly Nullable<Vec>[]): Nullable<readonly Vec[]> => {
+    let r: readonly Vec[] = []
+    for (const x of xs) {
+        if (x === null) { return null }
+        r = [...r, x]
+    }
+    return r
+}
 
-/** Encodes a SEQUENCE payload from ordered records. */
-export const encodeSequence: (...records: Sequence) => Vec =
+const genericEncodeSequence = (map: (vec: readonly Vec[]) => readonly Vec[]) => (...records: Sequence): Nullable<Vec> => {
+    const encoded = allOrNull(records.map(encode))
+    return encoded === null ? null : listToVec(map(encoded))
+}
+
+/** Encodes a SEQUENCE payload from ordered records. Propagates the over-cap `null`. */
+export const encodeSequence: (...records: Sequence) => Nullable<Vec> =
     genericEncodeSequence(identity)
 
 /** Decodes a SEQUENCE payload into records. */
@@ -257,8 +278,8 @@ export const decodeSequence = (v: Vec): Sequence => decodeAll(decode)(v)
 /** ASN.1 SET represented as a sequence of records. */
 export type Set = Sequence
 
-/** Encodes a SET payload with canonical byte ordering. */
-export const encodeSet: (...records: Sequence) => Vec =
+/** Encodes a SET payload with canonical byte ordering. Propagates the over-cap `null`. */
+export const encodeSet: (...records: Sequence) => Nullable<Vec> =
     genericEncodeSequence(v => v.toSorted((a, b) => msb.cmp(a)(b)))
 
 /** Decodes a SET payload. */
@@ -298,7 +319,7 @@ export type Record = SupportedRecord | UnsupportedRecord
 
 // encode
 
-const recordToRaw = ([tag, value]: SupportedRecord): Vec => {
+const recordToRaw = ([tag, value]: SupportedRecord): Nullable<Vec> => {
     switch (tag) {
         case boolean: return encodeBoolean(value)
         case integer: return encodeInteger(value)
@@ -309,9 +330,16 @@ const recordToRaw = ([tag, value]: SupportedRecord): Vec => {
     }
 }
 
-/** Encodes a supported ASN.1 record as TLV. */
-export const encode = (record: Record): Vec =>
-    isVec(record) ? record : encodeRaw([record[0], recordToRaw(record)])
+/**
+ * Encodes a supported ASN.1 record as TLV. Records wrap caller-supplied
+ * payloads (an `OCTET STRING` or `SEQUENCE` can be near `maxLength`), so this
+ * propagates the over-cap `null` through the recursive encode.
+ */
+export const encode = (record: Record): Nullable<Vec> => {
+    if (isVec(record)) { return record }
+    const raw = recordToRaw(record)
+    return raw === null ? null : encodeRaw([record[0], raw])
+}
 
 // decode
 
@@ -324,7 +352,9 @@ const rawToRecord = (raw: Raw): Record => {
         case objectIdentifier: return [objectIdentifier, decodeObjectIdentifier(value)]
         case constructedSequence: return [constructedSequence, decodeSequence(value)]
         case constructedSet: return [constructedSet, decodeSet(value)]
-        default: return encodeRaw(raw)
+        // Re-encoding a raw TLV decoded from already-bounded input; the over-cap
+        // `null` branch is dead.
+        default: return unwrap(encodeRaw(raw))
     }
 }
 

--- a/fs/asn.1/proof.f.ts
+++ b/fs/asn.1/proof.f.ts
@@ -1,26 +1,37 @@
 import { empty, isVec, length, msb, uint, unpack, vec, vec8, type Vec } from "../types/bit_vec/module.f.ts"
 import { asBase } from "../types/nominal/module.f.ts"
+import { unwrap } from "../types/nullable/module.f.ts"
+import type { List } from "../types/list/module.f.ts"
 import {
     decodeRaw,
     decodeInteger,
-    encodeRaw,
+    encodeRaw as encodeRawN,
     encodeInteger,
     integer,
     type SupportedRecord,
-    encode,
+    encode as encodeN,
     decode,
     constructedSequence,
     octetString,
     boolean,
     constructedSet,
-    encodeObjectIdentifier,
+    encodeObjectIdentifier as encodeObjectIdentifierN,
     decodeObjectIdentifier,
     type ObjectIdentifier,
+    type Raw,
+    type Record,
 } from "./module.f.ts"
 import { assertEq } from "../asserts/module.f.ts"
 
-const { concat, popFront: pop, listToVec } = msb
+const { concat, popFront: pop } = msb
 const pop8 = pop(8n)
+
+// Every value built in this proof is a small, bounded test fixture, so the
+// over-cap `null` branch of the now-`Nullable` encoders is provably dead here.
+const encodeRaw = (raw: Raw): Vec => unwrap(encodeRawN(raw))
+const encode = (record: Record): Vec => unwrap(encodeN(record))
+const encodeObjectIdentifier = (oid: ObjectIdentifier): Vec => unwrap(encodeObjectIdentifierN(oid))
+const listToVec = (list: List<Vec>): Vec => unwrap(msb.listToVec(list))
 
 const check = (tag: bigint, v: Vec, rest: Vec) => {
     const s = encodeRaw([tag, v])

--- a/fs/base64/module.f.ts
+++ b/fs/base64/module.f.ts
@@ -3,13 +3,13 @@
  *
  * @module
  */
-import { msb, type Vec, length, vec, empty } from "../types/bit_vec/module.f.ts"
+import { msb, type Vec, length, vec, empty, maxLength } from "../types/bit_vec/module.f.ts"
 import type { Nullable } from "../types/nullable/module.f.ts"
 import { baseN } from "../base_n/module.f.ts"
 
 const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
 
-const { popFront, concat } = msb
+const { concat } = msb
 
 const { vecToString, stringToVec } = baseN(6n, alphabet)
 
@@ -19,6 +19,10 @@ export const encode = (input: Vec): Nullable<string> => {
     if (len % 8n !== 0n) { return null }
     const rem = len % 24n
     const padBits = rem === 0n ? 0n : 6n - rem % 6n
+    // The octet-alignment padding can push a `maxLength`-bit input past the cap;
+    // reject it as `null` rather than building an over-`maxLength` `bigint`
+    // (which throws on `bun`).
+    if (len + padBits > maxLength) { return null }
     const v = padBits > 0n ? concat(input)(vec(padBits)(0n)) : input
     let result = vecToString(v)
     // Append `=` padding to make total length a multiple of 4.
@@ -37,18 +41,28 @@ export const decode = (input: string): Nullable<Vec> => {
     // Total chars must make a multiple of 4 with the padding.
     if ((body.length + padChars) % 4 !== 0) { return null }
 
-    // Decode each character to 6 bits.
-    const result = stringToVec(body)
-    if (result === null) { return null }
-
-    // Remove the zero-padding bits introduced during encode.
+    // The decoded length is known up front from the body length: each char is
+    // 6 bits, minus the padding bits introduced during encode. Reject over-cap
+    // input *before* building anything, so no intermediate `bigint` overflows.
     // padChars=1 → 2 padding bits removed, padChars=2 → 4 padding bits removed.
-    const removeBits = BigInt(padChars * 2)
-    const totalBits = length(result)
-    const targetLen = totalBits - removeBits
-    if (targetLen === 0n) { return empty }
-    const [kept, padVec] = popFront(targetLen)(result)
-    // Padding bits must be zero (RFC 4648 §3.5).
-    if (removeBits > 0n && padVec !== vec(removeBits)(0n)) { return null }
-    return vec(targetLen)(kept)
+    const removeBits = padChars * 2
+    const targetLen = BigInt(body.length) * 6n - BigInt(removeBits)
+    if (targetLen <= 0n) { return empty }
+    if (targetLen > maxLength) { return null }
+
+    // Build only the trimmed `targetLen` bits: decode every 6-bit chunk except
+    // the trailing one, then append just the data bits of the last char. A
+    // `maxLengthBytes` blob's full `body.length * 6` is `targetLen + removeBits`
+    // (a couple bits over the cap because of base64 octet padding), so keeping
+    // the last char out caps the largest intermediate vector at `< targetLen`.
+    const head = stringToVec(body.slice(0, body.length - 1))
+    if (head === null) { return null }
+    const lastIndex = alphabet.indexOf(body[body.length - 1])
+    if (lastIndex < 0) { return null }
+    // Padding bits must be zero (RFC 4648 §3.5). The discarded low `removeBits`
+    // of the last char are checked in the `number` domain — `lastIndex` and
+    // `removeBits` are both small numbers, so the mask stays numeric.
+    if ((lastIndex & ((1 << removeBits) - 1)) !== 0) { return null }
+    const dataBits = BigInt(6 - removeBits)
+    return concat(head)(vec(dataBits)(BigInt(lastIndex >> removeBits)))
 }

--- a/fs/cas/mcp/README.md
+++ b/fs/cas/mcp/README.md
@@ -71,9 +71,10 @@ the filesystem.
 Inline content (`text`/`base64`) resolves into a single `Vec`, which caps at
 `maxLength` bits — **128 KiB**. To store a larger blob, write it under
 `$HOME/cas_upload/` and pass `type: 'url'`, which streams the file with no size
-limit. (Graceful rejection of oversized inline content — today it fails inside
-`utf8` / base64 `decode` — is tracked in
-[`cas-add-inline-size-error`](../todo/cas-add-inline-size-error.md).)
+limit. Oversized inline content is rejected gracefully and identically on every
+JS engine: `utf8` / base64 `decode` return `null` *before* building an
+over-`maxLength` `bigint`, and `cas_add` turns that into a `isError` result that
+points at `type: 'url'` — never a thrown crash or a silently-stored blob.
 
 ## `cas_get`: metadata + optional inline content
 
@@ -143,10 +144,13 @@ parallel `detect` + UTF-8 check. The `type` then selects how `content` is encode
 
 The inline-content path buffers the whole blob into a single `Vec`, which caps at
 `maxLength` bits — **128 KiB**. A blob larger than that cannot be fetched inline.
-Because the size and type are derived first with the size-independent
-`detectStream` machine (the same one the metadata path uses), an oversized blob is
-*not* misreported as absent: it returns `isError` with a distinct message naming
-the byte size and pointing at the alternatives, e.g.
+The *serialized response* is bounded too: base64 expands the bytes ≈ 4/3× and the
+JSON envelope adds a little more, so even a blob at the `maxLengthBytes` limit can
+encode to a line that exceeds `maxLength` — that case is rejected the same way
+rather than handed to the transport. Because the size and type are derived first
+with the size-independent `detectStream` machine (the same one the metadata path
+uses), an oversized blob is *not* misreported as absent: it returns `isError` with
+a distinct message naming the byte size and pointing at the alternatives, e.g.
 
 ```
 blob too large to fetch inline (262144 bytes, limit 131072 bytes); use the url field (…) or omit content for metadata

--- a/fs/cas/mcp/module.f.ts
+++ b/fs/cas/mcp/module.f.ts
@@ -179,24 +179,20 @@ const casToolRegistry =
                         : rm(content).step(() => pure(okResult(vecToCBase32(v))))
                 )
             }
-            // type:'text' or 'base64' — resolve content to Vec, store via c.write()
-            let x: Effect<Rm, Vec|string>
-            switch(type) {
-                case 'base64':
-                    const value = base64Decode(content)
-                    x = pure(value === null ? `invalid base64 content: ${content}` : value)
-                    break
-                default:
-                    x = pure(utf8(content))
-                    break
+            // type:'text' or 'base64' — resolve content to a Vec, store via c.write().
+            // Both codecs return `null` for content that cannot be represented as a
+            // single `Vec` (malformed, or above the inline cap), so `cas_add` never
+            // assumes the size is bounded: a `null` becomes a generic content
+            // decoding error that points oversized callers at type:'url'.
+            const value = type === 'base64' ? base64Decode(content) : utf8(content)
+            if (value === null) {
+                return pure(errorResult(
+                    `content could not be decoded — it may be malformed or above the ${maxLengthBytes}-byte (128 KiB) inline limit; use type:"url" for large content`))
             }
-            return x.step(value => typeof value === 'string'
-                ? pure(errorResult(value))
-                // The resolved content fits in one chunk; feed it as a single-item stream.
-                : c.write(nonEmpty(ok(value), elEmpty<never, Ok<Vec>>())).step(([tag, hash]) => pure(tag === 'error'
-                    ? errorResult('write')
-                    : okResult(vecToCBase32(hash))))
-            )
+            // The resolved content fits in one chunk; feed it as a single-item stream.
+            return c.write(nonEmpty(ok(value), elEmpty<never, Ok<Vec>>())).step(([tag, hash]) => pure(tag === 'error'
+                ? errorResult('write')
+                : okResult(vecToCBase32(hash))))
         },
     ),
     toolEntry(
@@ -236,32 +232,37 @@ const casToolRegistry =
                 }
                 const { length, mime_type, type } = detected
                 const meta: Meta = { length: Number(length), mime_type, type, url }
+                const tooLarge = errorResult(
+                    `blob too large to fetch inline (${length} bytes, limit ${maxLengthBytes} bytes); use the url field (${url}) or omit content for metadata`)
                 // A single `Vec` caps at `maxLength` bits (`maxLengthBytes` bytes), so
                 // a larger blob cannot be buffered for inline transfer. Report the
                 // size and point at the size-independent alternatives instead of
                 // misreporting an existing blob as `no such hash`.
                 if (length > maxLengthBytes) {
-                    return pure(errorResult(
-                        `blob too large to fetch inline (${length} bytes, limit ${maxLengthBytes} bytes); use the url field (${url}) or omit content for metadata`))
+                    return pure(tooLarge)
                 }
                 return collectRead(c.read(key)).step(([collectTag, value]) => {
                     if (collectTag === 'error') {
                         return pure(errorResult(`no such hash: ${r.hash}`))
                     }
-                    if (type === 'text') {
-                        // `type: 'text'` means the detector validated `value` as UTF-8,
-                        // so `fromVec` is non-null here; guard defensively regardless.
-                        const str = fromVec(value)
-                        return pure(str === null
-                            ? errorResult(`content is not byte-aligned: ${r.hash}`)
-                            : okResult(toJson({ ...meta, content: str }))
-                        )
+                    // `type: 'text'` means the detector validated `value` as UTF-8.
+                    // A `null` here means the inline encoding overflows a single
+                    // `Vec` — base64 expands a `maxLengthBytes` blob ~4/3× past the
+                    // cap — so it is a too-large case, not a real byte-alignment
+                    // failure (the blob is byte-aligned by detection).
+                    const content = type === 'text' ? fromVec(value) : base64Encode(value)
+                    if (content === null) {
+                        return pure(tooLarge)
                     }
-                    const blob = base64Encode(value)
-                    return pure(blob === null
-                        ? errorResult(`content is not byte-aligned: ${r.hash}`)
-                        : okResult(toJson({ ...meta, content: blob }))
-                    )
+                    const json = toJson({ ...meta, content })
+                    // Even when `content` fits, the serialized response (base64 ≈ 4/3×
+                    // plus the JSON envelope) can exceed `maxLength` and be unwritable
+                    // as one line even for a `maxLengthBytes` blob. Bound it so the
+                    // transport is never handed an over-`maxLength` `Vec`.
+                    if (utf8(json) === null) {
+                        return pure(tooLarge)
+                    }
+                    return pure(okResult(json))
                 })
             })
         },

--- a/fs/cas/mcp/proof.f.ts
+++ b/fs/cas/mcp/proof.f.ts
@@ -4,10 +4,16 @@ import { run, type MemOperationMap } from '../../effects/mock/module.f.ts'
 import { asBase, asNominal, create, type Key, type MemOp } from '../../effects/memory/module.f.ts'
 import type { Unknown } from '../../json/module.f.ts'
 import type { Response } from '../../json/rpc/module.f.ts'
-import { msb, u8ListToVec, vec8, repeat, length, type Vec, maxLengthBytes } from '../../types/bit_vec/module.f.ts'
+import { msb, u8ListToVec as u8ListToVecRaw, vec8, repeat, length, type Vec, maxLengthBytes, type BitOrder } from '../../types/bit_vec/module.f.ts'
+import { unwrap } from '../../types/nullable/module.f.ts'
 import { vecToCBase32 } from '../../cbase32/module.f.ts'
 import { encode as base64Encode } from '../../base64/module.f.ts'
-import { utf8 } from '../../text/module.f.ts'
+import { utf8 as utf8Raw } from '../../text/module.f.ts'
+import type { List } from '../../types/list/module.f.ts'
+
+// Test fixtures are short literals, well within the cap.
+const u8ListToVec = (bo: BitOrder) => (list: List<number>): Vec => unwrap(u8ListToVecRaw(bo)(list))
+const utf8 = (s: string): Vec => unwrap(utf8Raw(s))
 import { type FileCasOperation } from '../module.f.ts'
 import {
     mcpStep, uninitializedState, type McpSessionState, type ToolsCallResult,
@@ -193,7 +199,46 @@ const symbolChunk = repeat(maxLengthBytes / 2n)(u8ListToVec(msb)([0xc3, 0xa9]))
 // A full chunk of 0xFF — an invalid UTF-8 lead byte, so binary (no magic match).
 const binaryChunk = repeat(maxLengthBytes)(vec8(0xffn))
 
+// Base64 of `n` ASCII 'a' (0x61) bytes, spelled out for any `n` (all three
+// `n % 3` residues), so the boundary sample decodes to exactly `n` bytes
+// without ever driving the encoder past `maxLength`: 'aaa' → 'YWFh', a trailing
+// single byte → 'YQ==', a trailing pair → 'YWE='.
+const base64OfA = (n: number): string => {
+    const tail = n % 3
+    return 'YWFh'.repeat((n - tail) / 3) + (tail === 1 ? 'YQ==' : tail === 2 ? 'YWE=' : '')
+}
+
+const maxBytes = Number(maxLengthBytes)
+
 export const proof = {
+    // Inline `text` at exactly `maxLengthBytes` (the largest single `Vec`) is
+    // stored, not rejected.
+    addTextAtMaxStores: () => {
+        const [resp] = session(call(2, 'cas_add', { content: 'a'.repeat(maxBytes) }))
+        assert(!resultOf(resp).isError)
+        assert(textOf(resp).length > 0)
+    },
+
+    // One byte over the cap is a clean `isError` on every engine — not a thrown
+    // crash, not a silently-stored over-`maxLength` blob.
+    addTextOverMaxIsError: () => {
+        const [resp] = session(call(2, 'cas_add', { content: 'a'.repeat(maxBytes + 1) }))
+        assertEq(resultOf(resp).isError, true)
+    },
+
+    // Inline `base64` decoding to exactly `maxLengthBytes` is stored.
+    addBase64AtMaxStores: () => {
+        const [resp] = session(call(2, 'cas_add', { content: base64OfA(maxBytes), type: 'base64' }))
+        assert(!resultOf(resp).isError)
+        assert(textOf(resp).length > 0)
+    },
+
+    // base64 decoding to one byte over the cap is a clean `isError`.
+    addBase64OverMaxIsError: () => {
+        const [resp] = session(call(2, 'cas_add', { content: base64OfA(maxBytes + 1), type: 'base64' }))
+        assertEq(resultOf(resp).isError, true)
+    },
+
     // Both chunks repeated ASCII → text/plain, no error on a > 128 KiB blob.
     getMetaLargeMultiChunkBlobNoError:
         largeMultiChunkBlobMeta(asciiChunk, asciiChunk, 'text', 'text/plain'),

--- a/fs/cas/proof.f.ts
+++ b/fs/cas/proof.f.ts
@@ -1,4 +1,5 @@
 import { length, maxLength, msb, vec, vec8, type Vec } from '../types/bit_vec/module.f.ts'
+import { unwrap } from '../types/nullable/module.f.ts'
 import { cBase32ToVec, vecToCBase32 } from '../cbase32/module.f.ts'
 import { computeSync, sha256 } from '../crypto/sha2/module.f.ts'
 import { fileCas, casAddFile, type FileCasOperation, casUpload } from './module.f.ts'
@@ -129,7 +130,7 @@ export const proof = {
                 })
         const [, readResult] = virtual(state1)(drain([])(c.read(hash)))
         if (readResult[0] !== 'ok') { throw ['expected read ok', readResult] }
-        if (msb.cmp(msb.listToVec(readResult[1]))(content) !== 0) { throw 'read content mismatch' }
+        if (msb.cmp(unwrap(msb.listToVec(readResult[1])))(content) !== 0) { throw 'read content mismatch' }
     },
     casReadMissingShard: () => {
         // A missing shard surfaces as an explicit error *item*, never as end-of-stream.
@@ -163,7 +164,7 @@ export const proof = {
         const [, readResult] = virtual(state1)(drain([])(c.read(hash)))
         if (readResult[0] !== 'ok') { throw ['expected read ok', readResult] }
         const expected = msb.concat(msb.concat(chunks[0])(chunks[1]))(chunks[2])
-        if (msb.cmp(msb.listToVec(readResult[1]))(expected) !== 0) { throw 'multi-chunk read content mismatch' }
+        if (msb.cmp(unwrap(msb.listToVec(readResult[1])))(expected) !== 0) { throw 'multi-chunk read content mismatch' }
     },
     casWriteDedup: () => {
         // Same content ⇒ same hash; the second upload's replace-`rename` publishes over the

--- a/fs/cas/todo/cas-add-inline-size-error.md
+++ b/fs/cas/todo/cas-add-inline-size-error.md
@@ -1,7 +1,7 @@
 ## cas-add-inline-size-error. Reject oversized `cas_add` inline content gracefully
 
 **Priority:** P3
-**Status:** open
+**Status:** done
 **Blocked by:** —
 
 ### Problem
@@ -246,21 +246,21 @@ checked assertion that throws *at the call site*, while keeping the public type 
 
 ### Tasks
 
-- [ ] `fs/types/bit_vec/module.f.ts`: make `unpackListToVec` return `Nullable<Unpacked>`
+- [x] `fs/types/bit_vec/module.f.ts`: make `unpackListToVec` return `Nullable<Unpacked>`
       (running-length guard, single bounded core); make `BitOrder.listToVec` and
       `u8ListToVec` return `Nullable<Vec>`; leave the **algebra primitives**
       `concat` / `push` / `xor` / `repeat` total with a documented `len ≤ maxLength`
       precondition.
-- [ ] `fs/types/nullable/module.f.ts`: add `unwrap<T>(value: Nullable<T>): T` (throws on
+- [x] `fs/types/nullable/module.f.ts`: add `unwrap<T>(value: Nullable<T>): T` (throws on
       `null`).
-- [ ] `fs/base64/module.f.ts` `decode`: return `null` (not throw) for over-`maxLength`
+- [x] `fs/base64/module.f.ts` `decode`: return `null` (not throw) for over-`maxLength`
       input; build only the trimmed `targetLen` bits so a `maxLengthBytes` blob does not
       overflow; **keep the RFC 4648 §3.5 padding-bit-zero check** (still reject
       non-canonical `AB==` / `AAB=`, all-`number` mask `=== 0`); signature stays
       `Nullable<Vec>`.
-- [ ] `fs/text/module.f.ts` `utf8`: return `Nullable<Vec>` (`null` only when the encoded
+- [x] `fs/text/module.f.ts` `utf8`: return `Nullable<Vec>` (`null` only when the encoded
       length would exceed `maxLength`).
-- [ ] **Propagate `Nullable<Vec>`** (default) through the data-dependent builders/consumers,
+- [x] **Propagate `Nullable<Vec>`** (default) through the data-dependent builders/consumers,
       threading `null` to their callers:
       - `fs/asn.1` encoders (`encode` / `encodeRaw` / `encodeSequence` / `encodeSet` /
         `encodeObjectIdentifier` / `lenEncode` / `parsedTagEncode`) — propagate through
@@ -270,10 +270,10 @@ checked assertion that throws *at the call site*, while keeping the public type 
         `Nullable<Vec>`.
       - `fs/sul/level/literal` `listToVec(...)` unless a SUL literal token is bounded by
         construction (then `unwrap`).
-- [ ] **`unwrap` only at the algorithm-fixed / literal sites:** `fs/crypto/sign` `concat`
+- [x] **`unwrap` only at the algorithm-fixed / literal sites:** `fs/crypto/sign` `concat`
       (fixed curve components); `fs/sul/id` id hash (fixed 40 bytes) and IV-seed literal;
       `proof.f.ts` fixtures. (`fs/base_n` `stringToVec` already propagates `Nullable`.)
-- [ ] Resolve the propagated `null` into a typed error at each boundary:
+- [x] Resolve the propagated `null` into a typed error at each boundary:
       - `fs/effects/node` `writeUtf8File` → `IoResult` `error`.
       - Node HTTP `createServer` runner (`fs/effects/node/module.ts`,
         `body: listToVec(reqBody)`) → error response (e.g. HTTP 413) on a `null` body.
@@ -283,17 +283,17 @@ checked assertion that throws *at the call site*, while keeping the public type 
       - `fs/cas/mcp` `cas_get` `content: true` → bound the *serialized response* (base64 +
         JSON envelope can exceed `maxLength` even for a `maxLengthBytes` blob) so the
         transport never gets an over-`maxLength` line.
-- [ ] `cas_add` handler (`fs/cas/mcp/module.f.ts`): treat `null` from `utf8` / `decode`
+- [x] `cas_add` handler (`fs/cas/mcp/module.f.ts`): treat `null` from `utf8` / `decode`
       as a generic content decoding error `isError` (static message that also points at
       `type: 'url'` for large content).
-- [ ] Proof tests: `fs/cas/mcp/proof.f.ts` — inline `text` and `base64` at exactly
+- [x] Proof tests: `fs/cas/mcp/proof.f.ts` — inline `text` and `base64` at exactly
       `maxLengthBytes` (stored) and one byte over (clean `isError` on every engine — not
       a thrown crash, not a silently-stored over-`maxLength` blob). Add a
       `base64OfA(n)` helper that spells out base64 of `n` ASCII `'a'` bytes for any `n`
       (handles all three `n % 3` residues), so the boundary sample never drives the
       encoder past `maxLength`. `fs/types/bit_vec/proof.f.ts` — `u8ListToVec` at and one
       past `maxLengthBytes`.
-- [ ] Confirm the documented inline limit in `fs/cas/mcp/README.md` and the `cas_add`
+- [x] Confirm the documented inline limit in `fs/cas/mcp/README.md` and the `cas_add`
       tool description match the implemented behaviour.
 
 ### Related

--- a/fs/ci/proof.f.ts
+++ b/fs/ci/proof.f.ts
@@ -8,6 +8,7 @@ import type { State } from '../effects/node/virtual/module.f.ts'
 import { emptyState, virtual, type Dir } from '../effects/node/virtual/module.f.ts'
 import { parse as jsonParse } from '../json/module.f.ts'
 import { unwrap } from '../types/result/module.f.ts'
+import { unwrap as unwrapNullable } from '../types/nullable/module.f.ts'
 import { definedValues } from '../types/object/module.f.ts'
 
 const hasRun = (cmd: string) => (gha: GitHubAction): boolean =>
@@ -20,7 +21,7 @@ const makeState = (rust: boolean, packageJson?: string) => ({
     ...emptyState,
     root: {
         '.github': { workflows: {} },
-        ...(packageJson !== undefined ? { 'package.json': [utf8(packageJson)] } : {}),
+        ...(packageJson !== undefined ? { 'package.json': [unwrapNullable(utf8(packageJson))] } : {}),
         ...(rust ? { 'Cargo.toml': [emptyVec] } : {}),
     },
 })

--- a/fs/crypto/hmac/proof.f.ts
+++ b/fs/crypto/hmac/proof.f.ts
@@ -1,6 +1,10 @@
 import { assertEq } from '../../asserts/module.f.ts'
-import { utf8 } from '../../text/module.f.ts'
+import { utf8 as utf8Raw } from '../../text/module.f.ts'
+import { unwrap } from '../../types/nullable/module.f.ts'
 import { uint, vec } from '../../types/bit_vec/module.f.ts'
+
+// Test inputs are short source literals, well within the cap.
+const utf8 = (s: string) => unwrap(utf8Raw(s))
 import { sha256, sha384, sha512 } from '../sha2/module.f.ts'
 import { hmac } from './module.f.ts'
 

--- a/fs/crypto/pow/proof.f.ts
+++ b/fs/crypto/pow/proof.f.ts
@@ -1,5 +1,9 @@
-import { utf8 } from '../../text/module.f.ts'
+import { utf8 as utf8Raw } from '../../text/module.f.ts'
+import { unwrap } from '../../types/nullable/module.f.ts'
 import { empty, uint } from '../../types/bit_vec/module.f.ts'
+
+// Test inputs are short source literals, well within the cap.
+const utf8 = (s: string) => unwrap(utf8Raw(s))
 import { computeSync, sha224, sha256 } from '../sha2/module.f.ts'
 import { bitcoinPow, genesisNBits, genesisTarget, pow, sha256Pow, targetFromNBits } from './module.f.ts'
 

--- a/fs/crypto/sha2/proof.f.ts
+++ b/fs/crypto/sha2/proof.f.ts
@@ -1,5 +1,9 @@
-import { utf8 } from '../../text/module.f.ts'
+import { utf8 as utf8Raw } from '../../text/module.f.ts'
+import { unwrap } from '../../types/nullable/module.f.ts'
 import { repeat, uint, vec } from '../../types/bit_vec/module.f.ts'
+
+// Test inputs are short source literals, well within the cap.
+const utf8 = (s: string) => unwrap(utf8Raw(s))
 import { flip } from '../../types/function/module.f.ts'
 import { map } from '../../types/list/module.f.ts'
 import {

--- a/fs/crypto/sign/module.f.ts
+++ b/fs/crypto/sign/module.f.ts
@@ -6,6 +6,7 @@
 import type { Array2 } from '../../types/array/module.f.ts'
 import { bitLength, divUp8, roundUp8 } from '../../types/bigint/module.f.ts'
 import { empty, length, msb, repeat, unpack, vec, vec8, type Vec } from '../../types/bit_vec/module.f.ts'
+import { unwrap } from '../../types/nullable/module.f.ts'
 import { hmac } from '../hmac/module.f.ts'
 import type { Curve } from '../secp/module.f.ts'
 import { computeSync, type Sha2 } from '../sha2/module.f.ts'
@@ -52,7 +53,10 @@ const x00 = vec8(0x00n)
 
 const { listToVec } = msb
 
-export const concat = (...x: readonly Vec[]): Vec => listToVec(x)
+// Joins a fixed number of fixed-size curve scalars / octet strings (size set by
+// the curve, never by user data), so the combined length is bounded by the
+// algorithm and the over-cap `null` branch is provably dead — hence `unwrap`.
+export const concat = (...x: readonly Vec[]): Vec => unwrap(listToVec(x))
 
 /**
  * Computes deterministic ECDSA nonce `k` as described by RFC6979.

--- a/fs/crypto/sign/proof.f.ts
+++ b/fs/crypto/sign/proof.f.ts
@@ -1,5 +1,9 @@
-import { utf8 } from "../../text/module.f.ts"
+import { utf8 as utf8Raw } from "../../text/module.f.ts"
+import { unwrap } from "../../types/nullable/module.f.ts"
 import type { Array4 } from "../../types/array/module.f.ts"
+
+// Test inputs are short source literals, well within the cap.
+const utf8 = (s: string) => unwrap(utf8Raw(s))
 import { empty, msb, repeat, vec, vec8, type Vec } from "../../types/bit_vec/module.f.ts"
 import { hmac } from "../hmac/module.f.ts"
 import { secp192r1, secp256r1, secp384r1, secp521r1, type Curve } from "../secp/module.f.ts"

--- a/fs/djs/proof.f.ts
+++ b/fs/djs/proof.f.ts
@@ -1,7 +1,11 @@
 import { compile } from './module.f.ts'
 import { virtual, emptyState } from '../effects/node/virtual/module.f.ts'
-import { utf8, utf8ToString } from '../text/module.f.ts'
+import { utf8 as utf8Raw, utf8ToString } from '../text/module.f.ts'
+import { unwrap } from '../types/nullable/module.f.ts'
 import type { Vec } from '../types/bit_vec/module.f.ts'
+
+// Test inputs are short source literals, well within the cap.
+const utf8 = (s: string) => unwrap(utf8Raw(s))
 
 const readOutput = (root: typeof emptyState.root, path: string): string => {
     const file = root[path]

--- a/fs/djs/transpiler/proof.f.ts
+++ b/fs/djs/transpiler/proof.f.ts
@@ -2,7 +2,11 @@ import { sort } from '../../types/object/module.f.ts'
 import { transpile } from './module.f.ts'
 import { stringifyAsTree } from '../serializer/module.f.ts'
 import { virtual, emptyState, type Dir } from '../../effects/node/virtual/module.f.ts'
-import { utf8 } from '../../text/module.f.ts'
+import { utf8 as utf8Raw } from '../../text/module.f.ts'
+import { unwrap } from '../../types/nullable/module.f.ts'
+
+// Test inputs are short source literals, well within the cap.
+const utf8 = (s: string) => unwrap(utf8Raw(s))
 
 const run = (root: Dir) => (path: string) => {
     const [_, result] = virtual({ ...emptyState, root })(transpile(path))

--- a/fs/effects/node/module.f.ts
+++ b/fs/effects/node/module.f.ts
@@ -124,8 +124,15 @@ export const writeFile: Func<WriteFile> =
     do_('writeFile')
 
 /** Writes a string to `path` as UTF-8 bytes. */
-export const writeUtf8File = (path: string, content: string): Effect<WriteFile, IoResult<void>> =>
-    writeFile(path, utf8(content))
+export const writeUtf8File = (path: string, content: string): Effect<WriteFile, IoResult<void>> => {
+    const v = utf8(content)
+    // `content` is data-derived; if its UTF-8 encoding exceeds a single `Vec`,
+    // resolve the over-cap `null` into this effect's error channel rather than
+    // silently writing nothing.
+    return v === null
+        ? pure(resultError('content exceeds maximum vector length'))
+        : writeFile(path, v)
+}
 
 // rm
 
@@ -326,8 +333,13 @@ export const write: Func<Write> = do_('write')
  * Encodes `s + '\n'` as UTF-8 and emits a `Write` effect to `stream`.
  * Shared implementation for `log` and `error`.
  */
-const writeString = (stream: WriteConsoles) => (s: string): Effect<Write, void> =>
-    write(stream, utf8(s + '\n'))
+const writeString = (stream: WriteConsoles) => (s: string): Effect<Write, void> => {
+    const v = utf8(s + '\n')
+    // The `write` primitive takes a single `Vec`, so a console line whose UTF-8
+    // encoding exceeds `maxLength` is currently unencodable; drop it rather than
+    // throw. The durable fix is a chunked-stream `write` primitive (follow-up).
+    return v === null ? pure(undefined) : write(stream, v)
+}
 
 export type Console = (s: string) => Effect<Write, void>
 

--- a/fs/effects/node/module.ts
+++ b/fs/effects/node/module.ts
@@ -43,7 +43,7 @@ import { error, ok, type Result } from '../../types/result/module.f.ts'
 import { asyncTryCatch } from '../../types/result/module.ts'
 import { fromVec, listToVec, toVec } from '../../types/uint8array/module.f.ts'
 import type { StringMap } from '../../types/object/module.f.ts'
-import { maxLengthBytes } from '../../types/bit_vec/module.f.ts'
+import { maxLengthBytes, type Vec } from '../../types/bit_vec/module.f.ts'
 
 type Server = {
     readonly listen: (port: number) => void
@@ -87,6 +87,20 @@ const { mkdir, open, readFile, readdir, rename, writeFile, rm, access, stat } = 
 const { exec } = childProcess
 
 const maxFileSizeBytes = Number(maxLengthBytes)
+
+/**
+ * Converts a `Uint8Array` to a `Vec`, throwing when it exceeds a single `Vec`'s
+ * capacity. Used inside the `asyncTryCatch` handlers (`fetch`/`readFile`/
+ * `readBytes`), where the throw becomes an `IoResult` error; the size-guarded
+ * callers never actually hit the `null`, but the type demands it be handled.
+ */
+const toVecOrThrow = (a: Uint8Array): Vec => {
+    const v = toVec(a)
+    if (v === null) {
+        throw new Error(`byte array exceeds maximum vector length of ${Number(maxLengthBytes) * 8} bits`)
+    }
+    return v
+}
 
 const prefix = 'file:///' as const
 
@@ -197,7 +211,7 @@ const runNodeEffect: EffectToPromise = asyncRun({
         if (!response.ok) {
             throw new Error(`Fetch error: ${response.status} ${response.statusText}`)
         }
-        return toVec(new Uint8Array(await response.arrayBuffer()))
+        return toVecOrThrow(new Uint8Array(await response.arrayBuffer()))
     }),
     mkdir: (...p) => asyncTryCatch(async() => { await mkdir(...p) }),
     readFile: path => asyncTryCatch(async() => {
@@ -206,7 +220,7 @@ const runNodeEffect: EffectToPromise = asyncRun({
         if (fileStats.size > maxFileSizeBytes) {
             throw new Error(`File size ${fileStats.size} exceeds maximum allowed size of ${Number(maxFileSizeBytes)} bytes`)
         }
-        return toVec(await readFile(path))
+        return toVecOrThrow(await readFile(path))
     }),
     readdir: (path, r) => asyncTryCatch(async() =>
         (await readdir(path, { ...r, withFileTypes: true }))
@@ -230,7 +244,7 @@ const runNodeEffect: EffectToPromise = asyncRun({
         try {
             const buffer = Buffer.alloc(size)
             const { bytesRead } = await fh.read(buffer, 0, size, offset)
-            return toVec(buffer.subarray(0, bytesRead))
+            return toVecOrThrow(buffer.subarray(0, bytesRead))
         } finally {
             await fh.close()
         }
@@ -269,11 +283,19 @@ const runNodeEffect: EffectToPromise = asyncRun({
         const nodeRl: RequestListener = async(req, res) => {
             const reqBody = await collect(req)
             const { method, url, headers } = req
+            const body = listToVec(reqBody)
+            // An over-`maxLength` request body cannot be represented as a single
+            // `Vec`; reject it with HTTP 413 rather than letting the `null`
+            // escape into the handler.
+            if (body === null) {
+                res.writeHead(413, {}).end(new Uint8Array())
+                return
+            }
             const { status, headers: outHeaders, body: outBody } = await runNodeEffect(erl({
                 method,
                 url,
                 headers,
-                body: listToVec(reqBody)
+                body,
             }))
             res
                 .writeHead(status, outHeaders)

--- a/fs/effects/node/proof.f.ts
+++ b/fs/effects/node/proof.f.ts
@@ -1,5 +1,6 @@
 import { empty, isVec, uint, vec8, type Vec } from "../../types/bit_vec/module.f.ts"
 import { utf8, utf8ToString } from "../../text/module.f.ts"
+import { unwrap } from "../../types/nullable/module.f.ts"
 import { decode, pure } from "../module.f.ts"
 import { both, fetch, mkdir, now, readdir, readFile, readUtf8File, rm, sandbox, writeFile, writeUtf8File, rename, readBytes, randomInt } from "./module.f.ts"
 import { create as memCreate, read as memRead, write as memWrite } from "../memory/module.f.ts"
@@ -104,7 +105,7 @@ export const proof = {
         ok: () => {
             const [_, [t, result]] = virtual({
                 ...emptyState,
-                root: { hello: [utf8('Hello, world!')] },
+                root: { hello: [unwrap(utf8('Hello, world!'))] },
             })(readUtf8File('hello'))
             if (t !== 'ok') { throw result }
             if (result !== 'Hello, world!') { throw result }

--- a/fs/html/module.f.ts
+++ b/fs/html/module.f.ts
@@ -11,6 +11,7 @@ import { compose } from '../types/function/module.f.ts'
 import { stringToList } from '../text/utf16/module.f.ts'
 import { includes } from '../types/array/module.f.ts'
 import { type Vec } from '../types/bit_vec/module.f.ts'
+import type { Nullable } from '../types/nullable/module.f.ts'
 import { utf8 } from '../text/module.f.ts'
 import { quotationMark, ampersand, lessThanSign, greaterThanSign } from '../text/ascii/module.f.ts'
 
@@ -159,7 +160,7 @@ const commonHead = [
  * // <!DOCTYPE html><html><head><meta charset="UTF-8">...<title>My Page</title></head><body><h1>Hello</h1></body></html>
  * ```
  */
-export const htmlUtf8 = (...head: readonly Node[]) => (...body: readonly Node[]): Vec =>
+export const htmlUtf8 = (...head: readonly Node[]) => (...body: readonly Node[]): Nullable<Vec> =>
     utf8(htmlToString(['html',
         ['head', ...commonHead, ...head],
         ['body', ...body]]

--- a/fs/mcp/stdio/module.f.ts
+++ b/fs/mcp/stdio/module.f.ts
@@ -43,8 +43,14 @@ const stringifyJson = stringify(sort)
 const parseErrorResponse: Response = { jsonrpc, error: parseError, id: null }
 
 /** Encodes a response as a newline-terminated UTF-8 line and writes it to `stdout`. */
-const writeResponse = (resp: Response): Effect<Write, void> =>
-    write('stdout', utf8(stringifyJson(resp as Unknown) + '\n'))
+const writeResponse = (resp: Response): Effect<Write, void> => {
+    const v = utf8(stringifyJson(resp as Unknown) + '\n')
+    // The `write` primitive takes a single `Vec`; a response whose UTF-8
+    // encoding exceeds `maxLength` is currently unencodable, so drop it rather
+    // than throw. Tools bound their own responses (e.g. `cas_get` rejects
+    // oversized inline content); the durable fix is a chunked-stream `write`.
+    return v === null ? pure(undefined) : write('stdout', v)
+}
 
 /** Writes `resp` when present, otherwise does nothing (notification). */
 const writeMaybe = (resp: Response | null): Effect<Write, void> =>

--- a/fs/mcp/stdio/proof.f.ts
+++ b/fs/mcp/stdio/proof.f.ts
@@ -4,6 +4,7 @@ import { emptyState, virtual, type State } from '../../effects/node/virtual/modu
 import type { Unknown } from '../../json/module.f.ts'
 import { stringify } from '../../json/module.f.ts'
 import { utf8 } from '../../text/module.f.ts'
+import { unwrap } from '../../types/nullable/module.f.ts'
 import { fromVec } from '../../types/uint8array/module.f.ts'
 import { sort } from '../../types/object/module.f.ts'
 import { jsonrpc, parseError, type Id, type Response } from '../../json/rpc/module.f.ts'
@@ -28,7 +29,7 @@ const echoStep: Step<never> = (value: Unknown): Effect<never, Response | null> =
 }
 
 // UTF-8 bytes of `s` as a plain array — the virtual stdin byte stream.
-const toBytes = (s: string): readonly number[] => [...fromVec(utf8(s))]
+const toBytes = (s: string): readonly number[] => [...fromVec(unwrap(utf8(s)))]
 
 // Run the transport with `step` over `input` fed to stdin one byte at a time;
 // return the final state. `input` is raw text so tests control newline framing.

--- a/fs/mime/proof.f.ts
+++ b/fs/mime/proof.f.ts
@@ -1,5 +1,6 @@
 import { assert, assertEq } from '../asserts/module.f.ts'
 import { msb, u8ListToVec, vec8, repeat, empty, type Vec } from '../types/bit_vec/module.f.ts'
+import { unwrap } from '../types/nullable/module.f.ts'
 import { decode, type Effect } from '../effects/module.f.ts'
 import { nonEmpty, empty as emptyList, type List } from '../effects/list/module.f.ts'
 import { ok, type Result } from '../types/result/module.f.ts'
@@ -7,7 +8,7 @@ import { detect, detectStream, detectVec, type DetectMeta } from './module.f.ts'
 
 // Builds a big-endian `Vec` from a list of byte values — mirrors how the CAS
 // store would hold the leading bytes of a stored blob.
-const bytes = (...b: readonly number[]): Vec => u8ListToVec(msb)(b)
+const bytes = (...b: readonly number[]): Vec => unwrap(u8ListToVec(msb)(b))
 
 // ── Streaming detector helpers ──────────────────────────────────────────────────
 

--- a/fs/sul/id/module.f.ts
+++ b/fs/sul/id/module.f.ts
@@ -23,6 +23,7 @@ import { base32, type V8 } from '../../crypto/sha2/module.f.ts'
 import { literal3ToVec } from '../level/literal/module.f.ts'
 import { log2 } from '../../types/bigint/module.f.ts'
 import { asBase, asNominal, type Nominal } from '../../types/nominal/module.f.ts'
+import { unwrap } from '../../types/nullable/module.f.ts'
 
 /** A 256-bit SUL identifier. One of three variants: level-3 literal, raw bit vector, or SHA2 hash. */
 export type Id = Nominal<
@@ -36,7 +37,9 @@ export type Id = Nominal<
 //              0123456789ABCDEF0123456789ABCDEF
 const ivSeed = "Synthetic Universal Language 001"
 
-const utf8IvSeed = utf8(ivSeed)
+// `ivSeed` is a fixed 32-char source literal, so its UTF-8 encoding is well
+// within the cap — the over-cap `null` branch is provably dead.
+const utf8IvSeed = unwrap(utf8(ivSeed))
 
 const c = secp256r1
 
@@ -127,8 +130,10 @@ const vecX20 = vec(0x20n)
 
 const { concat, listToVec } = msb
 
+// `hash2` yields a fixed 8-element digest, each mapped to a fixed 32-bit vec, so
+// the joined hash is a fixed 256-bit structure — the `null` branch is dead.
 const hashMerge = (a: Id, b: Id): Id =>
-    hashId(uint(listToVec(hash2((asBase(a) << 0x100n) | asBase(b)).map(vecX20))))
+    hashId(uint(unwrap(listToVec(hash2((asBase(a) << 0x100n) | asBase(b)).map(vecX20)))))
 
 export const compress = (a: Id, b: Id): Id => {
     if (isHash(a) || isHash(b)) {

--- a/fs/sul/level/literal/module.f.ts
+++ b/fs/sul/level/literal/module.f.ts
@@ -7,6 +7,7 @@
 
 import { log2 } from '../../../types/bigint/module.f.ts'
 import { msb, vec, type Vec } from '../../../types/bit_vec/module.f.ts'
+import { unwrap } from '../../../types/nullable/module.f.ts'
 import type { Func } from '../../../types/function/module.f.ts'
 import { strictEqual, type Equal, type StateScan } from '../../../types/function/operator/module.f.ts'
 import { equal, map, type List } from '../../../types/list/module.f.ts'
@@ -118,7 +119,10 @@ const { listToVec } = msb
 const literalToVec = (prior: LiteralToVec, e: bigint): LiteralToVec => {
     const m = map(prior)
     const { decode } = level(e)
-    return literal => listToVec(m(decode(literal)))
+    // A SUL literal token is bounded by construction (literal ids are ≤ 256
+    // bits), so the canonical bit vector for one cannot exceed the cap — the
+    // over-cap `null` branch is provably dead, hence `unwrap`.
+    return literal => unwrap(listToVec(m(decode(literal))))
 }
 
 /** Decodes a level-1 symbol to its canonical MSB bit vector. */

--- a/fs/text/module.f.ts
+++ b/fs/text/module.f.ts
@@ -6,6 +6,7 @@
  * @module
  */
 import { msb, u8List, u8ListToVec, type Vec } from '../types/bit_vec/module.f.ts'
+import type { Nullable } from '../types/nullable/module.f.ts'
 import { flatMap, type List } from '../types/list/module.f.ts'
 import { fromCodePointList, toCodePointList } from './utf8/module.f.ts'
 import { stringToCodePointList, codePointListToString } from './utf16/module.f.ts'
@@ -35,9 +36,10 @@ export type Utf8 = Vec
  * Converts a string to an UTF-8, represented as an MSB first bit vector.
  *
  * @param s The input string to be converted.
- * @returns The resulting UTF-8 bit vector, MSB first.
+ * @returns The resulting UTF-8 bit vector, MSB first, or `null` when the encoded
+ * length would exceed `maxLength` (every string is otherwise valid to encode).
  */
-export const utf8 = (s: string): Utf8 =>
+export const utf8 = (s: string): Nullable<Utf8> =>
     u8ListToVecMsb(fromCodePointList(stringToCodePointList(s)))
 
 /**

--- a/fs/text/proof.f.ts
+++ b/fs/text/proof.f.ts
@@ -1,5 +1,6 @@
 import { flat, utf8, utf8ToString, type Block } from './module.f.ts'
 import { join } from '../types/string/module.f.ts'
+import { unwrap } from '../types/nullable/module.f.ts'
 
 export const proof = {
     block: () => {
@@ -16,7 +17,7 @@ export const proof = {
         if (result !== 'a\nb\n:c\n::d\ne') { throw result }
     },
     encoding: () => {
-        const v = utf8('Hello world!')
+        const v = unwrap(utf8('Hello world!'))
         const r = utf8ToString(v)
         if (r !== 'Hello world!') { throw r }
     }

--- a/fs/text/sgr/module.f.ts
+++ b/fs/text/sgr/module.f.ts
@@ -9,7 +9,7 @@
 // https://en.wikipedia.org/wiki/ANSI_escape_code#C0_control_codes
 
 import { write, type Write, type WriteConsoles, type NodeProgramOptions } from '../../effects/node/module.f.ts'
-import { type Effect } from '../../effects/module.f.ts'
+import { pure, type Effect } from '../../effects/module.f.ts'
 import { utf8 } from "../module.f.ts"
 
 export const backspace: string = '\x08'
@@ -93,6 +93,11 @@ export const csiWrite =
     (s: string) => Effect<Write, void> =>
 {
     const toStr = str(std[stream].isTTY)
-    return (s: string): Effect<Write, void> =>
-        write(stream, utf8(toStr(s)))
+    return (s: string): Effect<Write, void> => {
+        const v = utf8(toStr(s))
+        // The `write` primitive takes a single `Vec`; output whose UTF-8
+        // encoding exceeds `maxLength` is currently unencodable, so drop it
+        // rather than throw. The durable fix is a chunked-stream `write`.
+        return v === null ? pure(undefined) : write(stream, v)
+    }
 }

--- a/fs/text/utf8/proof.f.ts
+++ b/fs/text/utf8/proof.f.ts
@@ -1,10 +1,14 @@
 import { toCodePointList, fromCodePointList, fromVec } from './module.f.ts'
 import { stringify as jsonStringify } from '../../json/module.f.ts'
 import { sort } from '../../types/object/module.f.ts'
-import { toArray } from '../../types/list/module.f.ts'
-import { msb, u8ListToVec } from '../../types/bit_vec/module.f.ts'
+import { toArray, type List } from '../../types/list/module.f.ts'
+import { msb, u8ListToVec as u8ListToVecRaw, type BitOrder, type Vec } from '../../types/bit_vec/module.f.ts'
+import { unwrap } from '../../types/nullable/module.f.ts'
 
 const stringify = jsonStringify(sort)
+
+// Test inputs are short byte literals, well within the cap.
+const u8ListToVec = (bo: BitOrder) => (list: List<number>): Vec => unwrap(u8ListToVecRaw(bo)(list))
 
 export const proof = {
     toCodePoint: [

--- a/fs/types/bit_vec/module.f.ts
+++ b/fs/types/bit_vec/module.f.ts
@@ -26,6 +26,7 @@ import { flip, identity } from '../function/module.f.ts'
 import type { Binary, Fold, Reduce as OpReduce } from '../function/operator/module.f.ts'
 import { iterable, map, type List, type Thunk } from '../list/module.f.ts'
 import { asBase, asNominal, type Nominal } from '../nominal/module.f.ts'
+import type { Nullable } from '../nullable/module.f.ts'
 import { repeat as mRepeat } from '../monoid/module.f.ts'
 import { cmp, max, min, type Sign } from '../function/compare/module.f.ts'
 
@@ -258,10 +259,12 @@ export type BitOrder = {
      *
      * Unlike `concat`, which joins exactly two vectors, this joins a whole list.
      *
-     * @returns The concatenation of every vector in the list, or `empty` when the
-     * list is empty.
+     * @returns The concatenation of every vector in the list, `empty` when the
+     * list is empty, or `null` when the combined length would exceed `maxLength`
+     * (so no intermediate `bigint` is ever built past the cap — uniform across
+     * JS engines).
      */
-    readonly listToVec: (list: List<Vec>) => Vec
+    readonly listToVec: (list: List<Vec>) => Nullable<Vec>
     /**
      * Computes the bitwise exclusive OR of two vectors after normalizing their lengths.
      *
@@ -310,11 +313,20 @@ const unpackEmpty = { length: 0n, uint: 0n } as const
  * This is the bit-vector analogue of a builder that accumulates appended pieces
  * and materializes the combined result on demand, such as `StringBuilder`
  * (Java, C#) or `strings.Builder` (Go).
+ *
+ * Tracks the running total length and returns `null` *before* combining an
+ * element that would push the result past `maxLength`, so no intermediate
+ * `bigint` is ever built over the ceiling. This is the single bounded core for
+ * every list builder; the added cost on the happy path is one `bigint` add +
+ * compare per element.
  */
 const unpackListToVec = (unpackConcat: BitOrder['unpackConcat']) =>
-    (list: List<Unpacked>): Unpacked => {
+    (list: List<Unpacked>): Nullable<Unpacked> => {
         let result: readonly Unpacked[] = []
+        let total = 0n
         for (const e of iterable(list)) {
+            total += e.length
+            if (total > maxLength) { return null }
             let v = e
             let i = 0
             while (true) {
@@ -363,7 +375,10 @@ const bo = ({ front, removeFront, norm, uintCmp, unpackSplit, unpackConcatUint }
         front,
         removeFront,
         concat,
-        listToVec: list => pack(unpackListToVec(unpackConcat)(map(unpack)(list))),
+        listToVec: list => {
+            const r = unpackListToVec(unpackConcat)(map(unpack)(list))
+            return r === null ? null : pack(r)
+        },
         xor: op(norm)(xor),
         unpackPopFront,
         popFront,
@@ -445,11 +460,14 @@ export const msb: BitOrder = bo({
  *
  * @param bo The bit order for the conversion
  * @param list The list of unsigned 8-bit integers to be converted.
- * @returns The resulting vector based on the provided bit order.
+ * @returns The resulting vector based on the provided bit order, or `null` when
+ * the combined length would exceed `maxLength`.
  */
-export const u8ListToVec = ({ unpackConcat }: BitOrder) => (list: List<number>): Vec =>
-    pack(unpackListToVec(unpackConcat)(
-        map((b: number): Unpacked => ({ length: 8n, uint: BigInt(b) }))(list)))
+export const u8ListToVec = ({ unpackConcat }: BitOrder) => (list: List<number>): Nullable<Vec> => {
+    const r = unpackListToVec(unpackConcat)(
+        map((b: number): Unpacked => ({ length: 8n, uint: BigInt(b) }))(list))
+    return r === null ? null : pack(r)
+}
 
 const unpackChunkList = ({ unpackSplit }: BitOrder) => (n: bigint): (u: Unpacked) => Thunk<Unpacked> => {
     const divUpN2 = divUp(n << 1n)

--- a/fs/types/bit_vec/proof.f.ts
+++ b/fs/types/bit_vec/proof.f.ts
@@ -1,7 +1,8 @@
 import { mask } from '../bigint/module.f.ts'
 import type { Sign } from '../function/compare/module.f.ts'
 import { asBase, asNominal } from '../nominal/module.f.ts'
-import { length, empty, uint, type Vec, vec, lsb, msb, type BitOrder, repeat, vec8, u8ListToVec, u8List, chunkList, fromSentinel } from './module.f.ts'
+import { length, empty, uint, type Vec, vec, lsb, msb, type BitOrder, repeat, vec8, u8ListToVec, u8List, chunkList, fromSentinel, maxLengthBytes } from './module.f.ts'
+import { unwrap } from '../nullable/module.f.ts'
 import { repeat as listRepeat, toArray } from '../list/module.f.ts'
 
 const unsafeVec = (a: bigint): Vec => asNominal(a)
@@ -392,13 +393,31 @@ export const proof = {
     },
     u8ListToVec: () => {
         // 131_072 is too much for Bun
-        const x = u8ListToVec(msb)(listRepeat(0x12)(131_071))
+        const x = unwrap(u8ListToVec(msb)(listRepeat(0x12)(131_071)))
         return () => {
             const m = u8List(msb)(x)
             const y = toArray(m)
             if (y.length !== 131_071) {
                 throw `y.lenght: ${y.length}`
             }
+        }
+    },
+    // A list whose combined length is exactly `maxLengthBytes` bytes
+    // (`maxLength` bits) is the largest a single `Vec` can hold: it is built,
+    // not rejected.
+    u8ListToVecAtMax: () => {
+        const n = Number(maxLengthBytes)
+        const x = u8ListToVec(msb)(listRepeat(0x12)(n))
+        if (x === null) { throw 'at maxLengthBytes should not be null' }
+        if (length(x) !== maxLengthBytes << 3n) { throw length(x) }
+    },
+    // One byte past `maxLengthBytes` cannot be a single `Vec`: the bounded core
+    // returns `null` *before* building an over-cap `bigint` (uniform across
+    // engines), rather than throwing or silently overflowing.
+    u8ListToVecOverMax: () => {
+        const n = Number(maxLengthBytes) + 1
+        if (u8ListToVec(msb)(listRepeat(0x12)(n)) !== null) {
+            throw 'one byte past maxLengthBytes should be null'
         }
     },
     u8ListUnaligned: () => {

--- a/fs/types/nullable/module.f.ts
+++ b/fs/types/nullable/module.f.ts
@@ -23,3 +23,19 @@ export const toOption = <T>(value: Nullable<T>): Option<T> => value === null ? [
  */
 export const fromUndefined = <T>(value: T | undefined): Nullable<T> =>
     value === undefined ? null : value
+
+/**
+ * Asserts a `Nullable<T>` is present, returning the `T` or throwing on `null`.
+ *
+ * Use this — never a bare `!` — only where the `null` branch is provably dead
+ * because the value's size is fixed by the algorithm (independent of input
+ * size) or comes from a source literal. A bare `!` only silences the
+ * type-checker, so a (supposedly impossible) `null` would survive to surface as
+ * an obscure error far from its cause; `unwrap` turns the invariant into a
+ * checked assertion that throws at the call site. Anything whose size is
+ * data-derived must propagate the `null` instead.
+ */
+export const unwrap = <T>(value: Nullable<T>): T => {
+    if (value === null) { throw 'unexpected null' }
+    return value
+}

--- a/fs/types/uint8array/module.f.ts
+++ b/fs/types/uint8array/module.f.ts
@@ -10,26 +10,24 @@
  * @module
  */
 import { utf8, utf8ToString } from '../../text/module.f.ts'
-import { maxLengthBytes, msb, u8List, u8ListToVec, type Vec } from '../bit_vec/module.f.ts'
-import { compose } from '../function/module.f.ts'
+import { msb, u8List, u8ListToVec, type Vec } from '../bit_vec/module.f.ts'
+import type { Nullable } from '../nullable/module.f.ts'
 import { flat, fromArrayLike, iterable, map, type List } from '../list/module.f.ts'
 
 const u8ListToVecMsb = u8ListToVec(msb)
 const u8ListMsb = u8List(msb)
 
 /**
- * Converts a Uint8Array into an MSB-first bit vector.
+ * Converts a Uint8Array into an MSB-first bit vector, or `null` when the array
+ * is larger than a single `Vec` can hold (`maxLength` bits). The `null` is the
+ * over-cap signal; callers at an I/O boundary turn it into a typed error.
  */
-export const toVec = (input: Uint8Array): Vec => {
-    if (input.length > maxLengthBytes) {
-        throw "the array is too big"
-    }
-    return u8ListToVecMsb(fromArrayLike(input))
-}
+export const toVec = (input: Uint8Array): Nullable<Vec> =>
+    u8ListToVecMsb(fromArrayLike(input))
 
 const m = map(fromArrayLike)
 
-export const listToVec = (input: List<Uint8Array>): Vec =>
+export const listToVec = (input: List<Uint8Array>): Nullable<Vec> =>
     u8ListToVecMsb(flat(m(input)))
 
 /**
@@ -38,8 +36,12 @@ export const listToVec = (input: List<Uint8Array>): Vec =>
 export const fromVec = (input: Vec): Uint8Array =>
     Uint8Array.from(iterable(u8ListMsb(input)))
 
-export const decodeUtf8: (input: Uint8Array) => string
-    = compose(toVec)(utf8ToString)
+export const decodeUtf8 = (input: Uint8Array): Nullable<string> => {
+    const v = toVec(input)
+    return v === null ? null : utf8ToString(v)
+}
 
-export const encodeUtf8: (input: string) => Uint8Array
-    = compose(utf8)(fromVec)
+export const encodeUtf8 = (input: string): Nullable<Uint8Array> => {
+    const v = utf8(input)
+    return v === null ? null : fromVec(v)
+}

--- a/fs/types/uint8array/proof.f.ts
+++ b/fs/types/uint8array/proof.f.ts
@@ -1,5 +1,6 @@
 import { maxLength, maxLengthBytes, vec } from '../bit_vec/module.f.ts'
 import { toVec, fromVec, listToVec, decodeUtf8, encodeUtf8 } from './module.f.ts'
+import { unwrap } from '../nullable/module.f.ts'
 import { strictEqual } from '../function/operator/module.f.ts'
 import { equal, fromArrayLike } from '../list/module.f.ts'
 
@@ -16,13 +17,13 @@ const assertArrayEq = (a: Uint8Array, b: Uint8Array) => {
 export const proof = {
     empty: () => {
         const input = new Uint8Array()
-        const vec = toVec(input)
+        const vec = unwrap(toVec(input))
         const output = fromVec(vec)
         assertArrayEq(output, input)
     },
     roundTrip: () => {
         const input = Uint8Array.from([0, 1, 2, 3, 255])
-        const vec = toVec(input)
+        const vec = unwrap(toVec(input))
         const output = fromVec(vec)
         assertArrayEq(output, input)
     },
@@ -32,34 +33,46 @@ export const proof = {
         assertArrayEq(output, Uint8Array.from([0xF0]))
     },
     encodeUtf8Empty: () => {
-        const output = encodeUtf8('')
+        const output = unwrap(encodeUtf8(''))
         assertArrayEq(output, new Uint8Array())
     },
     encodeUtf8Ascii: () => {
-        const output = encodeUtf8('Hi!')
+        const output = unwrap(encodeUtf8('Hi!'))
         assertArrayEq(output, Uint8Array.from([72, 105, 33]))
     },
     encodeUtf8Multibyte: () => {
-        const output = encodeUtf8('✓')
+        const output = unwrap(encodeUtf8('✓'))
         assertArrayEq(output, Uint8Array.from([0xE2, 0x9C, 0x93]))
     },
     decodeUtf8Ascii: () => {
-        const output = decodeUtf8(Uint8Array.from([102, 115]))
+        const output = unwrap(decodeUtf8(Uint8Array.from([102, 115])))
         assertEq(output, 'fs')
     },
     decodeUtf8Multibyte: () => {
-        const output = decodeUtf8(Uint8Array.from([0xE2, 0x9C, 0x93]))
+        const output = unwrap(decodeUtf8(Uint8Array.from([0xE2, 0x9C, 0x93])))
         assertEq(output, '✓')
     },
     utf8RoundTrip: () => {
         const input = 'FunctionalScript 🐝'
-        const output = decodeUtf8(encodeUtf8(input))
+        const output = unwrap(decodeUtf8(unwrap(encodeUtf8(input))))
         assertEq(output, input)
     },
     listToVec: () => {
-        const result = listToVec([Uint8Array.from([1, 2]), Uint8Array.from([3])])
+        const result = unwrap(listToVec([Uint8Array.from([1, 2]), Uint8Array.from([3])]))
         assertArrayEq(fromVec(result), Uint8Array.from([1, 2, 3]))
     },
-    maxLength: () => toVec(new Uint8Array(Number(maxLengthBytes))),
-    throw: () => toVec(new Uint8Array(Number(maxLengthBytes) + 1)),
+    // A `maxLengthBytes`-byte array is the largest a single `Vec` can hold: it
+    // converts (non-`null`).
+    maxLength: () => {
+        if (toVec(new Uint8Array(Number(maxLengthBytes))) === null) {
+            throw 'at maxLengthBytes should not be null'
+        }
+    },
+    // One byte past the cap returns `null` rather than throwing — the over-cap
+    // signal a boundary turns into a typed error.
+    overMaxIsNull: () => {
+        if (toVec(new Uint8Array(Number(maxLengthBytes) + 1)) !== null) {
+            throw 'one byte past maxLengthBytes should be null'
+        }
+    },
 }

--- a/fs/website/module.f.ts
+++ b/fs/website/module.f.ts
@@ -6,13 +6,15 @@
 import { htmlUtf8 } from '../html/module.f.ts'
 import { writeFile, type WriteFile } from '../effects/node/module.f.ts'
 import { pure, type Effect } from '../effects/module.f.ts'
+import { unwrap } from '../types/nullable/module.f.ts'
 import type { Vec } from '../types/bit_vec/module.f.ts'
 
-const html: Vec = htmlUtf8()(
+// Fixed source-literal content, so its UTF-8 encoding is well within the cap.
+const html: Vec = unwrap(htmlUtf8()(
     ['a',
         { href: 'https://github.com/functionalscript/functionalscript' },
         'GitHub Repository'
-    ])
+    ]))
 
 const program: Effect<WriteFile, number> =
     writeFile('index.html', html)


### PR DESCRIPTION
Make the over-maxLength signal a propagated `null` instead of a thrown `bigint`, so inline `cas_add` content above the 128 KiB cap fails as a clean `isError` identically on every JS engine.

- bit_vec: `unpackListToVec` is the single bounded core — it tracks the running total and returns `null` before building past `maxLength`; `listToVec` / `u8ListToVec` propagate it.
- nullable: add `unwrap` for the rare algorithm-fixed / source-literal sites where the `null` branch is provably dead.
- base64 `decode` rejects over-cap input up front and builds only the trimmed length (keeping the RFC 4648 §3.5 padding-bit check); `encode` guards against the octet-padding pushing past the cap.
- `text.utf8`, `uint8array.toVec`/`listToVec`, and the `asn.1` encoders propagate `Nullable<Vec>`; `crypto/sign`, `sul/id`, `sul/level/literal` `unwrap` at their bounded sites.
- Resolve the `null` at boundaries: `writeUtf8File` → IoResult error, the Node HTTP runner → 413, `cas_add` → content-decoding isError, and `cas_get` content:true bounds its serialized response.
- Proofs: cover text/base64 at exactly maxLengthBytes and one byte over, plus u8ListToVec / toVec at and past the cap.


Claude-Session: https://claude.ai/code/session_0162iJdUdbqgCk2Mvza3UKB6