### PR TITLE
Clarify contribution guidelines and issue tracking process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -685,10 +685,16 @@ Issues are tracked in `todo/` directories, not on GitHub. See
 [todo/README.md](./todo/README.md) for the full format and priority/status
 conventions.
 
+GitHub issues are an **intake** channel, not a tracker: external contributors
+cannot add `todo/` files, so they report there instead (see
+[CONTRIBUTING.md](./CONTRIBUTING.md)). A maintainer turns each such report into a
+`todo/` file — see the table below.
+
 | Situation                  | What to do                                                                                                                                                              |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Where to file**          | Next to the code it describes. A bug scoped to `fjs/foo/bar/` goes in `fjs/foo/bar/todo/{slug-kebab}.md`. Cross-cutting or language-design issues go in the top-level `todo/`. |
 | **How to file**            | Create `todo/{slug-kebab}.md` using a short kebab-case slug. Follow the issue format in `todo/README.md`: title, priority, status, problem, proposal, tasks, related links. |
+| **Reported on GitHub**     | Create the `todo/` file for the report, linking the GitHub issue from its `Related` section. The `todo/` file is the tracked issue from then on; the GitHub issue stays open only as the reporter's thread and is closed when the fix ships. |
 | **After fixing**           | Delete the issue file immediately in the same PR. Before deleting, ensure design decisions are captured in the codebase (see the documentation table in [§4](#4-documentation)). |
 | **Won't fix**              | Document the reason in the relevant `README.md`, in a code comment, or in another issue — then delete the issue file. Do not leave a status-only tombstone.                |
 | **Blocked by a third party** | File under `todo/blocked/{slug-kebab}.md`. Every file there **must** include a **Trigger** section stating the precise condition that unblocks it. Do not put third-party-blocked items in regular `todo/` directories. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,14 @@ Issues are tracked in `todo/` directories inside the repository, **not** on
 GitHub. Check [todo/README.md](./todo/README.md) for existing work before you
 start, and for the format to use when filing a new one.
 
-To report a bug or ask a question without opening a pull request, feel free to
-use [GitHub issues](https://github.com/functionalscript/functionalscript/issues).
+If you are already opening a pull request, add the `todo/` file there. To report
+a bug, request a feature, or ask a question without opening a pull request —
+the normal case for an external contributor, who cannot add a `todo/` file
+directly — open a
+[GitHub issue](https://github.com/functionalscript/functionalscript/issues)
+instead. A maintainer will create the corresponding `todo/` file and link it to
+your issue. GitHub issues are the intake channel; `todo/` files are where the
+work is tracked from then on.
 
 ## Requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,37 +1,89 @@
 # Contributing to FunctionalScript
 
-Check the [./todo/README.md](./todo/README.md) file for existing issues.
+This repository is a monorepo with two code bases: `fjs/` (the FunctionalScript
+language, its standard modules, and the `fjs` CLI) and `nanvm-lib/` (NaNVM, the
+native FunctionalScript VM, in Rust).
+
+**Coding style, testing rules, design principles, and pull request requirements
+all live in [AGENTS.md](./AGENTS.md).** Read it before opening a pull request —
+it applies to human and AI contributors alike. This file covers only getting a
+working environment; it links to `AGENTS.md` rather than restating it, so the two
+cannot drift apart.
+
+## Issues
+
+Issues are tracked in `todo/` directories inside the repository, **not** on
+GitHub. Check [todo/README.md](./todo/README.md) for existing work before you
+start, and for the format to use when filing a new one.
+
+To report a bug or ask a question without opening a pull request, feel free to
+use [GitHub issues](https://github.com/functionalscript/functionalscript/issues).
 
 ## Requirements
 
-- [Node.JS](https://nodejs.org/en/download), version **24** or later is required for development.
-- [Rust](https://www.rust-lang.org/tools/install).
+| Tool    | Version              | Required for                                                     |
+| ------- | -------------------- | ---------------------------------------------------------------- |
+| [Node.js](https://nodejs.org/en/download) | **latest** (22 min.) | Everything. Node 24+ for `node --test` and `npm run cov`.        |
+| [Rust](https://www.rust-lang.org/tools/install)    | **latest**           | NaNVM (`nanvm-lib`) development only.                            |
+| Deno    | latest               | Updating dependencies; an alternative test runtime.               |
+| Bun     | latest               | Updating dependencies; an alternative test runtime.               |
 
-You may also use the [Dockerfile](./docker/Dockerfile).
+You may also use the [Dockerfile](./docker/Dockerfile), which sets all of this up
+and is the easiest way to get a known-good environment.
 
-### Installing Dependencies
+Node 22 is enough for `npm test` and the repository's own test runner, but on
+Node 22 `node --test` reports every `throw`-tagged test as a failure, so a clean
+tree looks broken — see
+[AGENTS.md §1.3](./AGENTS.md#13-the-node-version-caveat).
+
+### Installing dependencies
 
 ```bash
-npm ci
-cargo fetch
+npm ci        # Node dependencies
+cargo fetch   # Rust dependencies
 ```
 
-### Running Tests
+### Running tests
 
 ```bash
-npm test
-cargo test
+npx tsc                  # type-check with the repository's TypeScript
+npm test                 # tsc + the FunctionalScript test suite
+cargo test               # only if you touched Rust
 cargo clippy
 cargo fmt -- --check
 ```
 
-Feel free to open [issues](https://github.com/functionalscript/functionalscript/issues).
+`npm test` is one of several ways to run the FunctionalScript suite; the Deno,
+Bun, and published-CLI equivalents are listed in
+[AGENTS.md §1.4](./AGENTS.md#14-ways-to-run-the-functionalscript-test-suite).
 
-## OpenAI Codex Environment
+New `.f.ts` modules need a co-located `proof.f.ts` with 100% proof coverage —
+see [AGENTS.md §3](./AGENTS.md#3-testing-and-proof-coverage).
 
-Set Node.js to 22.
+### Updating dependencies
 
-Setup Script:
+```bash
+npm run update
+```
+
+Run this after changing source code. It requires Node, Deno, and Bun to all be
+installed: `package-lock.json`, `deno.lock`, and `bun.lock` are all under Git
+control, and the update refreshes each of them (plus the generated CI workflow).
+
+## Opening a pull request
+
+The full workflow is in [AGENTS.md §2](./AGENTS.md#2-everyday-workflow) and
+[AGENTS.md §8](./AGENTS.md#8-pull-requests). In short: one feature or improvement
+per pull request, every check above passing, the `todo/` issue deleted in the
+same pull request, and — for code changes — a [CHANGELOG.md](./CHANGELOG.md)
+entry added with the real pull request number once the pull request exists.
+
+## OpenAI Codex environment
+
+Set Node.js to 22. Use `npm test` rather than `npm run cov` there, per the Node
+version caveat above.
+
+Setup script:
 
 ```sh
 rustup component add clippy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,10 +16,13 @@ Issues are tracked in `todo/` directories inside the repository, **not** on
 GitHub. Check [todo/README.md](./todo/README.md) for existing work before you
 start, and for the format to use when filing a new one.
 
-If you are already opening a pull request, add the `todo/` file there. To report
-a bug, request a feature, or ask a question without opening a pull request —
-the normal case for an external contributor, who cannot add a `todo/` file
-directly — open a
+To **file** an issue yourself, add its `todo/` file in a pull request. Note that
+a pull request that **fixes** an issue does the opposite — it deletes that
+issue's `todo/` file; see [AGENTS.md §2](./AGENTS.md#2-everyday-workflow).
+
+To report a bug, request a feature, or ask a question without opening a pull
+request — the normal case for an external contributor, who cannot add a `todo/`
+file directly — open a
 [GitHub issue](https://github.com/functionalscript/functionalscript/issues)
 instead. A maintainer will create the corresponding `todo/` file and link it to
 your issue. GitHub issues are the intake channel; `todo/` files are where the


### PR DESCRIPTION
## Summary

This PR significantly expands and clarifies the contribution guidelines in `CONTRIBUTING.md` and updates `AGENTS.md` to better explain the issue tracking workflow, particularly how GitHub issues relate to the internal `todo/` file system.

## Key Changes

- **Restructured CONTRIBUTING.md** with clearer sections:
  - Added monorepo structure explanation (fjs/ and nanvm-lib/)
  - Moved coding standards reference to AGENTS.md to avoid duplication
  - Expanded "Issues" section to explain the dual-channel system: GitHub issues as intake, `todo/` files as the actual tracker
  - Converted requirements to a table format with version details and use cases
  - Added Node version caveat explanation with link to AGENTS.md
  - Documented the dependency update workflow
  - Added pull request workflow summary with links to detailed sections in AGENTS.md
  - Clarified OpenAI Codex environment setup

- **Updated AGENTS.md** issue tracking table:
  - Added new row explaining how GitHub issues are converted to `todo/` files by maintainers
  - Clarified that GitHub issues serve as an intake channel for external contributors who cannot directly add `todo/` files
  - Explained the lifecycle: GitHub issue → `todo/` file creation → tracking in `todo/` → closure when fix ships

## Notable Details

- Emphasized that `AGENTS.md` is the single source of truth for coding standards, testing rules, and design principles
- Clarified the Node.js version requirements: 22 minimum for basic work, 24+ for full test coverage reporting
- Documented all available test runners (npm, Deno, Bun) with reference to AGENTS.md for details
- Made the contribution workflow more accessible by providing a clear path for both internal and external contributors

https://claude.ai/code/session_018Z6fGe3QDZ4ejeGp2kLfX8