### PR TITLE
Drop npm-check-updates entirely; manual dependency bumps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,13 +97,17 @@ the current working directory, and results are reported per test.
 
 ### 1.5 Updating dependencies
 
+To bump an npm devDependency version, edit `package.json` by hand first (there
+is no `npm-check-updates` step anymore). Then run:
+
 ```bash
 npm run update
 ```
 
 This requires **Node, Deno, and Bun to all be installed**: `package-lock.json`,
 `deno.lock`, and `bun.lock` are all under Git control, and the update refreshes
-each of them (plus the generated CI workflow).
+each of them (plus the generated CI workflow) to match whatever versions are
+currently declared in `package.json`.
 
 ### 1.6 Rust commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ history.
 
 ## Unreleased
 
+- `package.json`: drop `npm-check-updates` from `npm run update` entirely — it
+  now only reinstalls/relocks; `package.json` devDependency bumps are manual
+  until the internal replacement in
+  `fjs/ci/todo/replace-npm-check-updates-with-an-internal-script.md` lands
+  [#1392](https://github.com/functionalscript/functionalscript/pull/1392)
 - `package.json`: pin `@playwright/test` exactly (`=1.62.0`) and exclude it from
   `npm run update`'s `npm-check-updates` pass, so the pinned test runner version
   survives routine dependency updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ history.
 
 - `package.json`: drop `npm-check-updates` from `npm run update` entirely — it
   now only reinstalls/relocks; `package.json` devDependency bumps are manual
-  until the internal replacement in
-  `fjs/ci/todo/replace-npm-check-updates-with-an-internal-script.md` lands
+  for now
   [#1392](https://github.com/functionalscript/functionalscript/pull/1392)
 - `package.json`: pin `@playwright/test` exactly (`=1.62.0`) and exclude it from
   `npm run update`'s `npm-check-updates` pass, so the pinned test runner version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,13 +71,17 @@ see [AGENTS.md §3](./AGENTS.md#3-testing-and-proof-coverage).
 
 ### Updating dependencies
 
+To bump an npm devDependency version, edit `package.json` by hand first (there
+is no `npm-check-updates` step anymore). Then run:
+
 ```bash
 npm run update
 ```
 
 Run this after changing source code. It requires Node, Deno, and Bun to all be
 installed: `package-lock.json`, `deno.lock`, and `bun.lock` are all under Git
-control, and the update refreshes each of them (plus the generated CI workflow).
+control, and the update refreshes each of them (plus the generated CI workflow)
+to match whatever versions are currently declared in `package.json`.
 
 ## Opening a pull request
 

--- a/fjs/ci/todo/publishing-packages.md
+++ b/fjs/ci/todo/publishing-packages.md
@@ -17,7 +17,7 @@ FunctionalScript can't currently be installed from Git using NPM.
 
 ### Updating packages
 
-`npm run update` bumps dependencies via `npm-check-updates`, reinstalls, syncs `deno.lock`, and regenerates the CI workflow. The version is the single source of truth in `package.json`. We publish only when a new version appears on `main`. This strategy can also work for Rust packages.
+`npm run update` reinstalls, syncs `deno.lock`, and regenerates the CI workflow; dependency version bumps in `package.json` are manual until `replace-npm-check-updates-with-an-internal-script.md` lands. The version is the single source of truth in `package.json`. We publish only when a new version appears on `main`. This strategy can also work for Rust packages.
 
 ### CI publishing (merge to `main`)
 

--- a/fjs/ci/todo/publishing-packages.md
+++ b/fjs/ci/todo/publishing-packages.md
@@ -17,7 +17,7 @@ FunctionalScript can't currently be installed from Git using NPM.
 
 ### Updating packages
 
-`npm run update` reinstalls, syncs `deno.lock`, and regenerates the CI workflow; dependency version bumps in `package.json` are manual until `replace-npm-check-updates-with-an-internal-script.md` lands. The version is the single source of truth in `package.json`. We publish only when a new version appears on `main`. This strategy can also work for Rust packages.
+`npm run update` reinstalls, syncs `deno.lock`, and regenerates the CI workflow; dependency version bumps in `package.json` are manual until [replace-npm-check-updates-with-an-internal-script.md](./replace-npm-check-updates-with-an-internal-script.md) lands. The version is the single source of truth in `package.json`. We publish only when a new version appears on `main`. This strategy can also work for Rust packages.
 
 ### CI publishing (merge to `main`)
 

--- a/fjs/ci/todo/replace-npm-check-updates-with-an-internal-script.md
+++ b/fjs/ci/todo/replace-npm-check-updates-with-an-internal-script.md
@@ -3,7 +3,7 @@
 **Priority:** P3
 **Status:** open
 
-The `update` script currently uses `npx npm-check-updates -u` to bump dependency versions. Replace it with an internal FunctionalScript script so there is no runtime dependency on an external tool.
+The `update` script used to call `npx npm-check-updates -u` to bump dependency versions; that third-party dependency was dropped, so `package.json` devDependency bumps are manual for now. Replace the manual step with an internal FunctionalScript script so version bumps are automated again without a runtime dependency on an external tool.
 
 ### Idea: `ci-lock.json`
 
@@ -20,4 +20,4 @@ The internal update script would:
 - [ ] Implement `fjs update` (or `fjs u`) subcommand that updates `package.json` deps and `ci-lock.json` tool versions.
 - [ ] Update `fjs/ci/module.f.ts` to read `ci-lock.json` instead of importing `fjs/ci/config/module.f.ts`.
 - [ ] Bootstrap: generate a default `ci-lock.json` from the current `fjs/ci/config/module.f.ts` values.
-- [ ] Replace `npx npm-check-updates -u` in the `update` script with `fjs u` (or equivalent).
+- [ ] Wire `fjs u` (or equivalent) into the `update` script so dependency bumps are automated again.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "cov": "node --test --experimental-test-coverage --test-coverage-include=**/module.f.ts",
     "start": "node ./fjs/module.ts",
     "ci-update": "node ./fjs/module.ts ci",
-    "update": "npx npm-check-updates -u -x @playwright/test && npm install && deno install && bun install && npm run ci-update",
+    "update": "npm run ci-update && npm install && deno install && bun install && npm run ci-update",
     "index-html": "node ./fjs/module.ts r ./fjs/website/module.f.ts",
     "website": "npm run prepack && npm run index-html"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "cov": "node --test --experimental-test-coverage --test-coverage-include=**/module.f.ts",
     "start": "node ./fjs/module.ts",
     "ci-update": "node ./fjs/module.ts ci",
-    "update": "npm run ci-update && npm install && deno install && bun install && npm run ci-update",
+    "update": "npm run ci-update && npm install && deno install && bun install",
     "index-html": "node ./fjs/module.ts r ./fjs/website/module.f.ts",
     "website": "npm run prepack && npm run index-html"
   },


### PR DESCRIPTION
## Summary
- Removes `npm-check-updates` (a third-party tool) from `npm run update` entirely, rather than the excluded-package approach from #1391. `npm run update` now only reinstalls/relocks (`ci-update`, `npm install`, `deno install`, `bun install`); bumping `package.json` devDependency versions is manual until the internal replacement script lands.
- Fixes a leftover duplicate `npm run ci-update` in the `update` script.
- Updates the two docs that described the `npm-check-updates` behavior (`fjs/ci/todo/publishing-packages.md`, `fjs/ci/todo/replace-npm-check-updates-with-an-internal-script.md`) to match.

## Test plan
- [x] `npm run update` scripted commands reviewed for correctness (no `npm-check-updates` invocation remains)
- [ ] CI passes