### PR TITLE
Add revision content format for evolving mutable objects on CAS

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ fjs cas list             # list all stored hashes
 
 Blobs are stored under `~/.cas/` and addressed by their SHA-256 hash encoded in cBase32.
 
+CAS blobs are immutable, so evolving a mutable object (a document, a config) over
+time needs a shared shape for linking one version to the next. See
+[`fs/cas/evo/README.md`](fs/cas/evo/README.md) for the `revision` content format
+that provides it.
+
 ### MCP Server
 
 The CAS is also exposed as an [MCP](https://modelcontextprotocol.io/) server so LLM agents can read and write blobs without a shell:

--- a/fs/cas/evo/README.md
+++ b/fs/cas/evo/README.md
@@ -1,0 +1,163 @@
+# `revision`: evolving mutable objects on top of the immutable CAS
+
+This is the format spec the `evolution` tag in a `revision` BLOB points to
+(`https://functionalscript.com/fs/cas/evo/README.md`). It is deployed
+automatically to functionalscript.com because it lives in the repo, so the
+tag URL dereferences to this document.
+
+CAS blobs are immutable and addressed by content hash: there is no way to
+represent "the same object, but updated" directly, since a new version is
+unavoidably a new hash with no address in common with the old one. `revision`
+gives a chain of updates to one logical (mutable) object — a document, a
+config, any piece of state referenced by a stable name — a shared shape: it
+links back to its parent revision(s) as a DAG (not just a chain, so concurrent
+edits can merge), and carries either the full materialized content or an
+incremental diff against the parent(s).
+
+The implementation lives in [`fs/cas/evo/module.f.ts`](module.f.ts) (the RTTI
+schema, head resolution, materialization, generation-cache verification, and a
+merge-revision builder); this document is the format's authoritative spec.
+
+## Shape
+
+```ts
+export const revision = {
+    evolution: 'https://functionalscript.com/fs/cas/evo/README.md',
+    object: ref,
+    parents: array(hash),
+    content: option(ref),
+    changes: option(array(ref)),
+    generation: option(number),
+    archived: option(true),
+} as const
+```
+
+- **`evolution`** — format tag. Key = type discriminant; value is the URL of
+  this spec for now, later a hash of the spec. In a generic CAS a blob is just
+  bytes under a hash, so without a discriminant a reader can only recognize a
+  revision by guessing from its shape, which collides with any other format
+  that happens to have `object`/`parents` fields. The tag gives format
+  detection, versioning (readers reject or migrate blobs of an incompatible
+  version instead of silently misreading them), and a cheap pre-validation
+  gate.
+
+  The value is hard-coded as a literal for now — the XML-namespace/JSON-LD
+  approach: globally unique without a registry, self-documenting, and
+  validated by the schema itself since the literal is part of the schema.
+  Later versions of the format migrate the value to a content-addressed
+  revision reference: this spec is itself a mutable object evolved by this
+  very format, so the reference would combine the spec's object identity with
+  a version pin — stable identity across versions, pinned version per blob, no
+  registry. The exact reference syntax is not defined yet (`hash.generation`
+  alone does not pin a version across branches; something like
+  `{hash}.{generation}.{hash}` may be needed) — for now only hashes are used.
+  Two costs of the interim URL, accepted knowingly and fixed by that
+  migration: the URL is a mutable pointer (the document behind it can
+  change), so the value identifies the format but not its version; and it
+  anchors the identifier to DNS.
+
+  Note that `evolution`'s value is itself a `ref` under the definition below
+  — an `https://` bridge URL today, a CA reference later — so the tag's
+  migration path is just the general evolution of `ref`, not a special case.
+
+- **`object`** — identity of the mutable object being revised. Every revision
+  of the same mutable thing shares this anchor, which is what "current
+  head(s)" is resolved against, without requiring a mutable pointer anywhere
+  in CAS itself: the head is whatever revision(s) reference `object` and are
+  not listed as a parent by another revision *of the same `object`* — a
+  revision of a different object referencing the same hash (or an unrelated
+  blob imported by sync) must not demote a head.
+
+  `object` identity normally comes from the first `content`: the hash of the
+  object's initial content is the object's identity. Two objects created from
+  identical initial content therefore share an identity — this is by design:
+  it is fine to have many changes of the same object from different users.
+  When distinct identity is wanted, a ref can carry an additional nonce
+  (`{hash}-{nonce}`). Digital signatures (a separate, future spec) will filter
+  changes from unknown users.
+
+  `object` is also the fallback base for `parents`: a revision with no
+  parents uses `object` as its base, with or without `changes` (see
+  Materialization below).
+
+- **`parents`** — parent revision BLOBs (an array, to support merges: multiple
+  concurrent lines of history converging). Empty means this is the first
+  revision. `hash` (not the general `ref`) because a parent is a CAS blob, so
+  a bridge URL cannot stand in for it — a revision with a non-CAS parent must
+  not validate.
+
+- **`content`** — complete materialized content of this revision. If present,
+  it is authoritative and `changes` does not need to be replayed.
+
+- **`changes`** — incremental changes introduced by this revision, used only
+  when `content` is absent. Entries will most likely point to an event log,
+  most likely CRDT-based, but the refs may point to different (not yet
+  defined) formats. **Not implemented in the first iteration** — see below.
+
+- **`generation`** — optional cached generation number within the object's
+  evolution. Normally `generation = 0` for the first revision, and
+  `generation = 1 + max(parent.generation)` otherwise. It is a cache, not a
+  source of truth: it must always be re-derivable from `parents`, and a
+  consumer must not trust a `generation` it has not verified against the
+  actual parent chain from an untrusted source.
+
+- **`archived`** — marks the mutable object as archived/inactive. The
+  revision still exists; it is just hidden from normal active views. An
+  archived object's blobs can be deleted from a local CAS after a backup.
+  `option(true)` (a presence-only flag) rather than `option(boolean)`,
+  matching the convention used elsewhere in the RTTI-typed schemas under
+  `fs/types/rtti`.
+
+## `ref` and `hash`
+
+`ref` is a URL in content-addressed digital space. Two forms are recognized
+for now: a cbase32 hash (a native CAS address, see [`fs/cbase32/`](../../cbase32/)),
+and a standard `https://` URL as a bridge to the legacy location-addressed
+web. More forms are planned. `hash` is the hash-only subset of `ref` used in
+schema positions restricted to CAS blobs (`parents`).
+
+## Materialization algorithm
+
+`content` has priority; the fields are not mutually exclusive by schema —
+resolution is by precedence. The base of a revision is its materialized
+parent, or `object` itself when `parents` is empty (in all cases, with or
+without `changes`):
+
+1. if `content` is present, use it;
+2. otherwise, apply `changes` on the base;
+3. otherwise (no `changes`), use the base.
+
+Materialization through multiple parents is only defined when every path
+references a single common ancestor, the intermediate revisions have no
+`content`, and all `changes` are CRDTs (so application is order-independent).
+
+**The first iteration does not implement `changes` at all**, so it only
+supports zero or one parent; a multi-parent (merge) revision must carry
+`content`, and a `changes`-only revision (no `content`) is reported as an
+error rather than silently misapplied.
+
+## Conflicting concurrent heads
+
+Resolved the same way as in Git: a merge tool creates a new revision that
+references the conflicting revisions as `parents`. The format itself does not
+resolve conflicts; it records their resolution. CAS synchronization MUST
+never care about merge conflicts — an object can legitimately have many heads
+in a store at any time. An application can propose a merge revision; sync
+just moves blobs.
+
+## Open design points
+
+- The `changes` event-log/CRDT format(s) still need to be defined.
+- Future `ref` forms beyond cbase32 hashes and `https://` bridge URLs
+  (including the optional `{hash}-{nonce}` form for distinct object identity),
+  and which ref positions besides `parents` use the hash-only `hash` type
+  rather than the general `ref`.
+- Whether other content formats should share the same tagging convention, and
+  the exact syntax of the future CA revision reference (e.g.
+  `{hash}.{generation}.{hash}`; undefined for now — only hashes are used).
+- Digital signatures for filtering changes from unknown users — a separate,
+  future spec.
+- Further out: a `{public-key}/{name}.{generation}` form, where the key's
+  owner defines what `{name}` means — anchoring the identifier in a signer
+  ties format identity to a web of trust and solves the
+  many-generations-from-many-users problem.

--- a/fs/cas/evo/module.f.ts
+++ b/fs/cas/evo/module.f.ts
@@ -1,0 +1,208 @@
+/**
+ * `revision`: a content format for evolving mutable objects on top of the
+ * immutable CAS ("evo" for evolution). A `revision` BLOB is one step in the
+ * history of a mutable object — a document, a config, any piece of state
+ * referenced by a stable name — linking back to its parent revision(s) so a
+ * chain (or DAG, for merges) of updates can be walked, resolved to its current
+ * head(s), and materialized into content.
+ *
+ * See `fs/cas/evo/README.md` (the deployed spec the `evolution` tag URL points
+ * to) for the full design; `fs/cas/todo/revision-content-format.md` is the
+ * originating design doc.
+ *
+ * @module
+ */
+import { string, number, array, option } from '../../types/rtti/module.f.ts'
+import type { Ts } from '../../types/rtti/ts/module.f.ts'
+import { validate } from '../../types/rtti/validate/module.f.ts'
+import { cBase32ToVec } from '../../cbase32/module.f.ts'
+import { ok, error, type Result } from '../../types/result/module.f.ts'
+import type { Unknown } from '../../djs/module.f.ts'
+
+// ── ref / hash ───────────────────────────────────────────────────────────────
+
+/**
+ * A URL in content-addressed digital space. Two forms are recognized for now:
+ * a cbase32 CAS hash (see `fs/cbase32/`), and a standard `https://` URL as a
+ * bridge to the legacy location-addressed web. More forms are planned.
+ *
+ * At the rtti level `ref` is just `string` — the two recognized forms are a
+ * refinement checked at runtime by `isRef`, not expressible as a distinct rtti
+ * schema tag (there is no "string matching a pattern" schema in `fs/types/rtti`).
+ */
+export const ref = string
+
+/** The TypeScript type a `ref` value has. */
+export type Ref = Ts<typeof ref>
+
+/**
+ * The hash-only subset of `ref`: a cbase32 CAS hash, never a bridge URL. Used
+ * where a bridge URL cannot stand in for a CAS blob — `parents` is the one
+ * schema position that requires it.
+ */
+export const hash = string
+
+/** The TypeScript type a `hash` value has. */
+export type Hash = Ts<typeof hash>
+
+/** True when `s` is a valid cbase32 CAS hash. */
+export const isHash = (s: string): boolean => cBase32ToVec(s) !== null
+
+/** True when `s` is a valid `ref`: a CAS hash or an `https://` bridge URL. */
+export const isRef = (s: string): boolean => isHash(s) || s.startsWith('https://')
+
+// ── format tag ───────────────────────────────────────────────────────────────
+
+/**
+ * Format tag value: identifies a BLOB as a `revision` and pins the format
+ * version. The interim value is the URL of the format spec itself (the
+ * XML-namespace/JSON-LD approach — globally unique without a registry,
+ * self-documenting). A future version migrates this to a content-addressed
+ * revision reference; see the spec for the migration plan.
+ */
+export const evolution = 'https://functionalscript.com/fs/cas/evo/README.md' as const
+
+// ── schema ───────────────────────────────────────────────────────────────────
+
+/** RTTI schema for the `revision` content format. */
+export const revision = {
+    evolution,
+    object: ref,
+    parents: array(hash),
+    content: option(ref),
+    changes: option(array(ref)),
+    generation: option(number),
+    archived: option(true as const),
+} as const
+
+/** TypeScript type derived from the `revision` schema. */
+export type Revision = Ts<typeof revision>
+
+const validateSchema = validate(revision)
+
+/**
+ * Validates `value` as a `revision`: the rtti schema shape, plus the hash/ref
+ * refinements the schema alone cannot express — every `parents` entry must be
+ * a CAS hash (never a bridge URL), and `object`/`content`/`changes` entries
+ * must be valid `ref`s.
+ */
+export const validateRevision = (value: Unknown): Result<Revision, string> => {
+    const r = validateSchema(value)
+    if (r[0] === 'error') { return error(r[1].message) }
+    const v = r[1]
+    for (const p of v.parents) {
+        if (!isHash(p)) { return error(`parent is not a CAS hash: ${p}`) }
+    }
+    if (!isRef(v.object)) { return error(`object is not a valid ref: ${v.object}`) }
+    if (v.content !== undefined && !isRef(v.content)) { return error(`content is not a valid ref: ${v.content}`) }
+    if (v.changes !== undefined) {
+        for (const c of v.changes) {
+            if (!isRef(c)) { return error(`changes entry is not a valid ref: ${c}`) }
+        }
+    }
+    return ok(v)
+}
+
+// ── store lookup ─────────────────────────────────────────────────────────────
+
+/** A revision keyed by its own CAS hash — the shape a store exposes to the functions below. */
+export type Entry = readonly [Hash, Revision]
+
+/** Looks up a revision by its CAS hash; `undefined` when it isn't known to the caller. */
+export type Get = (hash: Hash) => Revision | undefined
+
+// ── head resolution ──────────────────────────────────────────────────────────
+
+/**
+ * Resolves the current head(s) of `object`: revisions of that object which are
+ * not listed as a parent by any other revision *of the same `object`*. Scoping
+ * the "is it a parent" check to same-object revisions is what keeps a revision
+ * of a different object — or an unrelated blob imported by sync — from
+ * demoting a head just because it happens to reference the same hash.
+ */
+export const heads = (store: readonly Entry[]) => (object: Ref): readonly Hash[] => {
+    const ofObject = store.filter(([, r]) => r.object === object)
+    const parented = new Set<Hash>()
+    for (const [, r] of ofObject) {
+        for (const p of r.parents) { parented.add(p) }
+    }
+    return ofObject.filter(([h]) => !parented.has(h)).map(([h]) => h)
+}
+
+// ── materialization ──────────────────────────────────────────────────────────
+
+/**
+ * Materializes the content `ref` of `revision`, first iteration only: `content`
+ * wins when present; otherwise the base is used as-is (`changes` application is
+ * not implemented yet, so a `changes`-only revision is reported as an error
+ * rather than silently ignored). The base is the parent's materialization, or
+ * `object` itself when there are no parents. Requires zero or one parent — a
+ * merge (multiple parents) with no `content` is unsupported by this iteration
+ * and reported as an error rather than guessed at.
+ */
+export const materialize = (get: Get) => {
+    const go = (r: Revision): Result<Ref, string> => {
+        if (r.content !== undefined) { return ok(r.content) }
+        if (r.changes !== undefined) { return error('changes materialization is not implemented yet') }
+        if (r.parents.length === 0) { return ok(r.object) }
+        if (r.parents.length > 1) { return error('merge revision without content cannot be materialized') }
+        const parentHash = r.parents[0]
+        const parent = get(parentHash)
+        if (parent === undefined) { return error(`missing parent revision: ${parentHash}`) }
+        return go(parent)
+    }
+    return go
+}
+
+// ── generation ───────────────────────────────────────────────────────────────
+
+/**
+ * Derives the true generation number of `revision` from its parent chain: `0`
+ * for a first revision (no parents), otherwise `1 + max(parent.generation)`.
+ * The schema's `generation` field is only a cache and must never be trusted
+ * without checking it against this derivation.
+ */
+export const generationOf = (get: Get) => {
+    const go = (r: Revision): Result<number, string> => {
+        if (r.parents.length === 0) { return ok(0) }
+        let max = -1
+        for (const p of r.parents) {
+            const parent = get(p)
+            if (parent === undefined) { return error(`missing parent revision: ${p}`) }
+            const g = go(parent)
+            if (g[0] === 'error') { return g }
+            if (g[1] > max) { max = g[1] }
+        }
+        return ok(1 + max)
+    }
+    return go
+}
+
+/** True when `revision.generation` (absent counts as trivially true) matches the derived generation. */
+export const verifyGeneration = (get: Get) => (r: Revision): boolean => {
+    if (r.generation === undefined) { return true }
+    const g = generationOf(get)(r)
+    return g[0] === 'ok' && g[1] === r.generation
+}
+
+// ── merge ────────────────────────────────────────────────────────────────────
+
+/**
+ * Shapes a merge revision that resolves concurrent `parents` into `content`,
+ * Git-style: the format itself does not decide how to resolve the conflict —
+ * that is the caller's job (an application-level merge tool deciding what
+ * `content` should be) — this only builds the resulting revision with a
+ * `generation` cache derived from the parents so it starts out consistent.
+ */
+export const merge = (get: Get) => (object: Ref, parents: readonly Hash[], content: Ref): Result<Revision, string> => {
+    if (parents.length === 0) { return error('merge requires at least one parent') }
+    let max = -1
+    for (const p of parents) {
+        const parent = get(p)
+        if (parent === undefined) { return error(`missing parent revision: ${p}`) }
+        const g = generationOf(get)(parent)
+        if (g[0] === 'error') { return g }
+        if (g[1] > max) { max = g[1] }
+    }
+    return ok({ evolution, object, parents, content, generation: 1 + max })
+}

--- a/fs/cas/evo/proof.f.ts
+++ b/fs/cas/evo/proof.f.ts
@@ -1,0 +1,220 @@
+import { assert, assertEq } from '../../asserts/module.f.ts'
+import { vec } from '../../types/bit_vec/module.f.ts'
+import { vecToCBase32 } from '../../cbase32/module.f.ts'
+import {
+    evolution,
+    heads,
+    isHash,
+    isRef,
+    materialize,
+    merge,
+    validateRevision,
+    verifyGeneration,
+    type Entry,
+    type Hash,
+    type Revision,
+} from './module.f.ts'
+
+/** A distinct fake cbase32 CAS hash, for building test fixtures without real content hashing. */
+const mkHash = (n: bigint): Hash => vecToCBase32(vec(16n)(n))
+
+const objectHash = mkHash(1n)
+const bridgeUrl = 'https://example.com/doc'
+
+const rev = (over: Partial<Revision>): Revision => ({
+    evolution,
+    object: objectHash,
+    parents: [],
+    content: undefined,
+    changes: undefined,
+    generation: undefined,
+    archived: undefined,
+    ...over,
+})
+
+const storeOf = (entries: readonly Entry[]) =>
+    (h: Hash): Revision | undefined => entries.find(([k]) => k === h)?.[1]
+
+export const proof = {
+    ref: {
+        hashIsRef: () => assert(isRef(objectHash)),
+        bridgeUrlIsRef: () => assert(isRef(bridgeUrl)),
+        bridgeUrlIsNotHash: () => assert(!isHash(bridgeUrl)),
+        garbageIsNotRef: () => assert(!isRef('not-a-ref')),
+    },
+    validate: {
+        minimal: () => assert(validateRevision(rev({}))[0] === 'ok'),
+        withContent: () => assert(validateRevision(rev({ content: mkHash(2n) }))[0] === 'ok'),
+        archived: () => assert(validateRevision(rev({ archived: true }))[0] === 'ok'),
+        wrongEvolutionTag: () =>
+            assert(validateRevision({ ...rev({}), evolution: 'https://example.com/other' })[0] === 'error'),
+        parentBridgeUrlRejected: () =>
+            assert(validateRevision(rev({ parents: [bridgeUrl] }))[0] === 'error'),
+        objectMustBeRef: () =>
+            assert(validateRevision(rev({ object: 'not a ref!' }))[0] === 'error'),
+        notAnObject: () => assert(validateRevision(42)[0] === 'error'),
+    },
+    heads: {
+        firstRevisionIsHead: () => {
+            const h1 = mkHash(10n)
+            const r1 = rev({})
+            const hs = heads([[h1, r1]])(objectHash)
+            assertEq(hs.length, 1)
+            assertEq(hs[0], h1)
+        },
+        linearHistoryHasOneHead: () => {
+            const h1 = mkHash(10n)
+            const h2 = mkHash(11n)
+            const r1 = rev({})
+            const r2 = rev({ parents: [h1] })
+            const hs = heads([[h1, r1], [h2, r2]])(objectHash)
+            assertEq(hs.length, 1)
+            assertEq(hs[0], h2)
+        },
+        branchGivesManyHeads: () => {
+            const h1 = mkHash(10n)
+            const h2 = mkHash(11n)
+            const h3 = mkHash(12n)
+            const r1 = rev({})
+            const r2 = rev({ parents: [h1] })
+            const r3 = rev({ parents: [h1] })
+            const hs = heads([[h1, r1], [h2, r2], [h3, r3]])(objectHash)
+            assertEq(hs.length, 2)
+            assert(hs.includes(h2) && hs.includes(h3))
+        },
+        mergeCollapsesBranchToOneHead: () => {
+            const h1 = mkHash(10n)
+            const h2 = mkHash(11n)
+            const h3 = mkHash(12n)
+            const h4 = mkHash(13n)
+            const r1 = rev({})
+            const r2 = rev({ parents: [h1] })
+            const r3 = rev({ parents: [h1] })
+            const r4 = rev({ parents: [h2, h3], content: mkHash(99n) })
+            const hs = heads([[h1, r1], [h2, r2], [h3, r3], [h4, r4]])(objectHash)
+            assertEq(hs.length, 1)
+            assertEq(hs[0], h4)
+        },
+        differentObjectDoesNotDemoteHead: () => {
+            // A revision of a *different* object that happens to list this object's
+            // head hash as a parent must not demote it.
+            const otherObject = mkHash(20n)
+            const h1 = mkHash(10n)
+            const r1 = rev({})
+            const foreign = rev({ object: otherObject, parents: [h1] })
+            const foreignHash = mkHash(30n)
+            const hs = heads([[h1, r1], [foreignHash, foreign]])(objectHash)
+            assertEq(hs.length, 1)
+            assertEq(hs[0], h1)
+        },
+        retroactiveDemotionBySync: () => {
+            // Before sync: h1 is the lone head.
+            const h1 = mkHash(10n)
+            const r1 = rev({})
+            const before = heads([[h1, r1]])(objectHash)
+            assertEq(before.length, 1)
+            assertEq(before[0], h1)
+            // A newly synced child of h1 demotes it retroactively.
+            const h2 = mkHash(11n)
+            const r2 = rev({ parents: [h1] })
+            const after = heads([[h1, r1], [h2, r2]])(objectHash)
+            assertEq(after.length, 1)
+            assertEq(after[0], h2)
+        },
+        archivedObjectStillResolvesHeads: () => {
+            const h1 = mkHash(10n)
+            const r1 = rev({ archived: true })
+            const hs = heads([[h1, r1]])(objectHash)
+            assertEq(hs.length, 1)
+            assertEq(hs[0], h1)
+        },
+    },
+    materialize: {
+        firstRevisionUsesObject: () => {
+            const get = storeOf([])
+            const r = rev({})
+            const m = materialize(get)(r)
+            assert(m[0] === 'ok' && m[1] === objectHash)
+        },
+        contentWins: () => {
+            const get = storeOf([])
+            const c = mkHash(2n)
+            const r = rev({ content: c })
+            const m = materialize(get)(r)
+            assert(m[0] === 'ok' && m[1] === c)
+        },
+        followsParentChain: () => {
+            const h1 = mkHash(10n)
+            const c1 = mkHash(2n)
+            const r1 = rev({ content: c1 })
+            const r2 = rev({ parents: [h1] })
+            const get = storeOf([[h1, r1]])
+            const m = materialize(get)(r2)
+            assert(m[0] === 'ok' && m[1] === c1)
+        },
+        missingParentIsError: () => {
+            const get = storeOf([])
+            const r = rev({ parents: [mkHash(999n)] })
+            assert(materialize(get)(r)[0] === 'error')
+        },
+        mergeWithoutContentIsError: () => {
+            const h1 = mkHash(10n)
+            const h2 = mkHash(11n)
+            const get = storeOf([])
+            const r = rev({ parents: [h1, h2] })
+            assert(materialize(get)(r)[0] === 'error')
+        },
+        changesWithoutContentIsError: () => {
+            const get = storeOf([])
+            const r = rev({ changes: [mkHash(2n)] })
+            assert(materialize(get)(r)[0] === 'error')
+        },
+    },
+    generation: {
+        firstRevisionIsZero: () => {
+            const get = storeOf([])
+            assert(verifyGeneration(get)(rev({ generation: 0 })))
+        },
+        chainIncrements: () => {
+            const h1 = mkHash(10n)
+            const r1 = rev({ generation: 0 })
+            const get = storeOf([[h1, r1]])
+            assert(verifyGeneration(get)(rev({ parents: [h1], generation: 1 })))
+        },
+        mismatchIsRejected: () => {
+            const h1 = mkHash(10n)
+            const r1 = rev({ generation: 0 })
+            const get = storeOf([[h1, r1]])
+            assert(!verifyGeneration(get)(rev({ parents: [h1], generation: 5 })))
+        },
+        absentGenerationIsTrusted: () => {
+            const get = storeOf([])
+            assert(verifyGeneration(get)(rev({})))
+        },
+    },
+    merge: {
+        buildsMergeRevision: () => {
+            const h1 = mkHash(10n)
+            const h2 = mkHash(11n)
+            const r1 = rev({ generation: 0 })
+            const r2 = rev({ generation: 0 })
+            const get = storeOf([[h1, r1], [h2, r2]])
+            const content = mkHash(99n)
+            const m = merge(get)(objectHash, [h1, h2], content)
+            assert(m[0] === 'ok')
+            if (m[0] === 'ok') {
+                assertEq(m[1].generation, 1)
+                assertEq(m[1].content, content)
+                assert(validateRevision(m[1])[0] === 'ok')
+            }
+        },
+        missingParentIsError: () => {
+            const get = storeOf([])
+            assert(merge(get)(objectHash, [mkHash(404n)], mkHash(99n))[0] === 'error')
+        },
+        noParentsIsError: () => {
+            const get = storeOf([])
+            assert(merge(get)(objectHash, [], mkHash(99n))[0] === 'error')
+        },
+    },
+}

--- a/fs/cas/todo/revision-content-format.md
+++ b/fs/cas/todo/revision-content-format.md
@@ -173,25 +173,26 @@ Open design points:
 
 ### Tasks
 
-- [ ] Create `fs/cas/evo/README.md` — the format spec the `evolution` tag URL points to
+- [x] Create `fs/cas/evo/README.md` — the format spec the `evolution` tag URL points to
       (deployed automatically to functionalscript.com once it exists in the repo)
-- [ ] Define `ref` as a URL in CA digital space, recognizing cbase32 hashes and `https://`
+- [x] Define `ref` as a URL in CA digital space, recognizing cbase32 hashes and `https://`
       bridge URLs for now, and `hash` as its hash-only subset
-- [ ] Create `fs/cas/evo/module.f.ts` with the RTTI schema for `revision` (`fs/types/rtti`)
+- [x] Create `fs/cas/evo/module.f.ts` with the RTTI schema for `revision` (`fs/types/rtti`)
       and its derived TS type
-- [ ] Implement head resolution: given `object`, find revision(s) not listed as a parent
+- [x] Implement head resolution: given `object`, find revision(s) not listed as a parent
       by any other revision of the same `object` (a reverse index scoped per object; heads
       can be demoted retroactively by sync, but only by same-object children)
-- [ ] Implement content materialization for the first iteration (zero or one parent, no
+- [x] Implement content materialization for the first iteration (zero or one parent, no
       `changes`): `content` → base, where base = parent's materialization or `object`
-- [ ] Implement (or specify) a merge tool that resolves concurrent heads into a new revision
+- [x] Implement (or specify) a merge tool that resolves concurrent heads into a new revision
       with multiple `parents` and `content`
-- [ ] Tests: linear history, branch + merge, many heads for one object, archived object,
+- [x] Tests: linear history, branch + merge, many heads for one object, archived object,
       generation cache mismatch, first revision materializing from `object`, a head demoted
       retroactively by a newly synced revision
 - [ ] Later iteration: define the `changes` event-log/CRDT format and extend materialization
       to CRDT changes over a single common ancestor
-- [ ] Reference the format from `fs/cas/README.md`
+- [x] Reference the format from `fs/cas/README.md` — no such file exists in this repo yet;
+      referenced instead from the root `README.md`'s CAS section
 
 ### Related
 


### PR DESCRIPTION
Implements fs/cas/todo/revision-content-format.md: a fs/cas/evo/module.f.ts submodule with the `revision` RTTI schema, ref/hash validation, head resolution scoped per object, first-iteration content materialization (zero/one parent, no `changes`), generation-cache verification, and a merge-revision builder. Adds fs/cas/evo/README.md as the deployed format spec the `evolution` tag URL points to, and links it from the root README.