### PR TITLE
effects: make foldStep and forEachStep step variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ test-results/
 index.html
 
 .cas/
+.claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ history.
 
 ## Unreleased
 
+- `fjs/effects`: **BREAKING CHANGES:** make `foldStep` and `forEachStep` step
+  variants — `foldStep(items, init, f)` / `forEachStep(items, f)`, with `items`
+  an `Effect<O, List<T>>`, so the effect leads as in `step` and `historyStep`
 - `fjs/types/list`: add `tryFold` and the `Accumulator<I, T, R>` type, the
   `try*`/`Nullable` sibling of `fold`; `bit_vec`'s early-exit fold driver moves
   onto it [#1370](https://github.com/functionalscript/functionalscript/pull/1370)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ history.
 - `fjs/effects`: **BREAKING CHANGES:** make `foldStep` and `forEachStep` step
   variants — `foldStep(items, init, f)` / `forEachStep(items, f)`, with `items`
   an `Effect<O, List<T>>`, so the effect leads as in `step` and `historyStep`
+  [#1373](https://github.com/functionalscript/functionalscript/pull/1373)
 - `fjs/types/list`: add `tryFold` and the `Accumulator<I, T, R>` type, the
   `try*`/`Nullable` sibling of `fold`; `bit_vec`'s early-exit fold driver moves
   onto it [#1370](https://github.com/functionalscript/functionalscript/pull/1370)

--- a/fjs/cas/cli/module.f.ts
+++ b/fjs/cas/cli/module.f.ts
@@ -18,6 +18,7 @@ import {
 import { dispatch, type Commands } from '../../cli/module.f.ts'
 import { type MemOp } from '../../effects/memory/module.f.ts'
 import { casAddFile, fileCas, type FileCasOperation } from '../module.f.ts'
+import type { Vec } from '../../types/bit_vec/module.f.ts'
 
 export const commands: Commands<FileCasOperation | WriteFile | Write | All | MemOp | Read> = [
     {
@@ -63,10 +64,7 @@ export const commands: Commands<FileCasOperation | WriteFile | Write | All | Mem
         description: 'List all stored content hashes',
         handler: ({ home }) => {
             const c = fileCas(sha256)(home)
-            const x0 = step(
-                c.list(),
-                forEachStep(j => log(vecToCBase32(j))),
-            )
+            const x0 = forEachStep<FileCasOperation | Write, Vec>(j => log(vecToCBase32(j)))(c.list())
             return step(
                 x0,
                 () => pure(0)

--- a/fjs/cas/cli/module.f.ts
+++ b/fjs/cas/cli/module.f.ts
@@ -18,7 +18,6 @@ import {
 import { dispatch, type Commands } from '../../cli/module.f.ts'
 import { type MemOp } from '../../effects/memory/module.f.ts'
 import { casAddFile, fileCas, type FileCasOperation } from '../module.f.ts'
-import type { Vec } from '../../types/bit_vec/module.f.ts'
 
 export const commands: Commands<FileCasOperation | WriteFile | Write | All | MemOp | Read> = [
     {
@@ -64,7 +63,7 @@ export const commands: Commands<FileCasOperation | WriteFile | Write | All | Mem
         description: 'List all stored content hashes',
         handler: ({ home }) => {
             const c = fileCas(sha256)(home)
-            const x0 = forEachStep<FileCasOperation | Write, Vec>(j => log(vecToCBase32(j)))(c.list())
+            const x0 = forEachStep(c.list(), j => log(vecToCBase32(j)))
             return step(
                 x0,
                 () => pure(0)

--- a/fjs/cas/evo/module.f.ts
+++ b/fjs/cas/evo/module.f.ts
@@ -171,16 +171,13 @@ export const decodeRevisionBlob = <O extends Operation>(cas: Cas<O>) => (hash: V
  * `vnd.fjs.revision` blobs found among them. Non-revision blobs are ignored.
  */
 export const buildCache = <O extends Operation>(cas: Cas<O>): Effect<O, Cache> =>
-    eff(cas.list())
-        .step(hashes =>
-            foldStep((hash: Vec) => (cache: Cache): Effect<O, Cache> =>
-                eff(decodeRevisionBlob(cas)(hash))
-                    .step(revision =>
-                        pure(revision === null ? cache : addRevisionToCache(vecToCBase32(hash), revision)(cache))
-                    )
-                    .value)
-            (emptyCache)(hashes))
-        .value
+    foldStep((hash: Vec) => (cache: Cache): Effect<O, Cache> =>
+        eff(decodeRevisionBlob(cas)(hash))
+            .step(revision =>
+                pure(revision === null ? cache : addRevisionToCache(vecToCBase32(hash), revision)(cache))
+            )
+            .value)
+    (emptyCache)(cas.list())
 
 /** Scans `cas` once and allocates a memory slot holding the resulting {@link Cache}. */
 export const initEvo = <O extends Operation>(cas: Cas<O>): Effect<O | MemOp, Key<Cache>> =>
@@ -237,7 +234,7 @@ const resolveParents = <O extends Operation>(cas: Cas<O>) => (parents: readonly 
                 pure(parentResult[0] === 'error' ? parentResult : ok([...acc[1], parentResult[1]]))
             )
             .value
-    })(init)(parents)
+    })(init)(pure(parents))
 }
 
 /**

--- a/fjs/cas/evo/module.f.ts
+++ b/fjs/cas/evo/module.f.ts
@@ -171,13 +171,15 @@ export const decodeRevisionBlob = <O extends Operation>(cas: Cas<O>) => (hash: V
  * `vnd.fjs.revision` blobs found among them. Non-revision blobs are ignored.
  */
 export const buildCache = <O extends Operation>(cas: Cas<O>): Effect<O, Cache> =>
-    foldStep((hash: Vec) => (cache: Cache): Effect<O, Cache> =>
-        eff(decodeRevisionBlob(cas)(hash))
-            .step(revision =>
-                pure(revision === null ? cache : addRevisionToCache(vecToCBase32(hash), revision)(cache))
-            )
-            .value)
-    (emptyCache)(cas.list())
+    foldStep(
+        cas.list(),
+        emptyCache,
+        hash => cache =>
+            eff(decodeRevisionBlob(cas)(hash))
+                .step(revision =>
+                    pure(revision === null ? cache : addRevisionToCache(vecToCBase32(hash), revision)(cache))
+                )
+                .value)
 
 /** Scans `cas` once and allocates a memory slot holding the resulting {@link Cache}. */
 export const initEvo = <O extends Operation>(cas: Cas<O>): Effect<O | MemOp, Key<Cache>> =>
@@ -227,14 +229,17 @@ const resolveParent = <O extends Operation>(cas: Cas<O>) => (parentRef: Hash): E
 /** Resolves and validates every entry of `parents`, in order, short-circuiting on the first failure. */
 const resolveParents = <O extends Operation>(cas: Cas<O>) => (parents: readonly Hash[]): Effect<O, Result<readonly Revision[], string>> => {
     const init: Result<readonly Revision[], string> = ok([])
-    return foldStep((parentRef: Hash) => (acc: Result<readonly Revision[], string>): Effect<O, Result<readonly Revision[], string>> => {
-        if (acc[0] === 'error') { return pure(acc) }
-        return eff(resolveParent(cas)(parentRef))
-            .step((parentResult): Effect<never, Result<readonly Revision[], string>> =>
-                pure(parentResult[0] === 'error' ? parentResult : ok([...acc[1], parentResult[1]]))
-            )
-            .value
-    })(init)(pure(parents))
+    return foldStep(
+        pure(parents),
+        init,
+        parentRef => (acc: Result<readonly Revision[], string>) => {
+            if (acc[0] === 'error') { return pure(acc) }
+            return eff(resolveParent(cas)(parentRef))
+                .step((parentResult): Effect<never, Result<readonly Revision[], string>> =>
+                    pure(parentResult[0] === 'error' ? parentResult : ok([...acc[1], parentResult[1]]))
+                )
+                .value
+        })
 }
 
 /**

--- a/fjs/cas/module.f.ts
+++ b/fjs/cas/module.f.ts
@@ -147,11 +147,12 @@ const gcStage = <O extends Now | Readdir | Rm>(stageDir: string): Effect<O, void
             if (k === 'error') { return pure(undefined) }
             const expired = v.flatMap(d =>
                 d.isFile && deadlineOf(d.name) < t ? [d.name] : [])
-            return forEachStep((name: string) =>
-                eff(rm(join(stageDir, name)))
-                    .step(() => pure(undefined))
-                    .value
-                )(pure(expired))
+            return forEachStep(
+                pure(expired),
+                name =>
+                    eff(rm(join(stageDir, name)))
+                        .step(() => pure(undefined))
+                        .value)
         })
         .value
 
@@ -292,11 +293,13 @@ export const fileCas = (sha2: Sha2) => (path: string): FileCas => {
 
 /** 256-bit random `Vec` built from 8 sequential `randomInt` (32-bit) calls. */
 const random256: Effect<RandomInt, Vec> =
-    foldStep((_: number) => (acc: Vec): Effect<RandomInt, Vec> =>
-        eff(randomInt())
-            .step(r => pure(msb.concat(acc)(vec(32n)(BigInt(r)))))
-            .value
-    )(empty)(pure([0, 1, 2, 3, 4, 5, 6, 7]))
+    foldStep(
+        pure([0, 1, 2, 3, 4, 5, 6, 7]),
+        empty,
+        () => (acc: Vec) =>
+            eff(randomInt())
+                .step(r => pure(msb.concat(acc)(vec(32n)(BigInt(r)))))
+                .value)
 
 /** Streams any file at `filePath` in `<=128 KiB` chunks as a `ListEffect` of `ok` items. */
 const streamFile = (filePath: string): List<ReadBytes, IoResult<Vec>> => {

--- a/fjs/cas/module.f.ts
+++ b/fjs/cas/module.f.ts
@@ -151,7 +151,7 @@ const gcStage = <O extends Now | Readdir | Rm>(stageDir: string): Effect<O, void
                 eff(rm(join(stageDir, name)))
                     .step(() => pure(undefined))
                     .value
-                )(expired)
+                )(pure(expired))
         })
         .value
 
@@ -296,7 +296,7 @@ const random256: Effect<RandomInt, Vec> =
         eff(randomInt())
             .step(r => pure(msb.concat(acc)(vec(32n)(BigInt(r)))))
             .value
-    )(empty)([0, 1, 2, 3, 4, 5, 6, 7])
+    )(empty)(pure([0, 1, 2, 3, 4, 5, 6, 7]))
 
 /** Streams any file at `filePath` in `<=128 KiB` chunks as a `ListEffect` of `ok` items. */
 const streamFile = (filePath: string): List<ReadBytes, IoResult<Vec>> => {

--- a/fjs/djs/transpiler/module.f.ts
+++ b/fjs/djs/transpiler/module.f.ts
@@ -64,7 +64,7 @@ const transpileWithImports
             const pathsCombine = listMap(pathConcat(dir))(parseModuleResult[1][0])
             const pathsArray = toArray(pathsCombine)
             const contextWithStack = { ...context, stack: { first: path, tail: context.stack } }
-            const x0 = foldStep(foldNextModuleOp)(contextWithStack)(pure(pathsArray))
+            const x0 = foldStep(pure(pathsArray), contextWithStack, foldNextModuleOp)
             return step(
                 x0,
                 contextWithImports => {

--- a/fjs/djs/transpiler/module.f.ts
+++ b/fjs/djs/transpiler/module.f.ts
@@ -65,7 +65,7 @@ const transpileWithImports
             const pathsArray = toArray(pathsCombine)
             const contextWithStack = { ...context, stack: { first: path, tail: context.stack } }
             return step(
-                foldStep(foldNextModuleOp)(contextWithStack)(pathsArray),
+                foldStep(foldNextModuleOp)(contextWithStack)(pure(pathsArray)),
                 contextWithImports => {
                     if (contextWithImports.error !== null) {
                         return pure(contextWithImports)

--- a/fjs/djs/transpiler/module.f.ts
+++ b/fjs/djs/transpiler/module.f.ts
@@ -64,8 +64,9 @@ const transpileWithImports
             const pathsCombine = listMap(pathConcat(dir))(parseModuleResult[1][0])
             const pathsArray = toArray(pathsCombine)
             const contextWithStack = { ...context, stack: { first: path, tail: context.stack } }
+            const x0 = foldStep(foldNextModuleOp)(contextWithStack)(pure(pathsArray))
             return step(
-                foldStep(foldNextModuleOp)(contextWithStack)(pure(pathsArray)),
+                x0,
                 contextWithImports => {
                     if (contextWithImports.error !== null) {
                         return pure(contextWithImports)

--- a/fjs/effects/module.f.ts
+++ b/fjs/effects/module.f.ts
@@ -307,8 +307,9 @@ export const do_ =
 export const foldStep =
     <O extends Operation, T, S>(f: (item: T) => (state: S) => Effect<O, S>) =>
     (init: S) =>
-    (items: List<T>): Effect<O, S> =>
-        fold<T, Effect<O, S>>(item => acc => step(acc, f(item)))(pure(init))(items)
+    (items: Effect<O, List<T>>): Effect<O, S> => step(
+        items,
+        fold<T, Effect<O, S>>(item => acc => step(acc, f(item)))(pure(init)))
 
 /**
  * Sequentially runs `f(item)` for each item in `items`, discarding intermediate
@@ -316,8 +317,7 @@ export const foldStep =
  */
 export const forEachStep =
     <O extends Operation, T>(f: (item: T) => Effect<O, void>) =>
-    (items: List<T>): Effect<O, void> =>
-    foldStep((item: T) => () => f(item))(undefined)(items)
+    foldStep((item: T) => () => f(item))(undefined)
 
 /**
  * A step adapter for the `error` short-circuit: `error` → pass it through

--- a/fjs/effects/module.f.ts
+++ b/fjs/effects/module.f.ts
@@ -44,6 +44,22 @@
  * return step(x1, h)
  * ```
  *
+ * **A step call that does not fit one line breaks after `(`, one argument per
+ * line.** This holds for every step variant — {@link step}, {@link historyStep},
+ * {@link foldStep}, {@link forEachStep} — and it is the same rule as taking the
+ * effect first, written out at the call site. A step variant is this module's
+ * `do` notation: the arguments are a statement list in execution order, so each
+ * one gets a line and the sequence reads down the page. Packing the leading
+ * effect onto the `(` line and wrapping the rest beneath it hides which of them
+ * runs first. The closing `)` may sit on its own line or trail the last
+ * argument:
+ *
+ * ```ts
+ * return step(
+ *     collectRead(cas.read(hash)),
+ *     ([tag, value]) => pure(tag === 'error' ? null : decodeRevisionVec(value)))
+ * ```
+ *
  * When a later link needs a value from an earlier one, that is not a reason to
  * nest: a nested continuation only reaches back because it closes over the
  * enclosing scope. {@link historyStep} carries the value forward instead, so
@@ -295,29 +311,60 @@ export const do_ =
     ({ command, payload, continuation: pure })
 
 /**
- * Sequentially threads a state value through an effect for each item in `items`.
+ * Sequentially threads a state value through an effect for each item produced by
+ * `items`.
  *
- * Given `f: item => state => Effect<O, state>`, `init: S`, and `items: [x₀, x₁, …]`,
- * builds `step(step(f(x₀)(init), f(x₁)), f(x₂))…` and yields a single
- * `Effect<O, S>` that produces the final state.
+ * Given `f: item => state => Effect<Q, state>`, `init: S`, and an `items` that
+ * yields `[x₀, x₁, …]`, builds `step(step(f(x₀)(init), f(x₁)), f(x₂))…` and
+ * yields a single effect producing the final state.
  *
  * Sequential — each step depends on the previous state. Compare to `all`,
  * which fans out independent effects.
+ *
+ * **A step variant** (see the two shapes described in this module's header): the
+ * effect comes first, as in {@link step} and {@link historyStep}. `items` is an
+ * `Effect<O, List<T>>` rather than a bare `List<T>` because the list a caller
+ * folds over is normally *produced* by an effect — `cas.list()`, a `readdir`.
+ * Taking the plain list would force every such caller to open a continuation
+ * just to name the list (`step(cas.list(), foldStep(…))`), which is the nesting
+ * this module exists to keep out of call sites. A caller that already holds the
+ * list lifts it with `pure`, which costs a wrapper but no indentation.
+ *
+ * `O` and `Q` are separate on purpose: the operations needed to produce the list
+ * are rarely the ones the body performs, and the result unions them.
+ *
+ * **The argument order is deliberately not `fold`'s** from `fjs/types/list`, and
+ * the difference is what the two combinators are *for*. `fold` is a data
+ * pipeline: it is curried `f`-first because the list is the thing being threaded
+ * through, and nothing about it happens in time. A step variant is a sequencing
+ * construct — it is this module's `do` notation, and reading one top-to-bottom
+ * is reading the order the program executes in. The effect therefore has to come
+ * first, because it is what happens first. Currying `f` ahead of `items` would
+ * put the *body* of the loop above the thing it loops over, which is exactly the
+ * inversion `do` exists to remove.
+ *
+ * That is also why the whole family — `step`, `historyStep`, `foldStep`,
+ * `forEachStep` — takes its effect first and breaks one argument per line when
+ * it wraps (see this module's header): every such call is a statement list, and
+ * each line is one statement in execution order.
  */
-export const foldStep =
-    <O extends Operation, T, S>(f: (item: T) => (state: S) => Effect<O, S>) =>
-    (init: S) =>
-    (items: Effect<O, List<T>>): Effect<O, S> => step(
-        items,
-        fold<T, Effect<O, S>>(item => acc => step(acc, f(item)))(pure(init)))
+export const foldStep = <O extends Operation, T, Q extends Operation, S>(
+    items: Effect<O, List<T>>,
+    init: S,
+    f: (item: T) => (state: S) => Effect<Q, S>
+): Effect<O | Q, S> =>
+    step(items, fold<T, Effect<O | Q, S>>(item => acc => step(acc, f(item)))(pure(init)))
 
 /**
- * Sequentially runs `f(item)` for each item in `items`, discarding intermediate
- * results. The `void` accumulator sibling of `foldStep`.
+ * Sequentially runs `f(item)` for each item produced by `items`, discarding
+ * intermediate results. The `void` accumulator sibling of {@link foldStep}, and
+ * a step variant on the same grounds.
  */
-export const forEachStep =
-    <O extends Operation, T>(f: (item: T) => Effect<O, void>) =>
-    foldStep((item: T) => () => f(item))(undefined)
+export const forEachStep = <O extends Operation, T, Q extends Operation>(
+    items: Effect<O, List<T>>,
+    f: (item: T) => Effect<Q, void>
+): Effect<O | Q, void> =>
+    foldStep(items, undefined, (item: T) => () => f(item))
 
 /**
  * A step adapter for the `error` short-circuit: `error` → pass it through

--- a/fjs/effects/proof.f.ts
+++ b/fjs/effects/proof.f.ts
@@ -23,34 +23,25 @@ const next = match<AddOp, number>({ add: (a, b) => a + b })
 export const proof = {
     foldStep: {
         empty: () => {
-            const e = foldStep
-                ((x: number) => (s: number) => pure(s + x))
-                (10)
-                (pure([]))
+            const e = foldStep(pure<readonly number[]>([]), 10, x => s => pure(s + x))
             assertPure(e, 10)
         },
         threadsState: () => {
-            const e = foldStep
-                ((x: number) => (s: number) => pure(s + x))
-                (0)
-                (pure([1, 2, 3, 4]))
+            const e = foldStep(pure([1, 2, 3, 4]), 0, x => s => pure(s + x))
             assertPure(e, 10)
         },
         order: () => {
-            const e = foldStep
-                ((x: string) => (s: string) => pure(s + x))
-                ('')
-                (pure(['a', 'b', 'c']))
+            const e = foldStep(pure(['a', 'b', 'c']), '', x => s => pure(s + x))
             assertPure(e, 'abc')
         },
     },
     forEachStep: {
         empty: () => {
-            const e = forEachStep<never, number>(() => pure(undefined))(pure([]))
+            const e = forEachStep(pure<readonly number[]>([]), () => pure(undefined))
             assertPure(e, undefined)
         },
         runs: () => {
-            const e = forEachStep<never, number>(() => pure(undefined))(pure([1, 2, 3]))
+            const e = forEachStep(pure([1, 2, 3]), () => pure(undefined))
             assertPure(e, undefined)
         },
     },

--- a/fjs/effects/proof.f.ts
+++ b/fjs/effects/proof.f.ts
@@ -26,31 +26,31 @@ export const proof = {
             const e = foldStep
                 ((x: number) => (s: number) => pure(s + x))
                 (10)
-                ([])
+                (pure([]))
             assertPure(e, 10)
         },
         threadsState: () => {
             const e = foldStep
                 ((x: number) => (s: number) => pure(s + x))
                 (0)
-                ([1, 2, 3, 4])
+                (pure([1, 2, 3, 4]))
             assertPure(e, 10)
         },
         order: () => {
             const e = foldStep
                 ((x: string) => (s: string) => pure(s + x))
                 ('')
-                (['a', 'b', 'c'])
+                (pure(['a', 'b', 'c']))
             assertPure(e, 'abc')
         },
     },
     forEachStep: {
         empty: () => {
-            const e = forEachStep<never, number>(() => pure(undefined))([])
+            const e = forEachStep<never, number>(() => pure(undefined))(pure([]))
             assertPure(e, undefined)
         },
         runs: () => {
-            const e = forEachStep<never, number>(() => pure(undefined))([1, 2, 3])
+            const e = forEachStep<never, number>(() => pure(undefined))(pure([1, 2, 3]))
             assertPure(e, undefined)
         },
     },

--- a/fjs/effects/todo/effect-list-fold.md
+++ b/fjs/effects/todo/effect-list-fold.md
@@ -1,0 +1,158 @@
+## effect-list-fold. Move `foldStep` / `forEachStep` into `fjs/effects/list` and fold streams
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+`foldStep` and `forEachStep` take `Effect<O, List<T>>` over `fjs/types/list`'s
+strict `List<T>` — an effect that yields a **fully materialized** list. Every
+element exists in memory before the first `f` runs, and the fold cannot begin
+until the last element has been produced.
+
+That is not the shape the codebase's real sequences have.
+`fjs/effects/list/module.f.ts` already defines the streaming one:
+
+```ts
+export type List<O extends Operation, T> = Effect<O, Next<O, T>>
+```
+
+one effect per cons cell, where the tail is not reached until a runner performs
+the command that produces it. So there are two list vocabularies, and the fold
+combinators speak the wrong one. Three consequences:
+
+**Producers materialize to satisfy the signature.** `cas.list()` is
+`Effect<O, readonly Vec[]>` built from a `recursive: true` readdir — every hash
+in the store lives in memory at once, purely because `foldStep` cannot consume
+anything else.
+
+**The layering is inverted.** `fjs/effects/module.f.ts` — the core effect module
+— imports `fjs/types/list` (line 95) for `fold` and `List`, and *nothing else in
+that file uses either*. The two fold combinators are the module's only dependency
+on the strict list type.
+
+**The stream fold is being hand-written separately.** See
+[fold-stream-combinator](./fold-stream-combinator.md): the *EOF → finalize;
+error item → propagate; chunk → fold and recurse* skeleton appears in four
+places. That is `foldStep` over a stream, plus a short-circuit.
+
+### Proposal
+
+**1. Rename `List<O, T>` → `EffectList<O, T>`** in
+`fjs/effects/list/module.f.ts`. It collides with `fjs/types/list`'s `List<T>`,
+and the eight importers currently alias around the clash — `elEmpty` in
+`fjs/cas`, `fjs/cas/evo`, `fjs/cas/mcp`; `emptyList` in `fjs/media/type/proof`.
+The rename has value independent of the rest of this issue.
+
+**2. Move `foldStep` / `forEachStep`** out of `fjs/effects/module.f.ts` and into
+`fjs/effects/list/module.f.ts`, retyped over `EffectList`:
+
+```ts
+export const foldStep = <O extends Operation, T, Q extends Operation, S>(
+    items: EffectList<O, T>,
+    init: S,
+    f: (item: T) => (state: S) => Effect<Q, S>
+): Effect<O | Q, S> =>
+    step(
+        items,
+        next => next === undefined
+            ? pure(init)
+            : step(f(next.first)(init), s => foldStep(next.tail, s, f)))
+```
+
+Keep the step-variant shape — effect first, one argument per line when the call
+wraps. That is not a style preference: a step variant is this module's `do`
+notation, so the argument list is a statement list in execution order and the
+effect comes first because it happens first. The rationale currently lives on
+`foldStep`'s JSDoc and in the `fjs/effects/module.f.ts` header; carry both over.
+
+**3. Add a strict-list converter.** All six current call sites hold a strict
+list, so the move needs a way in:
+
+```ts
+export const fromList = <O extends Operation, T>(items: List<T>): EffectList<O, T> =>
+```
+
+built from `empty` / `nonEmpty`. The four `pure(...)` call sites below become
+`fromList(...)`.
+
+**Layering.** `fjs/effects/list/module.f.ts` already imports `pure`, `Effect`
+and `Operation` from `../module.f.ts`; adding `step` is the same direction, so
+no cycle. After the move, `fjs/effects/module.f.ts` drops its
+`fjs/types/list` import entirely and the core effect module no longer depends on
+the strict list type at all.
+
+### Call sites
+
+Six, all currently strict:
+
+| site | argument | after |
+| --- | --- | --- |
+| `fjs/cas/cli/module.f.ts:66` | `c.list()` | streams once `cas.list()` does |
+| `fjs/cas/evo/module.f.ts:174` | `cas.list()` | streams once `cas.list()` does |
+| `fjs/cas/evo/module.f.ts:232` | `pure(parents)` | `fromList(parents)` |
+| `fjs/cas/module.f.ts:150` | `pure(expired)` | `fromList(expired)` |
+| `fjs/cas/module.f.ts:296` | `pure([0…7])` | `fromList([0…7])` |
+| `fjs/djs/transpiler/module.f.ts:67` | `pure(pathsArray)` | `fromList(pathsArray)` |
+
+The two `cas.list()` sites are the ones this exists for; converting them is a
+follow-up in `fjs/cas` (see *Related*), not part of this issue.
+
+### What it unblocks
+
+- **`foldStream` mostly dissolves.**
+  [fold-stream-combinator](./fold-stream-combinator.md) becomes `foldStep` plus
+  an `okStep`-shaped short-circuit over `Result`, rather than a fourth
+  hand-written skeleton. Re-scope or close that issue once this lands.
+- **`cas.list()` can stream.** `Effect<O, readonly Vec[]>` → `EffectList<O, Vec>`,
+  so a large store's hash list never materializes. This is where the memory win
+  actually is — `foldStep` taking a stream buys nothing until the producer
+  yields one.
+
+### Open questions
+
+- **Stack depth.** The recursion composes one `step` per element, and `step` is
+  eager on a `Pure` head, so a fully pure stream (anything from `fromList`)
+  folds at composition time and recurses O(n) deep. The current `fold`-based
+  implementation has the same property, so this is not a regression — but
+  confirm it with a large-`n` proof before relying on it. If it bites, the
+  answer is for producers to yield `Do` nodes, not to change the combinator.
+- **`S` inference.** `init` sitting before `f` already forces one annotation, at
+  `fjs/cas/evo/module.f.ts:235` (`acc: Result<readonly Revision[], string>`);
+  without it TypeScript fixes `S` to `Ok<…>` from `init` and the `'error'`
+  branch goes dead. The retype should not change this, but re-check.
+- **Proof coverage.** `fjs/effects/list/` has no `proof.f.ts` at all today.
+  AGENTS.md requires 100% proof coverage across every dimension, so the move
+  needs one created — covering `empty` and `nonEmpty` as well as the moved
+  combinators and `fromList`.
+- **Does `forEachStep` still earn its place** once `foldStep` is one line away?
+  It is `foldStep(items, undefined, item => () => f(item))`. Keep it — the
+  `void` accumulator is the common case — but confirm against call sites after
+  the move.
+
+### Tasks
+
+- [ ] Rename `List<O, T>` → `EffectList<O, T>` in `fjs/effects/list/module.f.ts`;
+      update the eight importers and drop the `elEmpty` / `emptyList` aliases
+      that existed only to dodge the name clash.
+- [ ] Add `fromList` to `fjs/effects/list/module.f.ts`.
+- [ ] Move `foldStep` / `forEachStep` there, retyped over `EffectList`, carrying
+      their JSDoc and the step-variant rationale.
+- [ ] Remove the now-unused `fjs/types/list` import from
+      `fjs/effects/module.f.ts`.
+- [ ] Migrate the six call sites; the four strict ones go through `fromList`.
+- [ ] Create `fjs/effects/list/proof.f.ts` with full coverage.
+- [ ] Re-scope or close [fold-stream-combinator](./fold-stream-combinator.md).
+- [ ] Run `npx tsc` and `fjs t`.
+
+### Related
+
+- [fold-stream-combinator](./fold-stream-combinator.md) — the stream fold this
+  subsumes; blocked-on/blocks relationship should be settled when this is
+  reviewed.
+- [allreduce-combinator](./allreduce-combinator.md) — the parallel sibling;
+  it is specified over `List<T>` and will want the same treatment.
+- [write-closed-helpers](../../cas/todo/write-closed-helpers.md) — already
+  blocked by `fold-stream-combinator`, so transitively affected.
+- `fjs/effects/module.f.ts` header — the step-variant / `do`-notation rationale
+  that fixes the argument order.

--- a/fjs/effects/todo/fold-stream-combinator.md
+++ b/fjs/effects/todo/fold-stream-combinator.md
@@ -2,6 +2,10 @@
 
 **Priority:** P3
 **Status:** open
+**May be subsumed by:** [effect-list-fold](./effect-list-fold.md) — if `foldStep`
+moves to `fjs/effects/list` and is retyped over `EffectList<O, T>`, `foldStream`
+becomes `foldStep` plus an `okStep`-shaped short-circuit rather than a separate
+combinator. Settle the scope of this issue after that one is reviewed.
 
 ### Problem
 
@@ -106,6 +110,8 @@ consumers first; the writers follow only if the shape stays clean.
 
 ### Related
 
+- [effect-list-fold](./effect-list-fold.md) — moves `foldStep`/`forEachStep` into
+  `fjs/effects/list` over the streaming list; largely subsumes this issue.
 - [66o-read-streamfile-dedup](../../cas/todo/66o-read-streamfile-dedup.md) —
   producer-side dedup of the same stream protocol.
 - [abstract-write](../../cas/todo/abstract-write.md) — writer-pair


### PR DESCRIPTION
@
Both combinators now take the effect first, matching `step` and `historyStep`:

```ts
foldStep(items, init, f)
forEachStep(items, f)
```

with `items` an `Effect<O, List<T>>` rather than a bare `List<T>`.

## Why this order

A step variant is this modules `do` notation: reading the call top-to-bottom is reading the order the program executes in, so the effect comes first because it is what happens first. Currying `f` ahead of `items` would put the *body* of the loop above the thing it loops over — exactly the inversion `do` exists to remove.

That is also why the order deliberately differs from `fold` in `fjs/types/list`. `fold` is a data pipeline, curried `f`-first because the list is what gets threaded through, and nothing about it happens in time.

The same premise fixes the formatting rule, now documented in the module header: a step call that does not fit one line breaks after `(`, one argument per line. The argument list is a statement list, so each statement gets a line; packing the leading effect onto the `(` line hides which one runs first.

## Effect on call sites

Callers holding an effectful list no longer open a continuation just to name it:

- `fjs/cas/cli` — drops its explicit type arguments and the `Vec` import; the callback parameter now infers.
- `buildCache` (`fjs/cas/evo`) — loses an eta-expanded `eff(...).step(hashes => ...(hashes)).value` wrapper.
- The four sites that already hold a strict list lift it with `pure`, which costs a wrapper but no indentation.

`O` and `Q` are now separate type parameters: the operations needed to produce the list are rarely the ones the body performs, and the result unions them.

One annotation is load-bearing — `acc: Result<readonly Revision[], string>` at `fjs/cas/evo/module.f.ts:235`. With `init` before `f`, TypeScript fixes `S` from `init` and narrows it to `Ok<...>`, which kills the `error` branch. Two alternative argument orders were tried and rejected: `(items)(init)(f)` breaks `S` inference the same way at more sites, and `(items)(f)(init)` typechecks but keeps the currying this PR is removing.

## Follow-up

`fjs/effects/todo/effect-list-fold.md` proposes moving both combinators into `fjs/effects/list` and retyping them over the streaming `EffectList<O, T>`, so folds stop materializing the list. It notes that `fjs/types/list` is imported into `fjs/effects/module.f.ts` *only* by these two functions, and that the change would largely subsume `fold-stream-combinator` — cross-linked there, not rescoped.

## Testing

- `npx tsc` — clean
- `node ./fjs/module.ts t` — 2206 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@