### PR TITLE
Add new-parser issue: BNF descent parser over token symbols

### DIFF
--- a/fjs/bnf/descent/todo/failure-tracking.md
+++ b/fjs/bnf/descent/todo/failure-tracking.md
@@ -1,0 +1,85 @@
+## Retain failure information in the descent parser
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+A failed `descentParser` match reports *that* the input was rejected and nothing
+usable about where. Two mechanisms in `fjs/bnf/descent/module.f.ts` destroy the
+information:
+
+1. **A failed result carries no matched symbols.** Every `mrFail` call site
+   passes an empty sequence (`:112`, `:125`, `:129`, `:141`, `:162`), so a failed
+   `DescentMatchResult` is `[{ tag, sequence: [] }, false, idx]`. On a failed
+   sequence item the accumulated `seq` is discarded for `[]` (`:162`) and that
+   empty failure propagates outward through every enclosing sequence. Nothing in
+   the result identifies the offending rule, and no `CodePointMeta` survives — so
+   the caller cannot recover the metadata of a single consumed symbol.
+2. **`idx` rewinds.** `:162` returns `frame.startIdx`, the start of the enclosing
+   sequence, rather than the position where matching stopped. Nested failures
+   rewind repeatedly, so a top-level failure can report index 0.
+
+`DescentMatchResult<T> = readonly[AstRuleMeta<T>, boolean, number]` (`:29`) has
+nowhere to carry the missing facts in any case.
+
+**This is not a live mis-reporting bug in today's consumers.** `tokenizeJs`
+(`fjs/djs/tokenizer/module.f.ts:530-534`) derives its error position from `len`
+when `len !== cp.length`, and for the token grammar — a repeat that matches a
+prefix and then stops — that is a *successful* match's consumed length, not a
+failure index. Probed with `'abc @'`, `'a\nb\n@'`, `'{ "x": 1 } @'` and
+`'let x = #'`, it reports the exact line and column of the bad character in all
+four. The gap bites when the whole match genuinely fails, which is the normal
+case for a grammar that must consume its entire input.
+
+### Proposal
+
+Track the furthest position reached across the whole match, plus the terminals
+expected there, and return it alongside the result.
+
+The furthest position is monotone — it only ever advances, and unlike `idx` it is
+never rewound by a failing frame — so it threads through the driver loop as a
+single value rather than per-frame state:
+
+```ts
+export type DescentFailure = {
+    /** Furthest symbol index reached by any attempted match. */
+    readonly idx: number
+    /** Terminals that would have allowed progress at `idx`. */
+    readonly expected: readonly TerminalRange[]
+}
+```
+
+Two candidate shapes for exposing it, to be settled when implementing:
+
+- widen the result to `readonly[AstRuleMeta<T>, boolean, number, DescentFailure]`,
+  which every consumer's destructuring must then be updated for; or
+- return a record instead of a tuple, which is the better API but a larger
+  breaking change.
+
+`expected` is the set worth having for messages ("expected `,` or `}`"), but it
+is separable: the furthest `idx` alone already turns "rejected" into "rejected at
+this token", and a first cut may ship only that.
+
+Because the furthest index points at a symbol, the caller pairs it with that
+symbol's metadata to build a real source position — which is what
+[new-parser](../../todo/new-parser.md) needs, and why that issue is blocked on
+this one.
+
+### Tasks
+
+- [ ] Thread the furthest reached index through the driver loop
+- [ ] Decide the result shape (widened tuple vs. record) and update consumers —
+      `fjs/djs/tokenizer`, `descentParserCpOnly`, and the proofs
+- [ ] Collect expected terminals at the furthest index, or record why it is
+      deferred
+- [ ] Proof coverage for a failing match: assert the reported index is the
+      furthest position, not the enclosing rule's start
+- [ ] `npx tsc`, `fjs t`
+
+### Related
+
+- [new-parser](../../todo/new-parser.md) — the consumer blocked on this; its
+  proposal item 4 reports error positions as metadata ranges and cannot do so
+  while a failed match carries no metadata
+- [../README.md](../README.md) — the backend being changed

--- a/fjs/bnf/todo/new-parser.md
+++ b/fjs/bnf/todo/new-parser.md
@@ -48,6 +48,26 @@ source position ride along as the descent parser's metadata — instantiate it a
 **3. Write the DJS grammar and fold its AST.** The module grammar in `fjs/bnf`
 combinators over that alphabet, then a fold from `AstRuleMeta<T>` to `AstModule`.
 
