### PR TITLE
Add test for registerModule with empty proof object

### DIFF
--- a/fjs/emergent_testing/proof.f.ts
+++ b/fjs/emergent_testing/proof.f.ts
@@ -352,6 +352,14 @@ export const registerThrowsWithoutThrowing = () => {
     assertEq(names[0], 'import("./a.f.ts").proof.throw.a()')
 }
 
+// registerModule with an empty proof object registers zero tests and
+// returns without invoking the mock's `test` op at all.
+export const registerEmptyProof = () => {
+    const runner = makeRegisterRunner((_runner, _ctx, name, _xf, _fn) => (s: RegisterMockState) => [[...s, name], undefined])
+    const [names] = runner([])(registerModule(registerNoopCtx, './a.f.ts', {}, ''))
+    assertEq(names.length, 0)
+}
+
 // direct unit tests for the pure path-format helpers
 export const helpers = {
     isInteger: () => {
@@ -463,6 +471,7 @@ export const proof = {
     githubReporterOutput,
     registerSuffixes,
     registerThrowsWithoutThrowing,
+    registerEmptyProof,
     defaultReporterExpectedToThrow,
     helpers
 }


### PR DESCRIPTION
## Summary
Added a new test case to verify that `registerModule` correctly handles empty proof objects by registering zero tests and not invoking the mock's `test` operation.

## Changes
- Added `registerEmptyProof` test function that validates the behavior when `registerModule` is called with an empty proof object (`{}`)
- The test verifies that:
  - No test names are registered (empty names array)
  - The mock's `test` operation is never invoked
- Exported the new test in the `proof` object for inclusion in the test suite

## Implementation Details
The test uses the existing `makeRegisterRunner` helper to create a mock runner and verifies the edge case where a module is registered with no proof tests defined. This ensures the registration system gracefully handles empty proof objects without side effects.

https://claude.ai/code/session_012C7p4VofFrGSmWp2wUnmhv