### PR TITLE
Generate OCI images from job flakes and run playwright in container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,7 +539,10 @@
           "uses": "actions/checkout@v7.0.1"
         },
         {
-          "run": "nix develop ./nix/generated/playwright --command bash -euo pipefail -c 'test \"$(node --version)\" = v26.5.1 && npm ci && test \"$(npx playwright --version)\" = \"Version 1.59.1\" && npx playwright test --browser=chromium && npx playwright test --browser=firefox && npx playwright test --browser=webkit'"
+          "run": "\"$(nix build ./nix/generated/playwright#oci --no-link --print-out-paths)\" | docker load"
+        },
+        {
+          "run": "docker run --rm --ipc=host --volume \"$PWD:/workspace\" functionalscript-playwright:21ea275a7c46aef9d4d6ddc962e6d562e9d94183 bash -euo pipefail -c 'test \"$(node --version)\" = v26.5.1 && npm ci && test \"$(npx playwright --version)\" = \"Version 1.59.1\" && npx playwright test --browser=chromium && npx playwright test --browser=firefox && npx playwright test --browser=webkit'"
         }
       ]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ history.
 
 ## Unreleased
 
+- `fjs/ci`: generate an OCI image from a job's Nix flake
+  (`packages.<system>.oci`) and run the `playwright` job's commands in a
+  container of it instead of a development shell
 - **BREAKING CHANGES:** `@playwright/test` moves to `1.59.1` to match the pinned
   Nixpkgs snapshot, which now provides the `playwright` CI job's browsers — the
   job runs in a generated Nix flake instead of installing them

--- a/fjs/ci/README.md
+++ b/fjs/ci/README.md
@@ -18,7 +18,9 @@ canonical Node job under `nix/generated/`.
   (`test`, `install`, `uses`).
 - `config/module.f.ts` — runner image matrix (OS × architecture → GitHub-hosted image name) and pinned tool/package versions, including the FunctionalScript package version used by generated smoke tests and the exact Nixpkgs commit the generated flakes pin.
 - `nix/module.f.ts` — writes one self-contained `nix/generated/<job>/flake.nix`
-  per declared job, using the Nix eDSL in `fjs/media/nix`.
+  per declared job, using the Nix eDSL in `fjs/media/nix`, and builds the
+  workflow commands that enter a flake (`nix develop`, or `docker` on the image
+  a job declares).
 - `node/module.f.ts` — Node.js job steps: platform smoke tests, canonical
   per-version jobs, coverage, package checks, and the Node flake declarations.
 - `rust/module.f.ts` — Rust toolchain setup and `cargo` build/test steps.
@@ -69,6 +71,23 @@ The job is deliberately separate from `node22`/`node24`/`node26`, which keep the
 run through `nix develop` — and give each migrated job its own version check inside
 the `nix develop` invocation, or nothing ties the Nix runtime to the version the
 Windows and macOS jobs install.
+
+### Generated job images
+
+A job may declare an `oci` image next to its packages and environment
+(`playwright/module.f.ts`). The generator then adds `packages.<system>.oci` to
+that job's flake — a `dockerTools.streamLayeredImage` built from the same
+declaration as the shell — and the job runs its commands with
+
+```sh
+"$(nix build ./nix/generated/<job>#oci --no-link --print-out-paths)" | docker load
+docker run --rm --ipc=host --volume "$PWD:/<workDirectory>" <name>:<nixpkgs-commit> bash -euo pipefail -c '<commands>'
+```
+
+instead of `nix develop`. The image is built by the job that uses it, from the
+pinned snapshot; no registry, no credentials, and no cache beyond the Nix binary
+cache the shell already uses. See [nix/README.md](../../nix/README.md) for what
+the image contains and why.
 
 ### Expected package scripts
 

--- a/fjs/ci/nix/module.f.ts
+++ b/fjs/ci/nix/module.f.ts
@@ -2,10 +2,11 @@
  * Generates one self-contained Nix flake per declared CI job.
  *
  * Each job gets its own `nix/generated/<id>/flake.nix` pinning the exact
- * Nixpkgs commit from `../config/module.f.ts` and exposing a single
- * `devShells.<system>.default` development shell. The files are static and
- * readable on purpose: no job selection, no shared Nix modules, no helper
- * libraries.
+ * Nixpkgs commit from `../config/module.f.ts` and exposing a
+ * `devShells.<system>.default` development shell, plus a
+ * `packages.<system>.oci` image for the jobs that run in a container. The files
+ * are static and readable on purpose: no job selection, no shared Nix modules,
+ * no helper libraries.
  *
  * @module
  */
@@ -27,6 +28,30 @@ export type EnvValue =
     | readonly ['string', string]
     | readonly ['pkgs', string, ...string[]]
 