+**4. Report positions from token metadata, never from `idx`.** `idx` in
+`DescentMatchResult` is an index into the *symbol* array; on the parser layer one
+symbol is a whole token, so the number says nothing about a position in a file.
+Errors instead carry a **range of positions taken from the metadata**: every
+matched symbol arrives as `readonly[symbol, DjsTokenWithMetadata]`, so a rule's
+span has a first and a last token, and each token's `TokenMetadata`
+(`{ path, line, column }`, `fjs/js/tokenizer/module.f.ts:158`) gives a real
+position. `ParseError` (`{ message, metadata: TokenMetadata | null }`,
+`fjs/djs/parser/module.f.ts:16`) widens from a single point to that range.
+
+`idx` is not a usable fallback even for picking which token to blame. On a failed
+sequence item the backend rewinds to the enclosing sequence's start —
+`result = mrFail(frame.tag, [], frame.startIdx)`
+(`fjs/bnf/descent/module.f.ts:161-162`) — so a failed match reports the start of
+the enclosing rule rather than where matching stopped, often index 0. Making the
+backend able to say where a parse stopped means tracking the furthest failure
+position, and the terminals expected there, inside `fjs/bnf/descent`. That is a
+separate change to the backend, worth doing for message quality but not required
+by the metadata-range scheme above.
+
 ### Open questions
 
 Deliberately unresolved — this issue exists to hold the task, not to settle these.
@@ -57,10 +77,10 @@ Deliberately unresolved — this issue exists to hold the task, not to settle th
   and `fjs/djs/parser`. If a grammar replaces the machine on the DJS side, §1
   loses one of its two consumers and the extraction stops paying for itself.
   Whichever lands first should say what happens to the other.
-- **Error reporting.** `parseFromTokens` returns `Result<AstModule, ParseError>`
-  with a message and metadata per failure. `DescentMatchResult` is
-  `[ast, matched, idx]` — a boolean and a position, no message. Something has to
-  turn a failed match at index `i` into a diagnostic.
+- **Furthest-failure tracking in `fjs/bnf/descent`.** Whether to add it as part
+  of this work or as its own issue — see proposal item 4. Without it the parser
+  can report *that* input was rejected, with the offending rule's position range,
+  but not the precise token where matching stopped.
 - **Scope of the grammar.** Whether it covers module framing (`import`, `const`,
   `export default`) or only values, with the framing left to a wrapper.
 - **Where the module lives** — a `fjs/djs/new_parser/` sibling, or inside
@@ -72,7 +92,8 @@ Deliberately unresolved — this issue exists to hold the task, not to settle th
 - [ ] Map `DjsToken` to symbols, with the token as descent metadata
 - [ ] Write the DJS grammar in `fjs/bnf` combinators
 - [ ] Fold `AstRuleMeta` into `AstModule`
-- [ ] Decide error reporting
+- [ ] Report errors as metadata position ranges; widen `ParseError.metadata`
+      from a single `TokenMetadata` to a range
 - [ ] `proof.f.ts` with full coverage; `npx tsc`, `fjs t`
 - [ ] Decide the fate of `parseFromTokens` and of [157](../../djs/todo/157.md) §1
 

--- a/fjs/bnf/todo/new-parser.md
+++ b/fjs/bnf/todo/new-parser.md
@@ -2,6 +2,7 @@
 
 **Priority:** P3
 **Status:** open
+**Blocked by:** [descent/failure-tracking](../descent/todo/failure-tracking.md)
 
 ### Problem
 
@@ -58,15 +59,12 @@ span has a first and a last token, and each token's `TokenMetadata`
 position. `ParseError` (`{ message, metadata: TokenMetadata | null }`,
 `fjs/djs/parser/module.f.ts:16`) widens from a single point to that range.
 
-`idx` is not a usable fallback even for picking which token to blame. On a failed
-sequence item the backend rewinds to the enclosing sequence's start —
-`result = mrFail(frame.tag, [], frame.startIdx)`
-(`fjs/bnf/descent/module.f.ts:161-162`) — so a failed match reports the start of
-the enclosing rule rather than where matching stopped, often index 0. Making the
-backend able to say where a parse stopped means tracking the furthest failure
-position, and the terminals expected there, inside `fjs/bnf/descent`. That is a
-separate change to the backend, worth doing for message quality but not required
-by the metadata-range scheme above.
+**This depends on the backend keeping failure information, which it does not
+today.** A failed match returns an empty sequence and a rewound index, so it
+carries no metadata to build a range from and no reliable token to blame. That is
+tracked separately as
+[descent/failure-tracking](../descent/todo/failure-tracking.md) and blocks this
+issue.
 
 ### Open questions
 
