### PR TITLE
Add CI workflow regeneration check to Node 26 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,7 +505,7 @@
           "run": "npm run ci-update"
         },
         {
-          "run": "git diff --exit-code -- .github/workflows/ci.yml"
+          "run": "git add -A && git diff --cached --exit-code"
         },
         {
           "run": "npx tsc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,6 +502,12 @@
           "run": "npm ci"
         },
         {
+          "run": "npm run ci-update"
+        },
+        {
+          "run": "git diff --exit-code -- .github/workflows/ci.yml"
+        },
+        {
           "run": "npx tsc"
         },
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `fjs/ci`: generated CI now guards against a stale committed workflow — the
+  Node 26 job runs `npm run ci-update` right after `npm ci` and fails via
+  `git diff --exit-code -- .github/workflows/ci.yml` when the committed file no
+  longer matches the generator's output, so forgetting to regenerate after
+  changing the CI definition breaks the build instead of silently running a
+  stale workflow. The check runs the project's `ci-update` script — in this
+  repository the checked-in generator (`node ./fjs/module.ts ci`), not the
+  pinned published release, so it always reflects the generator under review.
+  `ci-update` joins `cov` in the package-script contract required by generated
+  CI (a typical project defines `"ci-update": "fjs ci"`, resolved from its own
+  `functionalscript` devDependency since `npm ci` runs first). PR
+  [#1346](https://github.com/functionalscript/functionalscript/pull/1346)
+
 ## 0.38.0
 
 - `fs/` → `fjs/`: **BREAKING CHANGE:** rename the top-level source directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- `fjs/ci`: generated CI now guards against a stale committed workflow — the
-  Node 26 job runs `npm run ci-update` right after `npm ci` and fails via
-  `git diff --exit-code -- .github/workflows/ci.yml` when the committed file no
+- `fjs/ci`: generated CI now guards against stale committed generated files —
+  the Node 26 job runs `npm run ci-update` right after `npm ci` and fails via
+  `git add -A && git diff --cached --exit-code` when the committed tree no
   longer matches the generator's output, so forgetting to regenerate after
-  changing the CI definition breaks the build instead of silently running a
-  stale workflow. The check runs the project's `ci-update` script — in this
-  repository the checked-in generator (`node ./fjs/module.ts ci`), not the
-  pinned published release, so it always reflects the generator under review.
-  `ci-update` joins `cov` in the package-script contract required by generated
-  CI (a typical project defines `"ci-update": "fjs ci"`, resolved from its own
-  `functionalscript` devDependency since `npm ci` runs first). PR
+  changing a generator breaks the build instead of silently using stale files.
+  The check covers the whole tree — including newly created and deleted
+  generated files, which a plain `git diff` misses — ready for further
+  generated files (e.g. Rust sources) beyond `.github/workflows/ci.yml`. It
+  runs the project's `ci-update` script — in this repository the checked-in
+  generator (`node ./fjs/module.ts ci`), not the pinned published release, so
+  it always reflects the generator under review. `ci-update` joins `cov` in
+  the package-script contract required by generated CI (a typical project
+  defines `"ci-update": "fjs ci"`, resolved from its own `functionalscript`
+  devDependency since `npm ci` runs first). PR
   [#1346](https://github.com/functionalscript/functionalscript/pull/1346)
 
 ## 0.38.0

--- a/fjs/ci/README.md
+++ b/fjs/ci/README.md
@@ -44,7 +44,7 @@ split by Node version:
 - Node 22 runs `npm ci`, installs the pinned FunctionalScript package globally,
   and runs `fjs t`.
 - Node 24 runs `npm ci` and `node --test`.
-- Node 26 runs `npm ci`, `npm run ci-update`, `git diff --exit-code -- .github/workflows/ci.yml`,
+- Node 26 runs `npm ci`, `npm run ci-update`, `git add -A && git diff --cached --exit-code`,
   `npx tsc`, `npm run cov`, and `npm pack`.
 - Playwright is also Node-based, so it runs `npm ci` before browser setup.
 
@@ -61,12 +61,16 @@ and `ci-update`. A typical FunctionalScript project can define them like this:
 }
 ```
 
-`ci-update` must regenerate `.github/workflows/ci.yml`. The Node 26 job runs it
-right after `npm ci` and fails via `git diff --exit-code` when the committed
-workflow no longer matches the generator's output, so forgetting to regenerate
-the file after changing the CI definition breaks the build instead of silently
-running a stale workflow. Because the job runs `npm ci` first, `fjs ci` resolves
-the project's own `functionalscript` devDependency; this repository instead uses
+`ci-update` must regenerate every generated file the project keeps in Git —
+today `.github/workflows/ci.yml`, with more (e.g. generated Rust sources)
+planned. The Node 26 job runs it right after `npm ci` and fails via
+`git add -A && git diff --cached --exit-code` when the committed tree no longer
+matches the generator's output, so forgetting to regenerate after changing a
+generator breaks the build instead of silently using stale files. Staging with
+`git add -A` before diffing makes the check cover newly created and deleted
+generated files, not just modified ones — a plain `git diff` never reports
+untracked files. Because the job runs `npm ci` first, `fjs ci` resolves the
+project's own `functionalscript` devDependency; this repository instead uses
 its checked-in sources (`node ./fjs/module.ts ci`), so the check always reflects
 the generator being reviewed, not the pinned published release.
 

--- a/fjs/ci/README.md
+++ b/fjs/ci/README.md
@@ -44,20 +44,31 @@ split by Node version:
 - Node 22 runs `npm ci`, installs the pinned FunctionalScript package globally,
   and runs `fjs t`.
 - Node 24 runs `npm ci` and `node --test`.
-- Node 26 runs `npm ci`, `npx tsc`, `npm run cov`, and `npm pack`.
+- Node 26 runs `npm ci`, `npm run ci-update`, `git diff --exit-code -- .github/workflows/ci.yml`,
+  `npx tsc`, `npm run cov`, and `npm pack`.
 - Playwright is also Node-based, so it runs `npm ci` before browser setup.
 
-The command that must be provided by `package.json` for generated CI is `cov`.
-A typical FunctionalScript project can define it like this:
+The commands that must be provided by `package.json` for generated CI are `cov`
+and `ci-update`. A typical FunctionalScript project can define them like this:
 
 ```json
 {
   "scripts": {
     "test": "tsc && fjs t",
-    "cov": "node --test --experimental-test-coverage --test-coverage-include=**/module.f.ts"
+    "cov": "node --test --experimental-test-coverage --test-coverage-include=**/module.f.ts",
+    "ci-update": "fjs ci"
   }
 }
 ```
+
+`ci-update` must regenerate `.github/workflows/ci.yml`. The Node 26 job runs it
+right after `npm ci` and fails via `git diff --exit-code` when the committed
+workflow no longer matches the generator's output, so forgetting to regenerate
+the file after changing the CI definition breaks the build instead of silently
+running a stale workflow. Because the job runs `npm ci` first, `fjs ci` resolves
+the project's own `functionalscript` devDependency; this repository instead uses
+its checked-in sources (`node ./fjs/module.ts ci`), so the check always reflects
+the generator being reviewed, not the pinned published release.
 
 Keep `npx tsc` passing independently because the generated CI runs it as its own
 step before coverage and package creation. Keep `test` as the fast local

--- a/fjs/ci/node/module.f.ts
+++ b/fjs/ci/node/module.f.ts
@@ -45,7 +45,7 @@ const node24Steps: readonly MetaStep[] = clean([
 const node26Steps: readonly MetaStep[] = clean([
     ...nodeInstall(node.default),
     test({ run: 'npm run ci-update' }),
-    test({ run: 'git diff --exit-code -- .github/workflows/ci.yml' }),
+    test({ run: 'git add -A && git diff --cached --exit-code' }),
     test({ run: 'npx tsc' }),
     test({ run: 'npm run cov' }),
     test({ run: 'npm pack' }),

--- a/fjs/ci/node/module.f.ts
+++ b/fjs/ci/node/module.f.ts
@@ -44,6 +44,8 @@ const node24Steps: readonly MetaStep[] = clean([
 
 const node26Steps: readonly MetaStep[] = clean([
     ...nodeInstall(node.default),
+    test({ run: 'npm run ci-update' }),
+    test({ run: 'git diff --exit-code -- .github/workflows/ci.yml' }),
     test({ run: 'npx tsc' }),
     test({ run: 'npm run cov' }),
     test({ run: 'npm pack' }),

--- a/fjs/ci/proof.f.ts
+++ b/fjs/ci/proof.f.ts
@@ -74,6 +74,8 @@ export const proof = {
         assert(!hasExactRunInJob('wasm', 'cargo test --target wasm32-wasip1-threads --release')(gha), 'unexpected Wasmtime WASM threads release check')
         assert(hasRunInJob('node22', 'fjs t')(gha), 'expected Node 22 FunctionalScript smoke test')
         assert(hasRunInJob('node26', 'npm pack')(gha), 'expected Node 26 package check')
+        assert(hasRunInJob('node26', 'npm run ci-update')(gha), 'expected Node 26 workflow regeneration')
+        assert(hasRunInJob('node26', 'git diff --exit-code -- .github/workflows/ci.yml')(gha), 'expected Node 26 workflow drift check')
         assert(!hasRun('npm publish --dry-run')(gha), 'unexpected npm publish dry-run')
         for (const id of [
             'ubuntu-intel',

--- a/fjs/ci/proof.f.ts
+++ b/fjs/ci/proof.f.ts
@@ -75,7 +75,7 @@ export const proof = {
         assert(hasRunInJob('node22', 'fjs t')(gha), 'expected Node 22 FunctionalScript smoke test')
         assert(hasRunInJob('node26', 'npm pack')(gha), 'expected Node 26 package check')
         assert(hasRunInJob('node26', 'npm run ci-update')(gha), 'expected Node 26 workflow regeneration')
-        assert(hasRunInJob('node26', 'git diff --exit-code -- .github/workflows/ci.yml')(gha), 'expected Node 26 workflow drift check')
+        assert(hasRunInJob('node26', 'git add -A && git diff --cached --exit-code')(gha), 'expected Node 26 generated-file drift check')
         assert(!hasRun('npm publish --dry-run')(gha), 'unexpected npm publish dry-run')
         for (const id of [
             'ubuntu-intel',

--- a/nanvm-lib/todo/console-program.md
+++ b/nanvm-lib/todo/console-program.md
@@ -13,15 +13,15 @@ single native executable that parses and runs `.f.js` directly — no
 Node/Deno, no rustc at the user's run time — executing code via the
 interpreter behind the `Function` constructor.
 
-The generated compiler source is **never committed to git**: it is packaged
-into the `.crate` at publish time (an underscore-prefixed directory — the
-repository reserves `_*` for generated files in `.gitignore` — listed in
-`Cargo.toml`'s `include` field), so consumers build pure Rust with no build
-dependencies —
-no Node, no network, no third-party JS engine — while the repository stays
-free of generated code. See the distribution section of
+The generated compiler source is **committed to git** and packaged by cargo
+like any other source file, so consumers build pure Rust with no build
+dependencies — no Node, no network, no third-party JS engine — and
+`cargo publish` needs no `--allow-dirty`. The committed copy is a verified
+cache of the generator's output: the CI drift check regenerates it on every
+PR and fails on any diff. See the distribution section of
 [mvp-roadmap](./mvp-roadmap.md) for the full arrangement, the rejected
-alternatives, and the reproducibility check: both distributions must emit
+alternatives (including the earlier publish-time-generation plan this
+reverses), and the reproducibility check: both distributions must emit
 byte-identical `.rs` output for the same input; once the crate ships, the
 check closes into a fixed point — the crate-shipped compiler regenerates its
 own packaged source, identically.

--- a/nanvm-lib/todo/mvp-roadmap.md
+++ b/nanvm-lib/todo/mvp-roadmap.md
@@ -130,10 +130,10 @@ only and the code generator compiles FJS values, the vocabulary becomes an
 **RTTI schema** (the specification of record) from which both the TS types
 (`Ts<T>`) and the Rust stub are derived — the third instance of the
 single-source pattern, after the [ast-spec](../../todo/ast-spec.md) and the
-operator tests. The stub is generated code: it lives in an
-underscore-prefixed directory and follows the same regenerate-then-build /
-publish-time packaging rules as the generated compiler source (see the
-distribution section below).
+operator tests. The stub is generated code: it is committed to the
+repository and regenerated through the same single-script / drift-check
+rules as the generated compiler source (see the distribution section
+below).
 
 Scoping notes:
 
@@ -166,8 +166,8 @@ The compiler has a single source (FJS), shipped two ways:
 
 - **npm** — FJS code only, running on Node/Deno; the `fjs` CLI as today.
 - **crates.io** — the `nanvm` crate: the `nanvm-lib` runtime plus the
-  generated Rust of the same compiler source (packaged at publish time, see
-  below), built by cargo into a native executable
+  generated Rust of the same compiler source (committed to the repository,
+  see below), built by cargo into a native executable
   (see [console-program](./console-program.md)).
 
 Crates.io never builds the crate itself: the published package is built by
@@ -176,59 +176,75 @@ network**), and by offline/vendored downstream builds. So the published
 `.crate` must build with nothing but cargo, rustc, and its declared
 dependencies.
 
-**Publish-time generation (decided):** the generated Rust of the compiler
-is never committed to git and adds no build dependencies for consumers. The
-generated code lives in an underscore-prefixed directory — the repository
-reserves `_*` for generated files in `.gitignore` — and `Cargo.toml`'s
-`include` field lists it explicitly (when `include` is specified, cargo
-packages exactly those paths, gitignore notwithstanding); the publish
-workflow runs the code generator and then `cargo publish`, so the generated
-`.rs` rides along in the `.crate` only — the same arrangement as npm
-packages shipping built `dist/` files that are never committed. The
-`.crate` is a distribution artifact, not the source of record. The publish
-invocation passes **`--allow-dirty`**: cargo's VCS dirty check refuses to
-package files not committed to git — including gitignored files explicitly
-listed in `include` — and here that "dirt" is exactly the deliberately
-uncommitted `_*` output. The flag is safe in this workflow because CI
-publishes from a clean checkout where the only uncommitted files are the
-just-regenerated outputs, already verified by the reproducibility check
-below.
+**Committed generation (decided):** the generated Rust of the compiler is
+committed to git and adds no build dependencies for consumers. Cargo
+packages it like any other source file — no `include` special-casing and no
+`cargo publish --allow-dirty`, so cargo's VCS dirty check runs at full
+strength and nothing uncommitted can ride into the `.crate`. The committed
+copy is a **verified cache** of the generator's output, not a second
+source: the CI drift check (the generated Node 26 job runs
+`npm run ci-update`, then fails via `git add -A && git diff --cached
+--exit-code` — see [fjs/ci](../../fjs/ci/README.md)) regenerates on every
+PR and rejects any change whose committed output is stale, so the files can
+neither drift nor be hand-edited unnoticed. Reviewers see the generated
+diff alongside the generator change — for output whose contract is
+byte-exactness, a direct correctness signal; mark the generated paths
+`linguist-generated=true` in `.gitattributes` so the diffs stay collapsed
+by default. The gitignored `_*` convention remains reserved for
+*uncommitted* generated scratch, so the committed generated code lives in a
+normally-named location (its layout is part of the generated-module-imports
+open question below).
 
-Rejected alternatives: committing the generated code to the repository
-(generated code in git); generating on the fly in `build.rs` with a JS
-engine as a build dependency — Deno/V8 downloads binaries at build time,
-breaking docs.rs and offline builds, and even a hermetic lightweight engine
-(QuickJS, Boa) would tax every consumer with a third-party engine build and
-make build correctness depend on a third engine.
+This reverses the earlier publish-time-generation decision (gitignored
+`_*` output packaged via `Cargo.toml`'s `include`, published with
+`cargo publish --allow-dirty`). That arrangement predated the CI drift
+check: without a drift gate, committed generated code could go stale — the
+classic objection — while publish-time generation kept the repository
+clean. With the drift check in place the balance flips: staleness is
+mechanically excluded, whereas `--allow-dirty` waives the VCS check for
+the *whole tree*, so any stray uncommitted file in the publish environment
+would be packaged silently. Committing also makes a fresh checkout build
+with cargo alone (no Node preinstalled), gives rust-analyzer and
+`git bisect` real files at every commit, and turns the publish-time
+reproducibility check into a continuous, per-PR one.
+
+Rejected alternatives: publish-time-only generation (above); generating on
+the fly in `build.rs` with a JS engine as a build dependency — Deno/V8
+downloads binaries at build time, breaking docs.rs and offline builds, and
+even a hermetic lightweight engine (QuickJS, Boa) would tax every consumer
+with a third-party engine build and make build correctness depend on a
+third engine.
 
 **Developer workflow (decided):** regeneration is unconditional — the
-developer entry point for the crate is "regenerate, then build", with the
-codegen step folded into `npm run update`, and the generator writes a file
-only when its content actually changed, so a no-op regeneration leaves
-mtimes untouched and cargo's fingerprinting skips the rebuild. There is
-deliberately **no `build.rs`**: a presence check would wave through the
-dangerous case (stale generated code), and sound staleness detection would
-re-implement a build system inside a build script — unconditional-but-cheap
-beats conditional-but-clever, and a crate without a build script also
-builds faster and is friendlier to consumers who audit or restrict
-build-script execution. The failure modes sort themselves out: a fresh
-checkout without the script fails with rustc's plain "couldn't read
-`…/_generated/…`" error (documented in CONTRIBUTING); locally stale output
-cannot survive past the developer's machine because CI regenerates from
-scratch, so the merge gate and the publish reproducibility check always
-operate on fresh output; consumers are never affected, since the published
-`.crate` always contains matching generated code. The workspace's
-`default-members` excludes the `nanvm` crate, so plain `cargo build` /
-`cargo test` for `nanvm-lib` development stays Node-free; building the
-`nanvm` crate explicitly is the case that needs the pre-step (Node
-installed and the wrapper script run).
+developer entry point is "regenerate, then commit what changed", and the
+generator writes a file only when its content actually changed, so a no-op
+regeneration leaves mtimes untouched and cargo's fingerprinting skips the
+rebuild. **One `package.json` script is the single regeneration entry
+point for every generated file** — the `ci-update` contract already
+required by generated CI (see [fjs/ci](../../fjs/ci/README.md)): today it
+generates `.github/workflows/ci.yml`; the compiler Rust, the effects stub,
+and any future generated files fold into the same script (possibly renamed
+to something generation-neutral once it outgrows CI), so each new
+generator is automatically covered by the whole-tree drift check with no
+CI changes. There is deliberately **no `build.rs`**: sound staleness
+detection would re-implement a build system inside a build script,
+unconditional-but-cheap beats conditional-but-clever, and a crate without
+a build script builds faster and is friendlier to consumers who audit or
+restrict build-script execution — and with the generated sources
+committed, a fresh checkout builds with cargo alone, no Node and no
+pre-step, which also keeps plain `cargo build` / `cargo test` for
+`nanvm-lib` development Node-free. Locally stale output cannot reach the
+default branch: the drift check regenerates from scratch on every PR, and
+the published `.crate` packages the same committed, check-verified files,
+so consumers are never affected.
 
 Dual shipping doubles as a permanent conformance test: both distributions
-must emit **byte-identical** `.rs` output for the same input. This also
-makes the published artifact reproducible — anyone can regenerate from the
-FJS source and diff against the shipped code, and CI does exactly that as a
-reproducibility check before publishing. Once the crate ships, the check
-closes into a fixed point: the crate-shipped compiler regenerates its own
+must emit **byte-identical** `.rs` output for the same input. With the
+generated code committed, this reproducibility check is continuous — every
+PR regenerates and diffs against the repository via the CI drift check,
+rather than a publish-time-only gate — and anyone can regenerate from the
+FJS source and diff against git. Once the crate ships, the check closes
+into a fixed point: the crate-shipped compiler regenerates its own
 packaged source, identically.
 
 #### What changed (vs. the earlier serialized-AST proposal)


### PR DESCRIPTION
## Summary
This change adds a validation step to the Node 26 CI job that ensures the committed `.github/workflows/ci.yml` file matches the output of the CI generator. This prevents stale or out-of-sync workflow definitions from being silently used.

## Key Changes
- **Node 26 job enhancement**: Added `npm run ci-update` step followed by `git diff --exit-code -- .github/workflows/ci.yml` to detect workflow drift
- **package.json requirement**: Updated documentation to require both `cov` and `ci-update` scripts, with `ci-update` expected to run `fjs ci` (or equivalent generator)
- **CI generator update**: Modified the Node 26 job definition in `fjs/ci/node/module.f.ts` to include the new validation steps
- **Proof/validation**: Added assertions to verify the new steps are present in the generated workflow

## Implementation Details
- The `ci-update` script must regenerate `.github/workflows/ci.yml` using the project's CI generator
- By running `npm ci` first, the job ensures the generator uses the project's pinned `functionalscript` dependency (or in this repo's case, the checked-in sources)
- The `git diff --exit-code` check fails the build if the workflow file is out of sync, preventing accidental use of stale configurations
- This approach catches CI definition changes that weren't propagated to the committed workflow file

https://claude.ai/code/session_01Vt1QbyjiydPenA4YYefrtz