### PR TITLE
Add test for CAS write GC skipping live lease files

### DIFF
--- a/fjs/cas/proof.f.ts
+++ b/fjs/cas/proof.f.ts
@@ -238,6 +238,23 @@ export const proof = {
         const [, present] = virtual(state1)(access(stalePath))
         assert(present[0] === 'error', 'expected GC to reclaim the expired staging file')
     },
+    casWriteGcSkipsLiveLease: () => {
+        // A staging file whose deadline is still in the future is left alone by the GC
+        // that `write` runs before staging its own file.
+        const livePath = join('.', '.cas', '_stage', '0000000000002000000-live')
+        const state0 = {
+            ...emptyState,
+            epochNs: 1_000_000,
+            root: { '.cas': { '_stage': { '0000000000002000000-live': [vec8(0x99n)] } } },
+        }
+        const content = vec8(0x2An)
+        const c = fileCas(sha256)('.')
+        const x = c.write(nonEmpty(ok(content), empty<never, Ok<Vec>>()))
+        const [state1, w] = virtual(state0)(x)
+        assert(w[0] === 'ok', ['expected write ok', w])
+        const [, present] = virtual(state1)(access(livePath))
+        assert(present[0] === 'ok', 'expected GC to leave the live staging file alone')
+    },
     casUploadSuccess: () => {
         // A successful upload returns the hash and deletes the source file from cas_upload/.
         const content = vec8(0x2An)


### PR DESCRIPTION
## Summary
Added a new test case `casWriteGcSkipsLiveLease` to verify that the garbage collection process run by the `write` operation correctly preserves staging files with future deadlines.

## Key Changes
- Added test `casWriteGcSkipsLiveLease` that validates GC behavior during write operations
- Test verifies that staging files with deadlines still in the future are not reclaimed by GC
- Test creates a live staging file with epoch timestamp 1,000,000 and confirms it remains after a write operation completes

## Implementation Details
The test follows the existing pattern in the proof suite:
- Sets up initial state with a live staging file in `.cas/_stage/`
- Executes a `write` operation on the CAS
- Verifies the live staging file is still present after the operation (status 'ok')
- Complements the existing `casWriteGcReclaimsExpired` test by covering the inverse case where files should be preserved

https://claude.ai/code/session_01NAibNPvc2qCh9FAdczSaXY