+/** A Nixpkgs attribute path under `pkgs`, e.g. `['dockerTools', 'binSh']`. */
+export type PkgsPath = readonly [string, ...string[]]
+
+/**
+ * The OCI image built from a job's environment, for a job that runs its
+ * commands in a container instead of a development shell.
+ *
+ * The image carries the same `packages` and `env` as the shell — one
+ * declaration, two ways of entering it — plus the parts a shell inherits from
+ * the runner and an image has to provide itself.
+ */
+export type NixOci = {
+    /** Repository name of the generated image. */
+    readonly name: string
+    /**
+     * Nixpkgs attribute paths copied into the image root, on top of the job's
+     * `packages`: the shell, its utilities, and the certificate bundle a
+     * development shell inherits from the runner.
+     */
+    readonly contents: readonly PkgsPath[]
+    /** Root-level directory the container starts in, where CI mounts the checkout. */
+    readonly workDirectory: string
+}
+
 /** A CI job's development environment, one generated flake each. */
 export type NixJob = {
     /** Generated directory name under `nix/generated`, matching the CI job id. */
@@ -43,6 +68,8 @@ export type NixJob = {
     readonly env?: StringMap<string, EnvValue>
     /** Job-local shell initialization, when the job needs one. */
     readonly shellHook?: string
+    /** The job's OCI image, when the job runs in a container. */
+    readonly oci?: NixOci
 }
 
 /** Directory owned by this generator. */
@@ -52,32 +79,102 @@ const { commit } = nixpkgs
 
 const url = `github:NixOS/nixpkgs/${commit}`
 
+/** Flake output attribute holding a job's OCI image. */
+const ociAttribute = 'oci' as const
+
+/**
+ * `PATH` inside a generated image. `contents` links every package's `bin` into
+ * the image's `/bin`, and `dockerTools.usrBinEnv` provides `/usr/bin/env` for
+ * shebangs, so those two directories are the whole search path.
+ */
+const ociPath = 'PATH=/bin:/usr/bin' as const
+
+/**
+ * `HOME` inside a generated image. A development shell inherits the runner's
+ * home directory; a container has none, and `npm` needs a writable one for its
+ * cache.
+ */
+const ociHome = 'HOME=/tmp' as const
+
 const envExpression = (value: EnvValue): Expression =>
     value[0] === 'string' ? value[1] : ['ref', 'pkgs', ...value.slice(1)]
 
-const flake = ({ system, packages, env, shellHook }: NixJob): Expression => ['set',
+const envEntries = (env: StringMap<string, EnvValue> | undefined) =>
+    definedEntries<EnvValue>(env ?? {})
+
+const pkgsReference = (path: PkgsPath) => ['ref', 'pkgs', ...path] as const
+
+const devShell = ({ packages, env, shellHook }: NixJob): Expression => ['apply',
+    ['ref', 'pkgs', 'mkShell'],
+    ['set',
+        ['=', ['packages'], ['list', ...packages.map(p => pkgsReference([p]))]],
+        ...envEntries(env).map(([name, value]) => ['=', [name], envExpression(value)] as const),
+        ...(shellHook === undefined
+            ? []
+            : [['=', ['shellHook'], ['indented-string', shellHook]] as const])
+    ]
+]
+
+/**
+ * One `NAME=value` entry of the image's environment. A literal is written into
+ * the string; a Nixpkgs attribute path is interpolated, which is what puts the
+ * package's closure into the image — `streamLayeredImage` takes the image's
+ * configuration as a closure root.
+ */
+const ociEnvEntry = ([name, value]: readonly [string, EnvValue]) => {
+    if (value[0] === 'string') { return `${name}=${value[1]}` }
+    const [, attribute, ...rest] = value
+    return ['interpolated-string', `${name}=`, pkgsReference([attribute, ...rest])] as const
+}
+
+const ociImage = ({ packages, env }: NixJob, { name, contents, workDirectory }: NixOci): Expression => ['apply',
+    ['ref', 'pkgs', 'dockerTools', 'streamLayeredImage'],
+    ['set',
+        ['=', ['name'], name],
+        // The pinned snapshot and this repository's commit together determine
+        // the image, and the job builds it rather than pulling it, so the
+        // snapshot is the only identity it needs.
+        ['=', ['tag'], commit],
+        ['=', ['contents'], ['list',
+            ...packages.map(p => pkgsReference([p])),
+            ...contents.map(pkgsReference),
+        ]],
+        ['=', ['config'], ['set',
+            ['=', ['Env'], ['list',
+                ...envEntries(env).map(ociEnvEntry),
+                ociPath,
+                ociHome,
+            ]],
+            ['=', ['WorkingDir'], `/${workDirectory}`],
+            // Only reached by `docker run` without a command, i.e. when someone
+            // opens the image to look around.
+            ['=', ['Cmd'], ['list', '/bin/sh']],
+        ]],
+        // A `dockerTools` image contains exactly what is declared, so the
+        // directories the commands write to have to be created here.
+        ['=', ['extraCommands'], ['indented-string',
+            `mkdir -p tmp ${workDirectory}\nchmod 1777 tmp`]],
+    ]
+]
+
+const flake = (job: NixJob): Expression => ['set',
     ['=', ['inputs', 'nixpkgs', 'url'], url],
     ['=', ['outputs'], ['lambda',
         ['open-set-pattern', 'nixpkgs'],
-        ['set',
-            ['=', ['devShells', system, 'default'], ['let',
-                [['=', ['pkgs'], ['apply',
-                    ['ref', 'import'],
-                    ['ref', 'nixpkgs'],
-                    ['set', ['=', ['system'], system]]
-                ]]],
-                ['apply',
-                    ['ref', 'pkgs', 'mkShell'],
-                    ['set',
-                        ['=', ['packages'], ['list', ...packages.map(p => ['ref', 'pkgs', p] as const)]],
-                        ...definedEntries<EnvValue>(env ?? {}).map(
-                            ([name, value]) => ['=', [name], envExpression(value)] as const),
-                        ...(shellHook === undefined
-                            ? []
-                            : [['=', ['shellHook'], ['indented-string', shellHook]] as const])
-                    ]
-                ]
-            ]]
+        ['let',
+            [['=', ['pkgs'], ['apply',
+                ['ref', 'import'],
+                ['ref', 'nixpkgs'],
+                ['set', ['=', ['system'], job.system]]
+            ]]],
+            ['set',
+                ['=', ['devShells', job.system, 'default'], devShell(job)],
+                ...(job.oci === undefined
+                    ? []
+                    : [['=',
+                        ['packages', job.system, ociAttribute],
+                        ociImage(job, job.oci)] as const]),
+            ]
         ]
     ]]
 ]
@@ -134,6 +231,32 @@ const singleQuoted = (value: string): string =>
  */
 export const nixDevelopAll = (id: string, commands: readonly string[]): string =>
     nixDevelop(id, `bash -euo pipefail -c ${singleQuoted(commands.join(' && '))}`)
+
+/**
+ * Builds a job's image and loads it into the runner's Docker daemon.
+ *
+ * `streamLayeredImage` builds a script that writes the archive to standard
+ * output, so nothing but the layers themselves is ever stored twice. Building
+ * with `--no-link` keeps `result` out of the checked-out tree, and
+ * `--print-out-paths` names the script to run.
+ */
+export const ociLoad = (id: string): string =>
+    `"$(nix build ${flakePath(id)}#${ociAttribute} --no-link --print-out-paths)" | docker load`
+
+/** The `name:tag` a job's loaded image is addressed by. */
+const ociImageReference = ({ name }: NixOci): string => `${name}:${commit}`
+
+/**
+ * Runs a job's whole command sequence in a container of its image, with the
+ * checkout mounted at the image's working directory.
+ *
+ * `--ipc=host` gives the browsers the host's shared memory instead of Docker's
+ * 64 MB default, which Chromium runs out of; Playwright recommends it for
+ * exactly this reason. The commands are quoted the same way `nixDevelopAll`
+ * quotes them.
+ */
+export const ociRunAll = (oci: NixOci, commands: readonly string[]): string =>
+    `docker run --rm --ipc=host --volume "$PWD:/${oci.workDirectory}" ${ociImageReference(oci)} bash -euo pipefail -c ${singleQuoted(commands.join(' && '))}`
 
 /** Asserts the Node a development shell puts on `PATH`, from inside that shell. */
 export const nodeVersionCommand = (version: string): string =>

--- a/fjs/ci/nix/proof.f.ts
+++ b/fjs/ci/nix/proof.f.ts
@@ -17,6 +17,8 @@ import {
     nixDevelopAll,
     nixFlakes,
     nixInstall,
+    ociLoad,
+    ociRunAll,
     type NixJob,
 } from './module.f.ts'
 
@@ -35,15 +37,26 @@ const withShellHook: NixJob = {
     shellHook: `export NPM_CONFIG_PREFIX="$HOME/.npm-global"`,
 }
 
+const withOci: NixJob = {
+    ...plain,
+    id: 'browsers',
+    env: { BROWSERS: ['pkgs', 'playwright-driver', 'browsers'] },
+    oci: {
+        name: 'functionalscript-browsers',
+        contents: [['bashInteractive'], ['dockerTools', 'binSh']],
+        workDirectory: 'workspace',
+    },
+}
+
 const plainFlake = `{
     inputs.nixpkgs.url = "github:NixOS/nixpkgs/${commit}";
-    outputs = { nixpkgs, ... }: {
-        devShells.aarch64-linux.default = let
-            pkgs = import nixpkgs {
-                system = "aarch64-linux";
-            };
-        in
-        pkgs.mkShell {
+    outputs = { nixpkgs, ... }: let
+        pkgs = import nixpkgs {
+            system = "aarch64-linux";
+        };
+    in
+    {
+        devShells.aarch64-linux.default = pkgs.mkShell {
             packages = [ pkgs.nodejs_24 ];
         };
     };
@@ -52,16 +65,46 @@ const plainFlake = `{
 
 const shellHookFlake = `{
     inputs.nixpkgs.url = "github:NixOS/nixpkgs/${commit}";
-    outputs = { nixpkgs, ... }: {
-        devShells.aarch64-linux.default = let
-            pkgs = import nixpkgs {
-                system = "aarch64-linux";
-            };
-        in
-        pkgs.mkShell {
+    outputs = { nixpkgs, ... }: let
+        pkgs = import nixpkgs {
+            system = "aarch64-linux";
+        };
+    in
+    {
+        devShells.aarch64-linux.default = pkgs.mkShell {
             packages = [ pkgs.nodejs_22 ];
             shellHook = ''
                 export NPM_CONFIG_PREFIX="$HOME/.npm-global"
+            '';
+        };
+    };
+}
+`
+
+const ociFlake = `{
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/${commit}";
+    outputs = { nixpkgs, ... }: let
+        pkgs = import nixpkgs {
+            system = "aarch64-linux";
+        };
+    in
+    {
+        devShells.aarch64-linux.default = pkgs.mkShell {
+            packages = [ pkgs.nodejs_24 ];
+            BROWSERS = pkgs.playwright-driver.browsers;
+        };
+        packages.aarch64-linux.oci = pkgs.dockerTools.streamLayeredImage {
+            name = "functionalscript-browsers";
+            tag = "${commit}";
+            contents = [ pkgs.nodejs_24 pkgs.bashInteractive pkgs.dockerTools.binSh ];
+            config = {
+                Env = [ "BROWSERS=\${pkgs.playwright-driver.browsers}" "PATH=/bin:/usr/bin" "HOME=/tmp" ];
+                WorkingDir = "/workspace";
+                Cmd = [ "/bin/sh" ];
+            };
+            extraCommands = ''
+                mkdir -p tmp workspace
+                chmod 1777 tmp
             '';
         };
     };
@@ -81,6 +124,15 @@ export const proof = {
     flakeText: {
         plain: () => assertEq(flakeText(plain), plainFlake),
         shellHook: () => assertEq(flakeText(withShellHook), shellHookFlake),
+        // The image and the shell come from one declaration: the job's packages
+        // and environment reach both, and only the container-specific parts —
+        // its own `PATH` and `HOME`, and the directories it writes to — are
+        // added by the generator.
+        oci: () => assertEq(flakeText(withOci), ociFlake),
+        // A job without an image has no `packages` output at all.
+        noOci: () => assert(
+            !flakeText(plain).includes('packages.aarch64-linux'),
+            'expected no image output'),
     },
     nixFlakes: {
         write: () => assertEq(generated([plain], plain.id), plainFlake),
@@ -129,6 +181,16 @@ export const proof = {
             quote: () => assertEq(
                 nixDevelopAll(plain.id, [`printf '%s' 'a b'`]),
                 `nix develop ./nix/generated/node24 --command bash -euo pipefail -c 'printf '\\''%s'\\'' '\\''a b'\\'''`),
+        },
+        ociLoad: () => assertEq(
+            ociLoad(withOci.id),
+            '"$(nix build ./nix/generated/browsers#oci --no-link --print-out-paths)" | docker load'),
+        ociRunAll: () => {
+            const { oci } = withOci
+            assert(oci !== undefined, 'expected an image')
+            assertEq(
+                ociRunAll(oci, ['npm ci', 'npx playwright test']),
+                `docker run --rm --ipc=host --volume "$PWD:/workspace" functionalscript-browsers:${commit} bash -euo pipefail -c 'npm ci && npx playwright test'`)
         },
         nixInstall: () => {
             assertEq(nixInstall.type, 'install')

--- a/fjs/ci/playwright/module.f.ts
+++ b/fjs/ci/playwright/module.f.ts
@@ -1,19 +1,46 @@
 /**
  * CI job that runs the Playwright suite against Chromium, Firefox, and WebKit
- * inside the job's generated Nix development shell.
+ * inside an OCI image built from the job's generated Nix flake.
  *
  * @module
  */
 import { node, playwright } from '../config/module.f.ts'
 import { type Job, type MetaStep, test, ubuntuArm } from '../common/module.f.ts'
 import { major, nixSystem } from '../node/module.f.ts'
-import { nixDevelopAll, nixInstall, nodeVersionCommand, type NixJob } from '../nix/module.f.ts'
+import { nixInstall, nodeVersionCommand, ociLoad, ociRunAll, type NixJob, type NixOci } from '../nix/module.f.ts'
 
 const browsers = ['chromium', 'firefox', 'webkit'] as const
 
 /**
- * The Playwright job's development environment: the same Node the other jobs
- * use, plus Nixpkgs' prebuilt browser bundle.
+ * The image the job's commands run in.
+ *
+ * A development shell borrows the runner's shell, its core utilities, and its
+ * certificate bundle; an image starts empty, so the environment declares them.
+ * The Node the job uses is not repeated here — the generator copies the shell's
+ * `packages` into the image as well, so both entry points provide the same
+ * runtime.
+ */
+const playwrightOci: NixOci = {
+    name: 'functionalscript-playwright',
+    contents: [
+        ['bashInteractive'],
+        ['coreutils'],
+        // `/bin/sh` for the shells `npm` starts for lifecycle scripts, and
+        // `/usr/bin/env` for `#!` lines.
+        ['dockerTools', 'binSh'],
+        ['dockerTools', 'usrBinEnv'],
+        // `npm` reaches the registry over TLS, and Chromium, Firefox, and
+        // WebKit load pages the same way.
+        ['dockerTools', 'caCertificates'],
+        // `/etc/passwd` and `/etc/group`, which the browsers read at startup.
+        ['dockerTools', 'fakeNss'],
+    ],
+    workDirectory: 'workspace',
+}
+
+/**
+ * The Playwright job's environment: the same Node the other jobs use, plus
+ * Nixpkgs' prebuilt browser bundle.
  *
  * `pkgs.playwright-driver.browsers` is a link farm of Chromium, Firefox, and
  * WebKit builds already patched for the Nix store, so pointing Playwright at it
@@ -29,6 +56,7 @@ export const playwrightNixJob: NixJob = {
     id: 'playwright',
     system: nixSystem,
     packages: [`nodejs_${major(node.default)}`],
+    oci: playwrightOci,
     env: {
         PLAYWRIGHT_BROWSERS_PATH: ['pkgs', 'playwright-driver', 'browsers'],
         // `@playwright/test`'s postinstall would otherwise download a second
@@ -47,8 +75,8 @@ const playwrightVersionCommand =
     `test "$(npx playwright --version)" = "Version ${playwright}"`
 
 const commands: readonly string[] = [
-    // This job supplies its own Node, so it states the version expectation the
-    // shared `nix-flakes` job states for the others.
+    // The image supplies its own Node, so the job states the version
+    // expectation the shared `nix-flakes` job states for the others.
     nodeVersionCommand(node.default),
     'npm ci',
     // The browsers come from the pinned Nixpkgs commit while `@playwright/test`
@@ -58,9 +86,12 @@ const commands: readonly string[] = [
     ...browsers.map(browser => `npx playwright test --browser=${browser}`),
 ]
 
+// Building and loading the image is its own step so the workflow log times it
+// separately from the browser runs it wraps.
 const steps: readonly MetaStep[] = [
     nixInstall,
-    test({ run: nixDevelopAll(playwrightNixJob.id, commands) }),
+    test({ run: ociLoad(playwrightNixJob.id) }),
+    test({ run: ociRunAll(playwrightOci, commands) }),
 ]
 
 export const playwrightJob: Job = ubuntuArm(steps)

--- a/fjs/ci/proof.f.ts
+++ b/fjs/ci/proof.f.ts
@@ -208,13 +208,24 @@ export const proof = {
         assert(
             generated.includes('pkgs.playwright-driver.browsers'),
             'expected Nix-provided Playwright browsers')
+        // The image carries the same browsers as the shell, through its
+        // configuration rather than its contents.
+        assert(
+            generated.includes('pkgs.dockerTools.streamLayeredImage'),
+            'expected the job image')
         const gha = workflow(state)
         assert(
-            hasRunInJob('playwright', 'nix develop ./nix/generated/playwright')(gha),
-            'expected the Playwright job to run through its flake')
-        // The whole sequence shares one shell: a per-step `nix develop` would
-        // drop the browser environment between steps.
-        assertEq(gha.jobs['playwright']?.steps.filter(step => step.run !== undefined).length, 1)
+            hasRunInJob('playwright', 'nix build ./nix/generated/playwright#oci')(gha),
+            'expected the Playwright job to build its image from its flake')
+        assert(
+            hasRunInJob('playwright', 'docker run')(gha),
+            'expected the Playwright job to run in its image')
+        assert(
+            !hasRunInJob('playwright', 'nix develop')(gha),
+            'unexpected development shell in the containerized job')
+        // Build the image, then run everything in one container: a container
+        // per command would drop the browser environment between them.
+        assertEq(gha.jobs['playwright']?.steps.filter(step => step.run !== undefined).length, 2)
         assert(
             hasRunInJob('playwright', `= v${node.default}`)(gha),
             'expected the migrated job to check its own Node version')

--- a/fjs/ci/todo/65z-ci-nix-playwright.md
+++ b/fjs/ci/todo/65z-ci-nix-playwright.md
@@ -5,16 +5,22 @@
 
 ### Progress
 
-The Playwright job is the **first job migrated to `nix develop`**, ahead of the
-canonical Node jobs — its browser setup is what made it worth doing first.
+The Playwright job is the **first job migrated off the runner's own setup**, ahead of
+the canonical Node jobs — its browser setup is what made it worth doing first.
 
 `nix/generated/playwright/flake.nix` (from `playwrightNixJob` in
 `fjs/ci/playwright/module.f.ts`) provides `nodejs_26` and points Playwright at
-`pkgs.playwright-driver.browsers` through `mkShell` environment attributes. The job now
-has three workflow steps — install Nix, check out, and one `nix develop … --command bash
--euo pipefail -c '…'` invocation carrying the whole sequence. `actions/setup-node`,
-`actions/cache`, `npm install -g playwright`, `playwright install-deps`, and `playwright
-install` are all gone.
+`pkgs.playwright-driver.browsers`. `actions/setup-node`, `actions/cache`,
+`npm install -g playwright`, `playwright install-deps`, and `playwright install` are
+all gone.
+
+It first ran through `nix develop`, and now runs in an **OCI image generated from the
+same flake** — see [65Z-ci-scenario-docker](65z-ci-scenario-docker.md) for the image
+design. The job has four workflow steps: install Nix, check out, build the image and
+`docker load` it, and run the whole command sequence in one container with the checkout
+mounted at its working directory. The development shell stays in the flake as the
+fallback, and both entry points come from one declaration — the job's packages and
+environment are written once and reach the shell and the image alike.
 
 `fjs/ci/config/module.f.ts`'s `playwright` (and `package.json`'s `@playwright/test`) are
 pinned to `1.59.1` — the exact version `pkgs.playwright-driver` provides at the pinned
@@ -22,14 +28,20 @@ Nixpkgs commit. That match is what makes the Nix-provided browsers usable at all
 Playwright refuses browsers whose revision does not match its own.
 
 Because the job runs through its own flake, it no longer appears in the temporary
-`nix-flakes` job. It states its own guarantees inside the invocation instead: a Node
+`nix-flakes` job. It states its own guarantees inside the container instead: a Node
 version check (the one the shared job used to make) and a
 `npx playwright --version` check tying the Nixpkgs browsers to the `package.json` pin.
 
-**Verified in CI.** All three browsers pass against the Nix-provided bundle. The whole
-job takes roughly three minutes, nearly all of it the browser runs themselves (~42s per
-browser); realizing the shell — including the browsers — is a small fraction, so the
-store paths come from the binary cache rather than being built.
+**Verified in CI** while the job used `nix develop`: all three browsers pass against
+the Nix-provided bundle. The whole job took roughly three minutes, nearly all of it the
+browser runs themselves (~42s per browser); realizing the shell — including the
+browsers — was a small fraction, so the store paths come from the binary cache rather
+than being built.
+
+The image was verified the same way outside CI, on `x86_64-linux` against the same
+Nixpkgs release: all three browsers pass inside a container of it, Chromium in ~1
+minute. The image is ~2.4 GB. What the move to a container costs in CI — building the
+image and loading it into the daemon, on the job's own runner — is not measured yet.
 
 `PLAYWRIGHT_HOST_PLATFORM_OVERRIDE` is still unvalidated in the other direction: it was
 set preemptively from `driver.nix`'s note about WebKit, and no run has tried removing
@@ -74,6 +86,11 @@ PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
 PLAYWRIGHT_HOST_PLATFORM_OVERRIDE = "ubuntu-24.04";
 ```
 
+The image gets the same three variables, as `config.Env` entries. There the store path
+*is* interpolated, because a container's environment is a list of strings — and that is
+also what pulls the browsers into the image, since `streamLayeredImage` takes the image
+configuration as a closure root.
+
 This couples the repo's Playwright version to whatever Nixpkgs pins at the chosen
 commit: bumping one now means bumping the other. That is the accepted direction —
 generated flakes should use Nixpkgs-sourced package versions throughout, not just for
@@ -83,11 +100,13 @@ Node — and the job's `npx playwright --version` check is what makes a drift fa
 
 - **Try dropping `PLAYWRIGHT_HOST_PLATFORM_OVERRIDE`.** It was set preemptively, and the
   job passes with it; nothing shows whether it is actually needed on
-  `ubuntu-26.04-arm`. Remove it in its own commit so a failure names the cause.
-- **Compare wall-clock time** against the pre-migration job, using a run from before the
-  migration. The migrated job is ~3 minutes and is dominated by the browser runs
-  themselves, so there is little shell overhead left to remove — but the pre-migration
-  number was never recorded, so the actual saving is still unquantified.
+  `ubuntu-26.04-arm`. Remove it in its own commit so a failure names the cause. The
+  image makes it more likely to matter, not less: a container has no `/etc/os-release`
+  for Playwright to read.
+- **Compare wall-clock time** across all three shapes — the pre-migration job,
+  `nix develop`, and the container. The pre-migration number was never recorded, and the
+  image adds a build and a `docker load` the shell did not pay for, so the comparison
+  belongs to [65Z-ci-scenario-docker](65z-ci-scenario-docker.md)'s open measurement.
 - **Automate the paired bump.** Bumping the pinned Nixpkgs commit must re-read the
   Playwright driver version and update `fjs/ci/config/module.f.ts`, `package.json`,
   `package-lock.json`, `deno.lock`, and `bun.lock` together. A Playwright bump that
@@ -107,8 +126,11 @@ Node — and the job's `npx playwright --version` check is what makes a drift fa
 - [x] Run the job's whole sequence in one `nix develop --command` invocation, checking
       its own Node and Playwright versions inside it.
 - [x] Confirm all three browsers pass in CI against the Nix-provided bundle.
+- [x] Run the job in an OCI image generated from the same flake, keeping the
+      development shell as the fallback.
 - [ ] Check whether `PLAYWRIGHT_HOST_PLATFORM_OVERRIDE` is load-bearing.
-- [ ] Compare the migrated job's wall-clock time against a pre-migration run.
+- [ ] Compare the job's wall-clock time across the pre-migration, `nix develop`, and
+      container shapes.
 - [ ] Fold the driver-version check, and the `deno.lock`/`bun.lock` updates a Playwright
       bump requires, into the Nixpkgs bump process.
 
@@ -119,6 +141,8 @@ Node — and the job's `npx playwright --version` check is what makes a drift fa
   milestone.
 - [66B-dockerfile-nix-integration](66b-dockerfile-nix-integration.md) — the Node flake
   implementation this task follows the shape of.
+- [65Z-ci-scenario-docker](65z-ci-scenario-docker.md) — the image this job runs in, and
+  the measurement and publication questions still open about it.
 - [ci-package-aware-deno-bun-and-playwright-steps](ci-package-aware-deno-bun-and-playwright-steps.md)
   — separate, unrelated proposal to make the Playwright job conditional on
   `@playwright/test` presence.

--- a/fjs/ci/todo/65z-ci-nix.md
+++ b/fjs/ci/todo/65z-ci-nix.md
@@ -201,9 +201,13 @@ Add other jobs only when useful:
 - Rust should have its own experiment and TODO for concrete toolchain/target packages;
 - Playwright has its own TODO — see
   [65Z-ci-nix-playwright](65z-ci-nix-playwright.md) — and is in fact the first job
-  migrated to `nix develop`, since Nixpkgs-provided browsers remove its slowest steps;
-- OCI remains a later design and optimization task after one direct-Nix Linux job
-  completes validation.
+  migrated off the runner's setup, since Nixpkgs-provided browsers remove its slowest
+  steps;
+- OCI was the follow-up that validation unblocked: the Playwright job now runs in an
+  image generated from its own flake — see
+  [65Z-ci-scenario-docker](65z-ci-scenario-docker.md). A generated flake still describes
+  one environment; the image is an extra output of it, and the development shell remains
+  the fallback.
 
 A failure or unresolved design in one follow-up must not block unrelated flakes.
 
@@ -238,5 +242,5 @@ A failure or unresolved design in one follow-up must not block unrelated flakes.
   implementation.
 - [65Z-ci-nix-playwright](65z-ci-nix-playwright.md) — the first job actually migrated
   to `nix develop`, and the adoption shape the Node jobs should follow.
-- [65Z-ci-scenario-docker](65z-ci-scenario-docker.md) — optional OCI design work after
-  one direct-Nix job completes validation.
+- [65Z-ci-scenario-docker](65z-ci-scenario-docker.md) — the OCI image generated from a
+  job's flake, designed and implemented once direct Nix was validated.

--- a/fjs/ci/todo/65z-ci-scenario-docker.md
+++ b/fjs/ci/todo/65z-ci-scenario-docker.md
@@ -1,107 +1,103 @@
-## 65Z-ci-scenario-docker. Design OCI after one direct Nix job works
+## 65Z-ci-scenario-docker. Package a Nix CI environment as an OCI image
 
 **Priority:** P3
-**Status:** blocked
-**Blocked by:** [66B-dockerfile-nix-integration](66b-dockerfile-nix-integration.md),
-Phase 1 through Phase 3 for one selected Linux job
+**Status:** wip
+
+### Progress
+
+The design below was written against one proven direct-Nix job — `playwright`,
+migrated in [65Z-ci-nix-playwright](65z-ci-nix-playwright.md) — and is now
+**implemented for that job**. `fjs/ci/nix/module.f.ts` generates
+`packages.<system>.oci` next to the job's development shell, and the job builds
+that image, loads it into the runner's Docker daemon, and runs its whole command
+sequence in a container instead of `nix develop`.
+
+What is not done is the part that would make the image pay for itself: it is
+built by the job that uses it, so every run still pays for building and loading
+it. Publishing the image, and measuring both paths, are the open tasks below.
 
 ### Problem
 
-We do not yet know whether packaging a Nix CI environment as an OCI image improves total
-CI behavior. Selecting a builder, image layout, runtime model, identity, caching, or
-publication workflow before a direct-Nix job works would turn an optimization experiment
-into speculative implementation.
+We did not know whether packaging a Nix CI environment as an OCI image improves
+total CI behavior. Selecting a builder, image layout, runtime model, identity,
+caching, or publication workflow before a direct-Nix job worked would have turned
+an optimization experiment into speculative implementation — so the first
+direct-Nix milestone stayed independent of OCI work.
 
-The first direct-Nix milestone should therefore remain independent of OCI work.
+Direct Nix remains the reference behavior and the fallback: the flake keeps its
+development shell, and moving a job back to `nix develop` is a one-line change in
+its CI module.
 
-### Proposal
+### Design
 
-First prove this path for at least one Linux job:
+Decided for the `playwright` job, and generated from its existing declaration.
 
-```text
-declarative CI job -> generated flake.nix -> direct CI execution
-```
+**Builder.** `pkgs.dockerTools.streamLayeredImage` from the pinned Nixpkgs
+snapshot. No Dockerfile and no external builder: the image is another output of
+the flake the job already has, so it cannot drift from the shell. `stream…`
+rather than `build…` writes the archive to standard output instead of storing a
+second copy of every layer.
 
-Then use the working job and measurements to write and review a concrete OCI design.
-Do not implement an OCI output in this task. Rust, Playwright, and other unfinished
-complex jobs do not block this design work.
+**Contents.** The job's `packages` and environment variables, unchanged, plus
+what a shell inherits from the runner and a container has to carry itself: an
+interactive shell, the core utilities, `/bin/sh` and `/usr/bin/env`, the
+certificate bundle, `/etc/passwd` and `/etc/group`, a writable `/tmp`, and `PATH`
+and `HOME`. Everything else follows from the closure — the browsers reach the
+image because `Env` interpolates `pkgs.playwright-driver.browsers` and
+`streamLayeredImage` treats the image configuration as a closure root.
 
-#### Principles
+**Execution model.** No entry point of its own. The image's `Cmd` is a shell for
+someone opening it by hand; CI passes the job's command sequence as one
+`bash -euo pipefail -c '…'` argument, exactly as the `nix develop` invocation
+did, with the checkout bind-mounted at the image's `WorkingDir`.
 
-- direct Nix CI is the reference behavior and fallback;
-- OCI is an optional optimization;
-- design from a validated job and measured bottlenecks;
-- do not select a builder, image layout, or publication workflow before that evidence;
-- do not introduce a Dockerfile unless the reviewed design requires one;
-- preserve immutable identities and safe publication boundaries;
-- keep OCI-specific details out of the first generated flakes;
-- create a separate implementation TODO after the design is reviewed.
+**Identity.** `name:<nixpkgs-commit>`. The pinned snapshot and this repository's
+generated flake together determine the image, and the job builds it rather than
+resolving a tag, so a mutable-tag race cannot happen. A published image needs a
+stronger identity — see the open tasks.
 
-#### Entry criteria
+**Architecture.** `aarch64-linux`, the job's runner. One system per job, like the
+flake's development shell.
 
-Begin this design task after one selected Linux job has completed Phase 1 through Phase
-3 and has:
+**Credentials.** None. Nothing is pushed, so no package-write credential is ever
+exposed to pull-request code.
 
-- a simple committed self-contained flake;
-- a pinned Nix bootstrap in CI;
-- successful direct-Nix execution of its existing commands;
-- a reliable direct path that can serve as the fallback and comparison;
-- basic cold/warm build and cache measurements.
+### Remaining work
 
-Completion of the full [65Z-ci-nix](65z-ci-nix.md) task is not required.
-
-#### Design deliverable
-
-For the selected proven job, the proposal must decide and explain:
-
-- the OCI builder/provider;
-- which files, packages, and runtime dependencies enter the image;
-- the image entry point or command-execution model;
-- how the existing CI command sequence runs inside the image;
-- the immutable output identity and tag policy;
-- the required Linux architecture;
-- expected build, pull, and cache behavior compared with direct Nix;
-- credential and publication boundaries;
-- the direct-Nix fallback;
-- validation and acceptance criteria.
-
-Keep this design specific to one job. Do not generalize to combined images, additional
-architectures, or repository-wide publication until the first implementation produces
-real results.
-
-#### Handoff
-
-After the design is reviewed:
-
-1. create a separate implementation TODO containing the selected concrete design;
-2. implement the first OCI output there;
-3. run the same CI commands through direct Nix and OCI;
-4. compare image size, build time, pull time, and cache reuse;
-5. adopt OCI only if it improves total CI behavior.
-
-#### Publication constraints
-
-Any later implementation must:
-
-- publish only immutable identities;
-- avoid exposing package-write credentials to pull-request code;
-- validate before publishing;
-- keep direct Nix as the fallback/reference path.
+- **Measure both paths.** The job's `nix develop` runs took roughly three
+  minutes, nearly all of it the browser runs themselves. Record the image build,
+  `docker load`, and total time now, and compare: building an image in the job
+  that consumes it is strictly more work than entering a shell, and it is only
+  worth keeping if the difference is small enough to be paid back by publishing.
+- **Decide on publication.** Pushing to a registry is what turns the build into a
+  pull, but it needs an immutable identity (content-addressed tag or digest), a
+  workflow with package-write permission that pull-request code cannot reach, and
+  a rule for how a job pins the image it uses. A first pull request cannot
+  validate an image that only exists after it merges, so the pinning rule has to
+  answer that too. Design it only if the measurements say a pull would win.
+- **Decide whether other jobs get images.** The Node jobs have no browser bundle
+  and little to gain; do not generalize until one of them asks for it.
 
 ### Tasks
 
-- [ ] Complete Phase 1 through Phase 3 of
+- [x] Complete Phase 1 through Phase 3 of
       [66B-dockerfile-nix-integration](66b-dockerfile-nix-integration.md) for one
       selected Linux job.
-- [ ] Record direct-Nix build and cache measurements for that job.
-- [ ] Change this TODO from `blocked` to `open` when those criteria pass.
-- [ ] Write the job-specific OCI design covering every item in the design deliverable.
-- [ ] Review and accept or reject the OCI design.
-- [ ] Create a separate implementation TODO only after the design is accepted.
+- [x] Write the job-specific OCI design covering every item in the design
+      deliverable.
+- [x] Generate the image from the job's existing Nix declaration.
+- [x] Run the job's complete command sequence in a container of that image.
+- [ ] Record build, load, and total wall-clock time, and compare with the
+      `nix develop` runs of the same job.
+- [ ] Decide whether to publish the image, and design the identity, permission
+      boundary, and pinning rule if so.
+- [ ] Keep direct Nix as the documented fallback when a job moves to an image.
 
 ### Related
 
 - [65Z-ci-nix](65z-ci-nix.md) — declarative per-job Nix architecture.
-- [66B-dockerfile-nix-integration](66b-dockerfile-nix-integration.md) — direct Nix
-  implementation and prerequisite.
+- [65Z-ci-nix-playwright](65z-ci-nix-playwright.md) — the job this image was
+  designed for and is used by.
+- [66B-dockerfile-nix-integration](66b-dockerfile-nix-integration.md) — direct
+  Nix implementation and prerequisite.
 - [i096](96.md) — CI caching.

--- a/fjs/ci/todo/66b-dockerfile-nix-integration.md
+++ b/fjs/ci/todo/66b-dockerfile-nix-integration.md
@@ -257,5 +257,8 @@ milestone.
 ### Related
 
 - [65Z-ci-nix](65z-ci-nix.md) — architecture and task boundaries.
-- [65Z-ci-scenario-docker](65z-ci-scenario-docker.md) — later OCI design work after one
-  direct-Nix Linux job works.
+- [65Z-ci-scenario-docker](65z-ci-scenario-docker.md) — the OCI image the generator now
+  adds to a job's flake, once the Playwright job proved the direct-Nix path. It changed
+  the shape of every generated flake: `pkgs` moved into the `outputs` function's `let`,
+  so the shell and the image share it. The Node flakes are otherwise unchanged, and
+  nothing about this milestone depends on the image.

--- a/fjs/media/nix/module.f.ts
+++ b/fjs/media/nix/module.f.ts
@@ -30,7 +30,21 @@ type Reference = readonly ['ref', Identifier, ...AttributeName[]]
 
 type AttributeSet = readonly ['set', ...Binding[]]
 
-type NixList = readonly ['list', ...Reference[]]
+/**
+ * A double-quoted string with references interpolated into it, e.g.
+ * `"PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}"`. A store path
+ * only becomes a string this way, so the interpolated parts stay Nix values
+ * instead of text the generator has to know the shape of.
+ */
+type InterpolatedString = readonly ['interpolated-string', ...(string | Reference)[]]
+
+/**
+ * List items are limited to the forms Nix parses without parentheses, so the
+ * serializer never has to decide where to add them.
+ */
+type ListItem = string | Reference | InterpolatedString | AttributeSet | NixList
+
+type NixList = readonly ['list', ...ListItem[]]
 
 type ApplicationArgument = Reference | AttributeSet
 
@@ -54,6 +68,7 @@ export type Expression =
     | Lambda
     | Let
     | IndentedString
+    | InterpolatedString
 
 const reservedWords = [
     'assert',
@@ -141,6 +156,15 @@ const serializeReference = ([, name, ...selection]: Reference): string | undefin
         ? [name, ...selection.map(attributeName)].join('.')
         : undefined
 
+const serializeInterpolatedString = ([, ...parts]: InterpolatedString): string | undefined => {
+    const serialized = parts.map(part => {
+        if (typeof part === 'string') { return escapeQuoted(part) }
+        const reference = serializeReference(part)
+        return reference === undefined ? undefined : `\${${reference}}`
+    })
+    return serialized.includes(undefined) ? undefined : `"${serialized.join('')}"`
+}
+
 const serializeReferenceChunks = (reference: Reference): Chunks | undefined => {
     const serialized = serializeReference(reference)
     return serialized === undefined ? undefined : [serialized]
@@ -189,14 +213,14 @@ const serializeSet = ([, ...bindings]: AttributeSet, level: number): Chunks | un
     return body === undefined ? undefined : ['{\n', ...body, '\n', indent(level), '}']
 }
 
-const serializeList = ([, ...references]: NixList): Chunks | undefined => {
-    const items = references.map(serializeReference)
+const serializeList = ([, ...list]: NixList, level: number): Chunks | undefined => {
+    const items = list.map(item => serialize(item, level))
     const definedItems = items.flatMap(item => item === undefined ? [] : [item])
-    return items.includes(undefined)
+    return definedItems.length !== items.length
         ? undefined
         : items.length === 0
             ? ['[ ]']
-            : ['[ ', ...definedItems.flatMap((item, index) => index === 0 ? [item] : [' ', item]), ' ]']
+            : ['[ ', ...definedItems.flatMap((item, index) => index === 0 ? item : [' ', ...item]), ' ]']
 }
 
 const serializeApplication = ([, fn, ...args]: Application, level: number): Chunks | undefined => {
@@ -236,7 +260,11 @@ const serialize = (expression: Expression, level: number): Chunks | undefined =>
             return serializeReferenceChunks(expression)
         }
         case 'set': return serializeSet(expression, level)
-        case 'list': return serializeList(expression)
+        case 'list': return serializeList(expression, level)
+        case 'interpolated-string': {
+            const serialized = serializeInterpolatedString(expression)
+            return serialized === undefined ? undefined : [serialized]
+        }
         case 'apply': return serializeApplication(expression, level)
         case 'lambda': return serializeLambda(expression, level)
         case 'let': return serializeLet(expression, level)

--- a/fjs/media/nix/proof.f.ts
+++ b/fjs/media/nix/proof.f.ts
@@ -6,41 +6,39 @@ const nodeFlake = (nodePackage: string, shellHook: boolean): Expression => ['set
     ['=', ['inputs', 'nixpkgs', 'url'], 'github:NixOS/nixpkgs/<commit>'],
     ['=', ['outputs'], ['lambda',
         ['open-set-pattern', 'nixpkgs'],
-        ['set',
-            ['=', ['devShells', 'aarch64-linux', 'default'],
-                ['let', [
-                    ['=', ['pkgs'], ['apply',
-                        ['ref', 'import'],
-                        ['ref', 'nixpkgs'],
-                        ['set', ['=', ['system'], 'aarch64-linux']]
-                    ]]
-                ], ['apply',
-                    ['ref', 'pkgs', 'mkShell'],
-                    ['set',
-                        ['=', ['packages'], ['list', ['ref', 'pkgs', nodePackage]]],
-                        ...(shellHook ? [[
-                            '=',
-                            ['shellHook'],
-                            ['indented-string', `export NPM_CONFIG_PREFIX="$HOME/.npm-global"
+        ['let', [
+            ['=', ['pkgs'], ['apply',
+                ['ref', 'import'],
+                ['ref', 'nixpkgs'],
+                ['set', ['=', ['system'], 'aarch64-linux']]
+            ]]
+        ], ['set',
+            ['=', ['devShells', 'aarch64-linux', 'default'], ['apply',
+                ['ref', 'pkgs', 'mkShell'],
+                ['set',
+                    ['=', ['packages'], ['list', ['ref', 'pkgs', nodePackage]]],
+                    ...(shellHook ? [[
+                        '=',
+                        ['shellHook'],
+                        ['indented-string', `export NPM_CONFIG_PREFIX="$HOME/.npm-global"
 export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"
 mkdir -p "$NPM_CONFIG_PREFIX"`]
-                        ] as const] : [])
-                    ]
-                ]]
-            ]
-        ]
+                    ] as const] : [])
+                ]
+            ]]
+        ]]
     ]]
 ]
 
 const node24 = `{
     inputs.nixpkgs.url = "github:NixOS/nixpkgs/<commit>";
-    outputs = { nixpkgs, ... }: {
-        devShells.aarch64-linux.default = let
-            pkgs = import nixpkgs {
-                system = "aarch64-linux";
-            };
-        in
-        pkgs.mkShell {
+    outputs = { nixpkgs, ... }: let
+        pkgs = import nixpkgs {
+            system = "aarch64-linux";
+        };
+    in
+    {
+        devShells.aarch64-linux.default = pkgs.mkShell {
             packages = [ pkgs.nodejs_24 ];
         };
     };
@@ -49,13 +47,13 @@ const node24 = `{
 
 const node22 = `{
     inputs.nixpkgs.url = "github:NixOS/nixpkgs/<commit>";
-    outputs = { nixpkgs, ... }: {
-        devShells.aarch64-linux.default = let
-            pkgs = import nixpkgs {
-                system = "aarch64-linux";
-            };
-        in
-        pkgs.mkShell {
+    outputs = { nixpkgs, ... }: let
+        pkgs = import nixpkgs {
+            system = "aarch64-linux";
+        };
+    in
+    {
+        devShells.aarch64-linux.default = pkgs.mkShell {
             packages = [ pkgs.nodejs_22 ];
             shellHook = ''
                 export NPM_CONFIG_PREFIX="$HOME/.npm-global"
@@ -85,6 +83,29 @@ export const proof = {
             nixToString(['list', ['ref', 'pkgs', 'nodejs_22'], ['ref', 'pkgs', 'nodejs_24']]),
             '[ pkgs.nodejs_22 pkgs.nodejs_24 ]\n'
         )
+    },
+    // A list holds any expression Nix parses without parentheses, so an image's
+    // `Env` — plain strings next to interpolated store paths — is one list.
+    mixedList: () => {
+        assertEq(
+            nixToString(['list',
+                'HOME=/tmp',
+                ['interpolated-string', 'BROWSERS=', ['ref', 'pkgs', 'playwright-driver', 'browsers']],
+                ['set', ['=', ['x'], 'y']],
+                ['list', 'nested'],
+            ]),
+            '[ "HOME=/tmp" "BROWSERS=${pkgs.playwright-driver.browsers}" {\n    x = "y";\n} [ "nested" ] ]\n'
+        )
+    },
+    interpolatedString: () => {
+        assertEq(
+            nixToString(['interpolated-string', 'a=', ['ref', 'pkgs', 'b'], '/c']),
+            '"a=${pkgs.b}/c"\n'
+        )
+        // Literal parts are escaped as in any quoted string, so a `${` a job
+        // supplies stays text instead of starting an interpolation.
+        assertEq(nixToString(['interpolated-string', '${x}"']), '"\\${x}\\""\n')
+        assertEq(nixToString(['interpolated-string']), '""\n')
     },
     compatiblePaths: () => {
         assertEq(
@@ -153,6 +174,10 @@ export const proof = {
         ),
         listItem: () => assertEq(
             nixToString(['list', ['ref', 'valid'], ['ref', 'bad name']]),
+            undefined
+        ),
+        interpolatedReference: () => assertEq(
+            nixToString(['interpolated-string', 'a=', ['ref', 'bad name']]),
             undefined
         ),
         applicationFunction: () => assertEq(

--- a/nix/README.md
+++ b/nix/README.md
@@ -31,3 +31,30 @@ the root `.gitignore`); the pinned commit in `flake.nix` is the lock.
 CI's temporary `nix-flakes` job runs exactly that command for every generated
 flake and compares the output to the expected version, so these files are
 checked on every pull request even though no real job uses them yet.
+
+## Job images
+
+A job that runs in a container gets a second output in the same flake:
+
+```sh
+"$(nix build ./nix/generated/playwright#oci --no-link --print-out-paths)" | docker load
+docker run --rm --ipc=host --volume "$PWD:/workspace" functionalscript-playwright:<nixpkgs-commit> node --version
+```
+
+`packages.<system>.oci` is a `dockerTools.streamLayeredImage` derivation — a
+script that writes the image archive to standard output, so the archive is never
+stored alongside the layers it is made of. `--no-link` keeps a `result` symlink
+out of the checkout.
+
+The image and the development shell come from **one** declaration: the job's
+`packages` and environment variables reach both. Only what a shell inherits from
+the runner and a container has to provide itself is added — `PATH` and `HOME`,
+`/bin/sh` and the core utilities, the certificate bundle, `/etc/passwd`, and a
+writable `/tmp`.
+
+Store paths reach the image through the environment: `Env` interpolates them,
+and `streamLayeredImage` treats the image configuration as a closure root, so
+naming `pkgs.playwright-driver.browsers` there is what puts the browsers in the
+image. The image is tagged with the pinned Nixpkgs commit, which — together with
+the generated flake in this repository — is its whole identity. It is built by
+the job that uses it; nothing is pushed to a registry.

--- a/nix/generated/node22/flake.nix
+++ b/nix/generated/node22/flake.nix
@@ -1,12 +1,12 @@
 {
     inputs.nixpkgs.url = "github:NixOS/nixpkgs/21ea275a7c46aef9d4d6ddc962e6d562e9d94183";
-    outputs = { nixpkgs, ... }: {
-        devShells.aarch64-linux.default = let
-            pkgs = import nixpkgs {
-                system = "aarch64-linux";
-            };
-        in
-        pkgs.mkShell {
+    outputs = { nixpkgs, ... }: let
+        pkgs = import nixpkgs {
+            system = "aarch64-linux";
+        };
+    in
+    {
+        devShells.aarch64-linux.default = pkgs.mkShell {
             packages = [ pkgs.nodejs_22 ];
             shellHook = ''
                 export NPM_CONFIG_PREFIX="$HOME/.npm-global"

--- a/nix/generated/node24/flake.nix
+++ b/nix/generated/node24/flake.nix
@@ -1,12 +1,12 @@
 {
     inputs.nixpkgs.url = "github:NixOS/nixpkgs/21ea275a7c46aef9d4d6ddc962e6d562e9d94183";
-    outputs = { nixpkgs, ... }: {
-        devShells.aarch64-linux.default = let
-            pkgs = import nixpkgs {
-                system = "aarch64-linux";
-            };
-        in
-        pkgs.mkShell {
+    outputs = { nixpkgs, ... }: let
+        pkgs = import nixpkgs {
+            system = "aarch64-linux";
+        };
+    in
+    {
+        devShells.aarch64-linux.default = pkgs.mkShell {
             packages = [ pkgs.nodejs_24 ];
         };
     };

--- a/nix/generated/node26/flake.nix
+++ b/nix/generated/node26/flake.nix
@@ -1,12 +1,12 @@
 {
     inputs.nixpkgs.url = "github:NixOS/nixpkgs/21ea275a7c46aef9d4d6ddc962e6d562e9d94183";
-    outputs = { nixpkgs, ... }: {
-        devShells.aarch64-linux.default = let
-            pkgs = import nixpkgs {
-                system = "aarch64-linux";
-            };
-        in
-        pkgs.mkShell {
+    outputs = { nixpkgs, ... }: let
+        pkgs = import nixpkgs {
+            system = "aarch64-linux";
+        };
+    in
+    {
+        devShells.aarch64-linux.default = pkgs.mkShell {
             packages = [ pkgs.nodejs_26 ];
         };
     };

--- a/nix/generated/playwright/flake.nix
+++ b/nix/generated/playwright/flake.nix
@@ -1,16 +1,30 @@
 {
     inputs.nixpkgs.url = "github:NixOS/nixpkgs/21ea275a7c46aef9d4d6ddc962e6d562e9d94183";
-    outputs = { nixpkgs, ... }: {
-        devShells.aarch64-linux.default = let
-            pkgs = import nixpkgs {
-                system = "aarch64-linux";
-            };
-        in
-        pkgs.mkShell {
+    outputs = { nixpkgs, ... }: let
+        pkgs = import nixpkgs {
+            system = "aarch64-linux";
+        };
+    in
+    {
+        devShells.aarch64-linux.default = pkgs.mkShell {
             packages = [ pkgs.nodejs_26 ];
             PLAYWRIGHT_BROWSERS_PATH = pkgs.playwright-driver.browsers;
             PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
             PLAYWRIGHT_HOST_PLATFORM_OVERRIDE = "ubuntu-24.04";
+        };
+        packages.aarch64-linux.oci = pkgs.dockerTools.streamLayeredImage {
+            name = "functionalscript-playwright";
+            tag = "21ea275a7c46aef9d4d6ddc962e6d562e9d94183";
+            contents = [ pkgs.nodejs_26 pkgs.bashInteractive pkgs.coreutils pkgs.dockerTools.binSh pkgs.dockerTools.usrBinEnv pkgs.dockerTools.caCertificates pkgs.dockerTools.fakeNss ];
+            config = {
+                Env = [ "PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}" "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1" "PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu-24.04" "PATH=/bin:/usr/bin" "HOME=/tmp" ];
+                WorkingDir = "/workspace";
+                Cmd = [ "/bin/sh" ];
+            };
+            extraCommands = ''
+                mkdir -p tmp workspace
+                chmod 1777 tmp
+            '';
         };
     };
 }


### PR DESCRIPTION
## Summary

Implement OCI image generation for CI jobs and migrate the Playwright job to run its commands inside a container built from its Nix flake, rather than in a development shell.

## Key Changes

- **Nix flake generator** (`fjs/ci/nix/module.f.ts`):
  - Add `NixOci` type to declare an image alongside a job's packages and environment
  - Generate `packages.<system>.oci` output using `pkgs.dockerTools.streamLayeredImage`
  - Image carries the same packages and environment variables as the development shell, plus container-specific utilities (shell, coreutils, certificates, `/etc/passwd`, writable `/tmp`)
  - Image tagged with the pinned Nixpkgs commit for immutable identity
  - Add `ociLoad()` and `ociRunAll()` helper functions to build and run images in CI

- **Nix expression serializer** (`fjs/media/nix/module.f.ts`):
  - Add `InterpolatedString` expression type for double-quoted strings with `${...}` interpolations
  - Support mixed-type list items (strings, references, interpolations, sets, nested lists)
  - Enable store paths to be embedded in image environment variables via interpolation

- **Playwright job** (`fjs/ci/playwright/module.f.ts`):
  - Declare `playwrightOci` with image name, required utilities, and working directory
  - Add `oci` field to `playwrightNixJob` to generate the image
  - Job now builds the image and runs commands in a container instead of `nix develop`

- **Generated flakes**:
  - Restructure all generated flakes to use `let...in` at the outputs level for cleaner code
  - Playwright flake now includes both `devShells.aarch64-linux.default` (fallback) and `packages.aarch64-linux.oci` (container image)
  - Node flakes reformatted for consistency

- **CI workflow** (`.github/workflows/ci.yml`):
  - Playwright job now runs `nix build` to generate the image, `docker load` to import it, and `docker run` to execute commands
  - Checkout mounted at image's working directory

- **Documentation**:
  - Update task status in `65z-ci-scenario-docker.md` from "blocked" to "wip" with implementation details
  - Document design decisions: builder choice, image contents, execution model, identity scheme, architecture, and remaining work (measurement and publication)
  - Update `65z-ci-nix-playwright.md` to reflect container-based execution
  - Add image usage examples to `nix/README.md`

## Notable Implementation Details

- **One declaration, two entry points**: Job's packages and environment reach both the development shell and the image; only container-specific parts are added by the generator
- **No Dockerfile**: Image is a pure Nix output, cannot drift from the shell
- **Immutable identity**: Image tagged with Nixpkgs commit; job builds it rather than pulling, eliminating tag races
- **Store path interpolation**: Environment variables like `PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}` embed closures in the image
- **Fallback preserved**: Direct Nix remains the documented fallback; moving a job back to `nix develop` is a one-line change
- **Measurement pending**: Build/load/total time comparison with `nix develop` runs not yet recorded; publication design deferred until measurements justify it

https://claude.ai/code/session_013tyP6YkT2zmHPvbgzQbwpc