### PR TITLE
Add proof test for getOperatorToken error handling

### DIFF
--- a/fjs/js/tokenizer/module.f.ts
+++ b/fjs/js/tokenizer/module.f.ts
@@ -69,7 +69,7 @@ import {
     rightCurlyBracket,
     dollarSign
 }  from '../../text/ascii/module.f.ts'
-import { todo } from '../../asserts/module.f.ts'
+import { todo, assertEq } from '../../asserts/module.f.ts'
 
 const { fromCharCode } = String
 
@@ -923,6 +923,14 @@ export const tokenize
     }
 
 export const proof = {
+    // `getOperatorToken` is only ever called with a value already confirmed to be
+    // a known operator (`hasOperatorToken`, or a single char from `rangeOpStart`),
+    // so its `??` fallback is unreachable through `tokenize`. Call it directly
+    // with a non-operator string to cover that branch.
+    getOperatorTokenInvalid: () => {
+        const result = getOperatorToken('@')
+        assertEq(result.kind, 'error')
+    },
     throw: {
         // union throws when two distinct non-default handlers are merged for the same range;
         // this path is unreachable through the public API (no overlapping ranges in practice).


### PR DESCRIPTION
## Summary
Added a proof test to cover the unreachable error branch in `getOperatorToken` when called with an invalid operator string.

## Changes
- Imported `assertEq` from the asserts module alongside the existing `todo` import
- Added `getOperatorTokenInvalid` proof test that directly calls `getOperatorToken` with a non-operator string (`'@'`) to verify it returns an error result
- Included documentation explaining why this test is necessary: the fallback error case in `getOperatorToken` is unreachable through normal `tokenize` flow since the function is only called after confirming the input is a known operator

## Details
This improves test coverage by explicitly testing the error handling path in `getOperatorToken` that cannot be reached through the public API due to validation checks that occur before the function is invoked.

https://claude.ai/code/session_012atN5MMLDeb5AoBRuTZ1eh