### PR TITLE
Document incremental .f.mjs compiler migration

### DIFF
--- a/fjs/ci/todo/f-mjs-package-support.md
+++ b/fjs/ci/todo/f-mjs-package-support.md
@@ -11,6 +11,11 @@ extension. The current package configuration validates and publishes generated
 `.js` and `.d.ts`, but does not yet provide the corresponding authored `.mjs`
 and generated `.d.mts` path.
 
+The repository's authoritative FunctionalScript module rule also currently
+allows imports only from `.f.ts`. Incremental migration requires unmigrated
+`.f.ts` importers to target modules after those dependencies move to `.f.mjs`,
+while migrated `.f.mjs` modules must remain closed over migrated dependencies.
+
 This work blocks the P1 incremental compiler migration and fjs–nanvm integration.
 Keeping it only inside the broader P3 package-publishing roadmap makes the
 ordering unclear and allows a prerequisite to be deferred behind the work it
@@ -18,10 +23,10 @@ blocks.
 
 ### Proposal
 
-Implement the minimum validation, emission, package-content, and consumer tests
-needed before the first real `.f.mjs` module enters the repository's published
-runtime graph. The broader package strategy and other package targets remain in
-[`publishing-packages.md`](./publishing-packages.md).
+Implement the minimum validation, emission, package-content, repository-policy,
+and consumer tests needed before the first real `.f.mjs` module enters the
+repository's published runtime graph. The broader package strategy and other
+package targets remain in [`publishing-packages.md`](./publishing-packages.md).
 
 Use the authored/generated extension invariant:
 
@@ -41,6 +46,16 @@ Relative runtime or type references from authored `.f.mjs` must resolve to
 `.f.mjs` modules already migrated or converted in the same group. Authored
 `.ts` may import `.mjs`, and its generated outputs preserve the `.mjs`
 specifier.
+
+Update the FunctionalScript module rules in `AGENTS.md` with the same asymmetric
+policy:
+
+- authored `.f.ts` may import relative `.f.ts` or `.f.mjs` modules;
+- authored `.f.mjs` may import or reference relative `.f.mjs` modules only;
+- neither extension may use built-in or external Node modules.
+
+This permits unmigrated callers to follow a renamed dependency without weakening
+the dependency-closure invariant for compiler-ready `.f.mjs` source.
 
 ### Tasks
 
@@ -68,6 +83,11 @@ specifier.
       declaration dependencies.
 - [ ] Verify the packed archive contains authored `.mjs`, generated `.js`,
       `.d.ts`, and `.d.mts` files in the expected package paths.
+- [ ] Update `AGENTS.md` so `.f.ts` FunctionalScript modules may import relative
+      `.f.ts` or `.f.mjs`, while authored `.f.mjs` runtime and type dependencies
+      remain restricted to relative `.f.mjs`.
+- [ ] Add validation or proofs for the allowed `.f.ts` → `.f.mjs` direction and
+      the rejected `.f.mjs` → `.f.ts` / generated `.f.js` directions.
 
 ### Acceptance criteria
 
@@ -82,11 +102,14 @@ specifier.
   to unmigrated `.ts` or generated `.js` files.
 - A clean consumer can import the packed `.mjs` runtime and type-check against
   its emitted `.d.mts` declarations without access to repository source files.
+- `AGENTS.md` explicitly permits `.f.ts` modules to import `.f.mjs` and preserves
+  the dependency-closed import and type-reference rule for authored `.f.mjs`.
 - No package-time runtime-import or declaration-specifier rewriting is needed.
 
 ### Ordering
 
-Complete this task, together with
+Complete this task, including the `AGENTS.md` module-import policy update,
+together with
 [`.f.mjs` test and coverage support](../../emergent_testing/todo/f-mjs-test-and-coverage.md),
 before converting the first existing repository module from `.f.ts` to
 `.f.mjs`. A synthetic compiler fixture that does not enter the published runtime

--- a/fjs/ci/todo/f-mjs-package-support.md
+++ b/fjs/ci/todo/f-mjs-package-support.md
@@ -16,6 +16,11 @@ allows imports only from `.f.ts`. Incremental migration requires unmigrated
 `.f.ts` importers to target modules after those dependencies move to `.f.mjs`,
 while migrated `.f.mjs` modules must remain closed over migrated dependencies.
 
+Emission must also be repeatable in an ordinary working tree. A declaration
+produced by an earlier pack can be resolved as an input by a later declaration
+pass, even when generated declarations are excluded from root discovery. The
+second pass can then fail with TS5055 while trying to overwrite that input.
+
 This work blocks the P1 incremental compiler migration and fjs–nanvm integration.
 Keeping it only inside the broader P3 package-publishing roadmap makes the
 ordering unclear and allows a prerequisite to be deferred behind the work it
@@ -23,10 +28,11 @@ blocks.
 
 ### Proposal
 
-Implement the minimum validation, emission, package-content, repository-policy,
-and consumer tests needed before the first real `.f.mjs` module enters the
-repository's published runtime graph. The broader package strategy and other
-package targets remain in [`publishing-packages.md`](./publishing-packages.md).
+Implement the minimum validation, repeatable emission, package-content,
+repository-policy, and consumer tests needed before the first real `.f.mjs`
+module enters the repository's published runtime graph. The broader package
+strategy and other package targets remain in
+[`publishing-packages.md`](./publishing-packages.md).
 
 Use the authored/generated extension invariant:
 
@@ -38,6 +44,13 @@ source.mjs -> source.mjs + source.d.mts
 TypeScript validates both authored extensions. Declaration emission covers both
 `.ts` and `.mjs`, while JavaScript emission runs only for `.ts`; authored `.mjs`
 is copied unchanged into the package.
+
+Run a repository-owned generated-output cleanup before declaration emission.
+The cleanup derives output paths from authored `.ts` and `.mjs` inputs and
+removes only their generated `.js`, `.d.ts`, and `.d.mts` artifacts. It must not
+remove authored `.mjs`, unrelated files, or use a broad working-tree cleanup such
+as `git clean`. Starting every `prepack` from this known emission state prevents
+an earlier `.d.mts` from becoming an input to the next declaration pass.
 
 Do not introduce a staging tree or rewrite module specifiers during packaging.
 A migrated `.f.mjs` group must therefore be dependency-closed across both
@@ -66,12 +79,17 @@ the dependency-closure invariant for compiler-ready `.f.mjs` source.
       `.d.ts` and `.d.mts` declarations from source validation.
 - [ ] Update NPM package rules to include package-owned `.mjs` and `.d.mts`
       files while excluding unrelated `.mjs` files.
-- [ ] Replace the current one-pass `prepack` script with declaration emission
-      for `.ts` and `.mjs`, followed by JavaScript emission from `.ts` only.
+- [ ] Add a cross-platform repository script that derives and removes only the
+      generated `.js`, `.d.ts`, and `.d.mts` outputs for authored source.
+- [ ] Replace the current one-pass `prepack` script with generated-output
+      cleanup, declaration emission for `.ts` and `.mjs`, and JavaScript
+      emission from `.ts` only, in that order.
 - [ ] Add a package fixture containing an authored `.ts` module and an authored
       JSDoc `.mjs` module.
 - [ ] Test the supported mixed-source direction, authored `.ts` importing
       authored `.mjs`, in a clean checkout and from the packed archive.
+- [ ] Run `npm pack` twice consecutively without manual cleanup and verify that
+      both runs succeed and contain the same package file set.
 - [ ] Reject authored `.mjs` runtime imports that reference relative `.ts` or
       generated `.js` files.
 - [ ] Reject JSDoc or declaration-retained references from authored `.mjs` to
@@ -93,8 +111,12 @@ the dependency-closure invariant for compiler-ready `.f.mjs` source.
 
 - The main TypeScript check validates authored `.ts` and `.mjs` source without
   treating generated declarations as source inputs.
+- Every pack begins by removing only known generated outputs derived from
+  authored source.
 - Packing emits `.d.ts` for `.ts`, emits `.d.mts` for `.mjs`, emits `.js` only
   for `.ts`, and preserves authored `.mjs` unchanged.
+- Two consecutive `npm pack` runs succeed without manual cleanup, do not produce
+  TS5055, and contain the same package file set.
 - The package contains every runtime and declaration file needed by migrated
   `.f.mjs` modules and excludes unrelated `.mjs` files.
 - Authored `.ts` importing authored `.mjs` works before and after packing.
@@ -104,12 +126,13 @@ the dependency-closure invariant for compiler-ready `.f.mjs` source.
   its emitted `.d.mts` declarations without access to repository source files.
 - `AGENTS.md` explicitly permits `.f.ts` modules to import `.f.mjs` and preserves
   the dependency-closed import and type-reference rule for authored `.f.mjs`.
-- No package-time runtime-import or declaration-specifier rewriting is needed.
+- No staging tree or package-time runtime-import or declaration-specifier
+  rewriting is needed.
 
 ### Ordering
 
-Complete this task, including the `AGENTS.md` module-import policy update,
-together with
+Complete this task, including repeatable emission and the `AGENTS.md`
+module-import policy update, together with
 [`.f.mjs` test and coverage support](../../emergent_testing/todo/f-mjs-test-and-coverage.md),
 before converting the first existing repository module from `.f.ts` to
 `.f.mjs`. A synthetic compiler fixture that does not enter the published runtime

--- a/fjs/ci/todo/f-mjs-package-support.md
+++ b/fjs/ci/todo/f-mjs-package-support.md
@@ -1,0 +1,102 @@
+## Package support for authored `.f.mjs`
+
+**Priority:** P1
+**Status:** open
+
+### Problem
+
+The first existing repository module cannot move from `.f.ts` to authored
+`.f.mjs` until the TypeScript and NPM package pipeline understands that source
+extension. The current package configuration validates and publishes generated
+`.js` and `.d.ts`, but does not yet provide the corresponding authored `.mjs`
+and generated `.d.mts` path.
+
+This work blocks the P1 incremental compiler migration and fjs–nanvm integration.
+Keeping it only inside the broader P3 package-publishing roadmap makes the
+ordering unclear and allows a prerequisite to be deferred behind the work it
+blocks.
+
+### Proposal
+
+Implement the minimum validation, emission, package-content, and consumer tests
+needed before the first real `.f.mjs` module enters the repository's published
+runtime graph. The broader package strategy and other package targets remain in
+[`publishing-packages.md`](./publishing-packages.md).
+
+Use the authored/generated extension invariant:
+
+```text
+source.ts  -> source.js + source.d.ts
+source.mjs -> source.mjs + source.d.mts
+```
+
+TypeScript validates both authored extensions. Declaration emission covers both
+`.ts` and `.mjs`, while JavaScript emission runs only for `.ts`; authored `.mjs`
+is copied unchanged into the package.
+
+Do not introduce a staging tree or rewrite module specifiers during packaging.
+A migrated `.f.mjs` group must therefore be dependency-closed across both
+runtime imports and references retained in emitted `.d.mts` declarations.
+Relative runtime or type references from authored `.f.mjs` must resolve to
+`.f.mjs` modules already migrated or converted in the same group. Authored
+`.ts` may import `.mjs`, and its generated outputs preserve the `.mjs`
+specifier.
+
+### Tasks
+
+- [ ] Make `fjs/types/bigint/benchmark.mjs` pass TypeScript validation or delete
+      it if it is no longer needed.
+- [ ] Enable `allowJs` and `checkJs` in the main TypeScript configuration.
+- [ ] Include authored `.ts` and `.mjs` source while excluding generated
+      `.d.ts` and `.d.mts` declarations from source validation.
+- [ ] Update NPM package rules to include package-owned `.mjs` and `.d.mts`
+      files while excluding unrelated `.mjs` files.
+- [ ] Replace the current one-pass `prepack` script with declaration emission
+      for `.ts` and `.mjs`, followed by JavaScript emission from `.ts` only.
+- [ ] Add a package fixture containing an authored `.ts` module and an authored
+      JSDoc `.mjs` module.
+- [ ] Test the supported mixed-source direction, authored `.ts` importing
+      authored `.mjs`, in a clean checkout and from the packed archive.
+- [ ] Reject authored `.mjs` runtime imports that reference relative `.ts` or
+      generated `.js` files.
+- [ ] Reject JSDoc or declaration-retained references from authored `.mjs` to
+      relative `.ts` or generated `.js` files.
+- [ ] Verify emitted `.d.mts` files contain no references to files omitted from
+      the packed archive.
+- [ ] Type-check a clean consumer against the packed archive, including an
+      exported type from the authored `.mjs` fixture and its transitive
+      declaration dependencies.
+- [ ] Verify the packed archive contains authored `.mjs`, generated `.js`,
+      `.d.ts`, and `.d.mts` files in the expected package paths.
+
+### Acceptance criteria
+
+- The main TypeScript check validates authored `.ts` and `.mjs` source without
+  treating generated declarations as source inputs.
+- Packing emits `.d.ts` for `.ts`, emits `.d.mts` for `.mjs`, emits `.js` only
+  for `.ts`, and preserves authored `.mjs` unchanged.
+- The package contains every runtime and declaration file needed by migrated
+  `.f.mjs` modules and excludes unrelated `.mjs` files.
+- Authored `.ts` importing authored `.mjs` works before and after packing.
+- Authored `.mjs` cannot introduce relative runtime or declaration references
+  to unmigrated `.ts` or generated `.js` files.
+- A clean consumer can import the packed `.mjs` runtime and type-check against
+  its emitted `.d.mts` declarations without access to repository source files.
+- No package-time runtime-import or declaration-specifier rewriting is needed.
+
+### Ordering
+
+Complete this task, together with
+[`.f.mjs` test and coverage support](../../emergent_testing/todo/f-mjs-test-and-coverage.md),
+before converting the first existing repository module from `.f.ts` to
+`.f.mjs`. A synthetic compiler fixture that does not enter the published runtime
+graph may be used earlier.
+
+### Related
+
+- [`publishing-packages.md`](./publishing-packages.md) — broader P3 package
+  publishing roadmap and authored/generated JavaScript convention.
+- [`fjs/fsc/README.md`](../../fsc/README.md) — FunctionalScript extension
+  contract and incremental migration strategy.
+- [`todo/fjs-nanvm-integration.md`](../../../todo/fjs-nanvm-integration.md) — P1
+  integration plan blocked by this package prerequisite.

