### PR TITLE
Add test coverage for endArray non-array guard branch

### DIFF
--- a/fjs/djs/parser/module.f.ts
+++ b/fjs/djs/parser/module.f.ts
@@ -550,4 +550,21 @@ export const proof = {
             assertEq(result.state, 'error')
         },
     },
+    endArray: {
+        // `endArray` is only ever invoked while `state.top` is an array (the
+        // `'['`/`'[v'`/`'[,'` value-states guarantee it), so its non-array
+        // guard is a defensive branch unreachable through `parseFromTokens`.
+        // Call it directly to cover that branch.
+        nonArrayTop: () => {
+            const state: ParseValueState = {
+                state: 'exportValue',
+                module: { refs: null, modules: null, consts: null },
+                valueState: '[,',
+                top: null,
+                stack: null,
+            }
+            const result = endArray(state)
+            assertEq(result.state, 'result')
+        },
+    },
 }


### PR DESCRIPTION
## Summary
Added a new test case to improve code coverage for the `endArray` function by testing its defensive non-array guard branch that is unreachable through normal `parseFromTokens` execution.

## Key Changes
- Added `nonArrayTop` test case under the `endArray` proof object
- Tests the defensive branch where `state.top` is not an array (set to `null`)
- Verifies that the function correctly transitions to the `'result'` state when encountering this edge case
- Includes explanatory comment documenting why this branch is normally unreachable but important to test

## Implementation Details
The test creates a `ParseValueState` with:
- `valueState` set to `'[,'` (array value state)
- `top` set to `null` (non-array, triggering the guard)
- Other required state fields initialized appropriately

This ensures the defensive programming pattern in `endArray` is covered by tests, improving overall code coverage metrics.

https://claude.ai/code/session_01JtgbYMoJfDYseAtRQcrvby