### PR TITLE
Remove git cleanup steps from CI workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,9 +402,6 @@
         },
         {
           "run": "deno test --allow-read --allow-env --allow-sys --coverage && deno coverage --include='.*module\\.f\\.ts'"
-        },
-        {
-          "run": "git reset --hard HEAD && git clean -fdx"
         }
       ]
     },
@@ -431,9 +428,6 @@
         },
         {
           "run": "bun test --coverage"
-        },
-        {
-          "run": "git reset --hard HEAD && git clean -fdx"
         }
       ]
     },
@@ -457,9 +451,6 @@
         },
         {
           "run": "fjs t"
-        },
-        {
-          "run": "git reset --hard HEAD && git clean -fdx"
         }
       ]
     },
@@ -480,9 +471,6 @@
         },
         {
           "run": "node --test"
-        },
-        {
-          "run": "git reset --hard HEAD && git clean -fdx"
         }
       ]
     },
@@ -515,9 +503,6 @@
         },
         {
           "run": "npm pack"
-        },
-        {
-          "run": "git reset --hard HEAD && git clean -fdx"
         }
       ]
     },
@@ -560,9 +545,6 @@
         },
         {
           "run": "npx playwright test --browser=webkit"
-        },
-        {
-          "run": "git reset --hard HEAD && git clean -fdx"
         }
       ]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `fjs/ci`: drop the trailing `git reset --hard HEAD && git clean -fdx` step