--- a/fjs/ci/todo/publishing-packages.md
+++ b/fjs/ci/todo/publishing-packages.md
@@ -42,9 +42,11 @@ The extension invariant is:
 For FunctionalScript modules, [`fjs/fsc/README.md`](../../fsc/README.md) adds a
 stronger capability convention: `.f.mjs` is authored JavaScript that the
 current FunctionalScript parser and compiler must accept, while `.f.ts` may
-still use unsupported parser features or TypeScript syntax. This document owns
-the package-emission mechanics; the compiler README owns the FunctionalScript
-migration strategy.
+still use unsupported parser features or TypeScript syntax. The blocking P1
+implementation work required before the first real `.f.mjs` migration is
+tracked in [`f-mjs-package-support.md`](./f-mjs-package-support.md). This P3
+document remains the broader package-publishing roadmap and records the shared
+package-emission convention.
 
 The main `tsconfig.json` should validate authored TypeScript and JavaScript while excluding generated declarations:
 
@@ -117,28 +119,15 @@ outputs preserve that `.mjs` specifier, which works both in a checkout and in
 the packed artifact. No staging tree, package-time runtime-import rewrite, or
 declaration-specifier rewrite is planned.
 
-Tasks:
+### Tasks
 
-- [ ] Make `fjs/types/bigint/benchmark.mjs` pass TypeScript validation or delete it.
-- [ ] Enable `allowJs` and `checkJs` and add the authored-source `include` and generated-declaration `exclude` patterns to `tsconfig.json`.
-- [ ] Update the NPM package rules to include `.mjs` and `.d.mts` while excluding non-package `.mjs` files.
-- [ ] Replace the current one-pass `prepack` script with the two emission passes.
-- [ ] Add a package test containing one `.ts` module and one JSDoc `.mjs` module.
-- [ ] Test the supported mixed-source direction: authored `.ts` importing
-      authored `.mjs`, both before and after packing.
-- [ ] Add validation or a package test that rejects relative authored `.mjs`
-      runtime imports or JSDoc/declaration type references to `.ts` or generated
-      `.js`, enforcing dependency-closed runtime and declaration graphs.
-- [ ] Type-check a clean consumer against the packed archive and import an
-      exported type from the authored `.mjs` fixture, proving its `.d.mts` and
-      every transitive declaration reference resolve without repository source
-      files.
-- [ ] Verify emitted `.d.mts` files do not reference package-omitted `.ts` or
-      generated `.js` paths.
-- [ ] Verify the packed archive contains authored `.mjs`, generated `.js`, `.d.ts`, and `.d.mts` files.
+- [ ] Complete the blocking P1 authored-`.f.mjs` package work in
+      [`f-mjs-package-support.md`](./f-mjs-package-support.md).
 
 ### Related
 
