### PR TITLE
Upgrade actions/checkout to v7.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@
           "run": "npm install -g functionalscript@0.38.0"
         },
         {
-          "uses": "actions/checkout@v7"
+          "uses": "actions/checkout@v7.0.1"
         },
         {
           "run": "cargo test"
@@ -84,7 +84,7 @@
           "run": "npm install -g functionalscript@0.38.0"
         },
         {
-          "uses": "actions/checkout@v7"
+          "uses": "actions/checkout@v7.0.1"
         },
         {
           "run": "cargo test"
@@ -125,7 +125,7 @@
           "run": "npm install -g functionalscript@0.38.0"
         },
         {
-          "uses": "actions/checkout@v7"
+          "uses": "actions/checkout@v7.0.1"
         },
         {
           "run": "cargo test"
@@ -166,7 +166,7 @@
           "run": "npm install -g functionalscript@0.38.0"
         },
         {
-          "uses": "actions/checkout@v7"
+          "uses": "actions/checkout@v7.0.1"
         },
         {
           "run": "cargo test"
@@ -208,7 +208,7 @@
           "run": "npm install -g functionalscript@0.38.0"
         },
         {
-          "uses": "actions/checkout@v7"
+          "uses": "actions/checkout@v7.0.1"
         },
         {
           "run": "cargo test"
@@ -261,7 +261,7 @@
           "run": "npm install -g functionalscript@0.38.0"
         },
         {
-          "uses": "actions/checkout@v7"
+          "uses": "actions/checkout@v7.0.1"
         },
         {
           "run": "cargo test"
@@ -306,7 +306,7 @@
           }
         },
         {
-          "uses": "actions/checkout@v7"
+          "uses": "actions/checkout@v7.0.1"
         },
         {
           "run": "cargo fmt -- --check"
@@ -392,7 +392,7 @@
           "run": "deno install -g -A --minimum-dependency-age=0 npm:functionalscript@0.38.0"
         },
         {
-          "uses": "actions/checkout@v7"
+          "uses": "actions/checkout@v7.0.1"
         },
         {
           "run": "deno run -A --minimum-dependency-age=0 npm:functionalscript@0.38.0 t"
@@ -418,7 +418,7 @@
           "run": "bun install -g functionalscript@0.38.0"
         },
         {
-          "uses": "actions/checkout@v7"
+          "uses": "actions/checkout@v7.0.1"
         },
         {
           "run": "bun install --frozen-lockfile"
@@ -444,7 +444,7 @@
           "run": "npm install -g functionalscript@0.38.0"
         },
         {
-          "uses": "actions/checkout@v7"
+          "uses": "actions/checkout@v7.0.1"
         },
         {
           "run": "npm ci"
@@ -464,7 +464,7 @@
           }
         },
         {
-          "uses": "actions/checkout@v7"
+          "uses": "actions/checkout@v7.0.1"
         },
         {
           "run": "npm ci"
@@ -484,7 +484,7 @@
           }
         },
         {
-          "uses": "actions/checkout@v7"
+          "uses": "actions/checkout@v7.0.1"
         },
         {
           "run": "npm ci"
@@ -532,7 +532,7 @@
           "run": "playwright install"
         },
         {
-          "uses": "actions/checkout@v7"
+          "uses": "actions/checkout@v7.0.1"
         },
         {
           "run": "npm ci"

--- a/fjs/ci/config/module.f.ts
+++ b/fjs/ci/config/module.f.ts
@@ -55,7 +55,7 @@ export const wasmer = '7.2.1'
 // Note: dtolnay/rust-toolchain value is a Rust version, not an action version.
 export const actions = {
     // https://github.com/marketplace/actions/checkout
-    'actions/checkout': 'v7',
+    'actions/checkout': 'v7.0.1',
     // https://github.com/marketplace/actions/setup-node-js-environment
     'actions/setup-node': 'v7.0.0',
     // https://github.com/marketplace/actions/cache


### PR DESCRIPTION
## Summary
This pull request updates the `actions/checkout` GitHub Action from v7 to v7.0.1 across all CI workflows.

## Changes
- Updated the `actions/checkout` action version from `v7` to `v7.0.1` in `.github/workflows/ci.yml`
- Updated the corresponding configuration source in `fjs/ci/config/module.f.ts` to reflect the new version

The version bump is applied consistently across all workflow jobs that use the checkout action, ensuring uniform behavior across the entire CI pipeline.

## Details
This is a patch version update that likely includes bug fixes and improvements from the v7.0.1 release of the checkout action. The change is made at the source configuration level (`module.f.ts`), which generates the workflow file, ensuring maintainability and consistency.

https://claude.ai/code/session_01LtL1wUd29dVJ2kCxwkHoWD