### PR TITLE
Add test coverage for btree remove invariant guard

### DIFF
--- a/fjs/types/btree/remove/module.f.ts
+++ b/fjs/types/btree/remove/module.f.ts
@@ -9,6 +9,7 @@ import { type Path, type PathItem, find } from '../find/module.f.ts'
 import { fold, concat, next } from '../../list/module.f.ts'
 import type { Array2 } from '../../array/module.f.ts'
 import { map } from '../../nullable/module.f.ts'
+import { assertEq } from '../../../asserts/module.f.ts'
 
 type Leaf01<T> = null | Leaf1<T>
 
@@ -139,3 +140,20 @@ export const nodeRemove
 
 export const remove: <T>(c: Compare<T>) => (tree: Tree<T>) => Tree<T>
     = c => map(nodeRemove(c))
+
+// `reduceValue0`/`reduceValue2`/`initValue0`/`initValue1` merge a Branch1's lone
+// child into its Branch3 sibling. The sibling is always a Branch (length 3 or 5)
+// in every reachable tree shape, so the `default` arm guarding a mismatched
+// (leaf) sibling length can't be hit through the public `remove` API. Exercise
+// it directly here so the invariant guard itself stays covered.
+export const proof = {
+    reduceValue0DefaultBranch: () => {
+        let threw: unknown
+        try {
+            reduceValue0<string>([['leaf']])([['x'], 's', ['y']])
+        } catch (e) {
+            threw = e
+        }
+        assertEq(threw, 'invalid node')
+    },
+}

--- a/fjs/types/btree/remove/module.f.ts
+++ b/fjs/types/btree/remove/module.f.ts
@@ -9,7 +9,6 @@ import { type Path, type PathItem, find } from '../find/module.f.ts'
 import { fold, concat, next } from '../../list/module.f.ts'
 import type { Array2 } from '../../array/module.f.ts'
 import { map } from '../../nullable/module.f.ts'
-import { assertEq } from '../../../asserts/module.f.ts'
 
 type Leaf01<T> = null | Leaf1<T>
 
@@ -147,13 +146,9 @@ export const remove: <T>(c: Compare<T>) => (tree: Tree<T>) => Tree<T>
 // (leaf) sibling length can't be hit through the public `remove` API. Exercise
 // it directly here so the invariant guard itself stays covered.
 export const proof = {
-    reduceValue0DefaultBranch: () => {
-        let threw: unknown
-        try {
+    throw: {
+        reduceValue0DefaultBranch: () => {
             reduceValue0<string>([['leaf']])([['x'], 's', ['y']])
-        } catch (e) {
-            threw = e
-        }
-        assertEq(threw, 'invalid node')
+        },
     },
 }


### PR DESCRIPTION
## Summary
This change adds a proof/test case to ensure that an internal invariant guard in the btree remove operation stays covered by tests, even though it cannot be reached through the public API.

## Key Changes
- Added import of `assertEq` from the asserts module
- Created a `proof` export object containing `reduceValue0DefaultBranch` test case that directly exercises the `default` arm of the `reduceValue0` function
- The test verifies that an invalid node shape (a Leaf instead of expected Branch) correctly throws an 'invalid node' error

## Implementation Details
The btree remove implementation contains internal merge operations (`reduceValue0`, `reduceValue2`, `initValue0`, `initValue1`) that handle merging a Branch1's lone child into its Branch3 sibling. These operations have a defensive guard that expects the sibling to always be a Branch (length 3 or 5) in any reachable tree shape. However, this guard cannot be triggered through normal public API usage. This test directly invokes `reduceValue0` with an invalid input to ensure the invariant check remains covered by the test suite.

https://claude.ai/code/session_01XArQYmiRfKWfBSHBSGt8eP