### PR TITLE
effects/todo: design for making the raw value the effect (external step + covariant Do)

### DIFF
--- a/fjs/effects/todo/external-step-function.md
+++ b/fjs/effects/todo/external-step-function.md
@@ -75,14 +75,29 @@ the tag first, so a `write` node's continuation is only ever called with
 enables only the widening direction (`Effect<A>` <: `Effect<A | B>`); it does
 **not** enable the unsound narrowing.
 
-Verified **cast-free** end-to-end against the real shapes: concrete widening,
-generic widening (`Effect<Q>` → `Effect<O | Q>`, which `step`/`both` need
-internally), `decode` (positional `v[0]/v[1]/v[2]`), `doFull` (returns
-`[cmd, param, cont]`), external `step`, `all`, and `both` all type-check. The
-`Do` tuple keeps its positional shape, so `decode`/`match`/runners are
-unchanged in how they read a node. The one caveat is ordinary inference
-(`all(w, r)` unifies `O` to the first argument); call sites that already pass
-explicit type arguments (`both` does) are unaffected.
+The **variance handling is cast-free** — no `as` is needed to make the widening
+type-check. Verified against the real shapes: concrete widening, generic
+widening (`Effect<Q>` → `Effect<O | Q>`, which `step`/`both` need internally),
+`decode` (positional `v[0]/v[1]/v[2]`), `doFull` (returns `[cmd, param, cont]`),
+and external `step`. The `Do` tuple keeps its positional shape, so
+`decode`/`match`/runners are unchanged in how they read a node. The one
+inference caveat is that `all(w, r)` unifies `O` to the first argument; sites
+that pass explicit type arguments (`both` does) are unaffected.
+
+**`all` / `both` keep their existing casts.** These are *pre-existing and
+orthogonal* to this change — they exist in today's wrapper-based code and carry
+over unchanged; the variance work neither adds to nor removes them:
+
+- `all = do_('all') as <O, T>(...a: readonly Effect<O, T>[]) => Effect<O | All, readonly T[]>`
+  — `do_('all')` is typed against `All`'s erased operation signature
+  (`Effect<never, T>[]`), so the precise variadic signature is asserted with a
+  cast regardless of raw-vs-wrapper representation.
+- `both` casts `all<O0 | O1, T0 | T1>(a, b)`'s homogeneous
+  `readonly (T0 | T1)[]` result into the `readonly [T0, T1]` tuple it returns.
+
+Removing those two casts is a separate concern (a more precise `do_` / `All`
+signature, and a tuple-aware `all`), out of scope here; this issue does not
+claim to eliminate them.
 
 ### Design
 