+- [`f-mjs-package-support.md`](./f-mjs-package-support.md) — focused P1 package
+  prerequisite for the first real `.f.mjs` migration.
 - [`fjs/fsc/README.md`](../../fsc/README.md) — FunctionalScript source
   extensions and incremental repository migration.
 - [GitHub issue #398](https://github.com/functionalscript/functionalscript/issues/398)

--- a/fjs/ci/todo/publishing-packages.md
+++ b/fjs/ci/todo/publishing-packages.md
@@ -78,12 +78,11 @@ Enabling `checkJs` includes `fjs/types/bigint/benchmark.mjs`. Before enabling it
 
 NPM must include both runtime extensions and both declaration extensions. Non-package `.mjs` files must remain excluded from the packed archive.
 
-Publishing requires generated-output cleanup followed by two TypeScript emission passes:
+Publishing requires a repository-owned `clean:generated` script followed by two TypeScript emission passes:
 
 ```json
 {
   "scripts": {
-    "clean:generated": "node <repository-owned-cleanup-script>",
     "emit:declarations": "tsc --noEmit false --emitDeclarationOnly",
     "emit:typescript": "tsc --noEmit false --allowJs false --checkJs false --declaration false",
     "prepack": "npm run clean:generated && npm run emit:declarations && npm run emit:typescript"
@@ -95,7 +94,8 @@ The repository-owned cleanup derives output paths from authored `.ts` and
 `.mjs` inputs and removes only their generated `.js`, `.d.ts`, and `.d.mts`
 artifacts. It must preserve authored `.mjs` and unrelated files and must not use
 a broad working-tree cleanup. This makes repeated local `prepack` and `npm pack`
-runs independent of ignored outputs left by an earlier run.
+runs independent of ignored outputs left by an earlier run. The exact script
+location and implementation are left to the focused P1 task.
 
 The first emission pass emits declarations for both authored source extensions:
 

--- a/fjs/ci/todo/publishing-packages.md
+++ b/fjs/ci/todo/publishing-packages.md
@@ -78,26 +78,33 @@ Enabling `checkJs` includes `fjs/types/bigint/benchmark.mjs`. Before enabling it
 
 NPM must include both runtime extensions and both declaration extensions. Non-package `.mjs` files must remain excluded from the packed archive.
 
-Publishing requires two TypeScript emission passes:
+Publishing requires generated-output cleanup followed by two TypeScript emission passes:
 
 ```json
 {
   "scripts": {
+    "clean:generated": "node <repository-owned-cleanup-script>",
     "emit:declarations": "tsc --noEmit false --emitDeclarationOnly",
     "emit:typescript": "tsc --noEmit false --allowJs false --checkJs false --declaration false",
-    "prepack": "npm run emit:declarations && npm run emit:typescript"
+    "prepack": "npm run clean:generated && npm run emit:declarations && npm run emit:typescript"
   }
 }
 ```
 
-The first pass emits declarations for both authored source extensions:
+The repository-owned cleanup derives output paths from authored `.ts` and
+`.mjs` inputs and removes only their generated `.js`, `.d.ts`, and `.d.mts`
+artifacts. It must preserve authored `.mjs` and unrelated files and must not use
+a broad working-tree cleanup. This makes repeated local `prepack` and `npm pack`
+runs independent of ignored outputs left by an earlier run.
+
+The first emission pass emits declarations for both authored source extensions:
 
 ```text
 source.ts  -> source.d.ts
 source.mjs -> source.d.mts
 ```
 
-The second pass excludes JavaScript inputs and emits JavaScript only from TypeScript:
+The second emission pass excludes JavaScript inputs and emits JavaScript only from TypeScript:
 
 ```text
 source.ts -> source.js
@@ -122,7 +129,8 @@ declaration-specifier rewrite is planned.
 ### Tasks
 
 - [ ] Complete the blocking P1 authored-`.f.mjs` package work in
-      [`f-mjs-package-support.md`](./f-mjs-package-support.md).
+      [`f-mjs-package-support.md`](./f-mjs-package-support.md), including the
+      repeatable cleanup-and-emission sequence and consecutive-pack regression.
 
 ### Related
 

--- a/fjs/ci/todo/publishing-packages.md
+++ b/fjs/ci/todo/publishing-packages.md
@@ -103,6 +103,15 @@ source.ts -> source.js
 
 Changing a module from `.ts` to `.mjs` also changes its import extension. Importers must be updated from the TypeScript or generated `.js` path to the authored `.mjs` path.
 
+Authored `.mjs` is copied to the package without rewriting import specifiers.
+Therefore migration must be dependency-closed: an authored `.mjs` module must
+not import an unmigrated relative `.ts` source or generated `.js` sibling. Its
+relative runtime dependencies must already be authored `.mjs` or be converted
+in the same coherent group. An authored `.ts` module may import `.mjs`; its
+generated `.js` preserves that `.mjs` specifier, which works both in a checkout
+and in the packed artifact. No staging tree or package-time import-rewrite step
+is planned.
+
 Tasks:
 
 - [ ] Make `fjs/types/bigint/benchmark.mjs` pass TypeScript validation or delete it.
@@ -110,7 +119,11 @@ Tasks:
 - [ ] Update the NPM package rules to include `.mjs` and `.d.mts` while excluding non-package `.mjs` files.
 - [ ] Replace the current one-pass `prepack` script with the two emission passes.
 - [ ] Add a package test containing one `.ts` module and one JSDoc `.mjs` module.
-- [ ] Test imports in both directions between `.ts` and `.mjs` modules.
+- [ ] Test the supported mixed-source direction: authored `.ts` importing
+      authored `.mjs`, both before and after packing.
+- [ ] Add validation or a package test that rejects relative authored
+      `.mjs` imports of `.ts` or generated `.js`, enforcing dependency-closed
+      migration groups.
 - [ ] Verify the packed archive contains authored `.mjs`, generated `.js`, `.d.ts`, and `.d.mts` files.
 
 ### Related

--- a/fjs/ci/todo/publishing-packages.md
+++ b/fjs/ci/todo/publishing-packages.md
@@ -103,14 +103,19 @@ source.ts -> source.js
 
 Changing a module from `.ts` to `.mjs` also changes its import extension. Importers must be updated from the TypeScript or generated `.js` path to the authored `.mjs` path.
 
-Authored `.mjs` is copied to the package without rewriting import specifiers.
-Therefore migration must be dependency-closed: an authored `.mjs` module must
-not import an unmigrated relative `.ts` source or generated `.js` sibling. Its
-relative runtime dependencies must already be authored `.mjs` or be converted
-in the same coherent group. An authored `.ts` module may import `.mjs`; its
-generated `.js` preserves that `.mjs` specifier, which works both in a checkout
-and in the packed artifact. No staging tree or package-time import-rewrite step
-is planned.
+Authored `.mjs` is copied to the package without rewriting runtime import
+specifiers, and this plan does not rewrite module specifiers retained in emitted
+`.d.mts` declarations. Therefore migration must be dependency-closed in both
+graphs: an authored `.mjs` module must not reference an unmigrated relative
+`.ts` source or generated `.js` sibling through executable imports, JSDoc type
+imports, or any other declaration-retained reference. Its relative runtime and
+type dependencies must already be authored `.mjs` or be converted in the same
+coherent group.
+
+An authored `.ts` module may import `.mjs`; its generated `.js` and `.d.ts`
+outputs preserve that `.mjs` specifier, which works both in a checkout and in
+the packed artifact. No staging tree, package-time runtime-import rewrite, or
+declaration-specifier rewrite is planned.
 
 Tasks:
 
@@ -121,9 +126,15 @@ Tasks:
 - [ ] Add a package test containing one `.ts` module and one JSDoc `.mjs` module.
 - [ ] Test the supported mixed-source direction: authored `.ts` importing
       authored `.mjs`, both before and after packing.
-- [ ] Add validation or a package test that rejects relative authored
-      `.mjs` imports of `.ts` or generated `.js`, enforcing dependency-closed
-      migration groups.
+- [ ] Add validation or a package test that rejects relative authored `.mjs`
+      runtime imports or JSDoc/declaration type references to `.ts` or generated
+      `.js`, enforcing dependency-closed runtime and declaration graphs.
+- [ ] Type-check a clean consumer against the packed archive and import an
+      exported type from the authored `.mjs` fixture, proving its `.d.mts` and
+      every transitive declaration reference resolve without repository source
+      files.
+- [ ] Verify emitted `.d.mts` files do not reference package-omitted `.ts` or
+      generated `.js` paths.
 - [ ] Verify the packed archive contains authored `.mjs`, generated `.js`, `.d.ts`, and `.d.mts` files.
 
 ### Related

--- a/fjs/ci/todo/publishing-packages.md
+++ b/fjs/ci/todo/publishing-packages.md
@@ -39,6 +39,13 @@ The extension invariant is:
 - `.js` is generated JavaScript and is never authored;
 - `.d.ts` and `.d.mts` are generated declarations.
 
+For FunctionalScript modules, [`fjs/fsc/README.md`](../../fsc/README.md) adds a
+stronger capability convention: `.f.mjs` is authored JavaScript that the
+current FunctionalScript parser and compiler must accept, while `.f.ts` may
+still use unsupported parser features or TypeScript syntax. This document owns
+the package-emission mechanics; the compiler README owns the FunctionalScript
+migration strategy.
+
 The main `tsconfig.json` should validate authored TypeScript and JavaScript while excluding generated declarations:
 
 ```jsonc
@@ -108,5 +115,7 @@ Tasks:
 
 ### Related
 
+- [`fjs/fsc/README.md`](../../fsc/README.md) — FunctionalScript source
+  extensions and incremental repository migration.
 - [GitHub issue #398](https://github.com/functionalscript/functionalscript/issues/398)
   — the original report.

--- a/fjs/emergent_testing/todo/f-mjs-test-and-coverage.md
+++ b/fjs/emergent_testing/todo/f-mjs-test-and-coverage.md
@@ -1,0 +1,69 @@
+## Recognize `.f.mjs` in test and coverage tooling
+
+**Priority:** P1
+**Status:** open
+
+### Problem
+
+The repository migration strategy uses `.f.mjs` for authored FunctionalScript
+modules whose complete syntax is accepted by the current parser and compiler.
+Before the first `.f.ts` module is renamed, the existing test and coverage
+tooling must recognize the new extension.
+
+Current behavior is incomplete:
+
+- `fjs/dev/module.f.ts::shouldLoad` bulk-loads `.f.ts` and `.f.js`, but not
+  `.f.mjs`;
+- standalone `proof.mjs` files are already recognized, but an internal `proof`
+  export in `module.f.mjs` would be skipped because the module itself is not
+  loaded;
+- `npm run cov` includes only `**/module.f.ts`, so a migrated implementation
+  would disappear from coverage reporting.
+
+Without this task, renaming a covered module from `.f.ts` to `.f.mjs` could
+silently reduce proof execution and coverage even though the implementation is
+otherwise unchanged.
+
+### Proposal
+
+Treat authored `.f.mjs` FunctionalScript modules consistently with `.f.ts`
+modules in proof discovery and coverage:
+
+1. Extend `shouldLoad` to recognize `.f.mjs` as a FunctionalScript module.
+2. Update the `shouldLoad` documentation and proofs to cover `.f.mjs`.
+3. Extend `npm run cov` so both `module.f.ts` and `module.f.mjs`
+   implementations are included.
+4. Add a regression fixture proving that an internal `proof` export from a
+   `.f.mjs` module is executed.
+5. Verify that the `.f.mjs` fixture remains represented in coverage output.
+
+Keep the extension rules explicit: ordinary `.mjs` files remain opt-in through
+the existing `proof.mjs` convention unless
+[`664-emergent-testing-module-files.md`](./664-emergent-testing-module-files.md)
+is implemented. This task adds the FunctionalScript-specific `.f.mjs` rule; it
+does not replace or expand the ordinary `module.mjs` proposal.
+
+### Acceptance criteria
+
+- `shouldLoad('module.f.mjs')` returns `true`.
+- An exported `proof` from a `.f.mjs` module is executed by the normal test
+  command.
+- `npm run cov` includes both `.f.ts` and `.f.mjs` implementation modules.
+- Renaming an otherwise equivalent module from `.f.ts` to `.f.mjs` does not
+  remove its proofs or its implementation from coverage.
+- Existing `.f.ts`, generated `.f.js`, and standalone `proof.mjs` behavior is
+  unchanged.
+
+### Ordering
+
+Complete this task before converting the first repository module from `.f.ts`
+to `.f.mjs`. It is infrastructure for the migration strategy, not part of each
+individual module conversion.
+
+### Related
+
+- [`fjs/fsc/README.md`](../../fsc/README.md) — source-extension convention and
+  incremental repository migration.
+- [`664-emergent-testing-module-files.md`](./664-emergent-testing-module-files.md)
+  — separate proposal to bulk-load ordinary `module.*` files for white-box
+  testing.

--- a/fjs/emergent_testing/todo/f-mjs-test-and-coverage.md
+++ b/fjs/emergent_testing/todo/f-mjs-test-and-coverage.md
@@ -18,7 +18,13 @@ Current behavior is incomplete:
   export in `module.f.mjs` would be skipped because the module itself is not
   loaded;
 - `npm run cov` includes only `**/module.f.ts`, so a migrated implementation
-  would disappear from coverage reporting;
+  would disappear from Node coverage reporting;
+- `deno task cov` in `deno.json` filters coverage with
+  `.*module\.f\.ts`, so the same implementation would disappear from local
+  Deno coverage reporting;
+- the generated Deno CI step in `fjs/ci/deno/module.f.ts` uses the same
+  `.f.ts`-only filter, so CI could pass while omitting every migrated
+  implementation from Deno coverage;
 - `AGENTS.md` defines mandatory proof coverage only for `.f.ts`, so the
   repository's authoritative development rules do not yet govern `.f.mjs`
   modules or describe mixed `module.f.mjs` / `proof.f.ts` pairs.
@@ -37,13 +43,24 @@ modules in proof discovery, coverage, and repository policy:
 2. Update the `shouldLoad` documentation and proofs to cover `.f.mjs`.
 3. Extend `npm run cov` so both `module.f.ts` and `module.f.mjs`
    implementations are included.
-4. Add regression fixtures proving both supported proof layouts:
+4. Extend the Deno coverage filter in `deno.json` so `deno task cov` includes
+   both implementation extensions.
+5. Update the canonical Deno CI generator in `fjs/ci/deno/module.f.ts` with the
+   same coverage rule, add a regression proof for the generated command, and
+   regenerate the checked-in CI workflow.
+6. Add regression fixtures proving both supported proof layouts:
    - an internal `proof` export from a `.f.mjs` module is executed;
    - a co-located `proof.f.ts` can import and test `module.f.mjs`.
-5. Verify that the `.f.mjs` implementation remains represented in coverage for
-   both proof layouts.
-6. Update `AGENTS.md` so `.f.mjs` modules and functions have the same mandatory
+7. Verify that the `.f.mjs` implementation remains represented in both Node and
+   Deno coverage for the supported proof layouts.
+8. Update `AGENTS.md` so `.f.mjs` modules and functions have the same mandatory
    100% proof-coverage policy and proof-writing rules as `.f.ts`.
+
+Keep the Node and Deno inclusion rules semantically identical: both must select
+FunctionalScript implementation modules ending in `module.f.ts` or
+`module.f.mjs`. The CI generator is the source of truth for the generated
+workflow, while `deno.json` defines the equivalent local command. Cover both
+with proofs or validation so a later edit cannot restore extension drift.
 
 The implementation and proof extensions are independent during incremental
 migration. Renaming `module.f.ts` to `module.f.mjs` does not require renaming its
@@ -71,9 +88,13 @@ does not replace or expand the ordinary `module.mjs` proposal.
   test command.
 - A `proof.f.ts` importing `module.f.mjs` is executed by the normal test command.
 - `npm run cov` includes both `.f.ts` and `.f.mjs` implementation modules.
+- `deno task cov` includes both `.f.ts` and `.f.mjs` implementation modules.
+- The Deno CI generator emits a coverage command with the same two-extension
+  inclusion rule, and its proof fails if `.f.mjs` support is removed.
+- The checked-in CI workflow is regenerated from the updated generator.
 - Renaming an otherwise equivalent module from `.f.ts` to `.f.mjs` does not
-  remove its proofs or its implementation from coverage, even when the proof
-  remains `proof.f.ts`.
+  remove its proofs or its implementation from Node or Deno coverage, even when
+  the proof remains `proof.f.ts`.
 - `AGENTS.md` explicitly applies mandatory proof coverage to both `.f.ts` and
   `.f.mjs` FunctionalScript source and documents that a migrated
   `module.f.mjs` may keep a `proof.f.ts`.
@@ -85,10 +106,11 @@ does not replace or expand the ordinary `module.mjs` proposal.
 ### Ordering
 
 Complete this task before converting the first repository module from `.f.ts`
-to `.f.mjs`. The tooling and `AGENTS.md` policy changes land together so the
-first migrated module is both discovered correctly and governed by the same
-proof requirements. The proof itself may remain `.f.ts` and migrate separately.
-This is infrastructure for the migration strategy, not part of each individual
+to `.f.mjs`. The discovery, Node coverage, Deno coverage, generated CI, and
+`AGENTS.md` policy changes land together so the first migrated module is covered
+consistently across supported runners and governed by the same proof
+requirements. The proof itself may remain `.f.ts` and migrate separately. This
+is infrastructure for the migration strategy, not part of each individual
 module conversion.
 
 ### Related

--- a/fjs/emergent_testing/todo/f-mjs-test-and-coverage.md
+++ b/fjs/emergent_testing/todo/f-mjs-test-and-coverage.md
@@ -37,24 +37,7 @@ otherwise unchanged, and later contributors would not have an explicit
 ### Proposal
 
 Treat authored `.f.mjs` FunctionalScript modules consistently with `.f.ts`
-modules in proof discovery, coverage, and repository policy:
-
-1. Extend `shouldLoad` to recognize `.f.mjs` as a FunctionalScript module.
-2. Update the `shouldLoad` documentation and proofs to cover `.f.mjs`.
-3. Extend `npm run cov` so both `module.f.ts` and `module.f.mjs`
-   implementations are included.
-4. Extend the Deno coverage filter in `deno.json` so `deno task cov` includes
-   both implementation extensions.
-5. Update the canonical Deno CI generator in `fjs/ci/deno/module.f.ts` with the
-   same coverage rule, add a regression proof for the generated command, and
-   regenerate the checked-in CI workflow.
-6. Add regression fixtures proving both supported proof layouts:
-   - an internal `proof` export from a `.f.mjs` module is executed;
-   - a co-located `proof.f.ts` can import and test `module.f.mjs`.
-7. Verify that the `.f.mjs` implementation remains represented in both Node and
-   Deno coverage for the supported proof layouts.
-8. Update `AGENTS.md` so `.f.mjs` modules and functions have the same mandatory
-   100% proof-coverage policy and proof-writing rules as `.f.ts`.
+modules in proof discovery, coverage, and repository policy.
 
 Keep the Node and Deno inclusion rules semantically identical: both must select
 FunctionalScript implementation modules ending in `module.f.ts` or
@@ -80,6 +63,28 @@ the existing `proof.mjs` convention unless
 [`664-emergent-testing-module-files.md`](./664-emergent-testing-module-files.md)
 is implemented. This task adds the FunctionalScript-specific `.f.mjs` rule; it
 does not replace or expand the ordinary `module.mjs` proposal.
+
+### Tasks
+
+- [ ] Extend `shouldLoad` to recognize `.f.mjs` as a FunctionalScript module.
+- [ ] Update the `shouldLoad` documentation and proofs to cover `.f.mjs`.
+- [ ] Extend `npm run cov` so both `module.f.ts` and `module.f.mjs`
+      implementations are included.
+- [ ] Extend the Deno coverage filter in `deno.json` so `deno task cov`
+      includes both implementation extensions.
+- [ ] Update the canonical Deno CI generator in `fjs/ci/deno/module.f.ts` with
+      the same coverage rule and add a regression proof for the generated
+      command.
+- [ ] Regenerate the checked-in CI workflow from the updated generator.
+- [ ] Add a fixture proving that an internal `proof` export from a `.f.mjs`
+      module is executed.
+- [ ] Add a fixture proving that a co-located `proof.f.ts` can import and test
+      `module.f.mjs`.
+- [ ] Verify that `.f.mjs` implementations remain represented in both Node and
+      Deno coverage for the supported proof layouts.
+- [ ] Update `AGENTS.md` so `.f.mjs` modules and functions have the same
+      mandatory 100% proof-coverage policy and proof-writing rules as `.f.ts`,
+      including the mixed `module.f.mjs` / `proof.f.ts` convention.
 
 ### Acceptance criteria
 

--- a/fjs/emergent_testing/todo/f-mjs-test-and-coverage.md
+++ b/fjs/emergent_testing/todo/f-mjs-test-and-coverage.md
@@ -27,12 +27,14 @@ Current behavior is incomplete:
   implementation from Deno coverage;
 - `AGENTS.md` defines mandatory proof coverage only for `.f.ts`, so the
   repository's authoritative development rules do not yet govern `.f.mjs`
-  modules or describe mixed `module.f.mjs` / `proof.f.ts` pairs.
+  modules or describe mixed `module.f.mjs` / `proof.f.ts` pairs;
+- `CONTRIBUTING.md` repeats the `.f.ts`-only proof summary, so updating
+  `AGENTS.md` alone would leave contributor-facing guidance inconsistent.
 
 Without this task, renaming a covered module from `.f.ts` to `.f.mjs` could
 silently reduce proof execution and coverage even though the implementation is
-otherwise unchanged, and later contributors would not have an explicit
-`.f.mjs` proof policy to follow.
+otherwise unchanged, and later contributors would not have an explicit and
+consistent `.f.mjs` proof policy to follow.
 
 ### Proposal
 
@@ -57,6 +59,13 @@ The dependency-closed `.f.mjs` migration rule applies to files that are actually
 authored as `.f.mjs`; it does not prohibit a `.f.ts` proof from importing a
 `.f.mjs` implementation. This lets implementation coverage grow without forcing
 test infrastructure and its dependency graph to migrate first.
+
+Update `AGENTS.md` and the matching summary in `CONTRIBUTING.md` together. Both
+must state that new `.f.ts` and `.f.mjs` modules require mandatory proof
+coverage, and that `module.f.mjs` may use a co-located `proof.f.ts` during
+incremental migration or `proof.f.mjs` once the proof itself is compiler-ready.
+Until coverage commands enforce a failure threshold, this explicit contributor
+policy remains necessary and must not drift between the two documents.
 
 Keep the extension rules explicit: ordinary `.mjs` files remain opt-in through
 the existing `proof.mjs` convention unless
@@ -85,6 +94,9 @@ does not replace or expand the ordinary `module.mjs` proposal.
 - [ ] Update `AGENTS.md` so `.f.mjs` modules and functions have the same
       mandatory 100% proof-coverage policy and proof-writing rules as `.f.ts`,
       including the mixed `module.f.mjs` / `proof.f.ts` convention.
+- [ ] Update the proof summary in `CONTRIBUTING.md` in the same change so it
+      covers new `.f.ts` and `.f.mjs` modules and documents the allowed
+      `proof.f.ts` / `proof.f.mjs` layouts for `module.f.mjs`.
 
 ### Acceptance criteria
 
@@ -103,6 +115,8 @@ does not replace or expand the ordinary `module.mjs` proposal.
 - `AGENTS.md` explicitly applies mandatory proof coverage to both `.f.ts` and
   `.f.mjs` FunctionalScript source and documents that a migrated
   `module.f.mjs` may keep a `proof.f.ts`.
+- `CONTRIBUTING.md` gives the same proof requirement and mixed-layout guidance
+  without contradicting or narrowing `AGENTS.md`.
 - A `proof.f.mjs` is required to satisfy the same dependency-closed migration
   rule as any other authored `.f.mjs` file.
 - Existing `.f.ts`, generated `.f.js`, `proof.f.ts`, and standalone `proof.mjs`
@@ -111,12 +125,12 @@ does not replace or expand the ordinary `module.mjs` proposal.
 ### Ordering
 
 Complete this task before converting the first repository module from `.f.ts`
-to `.f.mjs`. The discovery, Node coverage, Deno coverage, generated CI, and
-`AGENTS.md` policy changes land together so the first migrated module is covered
-consistently across supported runners and governed by the same proof
-requirements. The proof itself may remain `.f.ts` and migrate separately. This
-is infrastructure for the migration strategy, not part of each individual
-module conversion.
+to `.f.mjs`. The discovery, Node coverage, Deno coverage, generated CI,
+`AGENTS.md`, and `CONTRIBUTING.md` policy changes land together so the first
+migrated module is covered consistently across supported runners and governed by
+one contributor-facing proof requirement. The proof itself may remain `.f.ts`
+and migrate separately. This is infrastructure for the migration strategy, not
+part of each individual module conversion.
 
 ### Related
 

--- a/fjs/emergent_testing/todo/f-mjs-test-and-coverage.md
+++ b/fjs/emergent_testing/todo/f-mjs-test-and-coverage.md
@@ -18,16 +18,20 @@ Current behavior is incomplete:
   export in `module.f.mjs` would be skipped because the module itself is not
   loaded;
 - `npm run cov` includes only `**/module.f.ts`, so a migrated implementation
-  would disappear from coverage reporting.
+  would disappear from coverage reporting;
+- `AGENTS.md` defines mandatory proof coverage and the
+  `module.f.ts`/`proof.f.ts` convention only for `.f.ts`, so the repository's
+  authoritative development rules do not yet govern `.f.mjs` modules.
 
 Without this task, renaming a covered module from `.f.ts` to `.f.mjs` could
 silently reduce proof execution and coverage even though the implementation is
-otherwise unchanged.
+otherwise unchanged, and later contributors would not have an explicit
+`.f.mjs` proof policy to follow.
 
 ### Proposal
 
 Treat authored `.f.mjs` FunctionalScript modules consistently with `.f.ts`
-modules in proof discovery and coverage:
+modules in proof discovery, coverage, and repository policy:
 
 1. Extend `shouldLoad` to recognize `.f.mjs` as a FunctionalScript module.
 2. Update the `shouldLoad` documentation and proofs to cover `.f.mjs`.
@@ -36,6 +40,9 @@ modules in proof discovery and coverage:
 4. Add a regression fixture proving that an internal `proof` export from a
    `.f.mjs` module is executed.
 5. Verify that the `.f.mjs` fixture remains represented in coverage output.
+6. Update `AGENTS.md` so `.f.mjs` modules and functions have the same mandatory
+   100% proof-coverage policy as `.f.ts`, including the
+   `module.f.mjs`/`proof.f.mjs` convention and the existing proof-writing rules.
 
 Keep the extension rules explicit: ordinary `.mjs` files remain opt-in through
 the existing `proof.mjs` convention unless
@@ -51,14 +58,18 @@ does not replace or expand the ordinary `module.mjs` proposal.
 - `npm run cov` includes both `.f.ts` and `.f.mjs` implementation modules.
 - Renaming an otherwise equivalent module from `.f.ts` to `.f.mjs` does not
   remove its proofs or its implementation from coverage.
+- `AGENTS.md` explicitly applies mandatory proof coverage and proof-file naming
+  rules to both `.f.ts` and `.f.mjs` FunctionalScript source.
 - Existing `.f.ts`, generated `.f.js`, and standalone `proof.mjs` behavior is
   unchanged.
 
 ### Ordering
 
 Complete this task before converting the first repository module from `.f.ts`
-to `.f.mjs`. It is infrastructure for the migration strategy, not part of each
-individual module conversion.
+to `.f.mjs`. The tooling and `AGENTS.md` policy changes land together so the
+first migrated module is both discovered correctly and governed by the same
+proof requirements. This is infrastructure for the migration strategy, not part
+of each individual module conversion.
 
 ### Related
 

--- a/fjs/emergent_testing/todo/f-mjs-test-and-coverage.md
+++ b/fjs/emergent_testing/todo/f-mjs-test-and-coverage.md
@@ -19,9 +19,9 @@ Current behavior is incomplete:
   loaded;
 - `npm run cov` includes only `**/module.f.ts`, so a migrated implementation
   would disappear from coverage reporting;
-- `AGENTS.md` defines mandatory proof coverage and the
-  `module.f.ts`/`proof.f.ts` convention only for `.f.ts`, so the repository's
-  authoritative development rules do not yet govern `.f.mjs` modules.
+- `AGENTS.md` defines mandatory proof coverage only for `.f.ts`, so the
+  repository's authoritative development rules do not yet govern `.f.mjs`
+  modules or describe mixed `module.f.mjs` / `proof.f.ts` pairs.
 
 Without this task, renaming a covered module from `.f.ts` to `.f.mjs` could
 silently reduce proof execution and coverage even though the implementation is
@@ -37,12 +37,26 @@ modules in proof discovery, coverage, and repository policy:
 2. Update the `shouldLoad` documentation and proofs to cover `.f.mjs`.
 3. Extend `npm run cov` so both `module.f.ts` and `module.f.mjs`
    implementations are included.
-4. Add a regression fixture proving that an internal `proof` export from a
-   `.f.mjs` module is executed.
-5. Verify that the `.f.mjs` fixture remains represented in coverage output.
+4. Add regression fixtures proving both supported proof layouts:
+   - an internal `proof` export from a `.f.mjs` module is executed;
+   - a co-located `proof.f.ts` can import and test `module.f.mjs`.
+5. Verify that the `.f.mjs` implementation remains represented in coverage for
+   both proof layouts.
 6. Update `AGENTS.md` so `.f.mjs` modules and functions have the same mandatory
-   100% proof-coverage policy as `.f.ts`, including the
-   `module.f.mjs`/`proof.f.mjs` convention and the existing proof-writing rules.
+   100% proof-coverage policy and proof-writing rules as `.f.ts`.
+
+The implementation and proof extensions are independent during incremental
+migration. Renaming `module.f.ts` to `module.f.mjs` does not require renaming its
+co-located `proof.f.ts`. The TypeScript proof may continue importing existing
+`.f.ts` test helpers, including `fjs/asserts/module.f.ts`, while importing the
+migrated implementation through its new `.f.mjs` path. Rename a proof to
+`proof.f.mjs` only when that proof's own syntax and relative FunctionalScript
+dependency closure are compiler-ready.
+
+The dependency-closed `.f.mjs` migration rule applies to files that are actually
+authored as `.f.mjs`; it does not prohibit a `.f.ts` proof from importing a
+`.f.mjs` implementation. This lets implementation coverage grow without forcing
+test infrastructure and its dependency graph to migrate first.
 
 Keep the extension rules explicit: ordinary `.mjs` files remain opt-in through
 the existing `proof.mjs` convention unless
@@ -53,23 +67,29 @@ does not replace or expand the ordinary `module.mjs` proposal.
 ### Acceptance criteria
 
 - `shouldLoad('module.f.mjs')` returns `true`.
-- An exported `proof` from a `.f.mjs` module is executed by the normal test
-  command.
+- An internal exported `proof` from a `.f.mjs` module is executed by the normal
+  test command.
+- A `proof.f.ts` importing `module.f.mjs` is executed by the normal test command.
 - `npm run cov` includes both `.f.ts` and `.f.mjs` implementation modules.
 - Renaming an otherwise equivalent module from `.f.ts` to `.f.mjs` does not
-  remove its proofs or its implementation from coverage.
-- `AGENTS.md` explicitly applies mandatory proof coverage and proof-file naming
-  rules to both `.f.ts` and `.f.mjs` FunctionalScript source.
-- Existing `.f.ts`, generated `.f.js`, and standalone `proof.mjs` behavior is
-  unchanged.
+  remove its proofs or its implementation from coverage, even when the proof
+  remains `proof.f.ts`.
+- `AGENTS.md` explicitly applies mandatory proof coverage to both `.f.ts` and
+  `.f.mjs` FunctionalScript source and documents that a migrated
+  `module.f.mjs` may keep a `proof.f.ts`.
+- A `proof.f.mjs` is required to satisfy the same dependency-closed migration
+  rule as any other authored `.f.mjs` file.
+- Existing `.f.ts`, generated `.f.js`, `proof.f.ts`, and standalone `proof.mjs`
+  behavior is unchanged.
 
 ### Ordering
 
 Complete this task before converting the first repository module from `.f.ts`
 to `.f.mjs`. The tooling and `AGENTS.md` policy changes land together so the
 first migrated module is both discovered correctly and governed by the same
-proof requirements. This is infrastructure for the migration strategy, not part
-of each individual module conversion.
+proof requirements. The proof itself may remain `.f.ts` and migrate separately.
+This is infrastructure for the migration strategy, not part of each individual
+module conversion.
 
 ### Related
 

--- a/fjs/fsc/README.md
+++ b/fjs/fsc/README.md
@@ -30,18 +30,32 @@ it. Before converting the first existing repository module, complete both:
   TypeScript checking, `.mjs`/`.d.mts` package inclusion, declaration emission,
   and package import tests, so published imports cannot reference omitted files.
 
-1. As soon as the parser supports the first useful function modules, select an
-   existing `.f.ts` file whose complete syntax is supported.
-2. Rename it to `.f.mjs` and replace TypeScript-only syntax with JSDoc types.
-3. Update imports to the authored `.f.mjs` path.
-4. Add the module to parser/compiler validation and preserve its existing proof,
-   coverage, type-checking, and package-publication expectations.
-5. Repeat as each new parser feature makes more modules eligible.
+Migration uses a dependency-closed order. An existing module is eligible only
+when every relative FunctionalScript runtime dependency it imports is already
+`.f.mjs` or is converted in the same coherent group. Authored `.f.mjs` must not
+import an unmigrated `.f.ts` module or generated `.f.js` output. Packaging copies
+`.mjs` source without rewriting its import specifiers, so this rule keeps the
+same source graph valid in a clean checkout and in the packed NPM artifact. If a
+module's dependency closure is not yet eligible, leave it as `.f.ts`; this plan
+does not introduce a staging or package-time import-rewrite mechanism.
 
-A file stays `.f.ts` until all syntax it uses is supported. Migration must not
-require implementing unrelated language features merely to convert a file.
-Likewise, `.f.mjs` must not be used as an aspirational label: once a module has
-that extension, accepting and compiling it is a compatibility requirement.
+1. As soon as the parser supports the first useful function modules, select an
+   existing dependency-closed `.f.ts` module or coherent group whose complete
+   syntax is supported.
+2. Rename the selected files to `.f.mjs` and replace TypeScript-only syntax with
+   JSDoc types.
+3. Update imports within the group and all importers of renamed modules to the
+   authored `.f.mjs` paths.
+4. Add the group to parser/compiler validation and preserve its existing proof,
+   coverage, type-checking, and package-publication expectations.
+5. Repeat as each new parser feature makes more dependency-closed groups
+   eligible.
+
+A file stays `.f.ts` until all syntax it uses and the required dependency closure
+are supported. Migration must not require implementing unrelated language
+features merely to convert a file. Likewise, `.f.mjs` must not be used as an
+aspirational label: once a module has that extension, accepting and compiling it
+is a compatibility requirement.
 
 The migration grows real-repository compiler coverage alongside the parser and
 code generator. It does not wait for the complete FunctionalScript feature set,

--- a/fjs/fsc/README.md
+++ b/fjs/fsc/README.md
@@ -27,8 +27,16 @@ it. Before converting the first existing repository module, complete both:
   so migrated modules remain in proof discovery and coverage reporting;
 - [authored `.f.mjs` package support](../ci/todo/f-mjs-package-support.md),
   including TypeScript checking, `.mjs`/`.d.mts` package inclusion, declaration
-  emission, runtime import tests, and packed-package type-resolution tests, so
-  published runtime and declaration imports cannot reference omitted files.
+  emission, runtime import tests, packed-package type-resolution tests, and the
+  repository module-import policy update, so published runtime and declaration
+  imports cannot reference omitted files and unmigrated callers may follow
+  renamed dependencies.
+
+The repository import policy is asymmetric during migration: authored `.f.ts`
+may import relative `.f.ts` or `.f.mjs` modules, while authored `.f.mjs` runtime
+imports and type references may target relative `.f.mjs` modules only. Update
+`AGENTS.md` with this rule as part of the package-support prerequisite before the
+first real rename.
 
 Migration uses a dependency-closed order. An existing module is eligible only
 when every relative FunctionalScript dependency referenced by its runtime code
@@ -48,7 +56,7 @@ staging, package-time import-rewrite, or declaration-rewrite mechanism.
 2. Rename the selected files to `.f.mjs` and replace TypeScript-only syntax with
    JSDoc types.
 3. Update runtime imports and JSDoc type references within the group, plus all
-   importers of renamed modules, to the authored `.f.mjs` paths.
+   `.f.ts` importers of renamed modules, to the authored `.f.mjs` paths.
 4. Add the group to parser/compiler validation and preserve its existing proof,
    coverage, type-checking, package-runtime, and package-type-resolution
    expectations.
@@ -95,7 +103,7 @@ the [project roadmap](../../todo/plan/roadmap.md) and the
 - `,` - comma
 - `-` - subtraction
   - `--` - decrement
-  - `-=` - subtractionAssignment
+  - `-=` - multiplicationAssignment
 - `.` - dot
   - `...` - spread
 - `/` - division

--- a/fjs/fsc/README.md
+++ b/fjs/fsc/README.md
@@ -19,17 +19,23 @@ The `.f.mjs` extension adds a stronger FunctionalScript-specific promise: it
 marks a module that is ready for translation by the compiler available in the
 same revision of the repository.
 
-Repository migration is incremental, not a single task or pull request. Before
-the first conversion, complete
-[`.f.mjs` test and coverage support](../emergent_testing/todo/f-mjs-test-and-coverage.md)
-so migrated modules remain in proof discovery and coverage reporting.
+Repository migration is incremental, not a single task or pull request. A
+synthetic `.f.mjs` compiler fixture may be added as soon as the parser supports
+it. Before converting the first existing repository module, complete both:
+
+- [`.f.mjs` test and coverage support](../emergent_testing/todo/f-mjs-test-and-coverage.md),
+  so migrated modules remain in proof discovery and coverage reporting;
+- the authored-`.mjs` tasks in
+  [`publishing-packages.md`](../ci/todo/publishing-packages.md), including
+  TypeScript checking, `.mjs`/`.d.mts` package inclusion, declaration emission,
+  and package import tests, so published imports cannot reference omitted files.
 
 1. As soon as the parser supports the first useful function modules, select an
    existing `.f.ts` file whose complete syntax is supported.
 2. Rename it to `.f.mjs` and replace TypeScript-only syntax with JSDoc types.
 3. Update imports to the authored `.f.mjs` path.
-4. Add the module to parser/compiler validation and preserve its existing proof
-   and coverage expectations.
+4. Add the module to parser/compiler validation and preserve its existing proof,
+   coverage, type-checking, and package-publication expectations.
 5. Repeat as each new parser feature makes more modules eligible.
 
 A file stays `.f.ts` until all syntax it uses is supported. Migration must not

--- a/fjs/fsc/README.md
+++ b/fjs/fsc/README.md
@@ -24,13 +24,14 @@ synthetic `.f.mjs` compiler fixture may be added as soon as the parser supports
 it. Before converting the first existing repository module, complete both:
 
 - [`.f.mjs` test and coverage support](../emergent_testing/todo/f-mjs-test-and-coverage.md),
-  so migrated modules remain in proof discovery and coverage reporting;
+  so migrated modules remain in proof discovery and coverage reporting and the
+  proof guidance in `AGENTS.md` and `CONTRIBUTING.md` stays aligned;
 - [authored `.f.mjs` package support](../ci/todo/f-mjs-package-support.md),
-  including TypeScript checking, `.mjs`/`.d.mts` package inclusion, declaration
-  emission, runtime import tests, packed-package type-resolution tests, and the
-  repository module-import policy update, so published runtime and declaration
-  imports cannot reference omitted files and unmigrated callers may follow
-  renamed dependencies.
+  including TypeScript checking, `.mjs`/`.d.mts` package inclusion, repeatable
+  cleanup and declaration emission, consecutive-pack validation, runtime import
+  tests, packed-package type-resolution tests, and the repository module-import
+  policy update, so published runtime and declaration imports cannot reference
+  omitted files and unmigrated callers may follow renamed dependencies.
 
 The repository import policy is asymmetric during migration: authored `.f.ts`
 may import relative `.f.ts` or `.f.mjs` modules, while authored `.f.mjs` runtime
@@ -58,7 +59,7 @@ staging, package-time import-rewrite, or declaration-rewrite mechanism.
 3. Update runtime imports and JSDoc type references within the group, plus all
    `.f.ts` importers of renamed modules, to the authored `.f.mjs` paths.
 4. Add the group to parser/compiler validation and preserve its existing proof,
-   coverage, type-checking, package-runtime, and package-type-resolution
+   coverage, type-checking, repeatable package-runtime, and package-type-resolution
    expectations.
 5. Repeat as each new parser feature makes more dependency-closed groups
    eligible.

--- a/fjs/fsc/README.md
+++ b/fjs/fsc/README.md
@@ -28,34 +28,40 @@ it. Before converting the first existing repository module, complete both:
 - the authored-`.mjs` tasks in
   [`publishing-packages.md`](../ci/todo/publishing-packages.md), including
   TypeScript checking, `.mjs`/`.d.mts` package inclusion, declaration emission,
-  and package import tests, so published imports cannot reference omitted files.
+  runtime import tests, and packed-package type-resolution tests, so published
+  runtime and declaration imports cannot reference omitted files.
 
 Migration uses a dependency-closed order. An existing module is eligible only
-when every relative FunctionalScript runtime dependency it imports is already
-`.f.mjs` or is converted in the same coherent group. Authored `.f.mjs` must not
-import an unmigrated `.f.ts` module or generated `.f.js` output. Packaging copies
-`.mjs` source without rewriting its import specifiers, so this rule keeps the
-same source graph valid in a clean checkout and in the packed NPM artifact. If a
-module's dependency closure is not yet eligible, leave it as `.f.ts`; this plan
-does not introduce a staging or package-time import-rewrite mechanism.
+when every relative FunctionalScript dependency referenced by its runtime code
+or retained in its emitted `.d.mts` declaration is already `.f.mjs` or is
+converted in the same coherent group. Authored `.f.mjs` runtime imports and
+JSDoc type references must not point to an unmigrated `.f.ts` module or generated
+`.f.js` output. Packaging copies `.mjs` source and emits declarations without a
+specifier-rewrite step, so the runtime and declaration graphs must both resolve
+in a clean checkout and in the packed NPM artifact. If either dependency closure
+is not yet eligible, leave the module as `.f.ts`; this plan does not introduce a
+staging, package-time import-rewrite, or declaration-rewrite mechanism.
 
 1. As soon as the parser supports the first useful function modules, select an
    existing dependency-closed `.f.ts` module or coherent group whose complete
-   syntax is supported.
+   syntax, runtime dependencies, and declaration-retained type dependencies are
+   supported.
 2. Rename the selected files to `.f.mjs` and replace TypeScript-only syntax with
    JSDoc types.
-3. Update imports within the group and all importers of renamed modules to the
-   authored `.f.mjs` paths.
+3. Update runtime imports and JSDoc type references within the group, plus all
+   importers of renamed modules, to the authored `.f.mjs` paths.
 4. Add the group to parser/compiler validation and preserve its existing proof,
-   coverage, type-checking, and package-publication expectations.
+   coverage, type-checking, package-runtime, and package-type-resolution
+   expectations.
 5. Repeat as each new parser feature makes more dependency-closed groups
    eligible.
 
-A file stays `.f.ts` until all syntax it uses and the required dependency closure
-are supported. Migration must not require implementing unrelated language
-features merely to convert a file. Likewise, `.f.mjs` must not be used as an
-aspirational label: once a module has that extension, accepting and compiling it
-is a compatibility requirement.
+A file stays `.f.ts` until all syntax it uses and both required dependency
+closures are supported. Migration must not require implementing unrelated
+language features merely to convert a file. Likewise, `.f.mjs` must not be used
+as an aspirational label: once a module has that extension, accepting and
+compiling it, resolving its runtime imports, and resolving its emitted types are
+compatibility requirements.
 
 The migration grows real-repository compiler coverage alongside the parser and
 code generator. It does not wait for the complete FunctionalScript feature set,

--- a/fjs/fsc/README.md
+++ b/fjs/fsc/README.md
@@ -19,14 +19,17 @@ The `.f.mjs` extension adds a stronger FunctionalScript-specific promise: it
 marks a module that is ready for translation by the compiler available in the
 same revision of the repository.
 
-Repository migration is incremental, not a single task or pull request:
+Repository migration is incremental, not a single task or pull request. Before
+the first conversion, complete
+[`.f.mjs` test and coverage support](../emergent_testing/todo/f-mjs-test-and-coverage.md)
+so migrated modules remain in proof discovery and coverage reporting.
 
 1. As soon as the parser supports the first useful function modules, select an
    existing `.f.ts` file whose complete syntax is supported.
 2. Rename it to `.f.mjs` and replace TypeScript-only syntax with JSDoc types.
 3. Update imports to the authored `.f.mjs` path.
-4. Add the module to parser/compiler validation so later changes cannot silently
-   move it outside the supported subset.
+4. Add the module to parser/compiler validation and preserve its existing proof
+   and coverage expectations.
 5. Repeat as each new parser feature makes more modules eligible.
 
 A file stays `.f.ts` until all syntax it uses is supported. Migration must not

--- a/fjs/fsc/README.md
+++ b/fjs/fsc/README.md
@@ -1,5 +1,45 @@
 # FunctionalScript Compiler
 
+## Source files and incremental repository migration
+
+The FunctionalScript repository uses file extensions to distinguish authored
+source, generated output, and the subset accepted by the current
+FunctionalScript compiler.
+
+| Extension | Meaning |
+|---|---|
+| `.f.ts` | Authored FunctionalScript-intent TypeScript. It may use TypeScript syntax or FunctionalScript features that the current parser does not support yet. |
+| `.f.mjs` | Authored FunctionalScript ESM JavaScript with JSDoc types. The complete module must be accepted by the current FunctionalScript parser and compiler. |
+| `.f.js` | Generated JavaScript emitted from `.f.ts`; never authored directly. |
+| `.d.ts`, `.d.mts` | Generated TypeScript declarations. |
+
+The general authored/generated JavaScript convention is described in
+[`fjs/ci/todo/publishing-packages.md`](../ci/todo/publishing-packages.md).
+The `.f.mjs` extension adds a stronger FunctionalScript-specific promise: it
+marks a module that is ready for translation by the compiler available in the
+same revision of the repository.
+
+Repository migration is incremental, not a single task or pull request:
+
+1. As soon as the parser supports the first useful function modules, select an
+   existing `.f.ts` file whose complete syntax is supported.
+2. Rename it to `.f.mjs` and replace TypeScript-only syntax with JSDoc types.
+3. Update imports to the authored `.f.mjs` path.
+4. Add the module to parser/compiler validation so later changes cannot silently
+   move it outside the supported subset.
+5. Repeat as each new parser feature makes more modules eligible.
+
+A file stays `.f.ts` until all syntax it uses is supported. Migration must not
+require implementing unrelated language features merely to convert a file.
+Likewise, `.f.mjs` must not be used as an aspirational label: once a module has
+that extension, accepting and compiling it is a compatibility requirement.
+
+The migration grows real-repository compiler coverage alongside the parser and
+code generator. It does not wait for the complete FunctionalScript feature set,
+and compiler progress does not wait for the entire repository to migrate. See
+the [project roadmap](../../todo/plan/roadmap.md) and the
+[fjs–nanvm integration plan](../../todo/fjs-nanvm-integration.md).
+
 ## Tokenizer
 
 - `!` - logicalNot

--- a/fjs/fsc/README.md
+++ b/fjs/fsc/README.md
@@ -103,7 +103,7 @@ the [project roadmap](../../todo/plan/roadmap.md) and the
 - `,` - comma
 - `-` - subtraction
   - `--` - decrement
-  - `-=` - multiplicationAssignment
+  - `-=` - subtraction assignment
 - `.` - dot
   - `...` - spread
 - `/` - division

--- a/fjs/fsc/README.md
+++ b/fjs/fsc/README.md
@@ -103,7 +103,7 @@ the [project roadmap](../../todo/plan/roadmap.md) and the
 - `,` - comma
 - `-` - subtraction
   - `--` - decrement
-  - `-=` - subtraction assignment
+  - `-=` - subtractionAssignment
 - `.` - dot
   - `...` - spread
 - `/` - division

--- a/fjs/fsc/README.md
+++ b/fjs/fsc/README.md
@@ -25,11 +25,10 @@ it. Before converting the first existing repository module, complete both:
 
 - [`.f.mjs` test and coverage support](../emergent_testing/todo/f-mjs-test-and-coverage.md),
   so migrated modules remain in proof discovery and coverage reporting;
-- the authored-`.mjs` tasks in
-  [`publishing-packages.md`](../ci/todo/publishing-packages.md), including
-  TypeScript checking, `.mjs`/`.d.mts` package inclusion, declaration emission,
-  runtime import tests, and packed-package type-resolution tests, so published
-  runtime and declaration imports cannot reference omitted files.
+- [authored `.f.mjs` package support](../ci/todo/f-mjs-package-support.md),
+  including TypeScript checking, `.mjs`/`.d.mts` package inclusion, declaration
+  emission, runtime import tests, and packed-package type-resolution tests, so
+  published runtime and declaration imports cannot reference omitted files.
 
 Migration uses a dependency-closed order. An existing module is eligible only
 when every relative FunctionalScript dependency referenced by its runtime code

--- a/nanvm-lib/todo/console-program.md
+++ b/nanvm-lib/todo/console-program.md
@@ -9,9 +9,14 @@ The `nanvm` **crate** — the self-hosting milestone of the
 of `fjs/effects/node` — see the effects section of the roadmap), the
 generated Rust of the FJS compiler (the same single source that ships on
 npm as FJS code), and a thin hand-written `main`, built by cargo into a
-single native executable that parses and runs `.f.js` directly — no
+single native executable that parses and runs authored `.f.mjs` directly — no
 Node/Deno, no rustc at the user's run time — executing code via the
 interpreter behind the `Function` constructor.
+
+`.f.mjs` is the native CLI source contract because it marks authored
+FunctionalScript accepted by the compiler in the same repository revision.
+`.f.js` remains generated JavaScript for JavaScript runtimes and is not the
+source extension accepted by this self-hosted command.
 
 The generated compiler source is **committed to git** and packaged by cargo
 like any other source file, so consumers build pure Rust with no build

--- a/nanvm-lib/todo/mvp-roadmap.md
+++ b/nanvm-lib/todo/mvp-roadmap.md
@@ -102,11 +102,15 @@ testing, self-hosting, and AOT embedding.
 The compiler CLI is pure FJS that *returns* effect descriptions
 (`Effect<NodeOp, T>`); all actual impurity lives in thin `.ts` runner
 modules (e.g. [`fjs/effects/node/module.ts`](../../fjs/effects/node/module.ts)),
-which are not FJS and never pass through the code generator. The
-`.f.ts`/`.ts` split is exactly the compiled/hand-written boundary: every
-`.f.ts` module compiles to Rust; every impure `.ts` runner needs a
-hand-written Rust twin interpreting the same operation vocabulary against
-the OS (`std::fs`, `std::process`, stdio) instead of Node built-ins.
+which are not FJS and never pass through the code generator. During compiler
+bootstrap, `.f.mjs` is the compiled source marker: every `.f.mjs` module must
+compile to Rust, while every impure `.ts` runner needs a hand-written Rust twin
+interpreting the same operation vocabulary against the OS (`std::fs`,
+`std::process`, stdio) instead of Node built-ins. Existing `.f.ts` modules are
+the broader FunctionalScript-intent source set; they move to `.f.mjs`
+incrementally when the parser supports their complete syntax and their
+TypeScript types have been moved to JSDoc. The extension contract and migration
+strategy are documented in [`fjs/fsc/README.md`](../../fjs/fsc/README.md).
 
 The Rust twin of `fjs/effects/node` is the **`nanvm-effects-node`** library
 crate — named to mirror the effect directory structure: this specific
@@ -149,10 +153,11 @@ Scoping notes:
   not a syscall port.
 - **Testing comes cheap.** The pure in-memory interpreters
   ([`fjs/effects/mock`](../../fjs/effects/mock),
-  [`fjs/effects/node/virtual`](../../fjs/effects/node/virtual)) are `.f.ts`
-  code, so they compile through the code generator unchanged: the compiled
-  CLI can run against in-memory effects with no Rust twins, and the
-  `nanvm-effects-node` runner can be cross-checked against the pure
+  [`fjs/effects/node/virtual`](../../fjs/effects/node/virtual)) are currently
+  `.f.ts` code. As the parser reaches the syntax each module uses, migrate it
+  to `.f.mjs`; from that point it compiles through the code generator unchanged,
+  so the compiled CLI can run against in-memory effects with no Rust twins.
+  The `nanvm-effects-node` runner can then be cross-checked against the pure
   interpreter operation by operation. The exception is
   [`fjs/effects/node/memory`](../../fjs/effects/node/memory) — the runner for
   the mutable memory effects (`MemOp`) — which is an impure `.ts` module
@@ -269,7 +274,7 @@ as a generic `Any` facility, post-MVP.
 - [ ] **Harness + walking skeleton** — a harness crate (or generated tests
       in `nanvm-lib`) whose `main` evaluates a generated module's
       `export default` and prints the result as JSON; wire the pipeline
-      end-to-end early with a minimal subset (e.g. a constant default
+      end-to-end early with a minimal `.f.mjs` subset (e.g. a constant default
       export), driven by `cargo test` in CI, so every later feature lands
       into a working pipeline. See
       [fjs-nanvm-integration](../../todo/fjs-nanvm-integration.md).
@@ -285,6 +290,11 @@ as a generic `Any` facility, post-MVP.
       Current status: [operator tables in `nanvm-lib/README.md`](../README.md).
       Spec: [operators](../../todo/lang/2340-operators.md).
 - [ ] **Parser**, using [`fjs/bnf/`](../../fjs/bnf/README.md) (FJS).
+- [ ] **Incremental repository coverage** — after the parser supports the first
+      useful function modules, convert the first eligible `.f.ts` module to
+      `.f.mjs`, move its types to JSDoc, and keep it in the end-to-end compiler
+      test set. Continue in separate changes as language coverage grows; do not
+      make whole-repository migration an MVP gate.
 
 #### P2
 
@@ -326,14 +336,16 @@ as a generic `Any` facility, post-MVP.
 Compile the compiler itself (written in FJS) to Rust with the code generator
 and ship it as the `nanvm` crate
 ([console-program](./console-program.md)): a single native executable that
-parses and runs `.f.js` directly — no Node/Deno, no rustc at the user's run
+parses and runs `.f.mjs` directly — no Node/Deno, no rustc at the user's run
 time — executing code via the interpreter behind the `Function` constructor,
 with its I/O interpreted by the `nanvm-effects-node` runner (see the effects
 section above).
 
 Reached incrementally: the code generator's language coverage grows with the
 operator/function/control tasks above until it covers everything the
-compiler's own code uses.
+compiler's own code uses. The corresponding compiler modules move from
+`.f.ts` to `.f.mjs` as they become supported, so self-hosting is the completion
+of the same repository-migration strategy rather than a separate rewrite.
 
 ### Open questions
 
@@ -360,6 +372,8 @@ compiler's own code uses.
 - [`todo/lang/README.md`](../../todo/lang/README.md) — the language spec and
   tag tables; §9 records the AST-as-data decision and the two execution
   paths.
+- [`fjs/fsc/README.md`](../../fjs/fsc/README.md) — source extension contract
+  and incremental repository migration.
 - [ast-spec](../../todo/ast-spec.md) — the schema (RTTI) of the
   code-describing `Any`; the `Function` constructor contract.
 - [fjs-nanvm-integration](../../todo/fjs-nanvm-integration.md) — the

--- a/todo/fjs-nanvm-integration.md
+++ b/todo/fjs-nanvm-integration.md
@@ -39,10 +39,10 @@ Before converting the first existing repository module, complete both:
 
 - [`.f.mjs` test and coverage support](../fjs/emergent_testing/todo/f-mjs-test-and-coverage.md),
   so the rename cannot silently remove internal proofs or coverage;
-- the authored-`.mjs` work in
-  [`publishing-packages.md`](../fjs/ci/todo/publishing-packages.md), including
-  TypeScript checking, package inclusion for `.mjs` and `.d.mts`, declaration
-  emission, runtime import tests, and packed-package type-resolution tests.
+- [authored `.f.mjs` package support](../fjs/ci/todo/f-mjs-package-support.md),
+  including TypeScript checking, package inclusion for `.mjs` and `.d.mts`,
+  declaration emission, runtime import tests, and packed-package
+  type-resolution tests.
 
 After those prerequisites, select a dependency-closed module or coherent group.
 Every relative FunctionalScript dependency used by executable code or retained
@@ -95,10 +95,8 @@ via the `Function` constructor — no rustc at the user's run time.
       the result printed to stdout as JSON.
 - [ ] Complete
       [`.f.mjs` test and coverage support](../fjs/emergent_testing/todo/f-mjs-test-and-coverage.md).
-- [ ] Complete the authored-`.mjs` TypeScript-checking, package-inclusion,
-      declaration-emission, mixed-source validation, runtime package-test, and
-      packed-package type-resolution tasks in
-      [`publishing-packages.md`](../fjs/ci/todo/publishing-packages.md).
+- [ ] Complete
+      [authored `.f.mjs` package support](../fjs/ci/todo/f-mjs-package-support.md).
 - [ ] Convert the first eligible repository module or group that is closed over
       both runtime and declaration-retained type dependencies from `.f.ts` to
       `.f.mjs`, and keep it in the end-to-end compiler, proof, coverage,
@@ -113,8 +111,10 @@ via the `Function` constructor — no rustc at the user's run time.
 - [`.f.mjs` test and coverage support](../fjs/emergent_testing/todo/f-mjs-test-and-coverage.md)
   — proof-discovery and coverage prerequisite for the first repository
   conversion.
-- [`publishing-packages.md`](../fjs/ci/todo/publishing-packages.md) — authored
-  `.mjs` validation, declaration emission, package inclusion, runtime/type
-  dependency rules, and package tests.
+- [authored `.f.mjs` package support](../fjs/ci/todo/f-mjs-package-support.md) —
+  focused P1 validation, emission, package-content, dependency, and consumer
+  type-resolution prerequisite.
+- [`publishing-packages.md`](../fjs/ci/todo/publishing-packages.md) — broader P3
+  package-publishing roadmap and shared authored/generated extension convention.
 - [ast-spec](./ast-spec.md) — the schema of the code-describing `Any`; the
   `Function` constructor contract.

--- a/todo/fjs-nanvm-integration.md
+++ b/todo/fjs-nanvm-integration.md
@@ -22,6 +22,25 @@ prove much. The entry point is the module's `export default`: the harness
 evaluates it, runs it if it is a function, and prints the result to stdout
 as JSON.
 
+### Repository source selection
+
+The first integration does not imply that every existing `.f.ts` module is
+accepted by the new parser. `.f.ts` is the broader authored
+FunctionalScript-intent source set and may contain TypeScript syntax or
+FunctionalScript features that are not implemented yet.
+
+Use `.f.mjs` for authored modules whose complete syntax is accepted by the
+current parser and compiler. Types in these modules are expressed with JSDoc,
+not TypeScript syntax. The initial walking skeleton may start with a minimal
+`.f.mjs` fixture; as soon as an existing repository module fits the supported
+subset, rename that module from `.f.ts` to `.f.mjs`, update its imports, and use
+it as an end-to-end compiler input.
+
+Repository migration then continues independently, one file or coherent group
+at a time, as parser features land. It is neither part of one large PR nor a
+gate on this integration task. See [`fjs/fsc/README.md`](../fjs/fsc/README.md)
+for the extension contract and migration strategy.
+
 ### CLI: an output target, not a command group (decided)
 
 `fjs compile <input> <output>` already dispatches on the output extension
@@ -52,9 +71,11 @@ via the `Function` constructor — no rustc at the user's run time.
 - [ ] Define the convention for generated module imports (`use` paths,
       file/directory layout — see the open question in
       [mvp-roadmap](../nanvm-lib/todo/mvp-roadmap.md#open-questions)).
-- [ ] Prove the pipeline with a minimal subset: a constant default export,
-      compiled by `fjs` to `.rs`, built and run by cargo, result printed to
-      stdout as JSON.
+- [ ] Prove the pipeline with a minimal `.f.mjs` subset: a constant default
+      export compiled by `fjs` to `.rs`, built and run by cargo, with the
+      result printed to stdout as JSON.
+- [ ] Convert the first eligible repository module from `.f.ts` to `.f.mjs`
+      and keep it in the end-to-end compiler test set.
 
 ### Related
 

--- a/todo/fjs-nanvm-integration.md
+++ b/todo/fjs-nanvm-integration.md
@@ -38,11 +38,12 @@ complete, because that fixture does not enter the published runtime graph.
 Before converting the first existing repository module, complete both:
 
 - [`.f.mjs` test and coverage support](../fjs/emergent_testing/todo/f-mjs-test-and-coverage.md),
-  so the rename cannot silently remove internal proofs or coverage;
+  so the rename cannot silently remove internal proofs or coverage and the
+  proof guidance in `AGENTS.md` and `CONTRIBUTING.md` remains consistent;
 - [authored `.f.mjs` package support](../fjs/ci/todo/f-mjs-package-support.md),
   including TypeScript checking, package inclusion for `.mjs` and `.d.mts`,
-  declaration emission, runtime import tests, and packed-package
-  type-resolution tests.
+  repeatable generated-output cleanup and declaration emission, consecutive-pack
+  validation, runtime import tests, and packed-package type-resolution tests.
 
 After those prerequisites, select a dependency-closed module or coherent group.
 Every relative FunctionalScript dependency used by executable code or retained
@@ -96,11 +97,13 @@ via the `Function` constructor — no rustc at the user's run time.
 - [ ] Complete
       [`.f.mjs` test and coverage support](../fjs/emergent_testing/todo/f-mjs-test-and-coverage.md).
 - [ ] Complete
-      [authored `.f.mjs` package support](../fjs/ci/todo/f-mjs-package-support.md).
+      [authored `.f.mjs` package support](../fjs/ci/todo/f-mjs-package-support.md),
+      including the consecutive-pack repeatability regression.
 - [ ] Convert the first eligible repository module or group that is closed over
       both runtime and declaration-retained type dependencies from `.f.ts` to
       `.f.mjs`, and keep it in the end-to-end compiler, proof, coverage,
-      type-checking, package-runtime, and package-type-resolution test sets.
+      type-checking, repeatable package-runtime, and package-type-resolution test
+      sets.
 
 ### Related
 
@@ -109,11 +112,11 @@ via the `Function` constructor — no rustc at the user's run time.
 - [nanvm-lib/todo/console-program.md](../nanvm-lib/todo/console-program.md) —
   the self-hosted `nanvm` crate (post-MVP).
 - [`.f.mjs` test and coverage support](../fjs/emergent_testing/todo/f-mjs-test-and-coverage.md)
-  — proof-discovery and coverage prerequisite for the first repository
-  conversion.
+  — proof-discovery, cross-runner coverage, and contributor-policy prerequisite
+  for the first repository conversion.
 - [authored `.f.mjs` package support](../fjs/ci/todo/f-mjs-package-support.md) —
-  focused P1 validation, emission, package-content, dependency, and consumer
-  type-resolution prerequisite.
+  focused P1 validation, repeatable emission, package-content, dependency, and
+  consumer type-resolution prerequisite.
 - [`publishing-packages.md`](../fjs/ci/todo/publishing-packages.md) — broader P3
   package-publishing roadmap and shared authored/generated extension convention.
 - [ast-spec](./ast-spec.md) — the schema of the code-describing `Any`; the

--- a/todo/fjs-nanvm-integration.md
+++ b/todo/fjs-nanvm-integration.md
@@ -32,13 +32,20 @@ FunctionalScript features that are not implemented yet.
 Use `.f.mjs` for authored modules whose complete syntax is accepted by the
 current parser and compiler. Types in these modules are expressed with JSDoc,
 not TypeScript syntax. The initial walking skeleton may start with a minimal
-`.f.mjs` fixture; as soon as an existing repository module fits the supported
-subset, rename that module from `.f.ts` to `.f.mjs`, update its imports, and use
-it as an end-to-end compiler input.
+synthetic `.f.mjs` fixture before repository-wide `.mjs` infrastructure is
+complete, because that fixture does not enter the published runtime graph.
 
-Before converting the first existing module, complete
-[`.f.mjs` test and coverage support](../fjs/emergent_testing/todo/f-mjs-test-and-coverage.md)
-so the rename cannot silently remove internal proofs or coverage. Repository
+Before converting the first existing repository module, complete both:
+
+- [`.f.mjs` test and coverage support](../fjs/emergent_testing/todo/f-mjs-test-and-coverage.md),
+  so the rename cannot silently remove internal proofs or coverage;
+- the authored-`.mjs` work in
+  [`publishing-packages.md`](../fjs/ci/todo/publishing-packages.md), including
+  TypeScript checking, package inclusion for `.mjs` and `.d.mts`, declaration
+  emission, and cross-extension package import tests.
+
+After those prerequisites, rename an eligible module from `.f.ts` to `.f.mjs`,
+update its imports, and use it as an end-to-end compiler input. Repository
 migration then continues independently, one file or coherent group at a time,
 as parser features land. It is neither part of one large PR nor a gate on the
 initial synthetic walking skeleton. See
@@ -75,13 +82,17 @@ via the `Function` constructor — no rustc at the user's run time.
 - [ ] Define the convention for generated module imports (`use` paths,
       file/directory layout — see the open question in
       [mvp-roadmap](../nanvm-lib/todo/mvp-roadmap.md#open-questions)).
-- [ ] Prove the pipeline with a minimal `.f.mjs` subset: a constant default
-      export compiled by `fjs` to `.rs`, built and run by cargo, with the
-      result printed to stdout as JSON.
+- [ ] Prove the pipeline with a minimal synthetic `.f.mjs` subset: a constant
+      default export compiled by `fjs` to `.rs`, built and run by cargo, with
+      the result printed to stdout as JSON.
 - [ ] Complete
       [`.f.mjs` test and coverage support](../fjs/emergent_testing/todo/f-mjs-test-and-coverage.md).
+- [ ] Complete the authored-`.mjs` TypeScript-checking, package-inclusion,
+      declaration-emission, and package-test tasks in
+      [`publishing-packages.md`](../fjs/ci/todo/publishing-packages.md).
 - [ ] Convert the first eligible repository module from `.f.ts` to `.f.mjs`
-      and keep it in the end-to-end compiler, proof, and coverage test sets.
+      and keep it in the end-to-end compiler, proof, coverage, type-checking,
+      and package test sets.
 
 ### Related
 
@@ -92,5 +103,7 @@ via the `Function` constructor — no rustc at the user's run time.
 - [`.f.mjs` test and coverage support](../fjs/emergent_testing/todo/f-mjs-test-and-coverage.md)
   — proof-discovery and coverage prerequisite for the first repository
   conversion.
+- [`publishing-packages.md`](../fjs/ci/todo/publishing-packages.md) — authored
+  `.mjs` validation, declaration emission, package inclusion, and package tests.
 - [ast-spec](./ast-spec.md) — the schema of the code-describing `Any`; the
   `Function` constructor contract.

--- a/todo/fjs-nanvm-integration.md
+++ b/todo/fjs-nanvm-integration.md
@@ -42,13 +42,19 @@ Before converting the first existing repository module, complete both:
 - the authored-`.mjs` work in
   [`publishing-packages.md`](../fjs/ci/todo/publishing-packages.md), including
   TypeScript checking, package inclusion for `.mjs` and `.d.mts`, declaration
-  emission, and cross-extension package import tests.
+  emission, and package import tests.
 
-After those prerequisites, rename an eligible module from `.f.ts` to `.f.mjs`,
-update its imports, and use it as an end-to-end compiler input. Repository
-migration then continues independently, one file or coherent group at a time,
-as parser features land. It is neither part of one large PR nor a gate on the
-initial synthetic walking skeleton. See
+After those prerequisites, select a dependency-closed module or coherent group:
+every relative FunctionalScript runtime dependency imported by the group must
+already be `.f.mjs` or be converted in the same change. Authored `.f.mjs` must
+not import unmigrated `.f.ts` or generated `.f.js`; package emission does not
+rewrite authored `.mjs` imports. Rename the group, update its importers, and use
+it as an end-to-end compiler input. If the required dependency closure is not
+yet supported, postpone that group and choose a smaller eligible leaf.
+
+Repository migration then continues independently, one dependency-closed group
+at a time, as parser features land. It is neither part of one large PR nor a
+gate on the initial synthetic walking skeleton. See
 [`fjs/fsc/README.md`](../fjs/fsc/README.md) for the extension contract and
 migration strategy.
 
@@ -88,11 +94,11 @@ via the `Function` constructor — no rustc at the user's run time.
 - [ ] Complete
       [`.f.mjs` test and coverage support](../fjs/emergent_testing/todo/f-mjs-test-and-coverage.md).
 - [ ] Complete the authored-`.mjs` TypeScript-checking, package-inclusion,
-      declaration-emission, and package-test tasks in
+      declaration-emission, mixed-source validation, and package-test tasks in
       [`publishing-packages.md`](../fjs/ci/todo/publishing-packages.md).
-- [ ] Convert the first eligible repository module from `.f.ts` to `.f.mjs`
-      and keep it in the end-to-end compiler, proof, coverage, type-checking,
-      and package test sets.
+- [ ] Convert the first eligible dependency-closed repository module or group
+      from `.f.ts` to `.f.mjs` and keep it in the end-to-end compiler, proof,
+      coverage, type-checking, and package test sets.
 
 ### Related
 
@@ -104,6 +110,7 @@ via the `Function` constructor — no rustc at the user's run time.
   — proof-discovery and coverage prerequisite for the first repository
   conversion.
 - [`publishing-packages.md`](../fjs/ci/todo/publishing-packages.md) — authored
-  `.mjs` validation, declaration emission, package inclusion, and package tests.
+  `.mjs` validation, declaration emission, package inclusion, mixed-source
+  import rules, and package tests.
 - [ast-spec](./ast-spec.md) — the schema of the code-describing `Any`; the
   `Function` constructor contract.

--- a/todo/fjs-nanvm-integration.md
+++ b/todo/fjs-nanvm-integration.md
@@ -42,15 +42,17 @@ Before converting the first existing repository module, complete both:
 - the authored-`.mjs` work in
   [`publishing-packages.md`](../fjs/ci/todo/publishing-packages.md), including
   TypeScript checking, package inclusion for `.mjs` and `.d.mts`, declaration
-  emission, and package import tests.
+  emission, runtime import tests, and packed-package type-resolution tests.
 
-After those prerequisites, select a dependency-closed module or coherent group:
-every relative FunctionalScript runtime dependency imported by the group must
-already be `.f.mjs` or be converted in the same change. Authored `.f.mjs` must
-not import unmigrated `.f.ts` or generated `.f.js`; package emission does not
-rewrite authored `.mjs` imports. Rename the group, update its importers, and use
-it as an end-to-end compiler input. If the required dependency closure is not
-yet supported, postpone that group and choose a smaller eligible leaf.
+After those prerequisites, select a dependency-closed module or coherent group.
+Every relative FunctionalScript dependency used by executable code or retained
+in emitted `.d.mts` declarations must already be `.f.mjs` or be converted in the
+same change. Authored `.f.mjs` runtime imports and JSDoc type references must not
+point to unmigrated `.f.ts` or generated `.f.js`; package emission does not
+rewrite authored `.mjs` imports or declaration specifiers. Rename the group,
+update its runtime and type references plus all importers, and use it as an
+end-to-end compiler input. If either required dependency closure is not yet
+supported, postpone that group and choose a smaller eligible leaf.
 
 Repository migration then continues independently, one dependency-closed group
 at a time, as parser features land. It is neither part of one large PR nor a
@@ -94,11 +96,13 @@ via the `Function` constructor — no rustc at the user's run time.
 - [ ] Complete
       [`.f.mjs` test and coverage support](../fjs/emergent_testing/todo/f-mjs-test-and-coverage.md).
 - [ ] Complete the authored-`.mjs` TypeScript-checking, package-inclusion,
-      declaration-emission, mixed-source validation, and package-test tasks in
+      declaration-emission, mixed-source validation, runtime package-test, and
+      packed-package type-resolution tasks in
       [`publishing-packages.md`](../fjs/ci/todo/publishing-packages.md).
-- [ ] Convert the first eligible dependency-closed repository module or group
-      from `.f.ts` to `.f.mjs` and keep it in the end-to-end compiler, proof,
-      coverage, type-checking, and package test sets.
+- [ ] Convert the first eligible repository module or group that is closed over
+      both runtime and declaration-retained type dependencies from `.f.ts` to
+      `.f.mjs`, and keep it in the end-to-end compiler, proof, coverage,
+      type-checking, package-runtime, and package-type-resolution test sets.
 
 ### Related
 
@@ -110,7 +114,7 @@ via the `Function` constructor — no rustc at the user's run time.
   — proof-discovery and coverage prerequisite for the first repository
   conversion.
 - [`publishing-packages.md`](../fjs/ci/todo/publishing-packages.md) — authored
-  `.mjs` validation, declaration emission, package inclusion, mixed-source
-  import rules, and package tests.
+  `.mjs` validation, declaration emission, package inclusion, runtime/type
+  dependency rules, and package tests.
 - [ast-spec](./ast-spec.md) — the schema of the code-describing `Any`; the
   `Function` constructor contract.

--- a/todo/fjs-nanvm-integration.md
+++ b/todo/fjs-nanvm-integration.md
@@ -36,10 +36,14 @@ not TypeScript syntax. The initial walking skeleton may start with a minimal
 subset, rename that module from `.f.ts` to `.f.mjs`, update its imports, and use
 it as an end-to-end compiler input.
 
-Repository migration then continues independently, one file or coherent group
-at a time, as parser features land. It is neither part of one large PR nor a
-gate on this integration task. See [`fjs/fsc/README.md`](../fjs/fsc/README.md)
-for the extension contract and migration strategy.
+Before converting the first existing module, complete
+[`.f.mjs` test and coverage support](../fjs/emergent_testing/todo/f-mjs-test-and-coverage.md)
+so the rename cannot silently remove internal proofs or coverage. Repository
+migration then continues independently, one file or coherent group at a time,
+as parser features land. It is neither part of one large PR nor a gate on the
+initial synthetic walking skeleton. See
+[`fjs/fsc/README.md`](../fjs/fsc/README.md) for the extension contract and
+migration strategy.
 
 ### CLI: an output target, not a command group (decided)
 
@@ -74,8 +78,10 @@ via the `Function` constructor — no rustc at the user's run time.
 - [ ] Prove the pipeline with a minimal `.f.mjs` subset: a constant default
       export compiled by `fjs` to `.rs`, built and run by cargo, with the
       result printed to stdout as JSON.
+- [ ] Complete
+      [`.f.mjs` test and coverage support](../fjs/emergent_testing/todo/f-mjs-test-and-coverage.md).
 - [ ] Convert the first eligible repository module from `.f.ts` to `.f.mjs`
-      and keep it in the end-to-end compiler test set.
+      and keep it in the end-to-end compiler, proof, and coverage test sets.
 
 ### Related
 
@@ -83,5 +89,8 @@ via the `Function` constructor — no rustc at the user's run time.
   definition and task list.
 - [nanvm-lib/todo/console-program.md](../nanvm-lib/todo/console-program.md) —
   the self-hosted `nanvm` crate (post-MVP).
+- [`.f.mjs` test and coverage support](../fjs/emergent_testing/todo/f-mjs-test-and-coverage.md)
+  — proof-discovery and coverage prerequisite for the first repository
+  conversion.
 - [ast-spec](./ast-spec.md) — the schema of the code-describing `Any`; the
   `Function` constructor contract.

--- a/todo/lang/README.md
+++ b/todo/lang/README.md
@@ -383,7 +383,7 @@ type AsyncMap<K, V> = {
 
 const fs = (state: AsyncMap<string, string>) => ({
    readFile: async(name: string): Promise<string> => { /* ? */ }
-   writeFile: async(k: string, v: string) => { /* ? */ }
+   writeFile: async(name: string, text: string): Promise<void> => { /* ? */ }
 })
 
 // Another option is to allow access to `let` in `async` functions.

--- a/todo/lang/README.md
+++ b/todo/lang/README.md
@@ -11,10 +11,19 @@ When we implement features of FunctionalScript, the first priority is a simplifi
 
 File Types:
 
-|File Type|Extension       |Notes                |
-|---------|----------------|---------------------|
-|JSON     |`.json`         |Tree.                |
-|FJS      |`.f.js`, `.f.ts`|Graph with functions.|
+|File Type|Extension|Notes|
+|---------|---------|-----|
+|JSON|`.json`|Tree.|
+|FJS source|`.f.ts`, `.f.mjs`|Graph with functions.|
+|Generated FJS|`.f.js`|Generated from `.f.ts`; never authored directly.|
+
+`.f.ts` is authored FunctionalScript-intent TypeScript and may contain syntax
+that the current FunctionalScript parser does not support yet. `.f.mjs` is
+authored ESM JavaScript with JSDoc types whose complete syntax must be accepted
+by the current parser and compiler. Repository modules move from `.f.ts` to
+`.f.mjs` incrementally as language support grows; this is not a single migration
+step. See [`fjs/fsc/README.md`](../../fjs/fsc/README.md) for the extension
+contract and migration strategy.
 
 **Note**: An FJS value can't be serialized without additional run-time infrastructure.
 
@@ -374,7 +383,7 @@ type AsyncMap<K, V> = {
 
 const fs = (state: AsyncMap<string, string>) => ({
    readFile: async(name: string): Promise<string> => { /* ? */ }
-   writeFile: async(name: string, text: string): Promise<void> => { /* ? */ }
+   writeFile: async(k: string, v: string) => Promise<void> => { /* ? */ }
 })
 
 // Another option is to allow access to `let` in `async` functions.

--- a/todo/lang/README.md
+++ b/todo/lang/README.md
@@ -383,7 +383,7 @@ type AsyncMap<K, V> = {
 
 const fs = (state: AsyncMap<string, string>) => ({
    readFile: async(name: string): Promise<string> => { /* ? */ }
-   writeFile: async(k: string, v: string) => Promise<void> => { /* ? */ }
+   writeFile: async(k: string, v: string) => { /* ? */ }
 })
 
 // Another option is to allow access to `let` in `async` functions.

--- a/todo/plan/roadmap.md
+++ b/todo/plan/roadmap.md
@@ -108,6 +108,25 @@ See [architecture.md §Human-readable paths](./architecture.md).
    bytecode is an optional, VM-internal, performance-oriented representation
 5. Generic `Any` serialization (CBOR) in `nanvm-lib` — covers code as data; needed for CAS/CAVM
 
+**Incremental repository migration:**
+
+The compiler will begin compiling the FunctionalScript repository as soon as it
+can parse the first useful function modules; it will not wait for the complete
+language feature set. Repository coverage grows together with parser and code
+generator coverage:
+
+1. Select an existing `.f.ts` module whose complete syntax is supported.
+2. Rename it to `.f.mjs`, move TypeScript types to JSDoc, and update imports.
+3. Make that module a permanent parser/compiler regression input.
+4. Repeat in separate, reviewable changes as more syntax becomes supported.
+
+`.f.mjs` is the marker for authored FunctionalScript that the compiler in the
+same repository revision must accept. Unsupported modules remain `.f.ts`; no
+migration should pull unrelated language features into scope merely to convert
+a file. This is a continuing strategy rather than a one-time migration task or
+a prerequisite for the compiler MVP. The extension contract and detailed
+workflow are documented in [`fjs/fsc/README.md`](../../fjs/fsc/README.md).
+
 This is the longest dependency chain. Everything after it depends on it.
 
 ---
@@ -145,6 +164,7 @@ Prerequisite: compiler + CA FunctionalScript complete.
 | SUL deduplication | `fjs/sul/` L1–L4 ✓ | CAS integration layer |
 | Compiler (parsing) | `fjs/djs/` data pipeline ✓, `fjs/bnf/` framework ✓ | Function support, FS grammar |
 | Compiler (codegen) | — | Rust code generator (FJS), `Function` constructor + interpreter in `nanvm-lib` |
+| Compiler (repository coverage) | Extension and migration strategy defined | First eligible `.f.ts` → `.f.mjs` conversion, then incremental expansion |
 | CA FunctionalScript | — | Depends on VM + AST canonicalization |
 | Sandboxed execution | — | Depends on CA FS |
 | Hybrid intelligence | — | Depends on all above |


### PR DESCRIPTION
## Summary

- define `.f.mjs` as authored FunctionalScript that the current parser and compiler must accept
- keep `.f.ts` as the broader FunctionalScript-intent TypeScript source set while parser coverage is incomplete
- reserve `.f.js` for generated JavaScript and move migrated module types to JSDoc
- add incremental repository migration to the project and nanvm MVP roadmaps
- make a synthetic `.f.mjs` module part of the end-to-end fjs–nanvm walking skeleton
- add a dedicated P1 TODO with a trackable checklist for `.f.mjs` proof discovery, Node/Deno coverage, generated CI, and synchronized `AGENTS.md`/`CONTRIBUTING.md` proof guidance
- add a focused P1 authored-`.f.mjs` package-support TODO instead of making the broad P3 publishing roadmap block migration
- make package emission repeatable through narrow generated-output cleanup and a consecutive-pack regression
- allow mixed `module.f.mjs` / `proof.f.ts` pairs so implementations and proofs migrate independently
- update the repository import policy so `.f.ts` may target `.f.mjs` while authored `.f.mjs` remains dependency-closed
- require authored-`.mjs` validation, declaration emission, package inclusion, runtime tests, and packed-package type-resolution tests before converting the first real repository module
- require migration groups to be closed over both runtime imports and declaration-retained type references, without package-time specifier rewriting
- align the self-hosted native console contract on authored `.f.mjs`
- cross-link the compiler, language, integration, testing, packaging, and console documentation

## Strategy

Migration is continuous rather than a one-time repository conversion. As parser features land, eligible `.f.ts` modules move to `.f.mjs` in separate reviewable changes. Each migrated module becomes a permanent parser/compiler regression input. Unsupported files remain `.f.ts`, and whole-repository migration is not an MVP gate.

A synthetic `.f.mjs` walking-skeleton fixture may be introduced early. Before the first existing repository module is converted, two focused P1 infrastructure prerequisites must be complete:

1. emergent-testing support must preserve proof discovery and implementation coverage for `.f.mjs` in Node, local Deno, and generated Deno CI; the CI generator must have a regression proof; and `AGENTS.md` plus `CONTRIBUTING.md` must state the same mandatory proof policy while allowing a migrated `module.f.mjs` to keep its co-located `proof.f.ts`;
2. authored-`.f.mjs` package support must type-check authored `.mjs`, clean known generated outputs before emission, emit `.d.mts`, include `.mjs`/`.d.mts` in the package, pass two consecutive `npm pack` runs with the same file set, test supported mixed-source imports, type-check a clean consumer against the packed declarations, and update `AGENTS.md` so `.f.ts` importers may follow dependencies renamed to `.f.mjs` without allowing `.f.mjs` to depend on `.f.ts`.

The generated-output cleanup is narrow and source-derived: it removes only generated `.js`, `.d.ts`, and `.d.mts` outputs for authored source. It does not remove authored `.mjs`, use a staging tree, or run a broad working-tree cleanup.

The broader package-publishing roadmap remains P3 and records shared package conventions and future targets; it no longer owns the blocking migration checklist.

Implementation and proof migration are independent. A `proof.f.ts` may import and test `module.f.mjs`, including continued use of existing `.f.ts` test helpers. The proof becomes `proof.f.mjs` only when its own syntax and dependency closure are compiler-ready.

The repository import policy is asymmetric during migration: authored `.f.ts` may import relative `.f.ts` or `.f.mjs`, while authored `.f.mjs` runtime imports and declaration-retained type references may target relative `.f.mjs` modules only.

Real repository implementation migration is dependency-closed across two graphs. Authored `.f.mjs` runtime imports and JSDoc/type references retained in emitted `.d.mts` declarations may depend only on `.f.mjs` modules already migrated or converted in the same group; they must not reference unmigrated `.f.ts` or generated `.f.js`. No staging tree, package-time runtime-import rewriting, or declaration-specifier rewriting is planned.

## Validation

Documentation-only change. Reviewed the branch comparison against `main`, aligned the previously conflicting MVP assumption that every `.f.ts` file was immediately compilable, defined runtime and declaration dependency-closure invariants, made `.f.mjs` the consistent source contract for the self-hosted native console, documented mixed `.f.mjs` implementation / `.f.ts` proof pairs, added explicit task checklists, made both coverage and package support actionable P1 prerequisites, synchronized contributor proof-guidance requirements, added repeatable package emission and consecutive-pack validation, and included the corresponding asymmetric repository import-policy update.