@@ -77,10 +75,6 @@ Deliberately unresolved — this issue exists to hold the task, not to settle th
   and `fjs/djs/parser`. If a grammar replaces the machine on the DJS side, §1
   loses one of its two consumers and the extraction stops paying for itself.
   Whichever lands first should say what happens to the other.
-- **Furthest-failure tracking in `fjs/bnf/descent`.** Whether to add it as part
-  of this work or as its own issue — see proposal item 4. Without it the parser
-  can report *that* input was rejected, with the offending rule's position range,
-  but not the precise token where matching stopped.
 - **Scope of the grammar.** Whether it covers module framing (`import`, `const`,
   `export default`) or only values, with the framing left to a wrapper.
 - **Where the module lives** — a `fjs/djs/new_parser/` sibling, or inside
@@ -93,7 +87,8 @@ Deliberately unresolved — this issue exists to hold the task, not to settle th
 - [ ] Write the DJS grammar in `fjs/bnf` combinators
 - [ ] Fold `AstRuleMeta` into `AstModule`
 - [ ] Report errors as metadata position ranges; widen `ParseError.metadata`
-      from a single `TokenMetadata` to a range
+      from a single `TokenMetadata` to a range (needs
+      [descent/failure-tracking](../descent/todo/failure-tracking.md))
 - [ ] `proof.f.ts` with full coverage; `npx tsc`, `fjs t`
 - [ ] Decide the fate of `parseFromTokens` and of [157](../../djs/todo/157.md) §1
 
@@ -106,4 +101,6 @@ Deliberately unresolved — this issue exists to hold the task, not to settle th
 - [../token_symbol/README.md](../token_symbol/README.md) — symbols for
   multi-character tokens
 - [../descent/README.md](../descent/README.md) — the backend being generalized
+- [descent/failure-tracking](../descent/todo/failure-tracking.md) — the blocker:
+  failure information the backend must keep before errors can be reported
 - [157](../../djs/todo/157.md) — the competing direction for the same code

--- a/fjs/bnf/todo/new-parser.md
+++ b/fjs/bnf/todo/new-parser.md
@@ -1,0 +1,88 @@
+## New parser: BNF descent over token symbols
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+`parseFromTokens` (`fjs/djs/parser/module.f.ts:526`) folds a
+`List<DjsTokenWithMetadata>` into an `AstModule` with a hand-written state
+machine: a nine-state value alphabet (`'' | '[' | '[v' | '[,' | '{' | '{k' |
+'{:' | '{v' | '{,'`) plus module framing, about 570 lines with its helpers. The
+grammar it implements is written down nowhere — it lives in the control flow of
+`parseValueOp`…`parseObjectCommaOp`, so the only way to know what DJS accepts is
+to read the machine.
+
+The layer below already went the other way. `fjs/djs/tokenizer` is a BNF grammar
+consumed by `descentParser`, and code points are its alphabet. The parser layer
+is the odd one out, even though [layered-parser](./layered-parser.md) has both
+layers reusing the same BNF engine — the tokenizer emitting one symbol per
+token, the parser above consuming those symbols as its alphabet.
+
+The piece that was missing is now in place: `fjs/bnf/token_symbol` gives
+multi-character operators and keywords a symbol of their own, so a token stream
+can be presented to a BNF parser as a plain symbol stream.
+
+### Proposal
+
+A second parser over the same token stream, built on `descentParser` and kept
+alongside `parseFromTokens` until it reaches parity. Call it `new_parser` for
+now; the final name, and whether it replaces `fjs/djs/parser`, are deliberately
+left open.
+
+**1. Generalize the descent alphabet.** `descentParser`
+(`fjs/bnf/descent/module.f.ts:58`) is already generic over metadata `T`, and its
+alphabet is `CodePointMeta<T> = readonly[CodePoint, T]` where `CodePoint =
+number` (`fjs/text/utf16/module.f.ts:50`). A token symbol is also a number in
+the same 24-bit space, so this is a widening and a rename (`CodePointMeta` →
+`SymbolMeta`, `CodePoint` → a symbol type), not a new backend. Matching goes
+through `rangeContains` on a `TerminalRange` and is unchanged.
+
+**2. Map `DjsToken` to a symbol.** Single-character operators (`{ } : , [ ] . =`)
+map to themselves, token categories get one ASCII symbol each (`i` identifier,
+`0` number, `s` string, …), and keywords plus anything multi-character come from
+`encoding()` in [token_symbol](../token_symbol/README.md). The token's value and
+source position ride along as the descent parser's metadata — instantiate it at
+`T = DjsTokenWithMetadata` and nothing is lost.
+
+**3. Write the DJS grammar and fold its AST.** The module grammar in `fjs/bnf`
+combinators over that alphabet, then a fold from `AstRuleMeta<T>` to `AstModule`.
+
+### Open questions
+
+Deliberately unresolved — this issue exists to hold the task, not to settle these.
+
+- **Overlap with [157](../../djs/todo/157.md) §1.** That issue extracts the
+  hand-written value machine into a factory shared by `fjs/media/json/parser`
+  and `fjs/djs/parser`. If a grammar replaces the machine on the DJS side, §1
+  loses one of its two consumers and the extraction stops paying for itself.
+  Whichever lands first should say what happens to the other.
+- **Error reporting.** `parseFromTokens` returns `Result<AstModule, ParseError>`
+  with a message and metadata per failure. `DescentMatchResult` is
+  `[ast, matched, idx]` — a boolean and a position, no message. Something has to
+  turn a failed match at index `i` into a diagnostic.
+- **Scope of the grammar.** Whether it covers module framing (`import`, `const`,
+  `export default`) or only values, with the framing left to a wrapper.
+- **Where the module lives** — a `fjs/djs/new_parser/` sibling, or inside
+  `fjs/djs/parser/`.
+
+### Tasks
+
+- [ ] Generalize the descent alphabet from code points to symbols
+- [ ] Map `DjsToken` to symbols, with the token as descent metadata
+- [ ] Write the DJS grammar in `fjs/bnf` combinators
+- [ ] Fold `AstRuleMeta` into `AstModule`
+- [ ] Decide error reporting
+- [ ] `proof.f.ts` with full coverage; `npx tsc`, `fjs t`
+- [ ] Decide the fate of `parseFromTokens` and of [157](../../djs/todo/157.md) §1
+
+### Related
+
+- [layered-parser](./layered-parser.md) — the architecture this implements: each
+  layer a BNF transducer, tokens as the alphabet of the next one
+- [tokens-with-extra-information](./tokens-with-extra-information.md) — the
+  token-plus-metadata stream the parser consumes
+- [../token_symbol/README.md](../token_symbol/README.md) — symbols for
+  multi-character tokens
+- [../descent/README.md](../descent/README.md) — the backend being generalized
+- [157](../../djs/todo/157.md) — the competing direction for the same code