--- a/fjs/effects/todo/external-step-function.md
+++ b/fjs/effects/todo/external-step-function.md
@@ -87,14 +87,22 @@ explicit type arguments (`both` does) are unaffected.
 ### Design
 
 - **`Effect<O, T>` = the raw value** (today's `Value`). Returned directly by
-  `pure`, `lazy`, `doFull`, `do_`, and every operation (`mkdir`, `readFile`, …).
+  `pure`, `lazy`, `doFull`, `do_`, and every operation (`mkdir`, `readFile`, …),
+  and it is the return type of every effect-producing function in the library.
   `decode` / `match` / runners consume it. It is plain data with no methods.
+- **External `step(e, f)`** — the data-first primitive: **raw `Effect` in, raw
+  `Effect` out**, a thin wrapper over `decode` (see below). Because it stays in
+  the raw type, it is the drop-in for the existing `.step` at call sites whose
+  surrounding context is a raw `Effect` (a function return, a runner argument,
+  a combinator argument). Chains: `step(step(e, f), g)`.
 - **`Eff<O, T>` = the `fn`-style wrapper**, `{ value: Effect<O, T>, step, … }`,
-  built by `eff(value)`, for optional method-chaining. Mirrors `fn` over
-  `compose`.
-- **External `step(e, f)`** — the data-first primitive, a thin wrapper over
-  `decode` (see below). `Eff.step` and any curried flavor are thin wrappers
-  over it.
+  built by `eff(value)`, for optional method-chaining. It mirrors `fn` over
+  `compose` **exactly, including the boundary**: `Eff.step` returns another
+  `Eff` (so `.step(f).step(g)` chains), and `.value` unwraps back to the raw
+  `Effect` — the analogue of `fn`'s `.result`. So a wrapped chain that has to
+  yield a raw effect ends in `.value`:
+  `eff(mkdir(...)).step(f).step(g).value`. An `Eff` is **not** assignable to
+  `Effect`; you must unwrap at the boundary. Verified type-checking end to end.
 
 ```ts
 export const step = <O extends Operation, T, Q extends Operation, R>(
@@ -108,15 +116,29 @@ export const step = <O extends Operation, T, Q extends Operation, R>(
 }
 ```
 
-At call sites:
+At call sites the old `x.step(f)` returned a (wrapper) `Effect`; in the new
+world the surrounding context is a *raw* `Effect`, so the migration must land
+back in the raw type:
 
 ```ts
 // before
-mkdir(...).step(f)
-// after — raw effect, wrap only when you want the chainer
-eff(mkdir(...)).step(f)   // fn-style
-step(mkdir(...), f)       // external primitive
+readFile(p).step(f)                 // returned Effect
+readFile(p).step(f).step(g)         // returned Effect
+
+// after — default: external step, raw in / raw out, no boundary
+step(readFile(p), f)
+step(step(readFile(p), f), g)
+
+// after — fn-style sugar: chains on Eff, `.value` unwraps at the boundary
+eff(readFile(p)).step(f).value
+eff(readFile(p)).step(f).step(g).value
 ```
+
+Prefer external `step` for the mechanical 161-site migration (it is
+type-equivalent to the old method — raw `Effect` in and out — so no site's
+return type changes). Reach for `eff(...).step(...).value` only where the
+method-chaining genuinely reads better; the `.value` is mandatory wherever the
+result flows into a raw-`Effect` slot.
 
 ### Design decisions
 
@@ -148,8 +170,10 @@ step(mkdir(...), f)       // external primitive
       doc, replacing the "must not be extended with new methods" framing.
 - [ ] Migrate the `.step(` call sites — ~161 across 25 files, including
       `List<O, T>` stream code (`fjs/effects/list`, `fjs/cas`) and the core's
-      own `foldStep` / `forEachStep` — to `eff(x).step(f)` (or external
-      `step(x, f)`).
+      own `foldStep` / `forEachStep` — to the external `step(x, f)` (raw in /
+      raw out, so no site's return type changes). Use `eff(x).step(f)…​.value`
+      only where method-chaining reads better, unwrapping with `.value` at the
+      raw-`Effect` boundary.
 
 ### Related
 

--- a/fjs/effects/todo/external-step-function.md
+++ b/fjs/effects/todo/external-step-function.md
@@ -26,7 +26,14 @@ per-node wrapper object to exist. Two goals:
    sugar.
 2. Drop the per-node `{ value, step }` wrapper as the type that flows around.
 
-### The variance constraint (why the naive collapse fails)
+### Proposal
+
+Make the raw value the primary `Effect` type, provide `step` externally plus an
+optional `fn`-style `eff()` wrapper, and make the raw value covariant in `O` by
+annotating the continuation `out O`. The rest of this section works through why
+the naive version fails and how the covariance annotation fixes it.
+
+#### The variance constraint (why the naive collapse fails)
 
 The obvious move — "delete `step` and let `Effect<O, T>` just be the raw
 `Value<O, T>` union" — does **not** type-check, and this is the crux of the
@@ -46,7 +53,7 @@ sound answer). A raw union/tuple is compared structurally instead and fails.
 Collapsing to a bare `Value` breaks ~150 widening sites — verified, not a
 hunch.
 
-### Solution: annotate the continuation `out O`
+#### Solution: annotate the continuation `out O`
 
 Make the raw value itself covariant in `O`, so it can be the primary type
 without any wrapper — **while keeping `Do` a positional tuple**.
@@ -99,7 +106,7 @@ Removing those two casts is a separate concern (a more precise `do_` / `All`
 signature, and a tuple-aware `all`), out of scope here; this issue does not
 claim to eliminate them.
 
-### Design
+#### Design
 
 - **`Effect<O, T>` = the raw value** (today's `Value`). Returned directly by
   `pure`, `lazy`, `doFull`, `do_`, and every operation (`mkdir`, `readFile`, …),
@@ -155,7 +162,7 @@ return type changes). Reach for `eff(...).step(...).value` only where the
 method-chaining genuinely reads better; the `.value` is mandatory wherever the
 result flows into a raw-`Effect` slot.
 
-### Design decisions
+#### Design decisions
 
 - **`Cont<out O, T>` is a documented invariant, not a hack.** JSDoc on `Cont`
   must state the tag-dispatch soundness argument so the annotation is never

--- a/fjs/effects/todo/external-step-function.md
+++ b/fjs/effects/todo/external-step-function.md
@@ -1,12 +1,13 @@
-## Replace the `step` method with an external `step` function
+## Make the raw value the effect, and move `step` out of it
 
 **Priority:** P2
 **Status:** open
 
 ### Problem
 
-Every `Effect` instance carries a `step` method whose implementation dispatches
-on whether the effect is pure or impure:
+Every `Effect` today is a `{ value, step }` wrapper. The `value` **is** the raw
+effect — a `Pure` thunk or a `Do` node — and `step` is a method whose
+implementation dispatches on whether the effect is pure or impure:
 
 - `pure` / `lazy` — `step: f => f(t())` (`fjs/effects/module.f.ts`)
 - `doFull` — `step` rebuilds a `Do` node wrapping the continuation
@@ -14,90 +15,150 @@ on whether the effect is pure or impure:
 
 That is the pure/impure dispatch encoded in **three** places. The doc comment
 on `decode` claims it is "the only function that knows how `Value` is laid
-out" — the constructors' `step` closures already contradict it. An external
-`step` built on the same shape analysis as `decode` restores a single source
-of truth.
+out" — the constructors' `step` closures already contradict it.
 
-The method also bakes one blessed composition API into every instance. With an
-external function the core contract shrinks to the data type plus `decode`,
-and every composition flavor becomes userland — users (or the library) can
-provide `step(b, f)`, a curried `step(f)(b)`, or an `fn`-style chainer
-`eff(b).step(f)`, each a thin wrapper over the one primitive. This mirrors
-`fjs/types/function`: `compose` is the primitive, `fn` is optional sugar.
+The method also bakes one blessed composition API into every node, and forces a
+per-node wrapper object to exist. Two goals:
 
-Once the method is gone the wrapper object has no reason to exist:
-`Effect<O, T>` collapses to `Value<O, T>` — a thunk or a
-`[command, payload, continuation]` tuple, plain data, one less allocation per
-node. That also matches the house style: `fold`, `map`, `decode`, `match` are
-all external functions; the `step` method is the outlier. Interpreters already
-go through `decode` / `match` exclusively, so only program-construction code
-is affected.
+1. Make the **raw value** the primary effect type, with `decode` as the single
+   shape inspector and composition provided externally — like
+   `fjs/types/function`, where `compose` is the primitive and `fn` is optional
+   sugar.
+2. Drop the per-node `{ value, step }` wrapper as the type that flows around.
 
-### Proposal
+### The variance constraint (why the naive collapse fails)
+
+The obvious move — "delete `step` and let `Effect<O, T>` just be the raw
+`Value<O, T>` union" — does **not** type-check, and this is the crux of the
+whole task.
+
+`Do<O, T>`'s continuation input is `Pr<O, O[0]>[1]` — the union of *all* the
+commands' output types. That is a **contravariant** position, so a bare
+`Value<O, T>` union is *not covariant in `O`*: `Value<Write>` is **not**
+assignable to `Value<Write | Read>`. But the effect system relies on exactly
+that widening everywhere — `all`, `both`, `step`'s `O | Q`, and every handler
+that returns a narrow effect into a wider `NodeOp` slot.
+
+The reason it works **today** is that `{ value, step }` is a recursive generic
+**object** alias; TypeScript measures such an alias's variance leniently and
+short-circuits the structural check (which here happens to give the *correct*,
+sound answer). A raw union/tuple is compared structurally instead and fails.
+Collapsing to a bare `Value` breaks ~150 widening sites — verified, not a
+hunch. So the wrapper object is doing real type-level work; it is not just
+ergonomic sugar.
+
+### Solution: a covariant object `Do`
+
+Make the raw value itself covariant in `O`, so it can be the primary type
+without any wrapper:
+
+```ts
+// 1. Do becomes a named-field OBJECT, not a positional tuple —
+//    TypeScript only allows variance annotations on object / function /
+//    mapped-type aliases, never on tuples or unions.
+// 2. Annotate the operation parameter `out O`.
+export type Do<out O extends Operation, T> = {
+    readonly command: O[0]
+    readonly payload: Pr<O, O[0]>[0]
+    readonly continuation: (_: Pr<O, O[0]>[1]) => Effect<O, T>
+}
+
+// The raw value is now the effect. `Pure` has no `O`; `Do` is declared
+// covariant; so the union is covariant in `O`.
+export type Effect<out O extends Operation, T> = Pure<T> | Do<O, T>
+export type Pure<T> = () => T
+```
+
+`out O` asserts the covariance TypeScript cannot derive through the conditional
+`Pr` type. **It is sound:** the `command` tag pins exactly which command's
+output the continuation receives, and every interpreter dispatches on the tag
+first, so a `write` node's continuation is only ever called with `void` — the
+op-set can grow without ever mishanding a continuation. `out` enables only the
+widening direction (`Effect<A>` <: `Effect<A | B>`); it does **not** enable the
+unsound narrowing.
+
+Verified **cast-free** end-to-end against the real shapes: concrete widening,
+generic widening (`Effect<Q>` → `Effect<O | Q>`, which `step`/`both` need
+internally), `decode`, `doFull`, external `step`, `all`, and `both` all
+type-check. The one caveat is ordinary inference (`all(w, r)` unifies `O` to
+the first argument); call sites that already pass explicit type arguments
+(`both` does) are unaffected.
+
+### Design
+
+- **`Effect<O, T>` = the raw value** (today's `Value`). Returned directly by
+  `pure`, `lazy`, `doFull`, `do_`, and every operation (`mkdir`, `readFile`, …).
+  `decode` / `match` / runners consume it. It is plain data with no methods.
+- **`Eff<O, T>` = the `fn`-style wrapper**, `{ value: Effect<O, T>, step, … }`,
+  built by `eff(value)`, for optional method-chaining. Mirrors `fn` over
+  `compose`.
+- **External `step(e, f)`** — the data-first primitive, a thin wrapper over
+  `decode` (see below). `Eff.step` and any curried flavor are thin wrappers
+  over it.
 
 ```ts
 export const step = <O extends Operation, T, Q extends Operation, R>(
     e: Effect<O, T>,
     f: (t: T) => Effect<Q, R>
-): Effect<O | Q, R> => { ... }
+): Effect<O | Q, R> => {
+    const d = decode(e)
+    return d.done
+        ? f(d.result)
+        : doFull<O | Q, R, O[0]>(d.command, d.payload, x => step(d.continuation(x), f))
+}
 ```
 
-Then chains become explicit sequencing:
+At call sites:
 
 ```ts
 // before
-const r = b.step(f).step(g)
-
-// after
-const b0 = step(b, f)
-const r = step(b0, g)
+mkdir(...).step(f)
+// after — raw effect, wrap only when you want the chainer
+eff(mkdir(...)).step(f)   // fn-style
+step(mkdir(...), f)       // external primitive
 ```
-
-Migration can be incremental — see Tasks.
 
 ### Design decisions
 
-- **Data-first for the library's own call sites.** `step(b, f)` lets
-  TypeScript contextually type the lambda parameter from the effect — the
-  common case at existing call sites. A curried data-last `step(f)(b)` infers
-  `f` before seeing the effect, forcing parameter annotations on anonymous
-  lambdas; it is still the right shape for point-free code where the
-  continuation is a named adapter (`okStep`), so it can ship alongside.
-  Multi-arg has precedent (`doFull`, `nonEmpty`).
-- **Exactly one function inspects the shape.** Every flavor must be a thin
-  wrapper over the one primitive (`step` or `decode`). A second
-  `typeof value === 'function'` check anywhere reintroduces the duplication.
-  State this in the module doc as bluntly as the current "must not be
-  extended with new methods" rule.
-- **The step-adapter convention survives.** Helpers like `okStep` remain
-  adapters, now passed as `step(e, okStep(f))`.
-- **Readability is neutral, not a motivation.** Linear chains become const
-  sequencing (more verbose, names the intermediates); deeply nested
-  continuations (e.g. `fileCas`'s `write` in `fjs/cas/module.f.ts`) are
-  nested because of data dependencies and stay nested either way.
-- **No perf regression.** The external function wraps continuations exactly
-  like `doFull.step` does today; the O(depth) cost of left-nested chains is
-  unchanged, and dropping the wrapper object saves an allocation per node.
+- **`out O` is a documented invariant, not a hack.** JSDoc on `Do`/`Effect`
+  must state the tag-dispatch soundness argument so the annotation is never
+  stripped. Anyone changing the continuation representation must re-check it.
+- **Exactly one function inspects the shape: `decode`.** `step` wraps it; no
+  second `typeof value === 'function'` (or `'command' in value`) check may
+  appear anywhere. State this in the module doc, replacing the current "must
+  not be extended with new methods" framing.
+- **`Do` becomes an object.** Interpreters read `.command` / `.payload` /
+  `.continuation` instead of `[0]` / `[1]` / `[2]`. Touches `decode`, `match`,
+  and the virtual/mock runners.
+- **Data-first `step(e, f)`** lets TypeScript contextually type the lambda from
+  the effect — the common case. A curried data-last `step(f)(b)` can ship
+  alongside only if a point-free site needs it (`foldStep`, `okStep`).
+- **The step-adapter convention survives.** `okStep` etc. stay adapters, passed
+  as `step(e, okStep(f))` / `eff(e).step(okStep(f))`.
 
 ### Tasks
 
-- [ ] Add the external data-first `step(e, f)` to `fjs/effects/module.f.ts`
-      (delegating to the method at first, or shape-based), plus the curried
-      data-last flavor if `foldStep` / point-free sites want it.
+- [ ] Change `Do` to the covariant named-field object and annotate
+      `Do<out O, T>` / `Effect<out O, T>`. Rename the raw `Value` → `Effect`;
+      the old `{ value, step }` wrapper type goes away as the flowing type.
+      Update `decode` / `match` to read object fields, and the virtual/mock
+      runners accordingly. Document the `out O` soundness invariant in JSDoc.
+- [ ] Add the `Eff<O, T>` wrapper + `eff()` and the external data-first
+      `step(e, f)` (a thin wrapper over `decode`).
 - [ ] State the "exactly one function inspects the shape" rule in the module
       doc, replacing the "must not be extended with new methods" framing.
-- [ ] Migrate call sites file by file — ~161 `.step(` sites across 25 files,
-      including `List<O, T>` stream code (`fjs/effects/list`, `fjs/cas`) and
-      the core's own `foldStep` / `forEachStep`.
-- [ ] Delete the `step` method and collapse `Effect<O, T>` to `Value<O, T>`
-      in one final commit — the payoff commit that actually removes the
-      duplicated dispatch. Update the `decode` doc comment so its
-      "only function that knows the layout" claim holds.
+- [ ] Migrate the `.step(` call sites — ~161 across 25 files, including
+      `List<O, T>` stream code (`fjs/effects/list`, `fjs/cas`) and the core's
+      own `foldStep` / `forEachStep` — to `eff(x).step(f)` (or external
+      `step(x, f)`).
 
 ### Related
 
 - `fjs/types/function/module.f.ts` — `compose` / `fn` precedent for
   "primitive + optional chainer".
-- `fjs/effects/list/module.f.ts` — `List<O, T>` call sites migrate the same
-  way (`s.step(f)` → `step(s, f)`).
+- `fjs/effects/list/module.f.ts` — `List<O, T>` is `Effect<O, Next<O, T>>`, so
+  its call sites migrate the same way.
 - `decode` / `match` — already the interpreter-facing half of this contract.
+- TypeScript variance annotations (`in` / `out`, TS 4.7+) — only legal on
+  object / function / mapped-type aliases (`TS2637`), which is why `Do` must be
+  an object rather than a tuple.

--- a/fjs/effects/todo/external-step-function.md
+++ b/fjs/effects/todo/external-step-function.md
@@ -44,45 +44,45 @@ The reason it works **today** is that `{ value, step }` is a recursive generic
 short-circuits the structural check (which here happens to give the *correct*,
 sound answer). A raw union/tuple is compared structurally instead and fails.
 Collapsing to a bare `Value` breaks ~150 widening sites — verified, not a
-hunch. So the wrapper object is doing real type-level work; it is not just
-ergonomic sugar.
+hunch.
 
-### Solution: a covariant object `Do`
+### Solution: annotate the continuation `out O`
 
 Make the raw value itself covariant in `O`, so it can be the primary type
-without any wrapper:
+without any wrapper — **while keeping `Do` a positional tuple**.
+
+TypeScript only accepts variance annotations (`in` / `out`, TS 4.7+) on
+**object, function, constructor, and mapped-type** aliases — never on a tuple
+or union alias (`TS2637`). So you cannot write `type Do<out O, T> = readonly[…]`
+directly. But the contravariance lives entirely in the continuation, which
+*is* a function type — extract it into its own alias and annotate that:
 
 ```ts
-// 1. Do becomes a named-field OBJECT, not a positional tuple —
-//    TypeScript only allows variance annotations on object / function /
-//    mapped-type aliases, never on tuples or unions.
-// 2. Annotate the operation parameter `out O`.
-export type Do<out O extends Operation, T> = {
-    readonly command: O[0]
-    readonly payload: Pr<O, O[0]>[0]
-    readonly continuation: (_: Pr<O, O[0]>[1]) => Effect<O, T>
-}
+export type Cont<out O extends Operation, T> = (_: Pr<O, O[0]>[1]) => Effect<O, T>
+export type Do<O extends Operation, T> = readonly[O[0], Pr<O, O[0]>[0], Cont<O, T>]
 
-// The raw value is now the effect. `Pure` has no `O`; `Do` is declared
-// covariant; so the union is covariant in `O`.
-export type Effect<out O extends Operation, T> = Pure<T> | Do<O, T>
+// The raw value is now the effect. `Pure` has no `O`; `Do` inherits covariance
+// from `Cont`; so the union is covariant in `O`.
+export type Effect<O extends Operation, T> = Pure<T> | Do<O, T>
 export type Pure<T> = () => T
 ```
 
-`out O` asserts the covariance TypeScript cannot derive through the conditional
-`Pr` type. **It is sound:** the `command` tag pins exactly which command's
-output the continuation receives, and every interpreter dispatches on the tag
-first, so a `write` node's continuation is only ever called with `void` — the
-op-set can grow without ever mishanding a continuation. `out` enables only the
-widening direction (`Effect<A>` <: `Effect<A | B>`); it does **not** enable the
-unsound narrowing.
+`Cont<out O, …>` asserts the covariance TypeScript cannot derive through the
+conditional `Pr` type. **It is sound:** the `command` tag pins exactly which
+command's output the continuation receives, and every interpreter dispatches on
+the tag first, so a `write` node's continuation is only ever called with
+`void` — the op-set can grow without ever mishanding a continuation. `out`
+enables only the widening direction (`Effect<A>` <: `Effect<A | B>`); it does
+**not** enable the unsound narrowing.
 
 Verified **cast-free** end-to-end against the real shapes: concrete widening,
 generic widening (`Effect<Q>` → `Effect<O | Q>`, which `step`/`both` need
-internally), `decode`, `doFull`, external `step`, `all`, and `both` all
-type-check. The one caveat is ordinary inference (`all(w, r)` unifies `O` to
-the first argument); call sites that already pass explicit type arguments
-(`both` does) are unaffected.
+internally), `decode` (positional `v[0]/v[1]/v[2]`), `doFull` (returns
+`[cmd, param, cont]`), external `step`, `all`, and `both` all type-check. The
+`Do` tuple keeps its positional shape, so `decode`/`match`/runners are
+unchanged in how they read a node. The one caveat is ordinary inference
+(`all(w, r)` unifies `O` to the first argument); call sites that already pass
+explicit type arguments (`both` does) are unaffected.
 
 ### Design
 
@@ -120,16 +120,16 @@ step(mkdir(...), f)       // external primitive
 
 ### Design decisions
 
-- **`out O` is a documented invariant, not a hack.** JSDoc on `Do`/`Effect`
+- **`Cont<out O, T>` is a documented invariant, not a hack.** JSDoc on `Cont`
   must state the tag-dispatch soundness argument so the annotation is never
   stripped. Anyone changing the continuation representation must re-check it.
+- **`Do` stays a positional tuple.** The `out` annotation goes on `Cont`, so
+  `decode` / `match` / the virtual/mock runners keep reading `[0]` / `[1]` /
+  `[2]` — no switch to named fields, no cast.
 - **Exactly one function inspects the shape: `decode`.** `step` wraps it; no
-  second `typeof value === 'function'` (or `'command' in value`) check may
-  appear anywhere. State this in the module doc, replacing the current "must
-  not be extended with new methods" framing.
-- **`Do` becomes an object.** Interpreters read `.command` / `.payload` /
-  `.continuation` instead of `[0]` / `[1]` / `[2]`. Touches `decode`, `match`,
-  and the virtual/mock runners.
+  second `typeof value === 'function'` check may appear anywhere. State this in
+  the module doc, replacing the current "must not be extended with new methods"
+  framing.
 - **Data-first `step(e, f)`** lets TypeScript contextually type the lambda from
   the effect — the common case. A curried data-last `step(f)(b)` can ship
   alongside only if a point-free site needs it (`foldStep`, `okStep`).
@@ -138,11 +138,10 @@ step(mkdir(...), f)       // external primitive
 
 ### Tasks
 
-- [ ] Change `Do` to the covariant named-field object and annotate
-      `Do<out O, T>` / `Effect<out O, T>`. Rename the raw `Value` → `Effect`;
-      the old `{ value, step }` wrapper type goes away as the flowing type.
-      Update `decode` / `match` to read object fields, and the virtual/mock
-      runners accordingly. Document the `out O` soundness invariant in JSDoc.
+- [ ] Extract the continuation into `Cont<out O, T>` and rebuild `Do` as
+      `readonly[O[0], Pr<O, O[0]>[0], Cont<O, T>]`. Rename the raw `Value` →
+      `Effect`; the old `{ value, step }` wrapper type goes away as the flowing
+      type. Document the `out O` soundness invariant in JSDoc on `Cont`.
 - [ ] Add the `Eff<O, T>` wrapper + `eff()` and the external data-first
       `step(e, f)` (a thin wrapper over `decode`).
 - [ ] State the "exactly one function inspects the shape" rule in the module
@@ -159,6 +158,6 @@ step(mkdir(...), f)       // external primitive
 - `fjs/effects/list/module.f.ts` — `List<O, T>` is `Effect<O, Next<O, T>>`, so
   its call sites migrate the same way.
 - `decode` / `match` — already the interpreter-facing half of this contract.
-- TypeScript variance annotations (`in` / `out`, TS 4.7+) — only legal on
-  object / function / mapped-type aliases (`TS2637`), which is why `Do` must be
-  an object rather than a tuple.
+- TypeScript variance annotations (`in` / `out`, TS 4.7+) — legal only on
+  object / function / mapped-type aliases (`TS2637`), which is why the `out`
+  goes on the `Cont` function alias rather than the `Do` tuple.


### PR DESCRIPTION
## Summary

Design-doc-only change. Rewrites `fjs/effects/todo/external-step-function.md` around a verified approach for making the **raw value** the primary effect type and moving `step` out of it into an external primitive plus an optional `fn`-style `eff()` wrapper.

The doc records the key finding and the fix:

- **Why the naive collapse fails:** a bare `Value<O, T>` union is not covariant in `O` — `Do`'s continuation input `Pr<O, O[0]>[1]` is contravariant — so `Effect<A>` → `Effect<A | B>` widening (relied on by `all`, `both`, `step`'s `O | Q`, handlers) breaks at ~150 sites. The `{ value, step }` object wrapper is what makes TypeScript measure `O` leniently today.

- **The fix (verified cast-free):** keep `Do` a positional tuple and put the `out` variance annotation on the continuation's function-type alias — `type Cont<out O, T> = (_: Pr<O, O[0]>[1]) => Effect<O, T>`; `type Do<O, T> = readonly[O[0], Pr<O, O[0]>[0], Cont<O, T>]`. Function-type aliases accept `out` (tuple/union aliases don't, `TS2637`). `decode`/`match`/runners keep positional `[0]/[1]/[2]` access.

- **Soundness:** `out O` is sound because the `command` tag pins which command's output the continuation receives, and interpreters dispatch on the tag first; `out` enables only the widening direction, never unsound narrowing.

- **Naming:** raw `Effect` (primary) + `Eff` wrapper via `eff()`. `mkdir(...).step(f)` → `eff(mkdir(...)).step(f)` or `step(mkdir(...), f)`.

No code changes yet — this is the concrete design to implement against.

https://claude.ai/code/session_01NVHNh7FMqQ8APzB6Ge8UPZ