+  from the `deno`, `bun`, `node22`, `node24`, `node26`, and `playwright` jobs.
+  It ran as each job's final step on ephemeral GitHub-hosted runners whose
+  workspace is discarded when the job ends, so cleaning the working tree there
+  was a no-op. The `clean` helper in `fjs/ci/common/module.f.ts` that appended
+  it is removed and its call sites unwrapped. PR
+  [#1353](https://github.com/functionalscript/functionalscript/pull/1353)
 - `fjs/ci`: generated CI now guards against stale committed generated files —
   the Node 26 job runs `npm run ci-update` right after `npm ci` and fails via
   `git add -A && git diff --cached --exit-code` when the committed tree no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- `fjs/ci`: drop the trailing `git reset --hard HEAD && git clean -fdx` step
-  from the `deno`, `bun`, `node22`, `node24`, `node26`, and `playwright` jobs.
-  It ran as each job's final step on ephemeral GitHub-hosted runners whose
-  workspace is discarded when the job ends, so cleaning the working tree there
-  was a no-op. The `clean` helper in `fjs/ci/common/module.f.ts` that appended
-  it is removed and its call sites unwrapped. PR
+- `fjs/ci`: **BREAKING CHANGE:** drop the trailing
+  `git reset --hard HEAD && git clean -fdx` step from the `deno`, `bun`,
+  `node22`, `node24`, `node26`, and `playwright` jobs. It ran as each job's
+  final step on ephemeral GitHub-hosted runners whose workspace is discarded
+  when the job ends, so cleaning the working tree there was a no-op. The
+  `clean` helper exported from `fjs/ci/common/module.f.ts` that appended it is
+  removed and its call sites unwrapped; since that module ships as a package
+  subpath, downstream imports of
+  `functionalscript/fjs/ci/common/module.js`'s `clean` no longer resolve. PR
   [#1353](https://github.com/functionalscript/functionalscript/pull/1353)
 - `fjs/ci`: generated CI now guards against stale committed generated files —
   the Node 26 job runs `npm run ci-update` right after `npm ci` and fails via

--- a/fjs/ci/README.md
+++ b/fjs/ci/README.md
@@ -14,7 +14,7 @@ with the latest matrix of jobs and steps.
   per-OS extra steps).
 - `common/module.f.ts` — shared RTTI schemas and types (`Step`, `Job`, `Jobs`,
   `GitHubAction`, `MetaStep`, `Os`, `Architecture`), and step-builder helpers
-  (`test`, `install`, `uses`, `clean`).
+  (`test`, `install`, `uses`).
 - `config/module.f.ts` — runner image matrix (OS × architecture → GitHub-hosted image name) and pinned tool/package versions, including the FunctionalScript package version used by generated smoke tests.
 - `node/module.f.ts` — Node.js job steps: platform smoke tests, canonical
   per-version jobs, coverage, and package checks.

--- a/fjs/ci/bun/module.f.ts
+++ b/fjs/ci/bun/module.f.ts
@@ -5,12 +5,12 @@
  * @module
  */
 import { bun } from '../config/module.f.ts'
-import { type MetaStep, clean, install, test, uses } from '../common/module.f.ts'
+import { type MetaStep, install, test, uses } from '../common/module.f.ts'
 
-export const bunSteps = (version: string): readonly MetaStep[] => clean([
+export const bunSteps = (version: string): readonly MetaStep[] => [
     install(uses('oven-sh/setup-bun', { 'bun-version': bun })),
     install({ run: `bun install -g functionalscript@${version}` }),
     test({ run: 'bun install --frozen-lockfile' }),
     test({ run: `bunx functionalscript@${version} t` }),
     test({ run: 'bun test --coverage' }),
-])
+]

--- a/fjs/ci/common/module.f.ts
+++ b/fjs/ci/common/module.f.ts
@@ -1,7 +1,7 @@
 /**
  * Shared CI types and helpers: GitHub Actions step/job RTTI schemas, the
  * `MetaStep` representation used by tool-specific modules, and assemblers like
- * `install`, `test`, `clean`, `ubuntu`, and `toSteps`.
+ * `install`, `test`, `ubuntu`, and `toSteps`.
  *
  * @module
  */
@@ -71,11 +71,6 @@ export const uses = (name: keyof typeof actions, w?: Record<string, string>): St
 export const install = (step: Step): MetaStep => ({ type: 'install', step })
 
 export const test = (step: Step): MetaStep => ({ type: 'test', step })
-
-export const clean = (steps: readonly MetaStep[]): readonly MetaStep[] => [
-    ...steps,
-    test({ run: 'git reset --hard HEAD && git clean -fdx' })
-]
 
 export const toSteps = (m: readonly MetaStep[]): readonly Step[] => {
     const filter = (st: StepType) => m.flatMap((mt: MetaStep): Step[] => mt.type === st ? [mt.step] : [])

--- a/fjs/ci/deno/module.f.ts
+++ b/fjs/ci/deno/module.f.ts
@@ -5,11 +5,11 @@
  * @module
  */
 import { deno } from '../config/module.f.ts'
-import { type MetaStep, clean, install, test, uses } from '../common/module.f.ts'
+import { type MetaStep, install, test, uses } from '../common/module.f.ts'
 
 const denoTest = 'deno test --allow-read --allow-env --allow-sys' as const
 
-export const denoSteps = (version: string): readonly MetaStep[] => clean([
+export const denoSteps = (version: string): readonly MetaStep[] => [
     install(uses('denoland/setup-deno', { 'deno-version': deno })),
     // We need --minimum-dependency-age=0 for functionalscript because we would like to use
     // the latest version of the package even if it is not yet 24 hours old,
@@ -19,4 +19,4 @@ export const denoSteps = (version: string): readonly MetaStep[] => clean([
     test({ run: `deno run -A --minimum-dependency-age=0 npm:functionalscript@${version} t` }),
     test({ run: 'deno install --frozen' }),
     test({ run: `${denoTest} --coverage && deno coverage --include='.*module\\.f\\.ts'` }),
-])
+]

--- a/fjs/ci/node/module.f.ts
+++ b/fjs/ci/node/module.f.ts
@@ -5,7 +5,7 @@
  * @module
  */
 import { node } from '../config/module.f.ts'
-import { type Job, type Jobs, type MetaStep, clean, install, test, ubuntuArm, uses } from '../common/module.f.ts'
+import { type Job, type Jobs, type MetaStep, install, test, ubuntuArm, uses } from '../common/module.f.ts'
 
 export const major = (v: string): string => v.split('.')[0]
 
@@ -17,10 +17,10 @@ const nodeInstall = (v: string) => [
     test({ run: 'npm ci' }),
 ]
 
-export const basicNode = (version: string) => (extra: readonly MetaStep[]): readonly MetaStep[] => clean([
+export const basicNode = (version: string) => (extra: readonly MetaStep[]): readonly MetaStep[] => [
     ...nodeInstall(version),
     ...extra,
-])
+]
 
 const fjsGlobalInstall = (version: string): MetaStep =>
     install({ run: `npm install -g functionalscript@${version}` })
@@ -31,25 +31,25 @@ export const platformNodeSteps = (version: string): readonly MetaStep[] => [
     test({ run: 'fjs t' }),
 ]
 
-const node22Steps = (version: string): readonly MetaStep[] => clean([
+const node22Steps = (version: string): readonly MetaStep[] => [
     ...nodeInstall(node.node22),
     fjsGlobalInstall(version),
     test({ run: 'fjs t' }),
-])
+]
 
-const node24Steps: readonly MetaStep[] = clean([
+const node24Steps: readonly MetaStep[] = [
     ...nodeInstall(node.node24),
     test({ run: 'node --test' }),
-])
+]
 
-const node26Steps: readonly MetaStep[] = clean([
+const node26Steps: readonly MetaStep[] = [
     ...nodeInstall(node.default),
     test({ run: 'npm run ci-update' }),
     test({ run: 'git add -A && git diff --cached --exit-code' }),
     test({ run: 'npx tsc' }),
     test({ run: 'npm run cov' }),
     test({ run: 'npm pack' }),
-])
+]
 
 const nodeJob = (steps: readonly MetaStep[]): Job => ubuntuArm(steps)
 

--- a/fjs/ci/todo/170.md
+++ b/fjs/ci/todo/170.md
@@ -5,37 +5,37 @@
 
 The three runtime-specific CI modules each build the same job shape — "set up
 the runtime, globally install `functionalscript`, run the smoke test and the
-runtime's own install/test commands, all wrapped in `clean(...)`":
+runtime's own install/test commands":
 
 ```ts
 // ci/bun/module.f.ts:10
-export const bunSteps = (version: string): readonly MetaStep[] => clean([
+export const bunSteps = (version: string): readonly MetaStep[] => [
     install(uses('oven-sh/setup-bun', { 'bun-version': bun })),
     install({ run: `bun install -g functionalscript@${version}` }),
     test({ run: 'bun install --frozen-lockfile' }),
     test({ run: `bunx functionalscript@${version} t` }),
     test({ run: 'bun test --coverage' }),
-])
+]
 
 // ci/deno/module.f.ts:12
-export const denoSteps = (version: string): readonly MetaStep[] => clean([
+export const denoSteps = (version: string): readonly MetaStep[] => [
     install(uses('denoland/setup-deno', { 'deno-version': deno })),
     install({ run: `deno install -g -A --minimum-dependency-age=0 npm:functionalscript@${version}` }),
     test({ run: `deno run -A --minimum-dependency-age=0 npm:functionalscript@${version} t` }),
     test({ run: 'deno install --frozen' }),
     test({ run: `${denoTest} --coverage && deno coverage --include='.*module\\.f\\.ts'` }),
-])
+]
 
 // ci/node/module.f.ts:15-58 — same ingredients, split into composable pieces
 const nodeInstall = (v: string) => [install(installNode(v)), test({ run: 'npm ci' })]
-export const basicNode = (version) => (extra) => clean([...nodeInstall(version), ...extra])
+export const basicNode = (version) => (extra) => [...nodeInstall(version), ...extra]
 const fjsGlobalInstall = (version) => install({ run: `npm install -g functionalscript@${version}` })
 export const platformNodeSteps = (version) => [...nodeInstall(node.default), fjsGlobalInstall(version), test({ run: 'fjs t' })]
-const node22Steps = (version) => clean([...nodeInstall(node.node22), fjsGlobalInstall(version), test({ run: 'fjs t' })])
+const node22Steps = (version) => [...nodeInstall(node.node22), fjsGlobalInstall(version), test({ run: 'fjs t' })]
 ```
 
-The skeleton `clean([ install(setup action), install(global fjs), …test
-commands ])` is repeated across the three runtimes. The deltas are data: the
+The skeleton `[ install(setup action), install(global fjs), …test commands ]`
+is repeated across the three runtimes. The deltas are data: the
 setup action + version key, the global-install command syntax, and the
 test-command strings:
 
@@ -57,13 +57,13 @@ export type ToolRecipe = {
     readonly tests: readonly string[],
 }
 export const toolSteps = (r: ToolRecipe) => (version: string): readonly MetaStep[] =>
-    clean([r.setup, install({ run: r.globalInstall(version) }), ...r.tests.map(run => test({ run }))])
+    [r.setup, install({ run: r.globalInstall(version) }), ...r.tests.map(run => test({ run }))]
 ```
 
 - `bunSteps`/`denoSteps` become `toolSteps(bunRecipe)`/`toolSteps(denoRecipe)`.
 - node builds its variants from the same pieces: `nodeInstall` stays (its
   `npm ci` sits between setup and the global install, unlike bun/deno), and
-  the per-version jobs keep composing `clean([...])` themselves or via thin
+  the per-version jobs keep composing their step arrays themselves or via thin
   wrappers.
 
 The setup step is passed pre-built (not as a raw action name) because bun's
@@ -95,7 +95,7 @@ install may vary per `(Os, Architecture)`; deno and node pass a fixed
 ### Related
 
 - `fjs/ci/common/module.f.ts` already centralizes
-  `install`/`test`/`clean`/`uses`/`toSteps`; `toolSteps` is the next
+  `install`/`test`/`uses`/`toSteps`; `toolSteps` is the next
   composition up the same ladder.
 - [66h-ci-npm-global-install.md](./66h-ci-npm-global-install.md) — the
   `npm install -g` family; the `globalInstall` field here is the


### PR DESCRIPTION
## Summary
Removed `git reset --hard HEAD && git clean -fdx` cleanup commands from the end of multiple CI workflow jobs.

## Changes
- Removed git cleanup step from Deno test job
- Removed git cleanup step from Bun test job
- Removed git cleanup step from FJS test job
- Removed git cleanup step from Node test job
- Removed git cleanup step from npm pack job
- Removed git cleanup step from Playwright test job

## Rationale
These cleanup commands were being executed at the end of each job to reset the working directory. Removing them simplifies the workflow configuration, as CI runners typically provide clean environments for each job and these cleanup steps may be unnecessary overhead.

https://claude.ai/code/session_01R72wVALKzYEqpeq56zdEcS