### PR DESCRIPTION
## Summary

Files `fjs/bnf/todo/new-parser.md` — an issue for a BNF descent parser over token symbols, as an alternative to the hand-written `parseFromTokens` state machine in `fjs/djs/parser`.

Documentation only; no CHANGELOG entry, per AGENTS.md §2 (`todo/`-only changes don't need one).

## Why

`parseFromTokens` (`fjs/djs/parser/module.f.ts:526`) folds a token list into an `AstModule` with a nine-state value machine plus module framing — about 570 lines with its helpers. The grammar it implements is written down nowhere: it lives in the control flow, so the only way to know what DJS accepts is to read the machine.

The layer below already went the other way — `fjs/djs/tokenizer` is a BNF grammar consumed by `descentParser`. The parser layer is the odd one out, even though `layered-parser` has both layers reusing the same BNF engine. The missing piece just landed in #1366: `fjs/bnf/token_symbol` gives multi-character operators and keywords a symbol of their own, so a token stream can be handed to a BNF parser as a plain symbol stream.

## What the issue proposes

1. **Generalize the descent alphabet.** `descentParser` is already generic over metadata `T`, and its alphabet is `CodePointMeta<T> = readonly[CodePoint, T]` where `CodePoint = number`. A token symbol is also a number in the same 24-bit space, so this is a widening and a rename, not a new backend.
2. **Map `DjsToken` to a symbol**, with the token's value and position carried as the descent parser's metadata (`T = DjsTokenWithMetadata`), so nothing is lost.
3. **Write the DJS grammar** in `fjs/bnf` combinators over that alphabet and fold the resulting AST into `AstModule`.

## Deliberately left open

The issue records these rather than settling them:

- **Overlap with `fjs/djs/todo/157.md` §1**, which extracts the same hand-written machine into a factory shared with `fjs/media/json/parser`. If a grammar replaces the machine on the DJS side, §1 loses one of its two consumers.
- **Error reporting** — the real gap. `parseFromTokens` returns `Result<AstModule, ParseError>` with a message and metadata; `DescentMatchResult` is `[ast, matched, idx]`, a boolean and a position with no message.
- Scope of the grammar (module framing or values only), and where the module lives.

Per AGENTS.md §2, the error-reporting question in particular wants an answer before implementation starts, since it shapes the backend's return type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
