### PR TITLE
Upgrade FunctionalScript to 0.38.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.37.0"
+          "run": "npm install -g functionalscript@0.38.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -81,7 +81,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.37.0"
+          "run": "npm install -g functionalscript@0.38.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -122,7 +122,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.37.0"
+          "run": "npm install -g functionalscript@0.38.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -163,7 +163,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.37.0"
+          "run": "npm install -g functionalscript@0.38.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -205,7 +205,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.37.0"
+          "run": "npm install -g functionalscript@0.38.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -258,7 +258,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.37.0"
+          "run": "npm install -g functionalscript@0.38.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -389,13 +389,13 @@
           }
         },
         {
-          "run": "deno install -g -A --minimum-dependency-age=0 npm:functionalscript@0.37.0"
+          "run": "deno install -g -A --minimum-dependency-age=0 npm:functionalscript@0.38.0"
         },
         {
           "uses": "actions/checkout@v7"
         },
         {
-          "run": "deno run -A --minimum-dependency-age=0 npm:functionalscript@0.37.0 t"
+          "run": "deno run -A --minimum-dependency-age=0 npm:functionalscript@0.38.0 t"
         },
         {
           "run": "deno install --frozen"
@@ -418,7 +418,7 @@
           }
         },
         {
-          "run": "bun install -g functionalscript@0.37.0"
+          "run": "bun install -g functionalscript@0.38.0"
         },
         {
           "uses": "actions/checkout@v7"
@@ -427,7 +427,7 @@
           "run": "bun install --frozen-lockfile"
         },
         {
-          "run": "bunx functionalscript@0.37.0 t"
+          "run": "bunx functionalscript@0.38.0 t"
         },
         {
           "run": "bun test --coverage"
@@ -447,7 +447,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.37.0"
+          "run": "npm install -g functionalscript@0.38.0"
         },
         {
           "uses": "actions/checkout@v7"

--- a/fjs/ci/config/module.f.ts
+++ b/fjs/ci/config/module.f.ts
@@ -25,7 +25,7 @@ export const images = {
 // published FunctionalScript release; do not tie it to package.json's current
 // in-repo version.
 // https://www.npmjs.com/package/functionalscript
-export const functionalscript = '0.37.0' as const
+export const functionalscript = '0.38.0' as const
 
 // https://bun.sh/
 export const bun = '1.3.14'


### PR DESCRIPTION
## Summary
Updates the FunctionalScript dependency from version 0.37.0 to 0.38.0 across all CI workflows and configuration files.

## Changes
- Updated `functionalscript` constant in `fjs/ci/config/module.f.ts` from `0.37.0` to `0.38.0`
- Updated all CI workflow references in `.github/workflows/ci.yml` to use FunctionalScript 0.38.0:
  - npm install commands (6 occurrences)
  - deno install and deno run commands (2 occurrences)
  - bun install and bunx commands (2 occurrences)

## Details
This is a routine dependency upgrade that ensures all CI environments use the latest stable version of FunctionalScript for testing and building the project.

https://claude.ai/code/session_01WkXTjiDyMS2qRdq9kra9Lz