### PR TITLE
effects: add `mapStep` and `Eff.map`, the effect functor map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ history.
 
 ## Unreleased
 
+- `fjs/effects`: add `mapStep` and the matching `Eff.map` — the functor map of
+  the effect monad, for the `step(e, x => pure(f(x)))` idiom. Neither widens the
+  operation set, since a pure projection issues no commands
+  [#1374](https://github.com/functionalscript/functionalscript/pull/1374)
 - `fjs/effects`: **BREAKING CHANGES:** make `foldStep` and `forEachStep` step
   variants — `foldStep(items, init, f)` / `forEachStep(items, f)`, with `items`
   an `Effect<O, List<T>>`, so the effect leads as in `step` and `historyStep`

--- a/fjs/cas/evo/module.f.ts
+++ b/fjs/cas/evo/module.f.ts
@@ -163,7 +163,7 @@ export const decodeRevisionVec = (value: Vec): Revision | null => {
  */
 export const decodeRevisionBlob = <O extends Operation>(cas: Cas<O>) => (hash: Vec): Effect<O, Revision | null> =>
     eff(collectRead(cas.read(hash)))
-        .step(([tag, value]) => pure(tag === 'error' ? null : decodeRevisionVec(value)))
+        .map(([tag, value]) => tag === 'error' ? null : decodeRevisionVec(value))
         .value
 
 /**

--- a/fjs/effects/eff/module.f.ts
+++ b/fjs/effects/eff/module.f.ts
@@ -1,4 +1,4 @@
-import { history, historyStep, pure, step, type Effect, type Operation } from '../module.f.ts'
+import { history, historyStep, mapStep, pure, type Effect, type Operation } from '../module.f.ts'
 
 /**
  * A fluent, method-chaining monad over a raw {@link Effect} that also
@@ -6,11 +6,19 @@ import { history, historyStep, pure, step, type Effect, type Operation } from '.
  * is bind — `f` receives the current value followed by every prior value,
  * most recent first (`f(t, ...p)`), and returns a raw `Effect`; `.step`
  * re-wraps the result together with that history so `.step(f).step(g)`
- * chains and stays in the `Eff` world throughout. `P` is the tuple of prior
- * values available to the *next* `.step` call; it grows by one element (the
- * current `T`) on every step, starting empty at {@link eff}. `.value` is the
- * exit back to a raw `Effect`, discarding the history. An `Eff` is not
- * assignable to `Effect`; unwrap through `.value`.
+ * chains and stays in the `Eff` world throughout. `.map(f)` is the functor
+ * map — the same thing for an `f` that returns a plain value rather than an
+ * effect, so it is exactly `.step((...tp) => pure(f(...tp)))`. `P` is the
+ * tuple of prior values available to the *next* `.step` call; it grows by one
+ * element (the current `T`) on every step, starting empty at {@link eff}.
+ * `.value` is the exit back to a raw `Effect`, discarding the history. An
+ * `Eff` is not assignable to `Effect`; unwrap through `.value`.
+ *
+ * **`.map` grows the history just as `.step` does, and does not widen `O`.**
+ * Both follow from it being that `.step` call and nothing else: a chain
+ * rewritten from `.step(v => pure(f(v)))` to `.map(f)` must hand later
+ * callbacks the same prior values it did before, and a projection performs no
+ * command, so it contributes no operation for a runner to interpret.
  *
  * **The history is positional, so every parameter a callback declares is
  * meaningful.** `f` is applied as `f(...tp)`, so a callback written
@@ -18,7 +26,10 @@ import { history, historyStep, pure, step, type Effect, type Operation } from '.
  * `rest` rather than the default or an empty rest — and where the types line up,
  * TypeScript will not object. Declare exactly as many parameters as the callback
  * intends to read; a defaulted or rest parameter after the current value is a
- * bug, not a convenience.
+ * bug, not a convenience. This is what makes `.map(g)` a *different* call from
+ * `.step(v => pure(g(v)))` whenever `g` is not genuinely unary — the lambda
+ * pins the arity at one, while passing `g` point-free exposes it to the prior
+ * values, the way `['1', '2', '3'].map(parseInt)` does.
  *
  * **`.value` is always an already-built `Effect`.** Reading it composes
  * nothing: the projection that drops the history tuple to its current value is
@@ -52,6 +63,7 @@ import { history, historyStep, pure, step, type Effect, type Operation } from '.
 export type Eff<O extends Operation, T, P extends readonly unknown[]> = {
     readonly value: Effect<O, T>
     readonly step: <Q extends Operation, R>(f: (...tp: readonly[T, ...P]) => Effect<Q, R>) => Eff<O | Q, R, readonly[T, ...P]>
+    readonly map: <R>(f: (...tp: readonly[T, ...P]) => R) => Eff<O, R, readonly[T, ...P]>
 }
 
 /**
@@ -69,8 +81,8 @@ export type Eff<O extends Operation, T, P extends readonly unknown[]> = {
  * `value` is either already in hand ({@link eff} was given it) or already built
  * (`.step` has just composed the chain it projects from), so storing it costs
  * no more than the projection itself. `h` is different: nothing needs the
- * history tuple until a later `.step` asks for it, and {@link step} is eager,
- * so holding a thunk is the only way to not compose it yet. That is what keeps
+ * history tuple until a later `.step` asks for it, and composing effects is
+ * eager, so holding a thunk is the only way to not compose it yet. That keeps
  * `eff(e)` free of work entirely.
  *
  * `.step` calls `h()` once and closes over the effect, so everything built
@@ -81,14 +93,20 @@ export type Eff<O extends Operation, T, P extends readonly unknown[]> = {
  */
 const create = <O extends Operation, T, P extends readonly unknown[]>(
     value: Effect<O, T>,
-    h: () => Effect<O, readonly[T, ...P]>): Eff<O, T, P> =>
-({
-    value,
-    step: f => {
-        const x1 = historyStep(h(), f)
-        return create(step(x1, ([t]) => pure(t)), () => x1)
+    h: () => Effect<O, readonly[T, ...P]>): Eff<O, T, P> => {
+    // `self` is named so `.map` can be *defined* as the `.step` call it is
+    // documented to equal, rather than as a second copy of `.step`'s body that
+    // has to be re-checked against it.
+    const self: Eff<O, T, P> = {
+        value,
+        step: f => {
+            const x1 = historyStep(h(), f)
+            return create(mapStep(x1, ([t]) => t), () => x1)
+        },
+        map: f => self.step((...tp) => pure(f(...tp)))
     }
-})
+    return self
+}
 
 /**
  * Wraps a raw {@link Effect}; the bridge into the `Eff` world, with an empty

--- a/fjs/effects/eff/proof.f.ts
+++ b/fjs/effects/eff/proof.f.ts
@@ -21,7 +21,7 @@ export const proof = {
             .value
         assertPure(x, 12)
     },
-    over_do: () => {
+    overDo: () => {
         const e = eff(do_<AddOp>('add')(2, 3))
             .step(r => pure(r + 1))
             .value
@@ -42,14 +42,14 @@ export const proof = {
         // it still reaches the pre-`map` value. This is the contract that makes
         // rewriting `.step(v => pure(f(v)))` into `.map(f)` a pure readability
         // change rather than one that alters what later callbacks receive.
-        grows_history: () => {
+        growsHistory: () => {
             const x = eff(pure(5))
                 .map(v => v + 1)
                 .step((v, prev) => pure(`${prev}${v}`))
                 .value
             assertPure(x, '56')
         },
-        over_do: () => {
+        overDo: () => {
             const e = eff(do_<AddOp>('add')(2, 3))
                 .map(r => r + 1)
                 .value

--- a/fjs/effects/eff/proof.f.ts
+++ b/fjs/effects/eff/proof.f.ts
@@ -30,4 +30,33 @@ export const proof = {
         assertEq(r[1], 5)
         assertPure(r[2](r[1]), 6)
     },
+    map: {
+        chain: () => {
+            const x = eff(pure(5))
+                .map(v => v + 1)
+                .map(v => v * 2)
+                .value
+            assertPure(x, 12)
+        },
+        // `.map` grows the history exactly as `.step` does, so a callback after
+        // it still reaches the pre-`map` value. This is the contract that makes
+        // rewriting `.step(v => pure(f(v)))` into `.map(f)` a pure readability
+        // change rather than one that alters what later callbacks receive.
+        grows_history: () => {
+            const x = eff(pure(5))
+                .map(v => v + 1)
+                .step((v, prev) => pure(`${prev}${v}`))
+                .value
+            assertPure(x, '56')
+        },
+        over_do: () => {
+            const e = eff(do_<AddOp>('add')(2, 3))
+                .map(r => r + 1)
+                .value
+            const r = next(e)
+            assert(r[0] === 'cont', r)
+            assertEq(r[1], 5)
+            assertPure(r[2](r[1]), 6)
+        },
+    },
 }

--- a/fjs/effects/module.f.ts
+++ b/fjs/effects/module.f.ts
@@ -29,7 +29,9 @@
  * Effect helpers come in two shapes. **Step adapters** return a continuation
  * `(t: T) => Effect<Q, R>` meant to be passed into a step — see {@link okStep}.
  * **Step variants** take the effect itself first, like {@link step} — see
- * {@link historyStep}.
+ * {@link historyStep}. {@link mapStep} is the variant for the end of a chain:
+ * a pure projection over an effect's result, which is a `step` that continues
+ * with no further effect.
  *
  * **Do not nest steps.** Bind each intermediate effect to its own name, so a
  * sequence reads top-to-bottom in evaluation order:
@@ -45,9 +47,10 @@
  * ```
  *
  * **A step call that does not fit one line breaks after `(`, one argument per
- * line.** This holds for every step variant — {@link step}, {@link historyStep},
- * {@link foldStep}, {@link forEachStep} — and it is the same rule as taking the
- * effect first, written out at the call site. A step variant is this module's
+ * line.** This holds for every step variant — {@link step}, {@link mapStep},
+ * {@link historyStep}, {@link foldStep}, {@link forEachStep} — and it is the
+ * same rule as taking the effect first, written out at the call site. A step
+ * variant is this module's
  * `do` notation: the arguments are a statement list in execution order, so each
  * one gets a line and the sequence reads down the page. Packing the leading
  * effect onto the `(` line and wrapping the rest beneath it hides which of them
@@ -223,6 +226,32 @@ export const step = <O extends Operation, T, Q extends Operation, R>(
     typeof e === 'function'
         ? f(e())
         : { ...e, continuation: x => step(e.continuation(x), f) }
+
+/**
+ * Applies a pure function to an effect's result: the functor `map` of the
+ * effect monad, and a {@link step} whose continuation performs nothing further.
+ *
+ * Prefer it over the `step(e, t => pure(f(t)))` it abbreviates. The two are the
+ * same value, but they read as different things: a `step` announces another
+ * link in a sequence of effects, and a trailing pure projection is not one —
+ * it is where the sequence ends. Saying so in the combinator's name keeps the
+ * "one name per link" shape of a chain honest about how many effects it runs.
+ *
+ * **The operation set does not widen.** The result is `Effect<O, R>`, not
+ * `Effect<O | Q, R>`, because a pure projection issues no commands — nothing a
+ * runner has to know how to interpret is added by `f`. That is what separates
+ * this from `step`, beyond the shorter spelling.
+ *
+ * A constant variant (`constStep(e, v)`) is deliberately absent: `mapStep(e,
+ * () => v)` already reads clearly, and it keeps `v`'s evaluation inside the
+ * continuation where `step` puts it, rather than moving it to where the
+ * composition is written.
+ */
+export const mapStep = <O extends Operation, T, R>(
+    e: Effect<O, T>,
+    f: (t: T) => R
+): Effect<O, R> =>
+    step(e, t => pure(f(t)))
 
 /**
  * An effect whose result is a **history tuple**: the values a chain has bound so

--- a/fjs/effects/node/module.f.ts
+++ b/fjs/effects/node/module.f.ts
@@ -17,7 +17,7 @@ import type { MemOp } from '../memory/module.f.ts'
 import type { Nominal } from '../../types/nominal/module.f.ts'
 import { ok, error as resultError, mapOk, type Result } from '../../types/result/module.f.ts'
 import type { StringMap } from '../../types/object/module.f.ts'
-import { type Effect, type Func, type Operation, type ToAsyncOperationMap, do_, okStep, pure, step } from '../module.f.ts'
+import { type Effect, type Func, type Operation, type ToAsyncOperationMap, do_, mapStep, okStep, pure, step } from '../module.f.ts'
 import type { List } from '../list/module.f.ts'
 
 export type IoResult<T> = Result<T, unknown>
@@ -89,10 +89,7 @@ export const readFile: Func<ReadFile> =
  * call site.
  */
 export const readUtf8File = (path: string): Effect<ReadFile, IoResult<string>> =>
-    step(
-        readFile(path),
-        r => pure(mapOk(utf8ToString)(r))
-    )
+    mapStep(readFile(path), mapOk(utf8ToString))
 
 // readdir
 
@@ -439,9 +436,7 @@ export type Await = readonly['await', (p: unknown) => readonly[unknown]]
 const awaitPromise: Func<Await> = do_('await')
 
 export const awaitIfPromise = (p: unknown) =>
-    step(
-        awaitPromise(p),
-        ([x]) => pure(x))
+    mapStep(awaitPromise(p), ([x]) => x)
 
 // Test registration
 
@@ -496,12 +491,10 @@ export type NodeEffect<T> = Effect<NodeOp, T>
 /**
  * Writes an error line to `stderr` and yields exit code `1`. The canonical
  * "fail with a message" program for a `NodeProgram`. For non-`1` exit codes,
- * compose `step(error(s), () => pure(n))` directly.
+ * compose `mapStep(error(s), () => n)` directly.
  */
 export const errorExit = (s: string): Effect<Write, number> =>
-    step(
-        error(s),
-        () => pure(1))
+    mapStep(error(s), () => 1)
 
 export type NodeOperationMap = ToAsyncOperationMap<NodeOp>
 

--- a/fjs/effects/proof.f.ts
+++ b/fjs/effects/proof.f.ts
@@ -117,7 +117,7 @@ export const proof = {
             // Chains as step(step(e, f), g), raw effect in and out.
             assertPure(step(step(pure(3), v => pure(v + 1)), v => pure(v * 2)), 8)
         },
-        over_do: () => {
+        overDo: () => {
             // Stepping a Do node preserves the command and threads the result
             // through the rebuilt continuation.
             const e = step(do_<AddOp>('add')(2, 3), r => pure(r * 10))
@@ -135,7 +135,7 @@ export const proof = {
             // The `() => v` shape a `constStep` would have covered.
             assertPure(mapStep(pure('ignored'), () => 1), 1)
         },
-        over_do: () => {
+        overDo: () => {
             // A projection over a `Do` node keeps the command intact and is
             // applied to the command's output when the continuation resumes.
             const r = next(mapStep(do_<AddOp>('add')(2, 3), v => v * 10))
@@ -152,7 +152,7 @@ export const proof = {
             assertEq(param, 3)
             assertEq(result, 6)
         },
-        over_do: () => {
+        overDo: () => {
             // The captured value survives a command boundary: the history is
             // rebuilt inside the continuation rather than lost when `e` is a Do.
             const c = next(historyStep(history(do_<AddOp>('add')(2, 3)), r => pure(r * 10)))
@@ -174,7 +174,7 @@ export const proof = {
                 step(b, ([z, y, x]) => pure(`${x}${y}${z}`)),
                 '123')
         },
-        f_receives_whole_history: () => {
+        fReceivesWholeHistory: () => {
             // `f` is handed the whole history spread as arguments, not just the
             // most recent value - which is what lets a later link reach back.
             const a = historyStep(history(pure(1)), x => pure(x + 1))

--- a/fjs/effects/proof.f.ts
+++ b/fjs/effects/proof.f.ts
@@ -1,4 +1,4 @@
-import { step, do_, foldStep, forEachStep, match, okStep, history, pure, runPure, type Effect, type Operation, historyStep } from './module.f.ts'
+import { step, do_, foldStep, forEachStep, mapStep, match, okStep, history, pure, runPure, type Effect, type Operation, historyStep } from './module.f.ts'
 import { error, ok } from '../types/result/module.f.ts'
 import { assert, assertEq } from '../asserts/module.f.ts'
 
@@ -122,6 +122,23 @@ export const proof = {
             // through the rebuilt continuation.
             const e = step(do_<AddOp>('add')(2, 3), r => pure(r * 10))
             const r = next(e)
+            assert(r[0] === 'cont', r)
+            assertEq(r[1], 5)
+            assertPure(r[2](r[1]), 50)
+        },
+    },
+    mapStep: {
+        pure: () => {
+            assertPure(mapStep(pure(3), v => v + 1), 4)
+        },
+        constant: () => {
+            // The `() => v` shape a `constStep` would have covered.
+            assertPure(mapStep(pure('ignored'), () => 1), 1)
+        },
+        over_do: () => {
+            // A projection over a `Do` node keeps the command intact and is
+            // applied to the command's output when the continuation resumes.
+            const r = next(mapStep(do_<AddOp>('add')(2, 3), v => v * 10))
             assert(r[0] === 'cont', r)
             assertEq(r[1], 5)
             assertPure(r[2](r[1]), 50)

--- a/fjs/effects/todo/map-step-combinator.md
+++ b/fjs/effects/todo/map-step-combinator.md
@@ -1,32 +1,29 @@
-## map-step-combinator. The effect functor `map` is missing — 45 sites spell it as `step(e, x => pure(f(x)))`
+## map-step-combinator. Convert the remaining `step(e, x => pure(f(x)))` sites to `mapStep` / `Eff.map`
 
 **Priority:** P3
 **Status:** open
 
+> **The APIs have landed.** `mapStep` is in `fjs/effects/module.f.ts` and
+> `Eff.map` in `fjs/effects/eff/module.f.ts`, each with proof coverage and with
+> its first real consumers converted in the same change — `readUtf8File`,
+> `awaitIfPromise` and `errorExit` (`fjs/effects/node/module.f.ts`),
+> `decodeRevisionBlob` (`fjs/cas/evo/module.f.ts`), and `Eff`'s own `.step`,
+> whose history projection is now a `mapStep`. What remains is the mechanical
+> part: the other call sites, module by module.
+
 ### Problem
 
 `fjs/effects/module.f.ts` ships `pure` (return) and `step` (bind), plus the
-derived combinators `frameStep`, `foldStep`, `forEachStep`, and the `okStep`
-adapter. The one combinator every monad also has — **`map`**, "run the effect,
-then apply a pure function to its result" — is absent, so every call site
-re-derives it as `step(e, x => pure(f(x)))`.
+derived combinators `historyStep`, `foldStep`, `forEachStep`, the `okStep`
+adapter — and now `mapStep`, the functor `map`: "run the effect, then apply a
+pure function to its result". Before it existed, every call site re-derived it
+as `step(e, x => pure(f(x)))`, and **about 41 of them still do**, in 14 modules.
 
-That idiom appears **45 times outside proof files**, in 15 modules. Two shapes,
-both the same thing:
+Two shapes, both the same thing:
 
-*Projection* (`x => pure(f(x))`) — 21 sites:
+*Projection* (`x => pure(f(x))`):
 
 ```ts
-// fjs/effects/node/module.f.ts:91-95
-export const readUtf8File = (path: string): Effect<ReadFile, IoResult<string>> =>
-    step(
-        readFile(path),
-        r => pure(mapOk(utf8ToString)(r))
-    )
-
-// fjs/cas/evo/module.f.ts:165
-eff(collectRead(cas.read(hash))).step(([tag, value]) => pure(tag === 'error' ? null : decodeRevisionVec(value))).value
-
 // fjs/mcp/module.f.ts:394-396
 : step(
     handlers.toolsList(pr),
@@ -34,14 +31,12 @@ eff(collectRead(cas.read(hash))).step(([tag, value]) => pure(tag === 'error' ? n
 )
 ```
 
-Also `fjs/effects/node/module.f.ts:442-444`, `fjs/dev/module.f.ts:73-75,80-83,115-122`,
-`fjs/cas/evo/module.f.ts:372`, `fjs/cas/evo/mcp/module.f.ts:69,78,87`,
-`fjs/cas/module.f.ts:200,223,248,261`, `fjs/cas/mcp/module.f.ts:286`,
-`fjs/mcp/module.f.ts:407-409`,
-`fjs/emergent_testing/module.f.ts:203,208,210,226,325`.
+Also `fjs/dev/module.f.ts`, `fjs/cas/evo/module.f.ts`,
+`fjs/cas/evo/mcp/module.f.ts`, `fjs/cas/module.f.ts`, `fjs/cas/mcp/module.f.ts`,
+`fjs/mcp/module.f.ts`, `fjs/emergent_testing/module.f.ts`.
 
-*Constant projection* (`() => pure(v)`) — 24 sites, overwhelmingly the
-"do the work, then yield an exit code" shape of a `NodeProgram`:
+*Constant projection* (`() => pure(v)`), overwhelmingly the "do the work, then
+yield an exit code" shape of a `NodeProgram`:
 
 ```ts
 // fjs/cli/module.f.ts:38-40
@@ -55,161 +50,80 @@ const program: Effect<WriteFile, number> = step(
     () => pure(0))
 ```
 
-Also `fjs/effects/node/module.f.ts:502-504` (`errorExit`),
-`fjs/djs/module.f.ts:31-33,42-44,49-51`, `fjs/module.f.ts:35-37`,
-`fjs/ci/module.f.ts:72-74`, `fjs/cas/evo/module.f.ts:184,356`,
-`fjs/cas/module.f.ts:148,205,296`, `fjs/cas/cli/module.f.ts:37,72`,
-`fjs/cas/mcp/module.f.ts:197`, `fjs/mcp/module.f.ts:335,369-371`,
-`fjs/mcp/stdio/module.f.ts:64,109`,
-`fjs/emergent_testing/module.f.ts:175,180,227,248,381`.
+Also `fjs/djs/module.f.ts`, `fjs/module.f.ts`, `fjs/ci/module.f.ts`,
+`fjs/cas/evo/module.f.ts`, `fjs/cas/module.f.ts`, `fjs/cas/cli/module.f.ts`,
+`fjs/cas/mcp/module.f.ts`, `fjs/mcp/module.f.ts`, `fjs/mcp/stdio/module.f.ts`,
+`fjs/emergent_testing/module.f.ts`.
 
-Two existing issues build on the idiom while proposing something else, which is
-itself evidence that it wants a name:
-[allreduce-combinator](./allreduce-combinator.md) ends in
-`step(all(...), rs => pure(rs.reduce(op, init)))` and
-[allvoid-combinator](./allvoid-combinator.md) in
-`step(all(...), () => pure(undefined))` — a pure projection tacked onto a
-fan-out in both cases.
-
-Beyond the repetition, the current spelling **misreports the shape of the
-chain**. A `step` whose continuation returns `pure` is not a link in a sequence
-of effects — it is the end of one. `AGENTS.md` asks that a sequence of effects
-read top-to-bottom with one name per link; a trailing pure projection is not a
-link at all, yet it costs a `step(` and a `pure(` and, when it needs a value from
-an earlier link, tempts exactly the nesting the rule forbids:
+Beyond the repetition, the old spelling **misreports the shape of the chain**.
+A `step` whose continuation returns `pure` is not a link in a sequence of
+effects — it is the end of one. `AGENTS.md` asks that a sequence of effects read
+top-to-bottom with one name per link; a trailing pure projection is not a link
+at all, yet it costs a `step(` and a `pure(` and, when it needs a value from an
+earlier link, tempts exactly the nesting the rule forbids:
 
 ```ts
-// today — the final projection looks like another effect
+// the old spelling — the final projection looks like another effect
 step(a, x => step(f(x), y => pure(g(x, y))))
 ```
 
 ### Proposal
 
-Add the functor map to `fjs/effects/module.f.ts`, next to `frameStep`, as a
-**step variant** (effect first, like `step` and `frameStep`):
+Rewrite each remaining site with the combinator that already exists:
 
 ```ts
-/**
- * Applies a pure function to an effect's result. The functor `map` of the
- * effect monad — `step` whose continuation performs no further effects.
- *
- * Prefer this over `step(e, x => pure(f(x)))`: it says, in the combinator's
- * name, that the chain ends here rather than continuing with another effect.
- */
-export const mapStep = <O extends Operation, T, R>(
-    e: Effect<O, T>,
-    f: (t: T) => R
-): Effect<O, R> =>
-    step(e, t => pure(f(t)))
+mapStep(e, f)                       // raw Effect
+eff(e).map(f).value                 // fluent Eff
 ```
 
-Note `mapStep` does **not** widen the operation set (`Effect<O, R>`, not
+`mapStep` does **not** widen the operation set (`Effect<O, R>`, not
 `Effect<O | Q, R>`) — a pure projection adds no commands. That is a small typing
-gain over `step` at every one of the 45 sites.
-
-The two shapes above become:
-
-```ts
-export const readUtf8File = (path: string): Effect<ReadFile, IoResult<string>> =>
-    mapStep(readFile(path), mapOk(utf8ToString))
-
-const program: Effect<WriteFile, number> = mapStep(writeFile('index.html', html), () => 0)
-```
+gain over `step` at every site.
 
 **One name, not two.** A dedicated constant variant (`constStep(e, v)`) was
-considered for the 24 constant sites and rejected: `mapStep(e, () => v)` already
-reads clearly, and two exported names for one concept costs more than the six
-characters it saves. It would also change evaluation timing (`v` eagerly at
+considered for the constant-projection sites and rejected: `mapStep(e, () => v)`
+already reads clearly, and two exported names for one concept costs more than the
+six characters it saves. It would also change evaluation timing (`v` eagerly at
 construction rather than inside the continuation), which is invisible for the
 cheap pure values used today but is a semantic difference not worth introducing
-for brevity.
+for brevity. The rationale is recorded in `mapStep`'s JSDoc.
 
-**`Eff` gets the same method.** Roughly a third of the sites are already in the
-fluent world (`eff(x).step(y => pure(f(y))).value`). Add the matching method to
-`fjs/effects/eff/module.f.ts` so those sites don't have to leave it.
-
-Since [#1360](https://github.com/functionalscript/functionalscript/pull/1360)
-an `Eff` is `Eff<O, T, P>`: `P` is the tuple of prior chain values, `.step`'s
-callback is applied as `f(t, ...p)`, and the result grows the history —
-`Eff<O | Q, R, readonly[T, ...P]>`. `.map` must fit that contract, not the
-two-parameter shape:
-
-```ts
-export type Eff<O extends Operation, T, P extends readonly unknown[]> = {
-    readonly value: Effect<O, T>
-    readonly step: <Q extends Operation, R>(f: (t: T, ...p: P) => Effect<Q, R>) => Eff<O | Q, R, readonly[T, ...P]>
-    readonly map: <R>(f: (t: T, ...p: P) => R) => Eff<O, R, readonly[T, ...P]>
-}
-```
-
-**History grows, exactly as it does for `.step`.** This is forced, not a
-preference: `.map(f)` has to be observationally identical to
-`.step((t, ...p) => pure(f(t, ...p)))`, because that is the rewrite this issue
-performs at every fluent site. Preserving `P` unchanged instead would mean the
-mechanical conversion silently changes what *later* callbacks in the chain
-receive — a behavioural change disguised as a readability one. `O` does not
-widen (no `Q`), for the same reason it doesn't in `mapStep`: a pure projection
-issues no commands.
-
-**Conversion hazard: callback arity.** `Eff`'s own docs warn that the history is
+**Conversion hazard: callback arity.** `Eff`'s docs warn that the history is
 positional, so "every parameter a callback declares is meaningful … a defaulted
 or rest parameter after the current value is a bug, not a convenience." A
 conversion from `.step(y => pure(f(y)))` to `.map(f)` is only safe when `f` is
 genuinely unary — the explicit lambda pins arity at one, while passing `f`
 point-free exposes it to the prior values. This is `["1","2","3"].map(parseInt)`
 with a longer history tuple. When converting, either keep the lambda or confirm
-the callee takes exactly one argument; `mapOk(utf8ToString)` and
-`vecToCBase32` qualify, and anything with optional parameters does not.
+the callee takes exactly one argument; `mapOk(utf8ToString)` and `vecToCBase32`
+qualify, and anything with optional parameters does not. `mapStep` is not exposed
+to this — it applies `f` to exactly one argument — so only the fluent sites need
+the check.
 
-**Scope.** `AGENTS.md` asks one improvement per PR, and it also asks that a new
-`export` ship with at least one external consumer *in the same change* — so the
-first PR adds the two APIs **and converts a first caller of each**, rather than
-landing them with proof coverage alone:
-
-1. `mapStep` + `Eff.map`, plus the nearest real consumers — `readUtf8File` and
-   `errorExit` in `fjs/effects/node/module.f.ts` (raw, one projection and one
-   constant projection) and `decodeRevisionBlob` in `fjs/cas/evo/module.f.ts:164-166`
-   (fluent). Each API is exercised by production code the moment it exists.
-2. …n. The remaining ~42 sites, grouped by module.
-
-Splitting this way keeps the first diff small without leaving a speculative
-export behind it. What must **not** happen is the reverse — landing the
-conversion as one 15-module diff.
+**Scope.** `AGENTS.md` asks one improvement per PR. Take one module or one
+closely related group per PR; what must **not** happen is landing the whole
+conversion as one 14-module diff.
 
 ### Tasks
 
-First PR — both APIs, each with a real consumer landing alongside it:
-
-- [ ] Add `mapStep` to `fjs/effects/module.f.ts` with proof coverage in
-      `fjs/effects/proof.f.ts`; document it in the module header alongside the
-      "step adapters vs. step variants" note.
-- [ ] Add `Eff.map` to `fjs/effects/eff/module.f.ts` with the `Eff<O, T, P>`
-      signature above (history grows by `T`, `O` unchanged) and proof coverage
-      that pins the history contract — a `.map(...).step(...)` chain asserting
-      the second callback still sees the pre-`map` value.
-- [ ] In the same PR, convert `readUtf8File`, `awaitIfPromise` and `errorExit`
-      in `fjs/effects/node/module.f.ts` to `mapStep`, and `decodeRevisionBlob`
-      (`fjs/cas/evo/module.f.ts:164-166`) to `Eff.map` — so neither export is
-      speculative.
-- [ ] When converting fluent sites, check callback arity (see the hazard note
-      above) rather than mechanically dropping the lambda.
-
-Follow-up PRs — the remaining sites, one module or group per PR:
-
 - [ ] The `NodeProgram` exit-code sites (`fjs/module.f.ts`, `fjs/cli`, `fjs/ci`,
       `fjs/djs`, `fjs/website`, `fjs/cas/cli`).
-- [ ] `fjs/mcp` + `fjs/mcp/stdio`, `fjs/cas` + `fjs/cas/evo` + `fjs/cas/mcp`,
-      `fjs/emergent_testing`, `fjs/dev`.
+- [ ] `fjs/mcp` + `fjs/mcp/stdio`.
+- [ ] `fjs/cas` + `fjs/cas/evo` + `fjs/cas/evo/mcp` + `fjs/cas/mcp`.
+- [ ] `fjs/emergent_testing`, `fjs/dev`.
+- [ ] When converting fluent sites, check callback arity (see the hazard note
+      above) rather than mechanically dropping the lambda.
 - [ ] `npx tsc` clean; `fjs t` passes after each PR.
 
 ### Related
 
 - [allreduce-combinator](./allreduce-combinator.md) — its proposed body
-  (`step(all(...), rs => pure(rs.reduce(...)))`) is `mapStep` over `all`;
-  landing this first simplifies it.
+  (`step(all(...), rs => pure(rs.reduce(...)))`) is `mapStep` over `all`, so it
+  can now be written that way directly.
 - [allvoid-combinator](./allvoid-combinator.md) — same, with a constant
   projection (`() => undefined`).
 - [fold-stream-combinator](./fold-stream-combinator.md) — its pure consumers
   (`detectStream`, `collectRead`) end in `pure(ok(...))` projections.
-- `fjs/effects/module.f.ts` — `step`, `frameStep`, `foldStep`, `forEachStep`,
-  `okStep`; the "do not nest steps" rule in the module header.
+- `fjs/effects/module.f.ts` — `mapStep`, `step`, `historyStep`, `foldStep`,
+  `forEachStep`, `okStep`; the "do not nest steps" rule in the module header.
+</content>

--- a/todo/camel-case-proof-keys.md
+++ b/todo/camel-case-proof-keys.md
@@ -1,0 +1,53 @@
+## camel-case-proof-keys. 48 `proof` test keys are snake_case
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+A `proof` object's keys are the test names the runner prints
+(`proof.historyStep.overDo()`), and the repository writes identifiers in
+camelCase everywhere else. 48 keys across 7 files are snake_case instead:
+
+| file | count |
+| --- | --- |
+| `fjs/sul/id/proof.f.ts` | 18 |
+| `fjs/sul/level/hash/proof.f.ts` | 11 |
+| `nanvm-lib/tests/proof.f.ts` | 6 |
+| `fjs/sul/proof.f.ts` | 5 |
+| `fjs/types/bit_vec/proof.f.ts` | 4 |
+| `fjs/types/prime_field/proof.f.ts` | 3 |
+| `fjs/fsc/proof.f.ts` | 1 |
+
+They are only names, so nothing is broken — but the split means a new proof
+has no single convention to copy from, which is how the inconsistency keeps
+reproducing. It was pointed out on
+[#1374](https://github.com/functionalscript/functionalscript/pull/1374),
+whose own new keys were converted there; the rest of the repository was left
+alone to keep that PR to one change.
+
+### Proposal
+
+Rename the remaining keys to camelCase, and state the rule in `AGENTS.md`
+next to the other proof-writing rules so it is checkable in review rather
+than inferred from neighbours.
+
+A key that names a language keyword or an export it exercises stays as it is
+spelled — `do_` in `fjs/effects/proof.f.ts` names the `do_` export, and
+`throw` is the runner's structural marker (see `AGENTS.md`), not a word to
+re-case.
+
+Purely a rename: no assertion, structure, or coverage changes. Worth doing in
+one pass per directory rather than opportunistically, so the convention lands
+everywhere at once.
+
+### Tasks
+
+- [ ] Rename the keys in the seven files above.
+- [ ] Add the convention to `AGENTS.md`, noting the keyword/export exception.
+- [ ] `npx tsc` clean; `fjs t` passes (test names change, counts do not).
+
+### Related
+
+- [#1374](https://github.com/functionalscript/functionalscript/pull/1374) —
+  where the convention was stated and applied to `fjs/effects`.


### PR DESCRIPTION
First PR of [`fjs/effects/todo/map-step-combinator.md`](https://github.com/functionalscript/functionalscript/blob/main/fjs/effects/todo/map-step-combinator.md).

## Problem

`fjs/effects/module.f.ts` shipped `pure` (return) and `step` (bind), plus `historyStep`, `foldStep`, `forEachStep` and the `okStep` adapter — but not the one combinator every monad also has: **`map`**, "run the effect, then apply a pure function to its result". So every call site re-derived it as `step(e, x => pure(f(x)))` — 45 times, in 15 modules.

Beyond the repetition, that spelling misreports the shape of the chain. A `step` whose continuation returns `pure` is not a link in a sequence of effects — it is where the sequence ends. `AGENTS.md` asks that a sequence read top-to-bottom with one name per link; a trailing pure projection is not a link at all, yet it costs a `step(` and a `pure(` and, when it needs a value from an earlier link, tempts exactly the nesting the rule forbids.

## Changes

**`mapStep`** in `fjs/effects/module.f.ts`, a step variant (effect first, like `step` and `historyStep`):

```ts
export const mapStep = <O extends Operation, T, R>(
    e: Effect<O, T>,
    f: (t: T) => R
): Effect<O, R> =>
    step(e, t => pure(f(t)))
```

It does **not** widen the operation set — `Effect<O, R>`, not `Effect<O | Q, R>` — because a pure projection issues no commands. That is a small typing gain over `step` at every site, not just a shorter spelling.

**`Eff.map`** in `fjs/effects/eff/module.f.ts`, for the roughly one third of sites already in the fluent world:

```ts
readonly map: <R>(f: (...tp: readonly[T, ...P]) => R) => Eff<O, R, readonly[T, ...P]>
```

The history grows exactly as it does for `.step`, which is forced rather than preferred: `.map(f)` has to be observationally identical to `.step((...tp) => pure(f(...tp)))`, because that is the rewrite the follow-up PRs perform at every fluent site. Preserving `P` unchanged would mean the mechanical conversion silently changes what *later* callbacks receive — a behavioural change disguised as a readability one. `create` therefore names its result `self` and defines `.map` as that exact `.step` call, rather than as a second copy of `.step`'s body that has to be re-checked against it.

**First consumers, converted in the same PR** so neither export is speculative:

| site | before | after |
| --- | --- | --- |
| `readUtf8File` (`fjs/effects/node`) | `step(readFile(path), r => pure(mapOk(utf8ToString)(r)))` | `mapStep(readFile(path), mapOk(utf8ToString))` |
| `awaitIfPromise` (`fjs/effects/node`) | `step(awaitPromise(p), ([x]) => pure(x))` | `mapStep(awaitPromise(p), ([x]) => x)` |
| `errorExit` (`fjs/effects/node`) | `step(error(s), () => pure(1))` | `mapStep(error(s), () => 1)` |
| `decodeRevisionBlob` (`fjs/cas/evo`) | `.step(([tag, value]) => pure(…))` | `.map(([tag, value]) => …)` |
| `Eff`'s history projection | `step(x1, ([t]) => pure(t))` | `mapStep(x1, ([t]) => t)` |

## Design notes

- **One name, not two.** A constant variant (`constStep(e, v)`) was considered for the 24 constant-projection sites and rejected: `mapStep(e, () => v)` already reads clearly, and it keeps `v`'s evaluation inside the continuation where `step` puts it. The rationale is recorded in `mapStep`'s JSDoc so it isn't re-litigated.
- **Arity hazard.** Converting a fluent `.step(y => pure(f(y)))` to `.map(f)` is only safe when `f` is genuinely unary — the lambda pins arity at one, while passing `f` point-free exposes it to the positional history. This is `['1','2','3'].map(parseInt)` with a longer tuple. Documented on `Eff`; `mapStep` is not exposed to it, since it applies `f` to exactly one argument.

## Scope

`AGENTS.md` asks one improvement per PR, and the issue is explicit that the conversion must not land as one 14-module diff. The ~41 remaining sites stay in the issue, regrouped module by module; the issue file is updated to record that both APIs now exist and that only the mechanical conversion remains.

## Testing

- `npx tsc` — clean.
- `npm test` (`fjs t`) — 2207 passed, 0 failed, including six new proofs: `mapStep.pure` / `.constant` / `.over_do`, and `map.chain` / `.grows_history` / `.over_do`. `grows_history` pins the history contract with a `.map(...).step(...)` chain asserting the second callback still sees the pre-`map` value.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKSVts1xeMsqyTCM2REMCT)_