### PR TITLE
Update dependencies and toolchain versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.38.0"
+          "run": "npm install -g functionalscript@0.39.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -81,7 +81,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.38.0"
+          "run": "npm install -g functionalscript@0.39.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -122,7 +122,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.38.0"
+          "run": "npm install -g functionalscript@0.39.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -163,7 +163,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.38.0"
+          "run": "npm install -g functionalscript@0.39.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -205,7 +205,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.38.0"
+          "run": "npm install -g functionalscript@0.39.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -258,7 +258,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.38.0"
+          "run": "npm install -g functionalscript@0.39.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -296,7 +296,7 @@
         {
           "uses": "bytecodealliance/actions/wasmtime/setup@v1.1.3",
           "with": {
-            "version": "47.0.2"
+            "version": "47.0.3"
           }
         },
         {
@@ -389,13 +389,13 @@
           }
         },
         {
-          "run": "deno install -g -A --minimum-dependency-age=0 npm:functionalscript@0.38.0"
+          "run": "deno install -g -A --minimum-dependency-age=0 npm:functionalscript@0.39.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
         },
         {
-          "run": "deno run -A --minimum-dependency-age=0 npm:functionalscript@0.38.0 t"
+          "run": "deno run -A --minimum-dependency-age=0 npm:functionalscript@0.39.0 t"
         },
         {
           "run": "deno install --frozen"
@@ -415,7 +415,7 @@
           }
         },
         {
-          "run": "bun install -g functionalscript@0.38.0"
+          "run": "bun install -g functionalscript@0.39.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -424,7 +424,7 @@
           "run": "bun install --frozen-lockfile"
         },
         {
-          "run": "bunx functionalscript@0.38.0 t"
+          "run": "bunx functionalscript@0.39.0 t"
         },
         {
           "run": "bun test --coverage"
@@ -437,11 +437,11 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "22.23.1"
+            "node-version": "22.23.2"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.38.0"
+          "run": "npm install -g functionalscript@0.39.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -519,7 +519,7 @@
           "uses": "actions/checkout@v7.0.1"
         },
         {
-          "run": "test \"$(nix develop ./nix/generated/node22 --command node --version)\" = v22.23.1"
+          "run": "test \"$(nix develop ./nix/generated/node22 --command node --version)\" = v22.23.2"
         },
         {
           "run": "test \"$(nix develop ./nix/generated/node24 --command node --version)\" = v24.18.0"

--- a/fjs/ci/config/module.f.ts
+++ b/fjs/ci/config/module.f.ts
@@ -24,7 +24,7 @@ export const images = {
 // published FunctionalScript release; do not tie it to package.json's current
 // in-repo version.
 // https://www.npmjs.com/package/functionalscript
-export const functionalscript = '0.38.0' as const
+export const functionalscript = '0.39.0' as const
 
 // https://bun.sh/
 export const bun = '1.3.14'
@@ -41,7 +41,7 @@ export const deno = '2.9.4'
 // https://nodejs.org/en/download
 export const node = {
     default: '26.5.1',
-    node22: '22.23.1',
+    node22: '22.23.2',
     node24: '24.18.0',
 } as const
 
@@ -52,11 +52,11 @@ export const node = {
 // https://channels.nixos.org/nixos-26.05/git-revision
 export const nixpkgs = {
     ref: 'nixos-26.05',
-    commit: '21ea275a7c46aef9d4d6ddc962e6d562e9d94183',
+    commit: '6d65bfc1bcef2ef39a239d38e577e92a89fb0f07',
 } as const
 
 // https://github.com/bytecodealliance/wasmtime/releases
-export const wasmtime = '47.0.2'
+export const wasmtime = '47.0.3'
 
 // https://github.com/wasmerio/wasmer/releases
 export const wasmer = '7.2.1'

--- a/nix/generated/node22/flake.nix
+++ b/nix/generated/node22/flake.nix
@@ -1,5 +1,5 @@
 {
-    inputs.nixpkgs.url = "github:NixOS/nixpkgs/21ea275a7c46aef9d4d6ddc962e6d562e9d94183";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/6d65bfc1bcef2ef39a239d38e577e92a89fb0f07";
     outputs = { nixpkgs, ... }: {
         devShells.aarch64-linux.default = let
             pkgs = import nixpkgs {

--- a/nix/generated/node24/flake.nix
+++ b/nix/generated/node24/flake.nix
@@ -1,5 +1,5 @@
 {
-    inputs.nixpkgs.url = "github:NixOS/nixpkgs/21ea275a7c46aef9d4d6ddc962e6d562e9d94183";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/6d65bfc1bcef2ef39a239d38e577e92a89fb0f07";
     outputs = { nixpkgs, ... }: {
         devShells.aarch64-linux.default = let
             pkgs = import nixpkgs {

--- a/nix/generated/node26/flake.nix
+++ b/nix/generated/node26/flake.nix
@@ -1,5 +1,5 @@
 {
-    inputs.nixpkgs.url = "github:NixOS/nixpkgs/21ea275a7c46aef9d4d6ddc962e6d562e9d94183";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/6d65bfc1bcef2ef39a239d38e577e92a89fb0f07";
     outputs = { nixpkgs, ... }: {
         devShells.aarch64-linux.default = let
             pkgs = import nixpkgs {


### PR DESCRIPTION
## Summary
This PR updates several development dependencies and toolchain versions to their latest releases, ensuring the project uses current and stable versions of key tools.

## Key Changes
- **FunctionalScript**: Updated from 0.38.0 to 0.39.0 across all CI workflows and configuration
- **Node.js 22**: Bumped from 22.23.1 to 22.23.2
- **Wasmtime**: Updated from 47.0.2 to 47.0.3
- **NixOS packages**: Updated nixpkgs commit from `21ea275a7c46aef9d4d6ddc962e6d562e9d94183` to `6d65bfc1bcef2ef39a239d38e577e92a89fb0f07` (nixos-26.05 channel)

## Implementation Details
- Updated the source configuration in `fjs/ci/config/module.f.ts` which is the single source of truth for dependency versions
- All CI workflow references in `.github/workflows/ci.yml` were automatically updated to reflect the new versions
- Updated Nix flake configurations for all Node.js development environments (node22, node24, node26) to use the latest nixpkgs commit

https://claude.ai/code/session_019JbfJYPA83hfcRJoo9kUV5