### PR TITLE
Document dialect-registry limitation in media detection

### DIFF
--- a/fjs/media/todo/dialect-registry.md
+++ b/fjs/media/todo/dialect-registry.md
@@ -46,13 +46,10 @@ entry can say to an rtti schema plus a typed refinement predicate** — no
 decoder, no media type, no separate dialect name:
 
 ```ts
-// An rtti struct schema whose `dialect` member is a string const — the subset
-// of `Type` that names its own dialect. Written as one record rather than
-// `Struct & { dialect: string }`: see the note below.
-export type DialectType = {
-    readonly [k: string]: Type | undefined
-    readonly dialect: string
-}
+// The dialect name a schema carries, and the schemas that carry one: an rtti
+// `Struct` whose `dialect` member is a direct string const.
+type DialectName<T extends Struct> = T['dialect'] extends string ? T['dialect'] : never
+type DialectSchema<T extends Struct> = T['dialect'] extends string ? T : never
 
 /** The registry entry: a dialect name and a predicate over a parsed value. */
 export type DialectEntry<S extends string> = {
@@ -61,10 +58,10 @@ export type DialectEntry<S extends string> = {
 }
 
 /** Registers a dialect for detection: its schema, plus whatever rtti can't say. */
-export const dialectEntry = <T extends DialectType>(
-    type: T,
+export const dialectEntry = <T extends Struct>(
+    type: DialectSchema<T>,
     extraValidate: (_: Ts<T>) => boolean = () => true,
-): DialectEntry<T['dialect']> => /* … */
+): DialectEntry<DialectName<T>> => /* … */
 ```
 
 A dialect schema is already a struct whose `dialect` member is a string const —
@@ -73,15 +70,25 @@ self-discriminating. So the dialect name is *in* the schema, and a separate
 `dialect` field alongside it would be a second copy that can disagree with the
 first. `detect` reads `type.dialect` and derives the media type from it.
 
-`DialectType` spells out the index signature instead of intersecting `Struct`
-with `{ dialect: string }`, per AGENTS.md's composition-over-intersection rule.
-The rule's usual remedy — embed the record as a named field — cannot apply
-here: an entry's schema *is* an rtti `Type`, and nesting it
-(`{ struct: Struct, dialect: string }`) would produce a value `validate` cannot
-consume. What the rule is actually against — an `&` that blurs where fields
-came from and tempts widening the part — is avoided by writing one record type
-whose index signature says the same thing `Struct` does
-(`StringMap<string, Type>`, i.e. `{ readonly [k in string]?: Type }`).
+The constraint is a conditional over rtti's own `Struct`, not a new record
+shape. Neither of the obvious spellings is allowed here: `Struct & { dialect:
+string }` is the intersection AGENTS.md rules out, and an inline
+`{ readonly [k: string]: Type | undefined, readonly dialect: string }` is the
+inline index signature it reserves for mutually-recursive types. The rule's
+usual remedy for the first — embed the record as a named field — cannot apply
+either, because an entry's schema *is* an rtti `Type`: nesting it
+(`{ struct: Struct, dialect: string }`) yields something `validate` cannot
+consume. Gating `T` on `T['dialect'] extends string` needs none of them; it
+reuses `Struct` (already `StringMap<string, Type>`) unchanged.
+
+This encoding is checked, not assumed — `tsc --strict` against the real
+`revisionSchema` confirms all four properties it has to have:
+`dialectEntry(revisionSchema, r => r.generation > 0)` infers `r` as the decoded
+`Revision` with no annotation, the returned entry's `dialect` is the literal
+`'vnd.fjs.revision'` (assigning it to another literal type errors), and a
+schema with no `dialect` member or with a thunk-form one is rejected at the
+call site — the parameter resolves to `never` — rather than silently producing
+an entry whose name is `never`.
 
 `extraValidate` closes the gap rtti leaves. Structural validation cannot say
 "this string is cbase32-decodable" or "this number is a non-negative safe
@@ -185,7 +192,7 @@ anyway.
 
 **The `dialect` member must be a direct string const**, not a thunk. rtti
 admits both forms — `dialect: 'vnd.fjs.revision'` and
-`() => ['const', 'vnd.fjs.revision']` — and `DialectType` above accepts only
+`() => ['const', 'vnd.fjs.revision']` — and `DialectSchema` above accepts only
 the first. That is the decision, not an implementer's choice: the direct form
 is what `revisionSchema` already uses, it is what rtti's own docstring
 prescribes outside recursive definitions, it makes `type.dialect` readable
@@ -237,6 +244,18 @@ predicate makes it a weaker claim than its own decoder would. Say so in the
 module docstring, and keep it true by never routing a decode decision through
 `detect`'s verdict.
 
+**`DetectMeta` is unchanged: no `dialect` field.** A matched entry is reported
+only through the derived `mime_type`, as today. `DetectMeta` is
+`fjs/media/type`'s result shape, shared with the dialect-unaware `detectStream`
+— putting a dialect field on it would place a dialect concept in the one layer
+that must not have one, and would leave that field permanently `undefined` on
+every streaming verdict. The caller loses little: it supplied the entry list,
+so it can compare `mime_type` against its own entries, and detection only ever
+claims a blob's shape, so a caller that intends to decode calls its dialect's
+decoder regardless. If a caller ever genuinely needs the matched entry, the
+place to widen is `fjs/media`'s own return type, not `fjs/media/type`'s —
+a separate change, and out of scope here.
+
 Two properties of the current implementation are deliberate and easy to lose
 while adding a registry:
 
@@ -271,10 +290,10 @@ while adding a registry:
       `detectDialect` call sites) and `fjs/media/proof.f.ts` — and add a
       `**BREAKING CHANGES:**` CHANGELOG entry per AGENTS.md §8.4. No
       compatibility shim.
-- [ ] Type `DialectType` so a schema whose `dialect` member is absent, not a
-      string, or a thunk-wrapped const is rejected at compile time — the direct
-      const form is required, per above. Do **not** grammar-check or allowlist
-      the name — record why in the JSDoc, since the rule differs from
+- [ ] Carry the `DialectSchema` / `DialectName` conditionals over as written, so
+      a schema whose `dialect` member is absent, not a string, or a thunk-
+      wrapped const is rejected at the call site. Do **not** grammar-check or
+      allowlist the name — record why in the JSDoc, since the rule differs from
       [detect-cbor](detect-cbor.md)'s blob-supplied names.
 - [ ] Proof coverage in `fjs/media/proof.f.ts`: a second dialect is recognized;
       first-match-wins ordering; no match falls through to the `fjs/media/type`
@@ -285,9 +304,6 @@ while adding a registry:
       structure alone; and a non-`vnd.fjs.*` dialect name yields its own derived
       type.
 - [ ] Confirm `detectStream` is untouched and still dialect-unaware.
-- [ ] Check whether `DetectMeta` needs to carry the matched dialect itself, not
-      only the derived `mime_type` — a caller that matched is usually about to
-      decode, and currently has to re-derive which dialect hit.
 
 ### Related
 
@@ -308,7 +324,7 @@ while adding a registry:
   `application/{dialect}+cbor`; its tier-2 names come from the blob, hence its
   allowlist and this module's lack of one.
 - [`fjs/types/rtti/module.f.ts`](../../types/rtti/module.f.ts) — `Struct` /
-  `Type` / `Const`; `DialectType` is the subset of `Type` with a string
-  `dialect` member, spelled without intersecting `Struct`.
+  `Type` / `Const`; `Struct` is the entry schema's constraint, narrowed by a
+  conditional rather than by intersecting or re-spelling it.
 - [`fjs/types/rtti/validate/module.f.ts`](../../types/rtti/validate/module.f.ts)
   — `validate`, what detection runs per entry over the once-parsed value.

--- a/fjs/media/todo/dialect-registry.md
+++ b/fjs/media/todo/dialect-registry.md
@@ -47,7 +47,7 @@ decoder, no media type, no separate dialect name:
 
 ```ts
 // `Struct`, `Ts` and `Unknown` are rtti's (`fjs/types/rtti`, `…/rtti/ts`),
-// `validate` is `…/rtti/validate`, `assert` is `fjs/asserts`.
+// `validate` and `Validate` are `…/rtti/validate`, `assert` is `fjs/asserts`.
 
 /** The registry entry: a dialect name and a predicate over a parsed value. */
 export type DialectEntry = {
@@ -57,6 +57,14 @@ export type DialectEntry = {
 
 const always = (): boolean => true
 
+/** Structural validation followed by the dialect's own refinement. */
+const matchWith = <T extends Struct>(v: Validate<T>) =>
+    (extraValidate: (_: Ts<T>) => boolean) =>
+    (u: Unknown): boolean => {
+        const [tag, value] = v(u)
+        return tag === 'ok' && extraValidate(value)
+    }
+
 /** Registers a dialect for detection: its schema, plus whatever rtti can't say. */
 export const dialectEntry = <T extends Struct>(
     type: T,
@@ -64,14 +72,7 @@ export const dialectEntry = <T extends Struct>(
 ): DialectEntry => {
     const { dialect } = type
     assert(typeof dialect === 'string', 'dialectEntry: schema has no direct string `dialect` member')
-    const v = validate(type)
-    return {
-        dialect,
-        match: u => {
-            const [tag, value] = v(u)
-            return tag === 'ok' && extraValidate(value)
-        },
-    }
+    return { dialect, match: matchWith(validate(type))(extraValidate) }
 }
 ```
 
@@ -210,13 +211,22 @@ of the open design questions settle:
   when there is one, deriving `application/{dialect}+cbor` from the same name.
   Keeping the name rather than a finished media type costs nothing now and
   avoids a second registry, or a media-type string to parse back apart, later.
-- **The tag and the schema cannot disagree.** With one field there is no entry
+- **`dialectEntry` cannot produce a tag that disagrees with its schema.** It
+  reads the name out of the schema it validates, so there is no registration
   that claims `vnd.fjs.foo` while validating `vnd.fjs.bar` blobs — no
   consistency rule for `detect` to enforce, and none for a proof to cover.
+  Nothing stops a caller from writing the struct literal by hand instead
+  (`{ dialect: 'vnd.fjs.foo', match: always }`), and `DialectEntry` is
+  deliberately *not* made opaque to prevent that: the list is the caller's own
+  declaration of what it wants recognized, passed to its own `detect` call, so
+  a fabricated entry mislabels only that caller's results. There is no trust
+  boundary between a caller and the entries it writes itself, and a brand would
+  add machinery to guard one that does not exist. The boundary that does exist
+  — untrusted *blob* content — is on the other side of `match` entirely.
 - **Parsing happens once.** Detection JSON-parses the text a single time and
   calls each entry's `match` on the parsed value. Validation lives in the
-  entry, not the detector: `dialectEntry` closes over
-  `rtti/validate`'s `validate(type)` and its `extraValidate`, and `match` runs
+  entry, not the detector: `dialectEntry` applies `matchWith` to
+  `rtti/validate`'s `validate(type)` and its `extraValidate`, so `match` runs
   the structural check followed by the refinement on the same value. `detect`
   never sees `type` or `extraValidate` — it walks the list calling `match` and
   takes the first `true`. N dialects therefore cost N structural validations,
@@ -322,10 +332,10 @@ while adding a registry:
 ### Tasks
 
 - [ ] Implement `dialectEntry(type, extraValidate?)` as written above — it owns
-      validation, closing over `validate(type)` and `extraValidate` inside
-      `match`, asserts the `dialect` member at registration, and takes its
-      default predicate from the module-scope `always` rather than a fresh
-      `() => true` per call.
+      validation, applying the module-scope `matchWith` to `validate(type)` and
+      `extraValidate` rather than nesting a `match` closure; it asserts the
+      `dialect` member at registration and takes its default predicate from the
+      module-scope `always` rather than a fresh `() => true` per call.
 - [ ] Implement in `fjs/media/module.f.ts`: `detect(dialects)(bytes)` — parse
       once, call each entry's `match` on the parsed value, and append `+json`
       to the first matching entry's `dialect`. `detect` handles no schemas and

--- a/fjs/media/todo/dialect-registry.md
+++ b/fjs/media/todo/dialect-registry.md
@@ -78,18 +78,41 @@ reason: `Ts<T>` has to be inferred from the schema. In
 call site; a bare `{ type, extraValidate }` object makes every author write
 `(_: Ts<typeof revisionSchema>)` by hand. What it *returns* can be a struct —
 an erased entry the detector consumes, e.g.
-`{ mediaType, match: (u: Unknown) => boolean }`, with the generic gone.
+`{ dialect: string, match: (u: Unknown) => boolean }`, with the generic gone.
+
+**No grammar check or allowlist on the dialect name.** A schema could say
+`dialect: 'foo'`, and `detect` would report `application/foo+json`. That is
+intended: `vnd.fjs.*` is this repo's convention for its *own* formats, not a
+constraint on what a caller may detect — another vendor's `vnd.rogaikopyta.*`
+blob, or a widely used name that is not under `vnd.` at all, is a legitimate
+thing to register, and an allowlist here would only stop callers from
+describing the formats they actually handle. The name is also not attacker-
+controlled: it comes from a schema a programmer wrote and passed to `dialect`,
+never from the blob being classified, so no untrusted string reaches
+`mime_type` along this path. That is what distinguishes it from
+[detect-cbor](detect-cbor.md)'s tier 2, which reads the dialect name *out of
+the blob* and therefore does need the RFC 6838 grammar check and the
+`vnd.fjs.*` allowlist before echoing it into a media type. Registering a name
+that is not a valid RFC 6838 restricted-name yields a malformed media type in
+the registrant's own results, and nowhere else.
 
 Because an entry is (almost) data — a schema and one bounded predicate — most
 of the open design questions settle:
 
 - **The media type is derived, not supplied.** `application/${dialect}+json`,
   the same mechanical derivation `fjs/media/revision` already documents, read
-  off the schema's own literal. An entry cannot name an arbitrary `mime_type`,
-  so a registered dialect can only ever claim its own `vnd.fjs.<name>` type —
-  no `mediaType` field to get wrong, and nothing to allowlist after the fact.
-  The generic `T` keeps the literal, so the derived media type can stay a
-  template-literal type the way `revision`'s `mediaType` is today.
+  off the schema's own literal. An entry has no `mediaType` field to get wrong
+  or to disagree with the schema it validates. The generic `T` keeps the
+  literal, so the derived media type can stay a template-literal type the way
+  `revision`'s `mediaType` is today.
+- **The entry names a dialect, not an encoding.** Erase to
+  `{ dialect, match }`, not `{ mediaType, match }`: the `+json` suffix is the
+  JSON detector's to append. Nothing else is needed today — there is no CBOR
+  codec yet, so `fjs/media/type` has no CBOR path to detect through — but the
+  same entries are what [detect-cbor](detect-cbor.md) would validate against
+  when there is one, deriving `application/{dialect}+cbor` from the same name.
+  Keeping the name rather than a finished media type costs nothing now and
+  avoids a second registry, or a media-type string to parse back apart, later.
 - **The tag and the schema cannot disagree.** With one field there is no entry
   that claims `vnd.fjs.foo` while validating `vnd.fjs.bar` blobs — no
   consistency rule for `detect` to enforce, and none for a proof to cover.
@@ -120,12 +143,22 @@ direct form — what `revisionSchema` uses, and what keeps `type.dialect`
 readable without evaluating anything. Either require it or unwrap the thunk
 when reading the name.
 
-Keep the current zero-argument `detect` as a binding over the single default
-entry, `dialect(revisionSchema, r => checkReferences(r)[0] === 'ok')`.
-Whether the list is a parameter (`detect(dialects)(bytes)`) or a module-level
-registry is an API-taste call for this repo; a parameter keeps the module pure
-and avoids registration-order questions, at the cost of every caller naming the
-dialects it cares about.
+**The dialect list is a parameter, and `detect` breaks.** `detect(dialects)`
+returns the classifier, so today's `detect(bytes)` becomes
+`detect(dialects)(bytes)` — a breaking change to a public export, made rather
+than worked around: a module-level registry would trade the purity and the
+explicit call site for registration-order questions, and a compatibility shim
+would keep exactly the hardcoded default this issue exists to remove. Per
+[AGENTS.md §8.4](../../../AGENTS.md#84-breaking-changes-and-versioning), every
+importer is updated in the same PR — `fjs/mcp/cas/module.f.ts` (two call sites)
+and `fjs/media/proof.f.ts` — and the CHANGELOG entry is prefixed
+`**BREAKING CHANGES:**`.
+
+The `revision` entry itself belongs in `fjs/media/revision`, which owns both
+halves of it: `dialect(revisionSchema, r => checkReferences(r)[0] === 'ok')`.
+`fjs/media` then imports no dialect at all — the hardcoded import from the
+Problem section disappears instead of being re-exported under another name —
+and `fjs/mcp/cas` passes the list it wants.
 
 **How strict detection is, is the dialect's call.** With `extraValidate`
 defaulting to `() => true`, a dialect that registers a bare schema gets
@@ -135,9 +168,9 @@ usable. A dialect that registers a predicate gets detection as strict as its
 decoder. Neither is a special case in `detect` — the difference is entirely in
 the entry.
 
-`revision` should register `checkReferences`, so today's results are preserved
-exactly: a blob satisfying `revisionSchema` with `"snapshot": "not a hash"`
-keeps classifying as `text/plain` rather than
+`revision` should register `checkReferences`, so that although the API breaks,
+the verdicts do not change: a blob satisfying `revisionSchema` with
+`"snapshot": "not a hash"` keeps classifying as `text/plain` rather than
 `application/vnd.fjs.revision+json`. That costs a one-line adapter —
 `checkReferences` returns `Result<Revision, string>` and the entry wants
 `boolean` — which is the right direction anyway: detection has no use for the
@@ -168,27 +201,33 @@ while adding a registry:
 
 ### Tasks
 
-- [ ] Decide whether dialects are a parameter or a module-level registry. The
-      entry shape itself is settled: `dialect(type, extraValidate?)` — an rtti
-      schema plus an optional `Ts<T> => boolean` refinement, with the dialect
-      name and media type both read off the schema.
-- [ ] Implement `dialect` and the erased entry it returns; confirm `Ts<T>` is
-      inferred at the call site so `extraValidate`'s parameter needs no
-      annotation (this is the reason registration is a function).
-- [ ] Implement in `fjs/media/module.f.ts`: parse once, `validate(type)` per
-      entry, then `extraValidate` on success, deriving the media type from
-      `type.dialect`; default to `dialect(revisionSchema, checkReferences`-as-
-      predicate`)` so current results are unchanged.
+- [ ] Implement `dialect(type, extraValidate?)` and the erased
+      `{ dialect, match }` entry it returns; confirm `Ts<T>` is inferred at the
+      call site so `extraValidate`'s parameter needs no annotation (this is the
+      reason registration is a function).
+- [ ] Implement in `fjs/media/module.f.ts`: `detect(dialects)(bytes)` — parse
+      once, `validate(type)` per entry, then `extraValidate` on success,
+      appending `+json` to the matched entry's `dialect`. No dialect import
+      remains in this module.
+- [ ] Move the `revision` entry to `fjs/media/revision`:
+      `dialect(revisionSchema, r => checkReferences(r)[0] === 'ok')`.
+- [ ] Update every importer in the same PR — `fjs/mcp/cas/module.f.ts` (two
+      `detectDialect` call sites) and `fjs/media/proof.f.ts` — and add a
+      `**BREAKING CHANGES:**` CHANGELOG entry per AGENTS.md §8.4. No
+      compatibility shim.
 - [ ] Type `DialectType` so a schema without a string `dialect` member is
       rejected at compile time, and decide the thunk-form question (require the
-      direct const, or unwrap when reading the name).
+      direct const, or unwrap when reading the name). Do **not** grammar-check
+      or allowlist the name — record why in the JSDoc, since the rule differs
+      from [detect-cbor](detect-cbor.md)'s blob-supplied names.
 - [ ] Proof coverage in `fjs/media/proof.f.ts`: a second dialect is recognized;
       first-match-wins ordering; no match falls through to the `fjs/media/type`
       verdict unchanged; a `revision` blob still reports
-      `application/vnd.fjs.revision+json` through the default; a structurally
-      valid revision with a non-cbase32 `snapshot` still falls through to
-      `text/plain` (the `extraValidate` path); and an entry registered without a
-      predicate matches on structure alone.
+      `application/vnd.fjs.revision+json`; a structurally valid revision with a
+      non-cbase32 `snapshot` still falls through to `text/plain` (the
+      `extraValidate` path); an entry registered without a predicate matches on
+      structure alone; and a non-`vnd.fjs.*` dialect name yields its own derived
+      type.
 - [ ] Confirm `detectStream` is untouched and still dialect-unaware.
 - [ ] Check whether `DetectMeta` needs to carry the matched dialect itself, not
       only the derived `mime_type` — a caller that matched is usually about to
@@ -201,12 +240,17 @@ while adding a registry:
 - [`fjs/media/type/module.f.ts`](../type/module.f.ts) — `detectVec` /
   `detectStream`, the layer below.
 - [`fjs/media/revision/module.f.ts`](../revision/module.f.ts) — `revisionSchema`
-  and `checkReferences`, the two halves of the default entry (`checkReferences`
-  is already exported separately, for callers that have a typed `Revision` —
-  exactly this case), plus `decodeText` / `mediaType`.
+  and `checkReferences`, the two halves of the entry this module should export
+  (`checkReferences` is already exported separately, for callers that have a
+  typed `Revision` — exactly this case), plus `decodeText` / `mediaType`.
 - [`fjs/media/revision/README.md`](../revision/README.md) — the `vnd.fjs.<name>`
   convention this gap makes only partially usable, and the mechanical media-type
   derivation an entry relies on instead of naming its own.
+- [`fjs/mcp/cas/module.f.ts`](../../mcp/cas/module.f.ts) — the only non-proof
+  importer of `detect`; updated in the same PR as the breaking change.
+- [detect-cbor](detect-cbor.md) — would reuse these entries for
+  `application/{dialect}+cbor`; its tier-2 names come from the blob, hence its
+  allowlist and this module's lack of one.
 - [`fjs/types/rtti/module.f.ts`](../../types/rtti/module.f.ts) — `Struct` /
   `Type` / `Const`; an entry is the subset of `Type` with a string `dialect`
   member.

--- a/fjs/media/todo/dialect-registry.md
+++ b/fjs/media/todo/dialect-registry.md
@@ -46,23 +46,24 @@ entry can say to an rtti schema plus a typed refinement predicate** — no
 decoder, no media type, no separate dialect name:
 
 ```ts
-/** A schema that names its own dialect: `StringMap<'dialect', string>`. */
-export type DialectType = StringMap<'dialect', string>
-
 /** The registry entry: a dialect name and a predicate over a parsed value. */
-export type DialectEntry<S extends string> = {
-    readonly dialect: S
+export type DialectEntry = {
+    readonly dialect: string
     readonly match: (_: Unknown) => boolean
 }
 
+const always = (): boolean => true
+
 /** Registers a dialect for detection: its schema, plus whatever rtti can't say. */
-export const dialectEntry = <T extends DialectType>(
+export const dialectEntry = <T extends Struct>(
     type: T,
-    extraValidate: (_: Ts<T>) => boolean = () => true,
-): DialectEntry<T['dialect']> => {
+    extraValidate: (_: Ts<T>) => boolean = always,
+): DialectEntry => {
+    const { dialect } = type
+    assert(typeof dialect === 'string', 'dialectEntry: schema has no direct string `dialect` member')
     const v = validate(type)
     return {
-        dialect: type.dialect,
+        dialect,
         match: u => {
             const [tag, value] = v(u)
             return tag === 'ok' && extraValidate(value)
@@ -77,42 +78,48 @@ self-discriminating. So the dialect name is *in* the schema, and a separate
 `dialect` field alongside it would be a second copy that can disagree with the
 first. `detect` reads `type.dialect` and derives the media type from it.
 
-The constraint is `StringMap<'dialect', string>` — the repo's spelling of
-`{ readonly dialect: string }` — and nothing more. Three other spellings were
-tried against the real `revisionSchema`, `Ts`, and `validate` with
-`tsc --strict`, and each fails:
+**The constraint is `Struct`, and the name is checked at registration.** Two
+properties are wanted from the signature — every member is a real rtti `Type`,
+and `dialect` is a direct string const — and TypeScript will not give both at
+once. Everything below was compiled against the real `revisionSchema`, `Ts`,
+and `validate` with `tsc --strict`:
 
-- `Struct & { readonly dialect: string }` — the intersection AGENTS.md rules
-  out. (Its usual remedy, embedding the record as a named field, cannot apply
-  here either: an entry's schema *is* an rtti `Type`, so
-  `{ struct: Struct, dialect: string }` yields something `validate` cannot
-  consume.)
+- `Struct & StringMap<'dialect', string>` in the constraint — TS2589, "type
+  instantiation is excessively deep". As a *parameter* type
+  (`type: T & DialectType`) it fails differently: TS2322 on `type.dialect`,
+  TS2345 on `Ts<T & …>` vs `Ts<T>`, plus TS2589. It is also the intersection
+  AGENTS.md rules out, whose usual remedy — embed the record as a named field —
+  cannot apply here anyway, since an entry's schema *is* an rtti `Type` and
+  `{ struct: Struct, dialect: string }` is not something `validate` consumes.
 - An inline `{ readonly [k: string]: Type | undefined, readonly dialect:
-  string }` — the inline index signature reserved for mutually-recursive types.
+  string }` — the inline index signature AGENTS.md reserves for
+  mutually-recursive types.
 - `<T extends Struct>` with the member gated by conditionals
-  (`type: DialectSchema<T>`, returning `DialectEntry<DialectName<T>>`). This
-  one type-checks at the *call site* but not in the body: `type.dialect` stays
-  `Type` (including `undefined`) rather than `DialectName<T>` (TS2322), and
-  `validate(type)` yields `Ts<DialectSchema<T>>`, which is not `Ts<T>` and so
-  cannot feed `extraValidate` (TS2345). Adding `Struct` to the constraint
-  alongside `StringMap<'dialect', string>` instead blows up with TS2589,
-  "type instantiation is excessively deep".
+  (`type: DialectSchema<T>` returning `DialectEntry<DialectName<T>>`) —
+  type-checks at the call site, but not in the body: `type.dialect` stays
+  `Type | undefined` (TS2322) and `validate(type)` yields
+  `Ts<DialectSchema<T>>`, which cannot feed `(_: Ts<T>)` (TS2345).
+- `<T extends DialectType>` alone — compiles, but drops the `Type` requirement
+  on the other members, and that is not a cosmetic loss:
+  `{ dialect: 'x', field: () => 42 }` satisfies it, and rtti reads `field` as a
+  thunk, so the *first* `match` throws `rtti is not a function or its return
+  value is not iterable` — verified — rather than returning `false`. One
+  accepted schema mistake would turn detection of unknown blobs into a panic.
 
-The version above compiles end to end, body included, with no `as`. Checked,
-not assumed: `dialectEntry(revisionSchema, r => r.generation >= 0)` infers `r`
-as the decoded `Revision` with no annotation; the entry's `dialect` is the
-literal `'vnd.fjs.revision'`, so
-`revisionDialect: DialectEntry<typeof dialect>` type-checks and assigning it to
-a different literal errors; a schema with no `dialect` member is rejected at
-the call site; and a thunk-form `dialect` is rejected too, since a function is
-not a `string` — which is what makes the direct-const rule below
-compile-enforced rather than merely stated.
+So `Struct` wins the constraint: it rejects `field: () => 42` at compile time,
+which is the failure that matters. The `dialect` member is then checked at
+registration with `assert` — loudly, once, when the entry is constructed, not
+per blob — and the entry type is not generic in the name. That last point
+gives up the literal `'vnd.fjs.revision'` in `DialectEntry`, which is
+acceptable precisely because the literal has nowhere to go:
+`DetectMeta.mime_type` is `string`, and `revision` keeps its own `mediaType`
+const for callers wanting the precise type.
 
-What this constraint does *not* say is that the schema's other members are rtti
-`Type`s — `Struct` cannot be added back, per TS2589 above. In practice the gap
-is small: `Const` admits every primitive, array, and object literal, so almost
-any member is a valid schema; a genuinely malformed one (a function that is not
-a thunk) is caught by `validate`, not by registration.
+The version above compiles end to end, body included, with no `as`:
+`dialectEntry(revisionSchema, r => r.generation >= 0)` infers `r` as the
+decoded `Revision` with no annotation, and
+`dialectEntry({ dialect: 'x', field: () => 42, s: string })` is a compile
+error.
 
 `extraValidate` closes the gap rtti leaves. Structural validation cannot say
 "this string is cbase32-decodable" or "this number is a non-negative safe
@@ -139,8 +146,12 @@ is therefore `dialectEntry`, not `dialect`, so no importer has to alias it, and
 
 ```ts
 // fjs/media/revision/module.f.ts
-export const revisionDialect: DialectEntry<typeof dialect> =
-    dialectEntry(revisionSchema, r => checkReferences(r)[0] === 'ok')
+const isValidRevision = (r: Revision): boolean => {
+    const [tag] = checkReferences(r)
+    return tag === 'ok'
+}
+
+export const revisionDialect: DialectEntry = dialectEntry(revisionSchema, isValidRevision)
 
 // fjs/mcp/cas/module.f.ts
 import { detect } from '../../media/module.f.ts'
@@ -179,10 +190,9 @@ of the open design questions settle:
   one: `DetectMeta.mime_type` is `string`, so no template-literal type survives
   into a detection verdict no matter how the entry is typed, and `revision`
   keeps its own `mediaType` const for callers that want the precise type.
-  `DialectEntry<S>` is generic in the name anyway — erased to
-  `DialectEntry<string>` only where `detect` consumes the heterogeneous list —
-  so a caller reading a single entry keeps the literal; that is the only place
-  it can survive.
+  The entry is not generic in the name, for the reason given above: keeping
+  `Struct` as the constraint is worth more than a literal that has nowhere to
+  survive to.
 - **The entry names a dialect, not an encoding.** Erase to
   `{ dialect, match }`, not `{ mediaType, match }`: the `+json` suffix is the
   JSON detector's to append. Nothing else is needed today — there is no CBOR
@@ -220,19 +230,18 @@ anyway.
 
 **The `dialect` member must be a direct string const**, not a thunk. rtti
 admits both forms — `dialect: 'vnd.fjs.revision'` and
-`() => ['const', 'vnd.fjs.revision']` — and `DialectType` above accepts only
-the first, since a thunk is not a `string`. That is the decision, not an
-implementer's choice: the direct form
-is what `revisionSchema` already uses, it is what rtti's own docstring
-prescribes outside recursive definitions, it makes `type.dialect` readable
-without evaluating anything, and it is enforceable at compile time by the entry
-type rather than at registration time by a runtime check. The requirement is
+`() => ['const', 'vnd.fjs.revision']` — and `dialectEntry`'s `assert` accepts
+only the first. That is the decision, not an implementer's choice: the direct
+form is what `revisionSchema` already uses, it is what rtti's own docstring
+prescribes outside recursive definitions, and it makes `type.dialect` readable
+without evaluating anything. Because the constraint is `Struct`, this one is
+enforced at registration rather than at compile time — the trade recorded
+above. The requirement is
 narrow and always satisfiable — it constrains one member of the top-level
 struct, so a schema that needs thunks anywhere else, recursion included, is
 unaffected, and an author holding a thunk-form schema writes the string
 directly instead. A thunk-form `dialect` is still a perfectly valid rtti
-schema; it just is not registerable, and `dialectEntry()` will not compile with
-one.
+schema; it just is not registerable, and `dialectEntry` refuses it.
 
 **The dialect list is a parameter, and `detect` breaks.** `detect(dialects)`
 returns the classifier, so today's `detect(bytes)` becomes
@@ -305,24 +314,25 @@ while adding a registry:
 
 - [ ] Implement `dialectEntry(type, extraValidate?)` as written above — it owns
       validation, closing over `validate(type)` and `extraValidate` inside
-      `match`; the returned `DialectEntry<T['dialect']>` is generic in the name
-      so the literal is not widened at the return boundary.
+      `match`, asserts the `dialect` member at registration, and takes its
+      default predicate from the module-scope `always` rather than a fresh
+      `() => true` per call.
 - [ ] Implement in `fjs/media/module.f.ts`: `detect(dialects)(bytes)` — parse
       once, call each entry's `match` on the parsed value, and append `+json`
       to the first matching entry's `dialect`. `detect` handles no schemas and
       no refinements of its own, and no dialect import remains in this module.
-- [ ] Add `revisionDialect` to `fjs/media/revision` —
-      `dialectEntry(revisionSchema, r => checkReferences(r)[0] === 'ok')` —
-      keeping the existing `dialect` string const untouched.
+- [ ] Add `revisionDialect` to `fjs/media/revision`, with the `isValidRevision`
+      adapter above — destructured (`const [tag] = checkReferences(r)`), not
+      `checkReferences(r)[0]` — and keep the existing `dialect` string const
+      untouched.
 - [ ] Update every importer in the same PR — `fjs/mcp/cas/module.f.ts` (two
       `detectDialect` call sites) and `fjs/media/proof.f.ts` — and add a
       `**BREAKING CHANGES:**` CHANGELOG entry per AGENTS.md §8.4. No
       compatibility shim.
-- [ ] Keep the `DialectType = StringMap<'dialect', string>` constraint as
-      written — it is what rejects a schema with no `dialect` member or a
-      thunk-form one at the call site, and the alternatives above do not
-      compile. Do **not** grammar-check or allowlist the name — record why in
-      the JSDoc, since the rule differs from
+- [ ] Keep `Struct` as the constraint — it is what rejects a member like
+      `() => 42` that would make `match` throw, and the alternatives above
+      either do not compile or give that safety up. Do **not** grammar-check or
+      allowlist the name — record why in the JSDoc, since the rule differs from
       [detect-cbor](detect-cbor.md)'s blob-supplied names.
 - [ ] Proof coverage in `fjs/media/proof.f.ts`: a second dialect is recognized;
       first-match-wins ordering; no match falls through to the `fjs/media/type`
@@ -353,9 +363,11 @@ while adding a registry:
   `application/{dialect}+cbor`; its tier-2 names come from the blob, hence its
   allowlist and this module's lack of one.
 - [`fjs/types/rtti/module.f.ts`](../../types/rtti/module.f.ts) — `Struct` /
-  `Type` / `Const`; `Struct` is what a dialect schema is, though the entry's
-  constraint is `StringMap<'dialect', string>` (see the compile notes above).
-- [`fjs/types/object/module.f.ts`](../../types/object/module.f.ts) —
-  `StringMap`, which spells that constraint.
+  `Type` / `Const`; `Struct` is `dialectEntry`'s constraint (see the compile
+  notes above).
 - [`fjs/types/rtti/validate/module.f.ts`](../../types/rtti/validate/module.f.ts)
-  — `validate`, what detection runs per entry over the once-parsed value.
+  — `validate`, which each entry's `match` closes over; it throws rather than
+  erroring on a schema member that is not a `Type`, which is why the constraint
+  has to be `Struct`.
+- [`fjs/asserts/module.f.ts`](../../asserts/module.f.ts) — `assert`, used once
+  per registration to check the `dialect` member.

--- a/fjs/media/todo/dialect-registry.md
+++ b/fjs/media/todo/dialect-registry.md
@@ -224,7 +224,14 @@ of the open design questions settle:
   add machinery to guard one that does not exist. The boundary that does exist
   — untrusted *blob* content — is on the other side of `match` entirely.
 - **Parsing happens once.** Detection JSON-parses the text a single time and
-  calls each entry's `match` on the parsed value. Validation lives in the
+  calls each entry's `match` on the parsed value. It must parse with the pure,
+  total pipeline — `parse(tokenize(stringToList(text)))`, returning
+  `Result<Unknown, string>` — and **not** with `fjs/media/json`'s `parse`,
+  which is native `JSON.parse`: it throws on malformed input, so ordinary
+  non-JSON text would blow up instead of falling through to the
+  `fjs/media/type` verdict. Today's `detect` never parses (it hands the text to
+  `decodeRevisionText`, which composes the pipeline internally), so this is new
+  ground for the module; see the prerequisite below. Validation lives in the
   entry, not the detector: `dialectEntry` applies `matchWith` to
   `rtti/validate`'s `validate(type)` and its `extraValidate`, so `match` runs
   the structural check followed by the refinement on the same value. `detect`
@@ -301,6 +308,16 @@ predicate makes it a weaker claim than its own decoder would. Say so in the
 module docstring, and keep it true by never routing a decode decision through
 `detect`'s verdict.
 
+**Prerequisite:
+[fjs/media/json parse-text-pipeline](../json/todo/parse-text-pipeline.md).**
+That issue adds the `Result`-returning `text → Unknown` entry point this design
+needs, built on `fjs/media/json`'s own tokenizer and parser. It is already
+justified without this issue — `revision`, `fjs/dev/package_json`, and
+`fjs/protocol/mcp/stdio` each re-wire the same three-call pipeline by hand —
+and `detect` would be the fourth. Land it first and consume it; do not inline
+another copy in `fjs/media/module.f.ts`. Nothing else here depends on it, so
+the rest of the design can be reviewed and settled meanwhile.
+
 **`DetectMeta` is unchanged: no `dialect` field.** A matched entry is reported
 only through the derived `mime_type`, as today. `DetectMeta` is
 `fjs/media/type`'s result shape, shared with the dialect-unaware `detectStream`
@@ -336,10 +353,16 @@ while adding a registry:
       `extraValidate` rather than nesting a `match` closure; it asserts the
       `dialect` member at registration and takes its default predicate from the
       module-scope `always` rather than a fresh `() => true` per call.
+- [ ] Land [parse-text-pipeline](../json/todo/parse-text-pipeline.md) first —
+      `detect` needs its `Result`-returning `text → Unknown` entry point, and
+      must not inline a fourth copy of the pipeline or reach for
+      `fjs/media/json`'s throwing `parse`.
 - [ ] Implement in `fjs/media/module.f.ts`: `detect(dialects)(bytes)` — parse
-      once, call each entry's `match` on the parsed value, and append `+json`
-      to the first matching entry's `dialect`. `detect` handles no schemas and
-      no refinements of its own, and no dialect import remains in this module.
+      once with that entry point, fall through to the `fjs/media/type` verdict
+      on a parse error, call each entry's `match` on the parsed value, and
+      append `+json` to the first matching entry's `dialect`. `detect` handles
+      no schemas and no refinements of its own, and no dialect import remains
+      in this module.
 - [ ] Add `revisionDialect` to `fjs/media/revision`, with the `isValidRevision`
       adapter above — destructured (`const [tag] = checkReferences(r)`), not
       `checkReferences(r)[0]` — and keep the existing `dialect` string const
@@ -378,6 +401,10 @@ while adding a registry:
   derivation an entry relies on instead of naming its own.
 - [`fjs/mcp/cas/module.f.ts`](../../mcp/cas/module.f.ts) — the only non-proof
   importer of `detect`; updated in the same PR as the breaking change.
+- [fjs/media/json parse-text-pipeline](../json/todo/parse-text-pipeline.md) —
+  the prerequisite: the `Result`-returning `text → Unknown` parse `detect`
+  needs. `fjs/media/json`'s own `parse` export is native `JSON.parse` and
+  throws, so it is not usable here.
 - [detect-cbor](detect-cbor.md) — would reuse these entries for
   `application/{dialect}+cbor`; its tier-2 names come from the blob, hence its
   allowlist and this module's lack of one.

--- a/fjs/media/todo/dialect-registry.md
+++ b/fjs/media/todo/dialect-registry.md
@@ -46,15 +46,25 @@ entry can say to an rtti schema plus a typed refinement predicate** — no
 decoder, no media type, no separate dialect name:
 
 ```ts
-// `Struct` from `fjs/types/rtti`: a struct schema whose `dialect` member is a
-// string const — the subset of `Type` that names its own dialect.
-export type DialectType = Struct & { readonly dialect: string }
+// An rtti struct schema whose `dialect` member is a string const — the subset
+// of `Type` that names its own dialect. Written as one record rather than
+// `Struct & { dialect: string }`: see the note below.
+export type DialectType = {
+    readonly [k: string]: Type | undefined
+    readonly dialect: string
+}
+
+/** The registry entry: a dialect name and a predicate over a parsed value. */
+export type DialectEntry<S extends string> = {
+    readonly dialect: S
+    readonly match: (_: Unknown) => boolean
+}
 
 /** Registers a dialect for detection: its schema, plus whatever rtti can't say. */
-export const dialect = <T extends DialectType>(
+export const dialectEntry = <T extends DialectType>(
     type: T,
     extraValidate: (_: Ts<T>) => boolean = () => true,
-): Dialect => /* … */
+): DialectEntry<T['dialect']> => /* … */
 ```
 
 A dialect schema is already a struct whose `dialect` member is a string const —
@@ -62,6 +72,16 @@ that is how `revisionSchema` is written, and it is what makes the schema
 self-discriminating. So the dialect name is *in* the schema, and a separate
 `dialect` field alongside it would be a second copy that can disagree with the
 first. `detect` reads `type.dialect` and derives the media type from it.
+
+`DialectType` spells out the index signature instead of intersecting `Struct`
+with `{ dialect: string }`, per AGENTS.md's composition-over-intersection rule.
+The rule's usual remedy — embed the record as a named field — cannot apply
+here: an entry's schema *is* an rtti `Type`, and nesting it
+(`{ struct: Struct, dialect: string }`) would produce a value `validate` cannot
+consume. What the rule is actually against — an `&` that blurs where fields
+came from and tempts widening the part — is avoided by writing one record type
+whose index signature says the same thing `Struct` does
+(`StringMap<string, Type>`, i.e. `{ readonly [k in string]?: Type }`).
 
 `extraValidate` closes the gap rtti leaves. Structural validation cannot say
 "this string is cbase32-decodable" or "this number is a non-negative safe
@@ -74,11 +94,32 @@ the blob.
 
 Registration is a function rather than a struct literal for one concrete
 reason: `Ts<T>` has to be inferred from the schema. In
-`dialect(revisionSchema, r => …)` the parameter `r` types as `Revision` at the
-call site; a bare `{ type, extraValidate }` object makes every author write
-`(_: Ts<typeof revisionSchema>)` by hand. What it *returns* can be a struct —
-an erased entry the detector consumes, e.g.
-`{ dialect: string, match: (u: Unknown) => boolean }`, with the generic gone.
+`dialectEntry(revisionSchema, r => …)` the parameter `r` types as `Revision` at
+the call site; a bare `{ type, extraValidate }` object makes every author write
+`(_: Ts<typeof revisionSchema>)` by hand. What it *returns* is a struct — the
+entry the detector consumes, with the schema and the predicate collapsed into
+one `match`.
+
+**Names, since `fjs/media/revision` already has a `dialect` export** (the
+string const `'vnd.fjs.revision'`, `module.f.ts:31`). The registration function
+is therefore `dialectEntry`, not `dialect`, so no importer has to alias it, and
+`revision` exports its entry as `revisionDialect` — matching the
+`revisionSchema` naming already in that module:
+
+```ts
+// fjs/media/revision/module.f.ts
+export const revisionDialect: DialectEntry<typeof dialect> =
+    dialectEntry(revisionSchema, r => checkReferences(r)[0] === 'ok')
+
+// fjs/mcp/cas/module.f.ts
+import { detect } from '../../media/module.f.ts'
+import { revisionDialect } from '../../media/revision/module.f.ts'
+const detectDialect = detect([revisionDialect])
+```
+
+`fjs/mcp/cas` keeps its existing local name `detectDialect` for the bound
+classifier, so its two call sites change only in where the function comes
+from.
 
 **No grammar check or allowlist on the dialect name.** A schema could say
 `dialect: 'foo'`, and `detect` would report `application/foo+json`. That is
@@ -87,7 +128,8 @@ constraint on what a caller may detect — another vendor's `vnd.rogaikopyta.*`
 blob, or a widely used name that is not under `vnd.` at all, is a legitimate
 thing to register, and an allowlist here would only stop callers from
 describing the formats they actually handle. The name is also not attacker-
-controlled: it comes from a schema a programmer wrote and passed to `dialect`,
+controlled: it comes from a schema a programmer wrote and passed to
+`dialectEntry`,
 never from the blob being classified, so no untrusted string reaches
 `mime_type` along this path. That is what distinguishes it from
 [detect-cbor](detect-cbor.md)'s tier 2, which reads the dialect name *out of
@@ -106,10 +148,10 @@ of the open design questions settle:
   one: `DetectMeta.mime_type` is `string`, so no template-literal type survives
   into a detection verdict no matter how the entry is typed, and `revision`
   keeps its own `mediaType` const for callers that want the precise type.
-  Making the entry generic in the name — `Dialect<S extends string>` with
-  `dialect: S`, erased to `Dialect<string>` only where `detect` consumes the
-  heterogeneous list — is still worth doing so a caller reading a single entry
-  keeps the literal; that is the only place it can survive.
+  `DialectEntry<S>` is generic in the name anyway — erased to
+  `DialectEntry<string>` only where `detect` consumes the heterogeneous list —
+  so a caller reading a single entry keeps the literal; that is the only place
+  it can survive.
 - **The entry names a dialect, not an encoding.** Erase to
   `{ dialect, match }`, not `{ mediaType, match }`: the `+json` suffix is the
   JSON detector's to append. Nothing else is needed today — there is no CBOR
@@ -153,7 +195,8 @@ narrow and always satisfiable — it constrains one member of the top-level
 struct, so a schema that needs thunks anywhere else, recursion included, is
 unaffected, and an author holding a thunk-form schema writes the string
 directly instead. A thunk-form `dialect` is still a perfectly valid rtti
-schema; it just is not registerable, and `dialect()` will not compile with one.
+schema; it just is not registerable, and `dialectEntry()` will not compile with
+one.
 
 **The dialect list is a parameter, and `detect` breaks.** `detect(dialects)`
 returns the classifier, so today's `detect(bytes)` becomes
@@ -166,11 +209,10 @@ importer is updated in the same PR — `fjs/mcp/cas/module.f.ts` (two call sites
 and `fjs/media/proof.f.ts` — and the CHANGELOG entry is prefixed
 `**BREAKING CHANGES:**`.
 
-The `revision` entry itself belongs in `fjs/media/revision`, which owns both
-halves of it: `dialect(revisionSchema, r => checkReferences(r)[0] === 'ok')`.
-`fjs/media` then imports no dialect at all — the hardcoded import from the
-Problem section disappears instead of being re-exported under another name —
-and `fjs/mcp/cas` passes the list it wants.
+The `revisionDialect` entry itself belongs in `fjs/media/revision`, which owns
+both halves of it. `fjs/media` then imports no dialect at all — the hardcoded
+import from the Problem section disappears instead of being re-exported under
+another name — and `fjs/mcp/cas` passes the list it wants.
 
 **How strict detection is, is the dialect's call.** With `extraValidate`
 defaulting to `() => true`, a dialect that registers a bare schema gets
@@ -213,8 +255,8 @@ while adding a registry:
 
 ### Tasks
 
-- [ ] Implement `dialect(type, extraValidate?)` and the `{ dialect, match }`
-      entry it returns, generic in the name (`Dialect<T['dialect']>`) so the
+- [ ] Implement `dialectEntry(type, extraValidate?)` and the
+      `DialectEntry<T['dialect']>` it returns — generic in the name, so the
       literal is not widened at the return boundary; confirm `Ts<T>` is
       inferred at the call site so `extraValidate`'s parameter needs no
       annotation (this is the reason registration is a function).
@@ -222,8 +264,9 @@ while adding a registry:
       once, `validate(type)` per entry, then `extraValidate` on success,
       appending `+json` to the matched entry's `dialect`. No dialect import
       remains in this module.
-- [ ] Move the `revision` entry to `fjs/media/revision`:
-      `dialect(revisionSchema, r => checkReferences(r)[0] === 'ok')`.
+- [ ] Add `revisionDialect` to `fjs/media/revision` —
+      `dialectEntry(revisionSchema, r => checkReferences(r)[0] === 'ok')` —
+      keeping the existing `dialect` string const untouched.
 - [ ] Update every importer in the same PR — `fjs/mcp/cas/module.f.ts` (two
       `detectDialect` call sites) and `fjs/media/proof.f.ts` — and add a
       `**BREAKING CHANGES:**` CHANGELOG entry per AGENTS.md §8.4. No
@@ -265,7 +308,7 @@ while adding a registry:
   `application/{dialect}+cbor`; its tier-2 names come from the blob, hence its
   allowlist and this module's lack of one.
 - [`fjs/types/rtti/module.f.ts`](../../types/rtti/module.f.ts) — `Struct` /
-  `Type` / `Const`; an entry is the subset of `Type` with a string `dialect`
-  member.
+  `Type` / `Const`; `DialectType` is the subset of `Type` with a string
+  `dialect` member, spelled without intersecting `Struct`.
 - [`fjs/types/rtti/validate/module.f.ts`](../../types/rtti/validate/module.f.ts)
   — `validate`, what detection runs per entry over the once-parsed value.

--- a/fjs/media/todo/dialect-registry.md
+++ b/fjs/media/todo/dialect-registry.md
@@ -102,9 +102,14 @@ of the open design questions settle:
 - **The media type is derived, not supplied.** `application/${dialect}+json`,
   the same mechanical derivation `fjs/media/revision` already documents, read
   off the schema's own literal. An entry has no `mediaType` field to get wrong
-  or to disagree with the schema it validates. The generic `T` keeps the
-  literal, so the derived media type can stay a template-literal type the way
-  `revision`'s `mediaType` is today.
+  or to disagree with the schema it validates. The derivation is a runtime
+  one: `DetectMeta.mime_type` is `string`, so no template-literal type survives
+  into a detection verdict no matter how the entry is typed, and `revision`
+  keeps its own `mediaType` const for callers that want the precise type.
+  Making the entry generic in the name — `Dialect<S extends string>` with
+  `dialect: S`, erased to `Dialect<string>` only where `detect` consumes the
+  heterogeneous list — is still worth doing so a caller reading a single entry
+  keeps the literal; that is the only place it can survive.
 - **The entry names a dialect, not an encoding.** Erase to
   `{ dialect, match }`, not `{ mediaType, match }`: the `+json` suffix is the
   JSON detector's to append. Nothing else is needed today — there is no CBOR
@@ -136,12 +141,19 @@ every other dialect's blob, so disjointness is a property of the entries rather
 than a rule `detect` enforces. First match still wins for entries that overlap
 anyway.
 
-One wrinkle to pin down: rtti admits both the direct const form
-(`dialect: 'vnd.fjs.revision'`) and the thunk form
-(`() => ['const', 'vnd.fjs.revision']`). `DialectType` above accepts only the
-direct form — what `revisionSchema` uses, and what keeps `type.dialect`
-readable without evaluating anything. Either require it or unwrap the thunk
-when reading the name.
+**The `dialect` member must be a direct string const**, not a thunk. rtti
+admits both forms — `dialect: 'vnd.fjs.revision'` and
+`() => ['const', 'vnd.fjs.revision']` — and `DialectType` above accepts only
+the first. That is the decision, not an implementer's choice: the direct form
+is what `revisionSchema` already uses, it is what rtti's own docstring
+prescribes outside recursive definitions, it makes `type.dialect` readable
+without evaluating anything, and it is enforceable at compile time by the entry
+type rather than at registration time by a runtime check. The requirement is
+narrow and always satisfiable — it constrains one member of the top-level
+struct, so a schema that needs thunks anywhere else, recursion included, is
+unaffected, and an author holding a thunk-form schema writes the string
+directly instead. A thunk-form `dialect` is still a perfectly valid rtti
+schema; it just is not registerable, and `dialect()` will not compile with one.
 
 **The dialect list is a parameter, and `detect` breaks.** `detect(dialects)`
 returns the classifier, so today's `detect(bytes)` becomes
@@ -201,10 +213,11 @@ while adding a registry:
 
 ### Tasks
 
-- [ ] Implement `dialect(type, extraValidate?)` and the erased
-      `{ dialect, match }` entry it returns; confirm `Ts<T>` is inferred at the
-      call site so `extraValidate`'s parameter needs no annotation (this is the
-      reason registration is a function).
+- [ ] Implement `dialect(type, extraValidate?)` and the `{ dialect, match }`
+      entry it returns, generic in the name (`Dialect<T['dialect']>`) so the
+      literal is not widened at the return boundary; confirm `Ts<T>` is
+      inferred at the call site so `extraValidate`'s parameter needs no
+      annotation (this is the reason registration is a function).
 - [ ] Implement in `fjs/media/module.f.ts`: `detect(dialects)(bytes)` — parse
       once, `validate(type)` per entry, then `extraValidate` on success,
       appending `+json` to the matched entry's `dialect`. No dialect import
@@ -215,11 +228,11 @@ while adding a registry:
       `detectDialect` call sites) and `fjs/media/proof.f.ts` — and add a
       `**BREAKING CHANGES:**` CHANGELOG entry per AGENTS.md §8.4. No
       compatibility shim.
-- [ ] Type `DialectType` so a schema without a string `dialect` member is
-      rejected at compile time, and decide the thunk-form question (require the
-      direct const, or unwrap when reading the name). Do **not** grammar-check
-      or allowlist the name — record why in the JSDoc, since the rule differs
-      from [detect-cbor](detect-cbor.md)'s blob-supplied names.
+- [ ] Type `DialectType` so a schema whose `dialect` member is absent, not a
+      string, or a thunk-wrapped const is rejected at compile time — the direct
+      const form is required, per above. Do **not** grammar-check or allowlist
+      the name — record why in the JSDoc, since the rule differs from
+      [detect-cbor](detect-cbor.md)'s blob-supplied names.
 - [ ] Proof coverage in `fjs/media/proof.f.ts`: a second dialect is recognized;
       first-match-wins ordering; no match falls through to the `fjs/media/type`
       verdict unchanged; a `revision` blob still reports

--- a/fjs/media/todo/dialect-registry.md
+++ b/fjs/media/todo/dialect-registry.md
@@ -42,43 +42,70 @@ provenance, which is what `detect` exists for.
 ### Proposal
 
 Make the set of dialects a parameter rather than an import, and **limit what an
-entry can say to a dialect name plus an rtti schema** — nothing else:
+entry can say to an rtti schema plus a typed refinement predicate** — no
+decoder, no media type, no separate dialect name:
 
 ```ts
 // `Struct` from `fjs/types/rtti`: a struct schema whose `dialect` member is a
 // string const — the subset of `Type` that names its own dialect.
-export type Dialect = Struct & { readonly dialect: string }
+export type DialectType = Struct & { readonly dialect: string }
+
+/** Registers a dialect for detection: its schema, plus whatever rtti can't say. */
+export const dialect = <T extends DialectType>(
+    type: T,
+    extraValidate: (_: Ts<T>) => boolean = () => true,
+): Dialect => /* … */
 ```
 
 A dialect schema is already a struct whose `dialect` member is a string const —
 that is how `revisionSchema` is written, and it is what makes the schema
 self-discriminating. So the dialect name is *in* the schema, and a separate
 `dialect` field alongside it would be a second copy that can disagree with the
-first. An entry is one rtti schema and nothing else: the subset of `Type` that
-carries a string `dialect` member. `detect` reads `schema.dialect` and derives
-the media type from it.
+first. `detect` reads `type.dialect` and derives the media type from it.
 
-That an entry is data, not code, settles most of the open design questions:
+`extraValidate` closes the gap rtti leaves. Structural validation cannot say
+"this string is cbase32-decodable" or "this number is a non-negative safe
+integer", and a dialect that needs those has nowhere to put them under a
+schema-only entry. Here it does: the predicate runs on the value *after*
+structural validation, so its parameter is `Ts<T>` — the dialect's own decoded
+type, not `Unknown`. `revision` registers `revisionSchema` together with
+`checkReferences` and is then detected exactly when `decodeText` would accept
+the blob.
+
+Registration is a function rather than a struct literal for one concrete
+reason: `Ts<T>` has to be inferred from the schema. In
+`dialect(revisionSchema, r => …)` the parameter `r` types as `Revision` at the
+call site; a bare `{ type, extraValidate }` object makes every author write
+`(_: Ts<typeof revisionSchema>)` by hand. What it *returns* can be a struct —
+an erased entry the detector consumes, e.g.
+`{ mediaType, match: (u: Unknown) => boolean }`, with the generic gone.
+
+Because an entry is (almost) data — a schema and one bounded predicate — most
+of the open design questions settle:
 
 - **The media type is derived, not supplied.** `application/${dialect}+json`,
   the same mechanical derivation `fjs/media/revision` already documents, read
   off the schema's own literal. An entry cannot name an arbitrary `mime_type`,
   so a registered dialect can only ever claim its own `vnd.fjs.<name>` type —
   no `mediaType` field to get wrong, and nothing to allowlist after the fact.
-  Under a generic `<S extends Dialect>` the literal survives into the type, so
-  the derived media type can stay a template-literal type the way `revision`'s
-  `mediaType` is today.
+  The generic `T` keeps the literal, so the derived media type can stay a
+  template-literal type the way `revision`'s `mediaType` is today.
 - **The tag and the schema cannot disagree.** With one field there is no entry
   that claims `vnd.fjs.foo` while validating `vnd.fjs.bar` blobs — no
   consistency rule for `detect` to enforce, and none for a proof to cover.
 - **Parsing happens once.** Detection JSON-parses the text a single time and
-  runs `rtti/validate`'s `validate(schema)` over the parsed value for each
-  entry, so N dialects cost N structural validations, not N parses. The
-  "N decoders, N parses" cost of a `decodeText`-shaped entry never arises.
-- **No caller-supplied code runs during detection.** A registry of functions
-  would let any entry do arbitrary work — throw, recurse, or take
-  pathological time — on bytes of unknown provenance, which is exactly the
-  input `detect` exists to classify. Validating data against a schema cannot.
+  runs `rtti/validate`'s `validate(type)` over the parsed value for each entry,
+  with `extraValidate` on the same value when that succeeds. N dialects cost N
+  structural validations, not N parses — the "N decoders, N parses" cost of a
+  `decodeText`-shaped entry never arises.
+- **The one function an entry contributes is narrow.** A `decodeText`-shaped
+  entry owns parsing, so it does arbitrary work on bytes of unknown provenance
+  — exactly the input `detect` exists to classify. `extraValidate` never sees
+  those bytes: it runs only on an already-parsed, already-structurally-valid,
+  already size-bounded `Ts<T>`, and it returns `boolean`, so it has no error
+  channel to abuse and nothing to report but yes or no. Detection keeps the
+  parse and the schema walk; the dialect supplies a predicate over its own
+  type.
 
 Detection needs no separate tag check on top of validation: matching `dialect`
 as an exact string literal is what makes structural validation alone reject
@@ -88,35 +115,40 @@ anyway.
 
 One wrinkle to pin down: rtti admits both the direct const form
 (`dialect: 'vnd.fjs.revision'`) and the thunk form
-(`() => ['const', 'vnd.fjs.revision']`). The type above accepts only the direct
-form — what `revisionSchema` uses, and what keeps `schema.dialect` readable
-without evaluating anything. Either require it or unwrap the thunk when reading
-the name.
+(`() => ['const', 'vnd.fjs.revision']`). `DialectType` above accepts only the
+direct form — what `revisionSchema` uses, and what keeps `type.dialect`
+readable without evaluating anything. Either require it or unwrap the thunk
+when reading the name.
 
-Keep the current zero-argument `detect` as a binding over `[revision]`.
+Keep the current zero-argument `detect` as a binding over the single default
+entry, `dialect(revisionSchema, r => checkReferences(r)[0] === 'ok')`.
 Whether the list is a parameter (`detect(dialects)(bytes)`) or a module-level
 registry is an API-taste call for this repo; a parameter keeps the module pure
 and avoids registration-order questions, at the cost of every caller naming the
 dialects it cares about.
 
-**The one consequence to decide.** rtti validation is structural only, and
-`revision`'s `decodeText` is structural *plus* `checkReferences` — cbase32
-hashes, non-negative safe-integer `generation`. A blob that satisfies
-`revisionSchema` but carries `"snapshot": "not a hash"` classifies as
-`text/plain` today and would classify as `application/vnd.fjs.revision+json`
-under a schema-only entry. Two ways to take it:
+**How strict detection is, is the dialect's call.** With `extraValidate`
+defaulting to `() => true`, a dialect that registers a bare schema gets
+classification: `detect` reports what a blob claims to be and structurally
+looks like, and the caller's own decoder stays the authority on whether it is
+usable. A dialect that registers a predicate gets detection as strict as its
+decoder. Neither is a special case in `detect` — the difference is entirely in
+the entry.
 
-1. Accept the widening: `detect` classifies, it does not validate. It reports
-   what a blob claims to be and structurally looks like; the caller's own
-   `decodeText` stays the authority on whether it is usable. This keeps every
-   entry pure data.
-2. Keep semantic refinement out of the entry but let the default `[revision]`
-   binding re-check it, so the default path's results are bit-for-bit what they
-   are today — at the cost of the default no longer being expressible as a
-   plain entry list, which is most of the point.
+`revision` should register `checkReferences`, so today's results are preserved
+exactly: a blob satisfying `revisionSchema` with `"snapshot": "not a hash"`
+keeps classifying as `text/plain` rather than
+`application/vnd.fjs.revision+json`. That costs a one-line adapter —
+`checkReferences` returns `Result<Revision, string>` and the entry wants
+`boolean` — which is the right direction anyway: detection has no use for the
+error message, and discarding it at the boundary keeps the predicate's
+signature the minimal one.
 
-Option 1 is the simpler contract and the one this proposal assumes; it is
-called out because it changes an existing result.
+The residual cost is that a `mime_type` from `detect` is a claim about a blob's
+shape, not a promise that decoding it succeeds — a dialect that supplies no
+predicate makes it a weaker claim than its own decoder would. Say so in the
+module docstring, and keep it true by never routing a decode decision through
+`detect`'s verdict.
 
 Two properties of the current implementation are deliberate and easy to lose
 while adding a registry:
@@ -136,22 +168,27 @@ while adding a registry:
 
 ### Tasks
 
-- [ ] Decide the structural-only widening (option 1 vs. 2 above) and whether
-      dialects are a parameter or a registry. The entry shape itself is settled:
-      an rtti schema, nothing beside it — no functions, dialect and media type
-      both read off the schema.
-- [ ] Implement in `fjs/media/module.f.ts`: parse once, then `validate(schema)`
-      per entry, deriving the media type from `schema.dialect`; keep a default
-      wired to `[revisionSchema]` so current callers are unaffected.
-- [ ] Type `Dialect` so a schema without a string `dialect` member is rejected
-      at compile time, and decide the thunk-form question (require the direct
-      const, or unwrap when reading the name).
+- [ ] Decide whether dialects are a parameter or a module-level registry. The
+      entry shape itself is settled: `dialect(type, extraValidate?)` — an rtti
+      schema plus an optional `Ts<T> => boolean` refinement, with the dialect
+      name and media type both read off the schema.
+- [ ] Implement `dialect` and the erased entry it returns; confirm `Ts<T>` is
+      inferred at the call site so `extraValidate`'s parameter needs no
+      annotation (this is the reason registration is a function).
+- [ ] Implement in `fjs/media/module.f.ts`: parse once, `validate(type)` per
+      entry, then `extraValidate` on success, deriving the media type from
+      `type.dialect`; default to `dialect(revisionSchema, checkReferences`-as-
+      predicate`)` so current results are unchanged.
+- [ ] Type `DialectType` so a schema without a string `dialect` member is
+      rejected at compile time, and decide the thunk-form question (require the
+      direct const, or unwrap when reading the name).
 - [ ] Proof coverage in `fjs/media/proof.f.ts`: a second dialect is recognized;
       first-match-wins ordering; no match falls through to the `fjs/media/type`
       verdict unchanged; a `revision` blob still reports
-      `application/vnd.fjs.revision+json` through the default; and — per the
-      widening decision — a structurally valid revision with a non-cbase32
-      `snapshot`, pinning whichever verdict was chosen.
+      `application/vnd.fjs.revision+json` through the default; a structurally
+      valid revision with a non-cbase32 `snapshot` still falls through to
+      `text/plain` (the `extraValidate` path); and an entry registered without a
+      predicate matches on structure alone.
 - [ ] Confirm `detectStream` is untouched and still dialect-unaware.
 - [ ] Check whether `DetectMeta` needs to carry the matched dialect itself, not
       only the derived `mime_type` — a caller that matched is usually about to
@@ -164,8 +201,9 @@ while adding a registry:
 - [`fjs/media/type/module.f.ts`](../type/module.f.ts) — `detectVec` /
   `detectStream`, the layer below.
 - [`fjs/media/revision/module.f.ts`](../revision/module.f.ts) — `revisionSchema`
-  (the entry itself, `dialect` literal included), plus `decodeText`, `mediaType`
-  and the `checkReferences` semantics that stay outside detection.
+  and `checkReferences`, the two halves of the default entry (`checkReferences`
+  is already exported separately, for callers that have a typed `Revision` —
+  exactly this case), plus `decodeText` / `mediaType`.
 - [`fjs/media/revision/README.md`](../revision/README.md) — the `vnd.fjs.<name>`
   convention this gap makes only partially usable, and the mechanical media-type
   derivation an entry relies on instead of naming its own.

--- a/fjs/media/todo/dialect-registry.md
+++ b/fjs/media/todo/dialect-registry.md
@@ -41,28 +41,65 @@ provenance, which is what `detect` exists for.
 
 ### Proposal
 
-Make the set of dialects a parameter rather than an import.
-
-`fjs/media/revision` already exports exactly the pair an entry needs —
-`decodeText: (text: string) => Result<T, E>` and `mediaType: string` — so its
-own shape is the natural interface, and no new type has to be invented:
+Make the set of dialects a parameter rather than an import, and **limit what an
+entry can say to a dialect name plus an rtti schema** — nothing else:
 
 ```ts
 export type Dialect = {
-    readonly decodeText: (text: string) => Result<unknown, unknown>
-    readonly mediaType: string
+    readonly dialect: string
+    readonly schema: Type // `fjs/types/rtti` `Type`
 }
 ```
 
-`detect` tries each in order and reports the first whose `decodeText` returns
-`ok`, falling through to the `fjs/media/type` verdict when none match. Keep the
-current zero-argument `detect` as a binding over `[revision]` so existing
-callers are unaffected.
+An entry is data, not code. That single restriction settles most of the open
+design questions:
 
+- **The media type is derived, not supplied.** `application/${dialect}+json`,
+  the same mechanical derivation `fjs/media/revision` already documents. An
+  entry cannot name an arbitrary `mime_type`, so a registered dialect can only
+  ever claim its own `vnd.fjs.<name>` type — no `mediaType` field to get wrong,
+  and nothing to allowlist after the fact.
+- **Parsing happens once.** Detection JSON-parses the text a single time and
+  runs `rtti/validate`'s `validate(schema)` over the parsed value for each
+  entry, so N dialects cost N structural validations, not N parses. The
+  "N decoders, N parses" cost of a `decodeText`-shaped entry never arises.
+- **No caller-supplied code runs during detection.** A registry of functions
+  would let any entry do arbitrary work — throw, recurse, or take
+  pathological time — on bytes of unknown provenance, which is exactly the
+  input `detect` exists to classify. Validating data against a schema cannot.
+
+Dialect schemas are self-discriminating, so this does not need a separate tag
+check: `revisionSchema` matches `dialect` as an exact string literal, so
+structural validation alone rejects every other dialect's blob. Require the
+same of any registered entry — a schema whose `dialect` field is the literal
+`dialect` of the entry — and disjointness is a property of the entries, not a
+rule `detect` has to enforce. First match still wins for entries that overlap
+anyway.
+
+Keep the current zero-argument `detect` as a binding over `[revision]`.
 Whether the list is a parameter (`detect(dialects)(bytes)`) or a module-level
 registry is an API-taste call for this repo; a parameter keeps the module pure
 and avoids registration-order questions, at the cost of every caller naming the
 dialects it cares about.
+
+**The one consequence to decide.** rtti validation is structural only, and
+`revision`'s `decodeText` is structural *plus* `checkReferences` — cbase32
+hashes, non-negative safe-integer `generation`. A blob that satisfies
+`revisionSchema` but carries `"snapshot": "not a hash"` classifies as
+`text/plain` today and would classify as `application/vnd.fjs.revision+json`
+under a schema-only entry. Two ways to take it:
+
+1. Accept the widening: `detect` classifies, it does not validate. It reports
+   what a blob claims to be and structurally looks like; the caller's own
+   `decodeText` stays the authority on whether it is usable. This keeps every
+   entry pure data.
+2. Keep semantic refinement out of the entry but let the default `[revision]`
+   binding re-check it, so the default path's results are bit-for-bit what they
+   are today — at the cost of the default no longer being expressible as a
+   plain entry list, which is most of the point.
+
+Option 1 is the simpler contract and the one this proposal assumes; it is
+called out because it changes an existing result.
 
 Two properties of the current implementation are deliberate and easy to lose
 while adding a registry:
@@ -70,30 +107,33 @@ while adding a registry:
 - **Detection is semantic, not syntactic.** Any JSON satisfying a dialect's
   schema is recognized regardless of key order or whitespace — the docstring
   calls this out and specifically rules out a byte-level `{"dialect":` prefix
-  check. A registry makes such a shortcut tempting as an optimization (test the
-  tag, then dispatch to one decoder); it would change the contract.
+  check. A registry makes such a shortcut tempting as an optimization (read the
+  tag, then dispatch to one schema); it would change the contract. Note that
+  schema validation already subsumes the tag check, so the shortcut buys only
+  the difference between one validation and N.
 - **Dialect detection is size-bounded by construction.** It runs only on a
   single already-buffered `Vec` (capped at `maxLength`, 128 KiB) because schema
   validation needs the whole parsed value. `fjs/media/type`'s `detectStream`
   stays a pure byte-signature/UTF-8 classifier with no dialect awareness. A
   registry must not push dialect validation into the streaming path.
 
-Trying N decoders is N JSON parses in the worst case. If that matters, parse
-once and validate the parsed value against each schema — but note that
-`decodeText` is the exported entry point today, so a parse-once design wants a
-`validate`-shaped member in the entry type instead of, or alongside,
-`decodeText`.
-
 ### Tasks
 
-- [ ] Decide the entry shape (`{ decodeText, mediaType }` vs. a `validate`-based
-      one that parses once) and whether dialects are a parameter or a registry.
-- [ ] Implement in `fjs/media/module.f.ts`; keep a default wired to `[revision]`
-      so current callers and their results are unchanged.
+- [ ] Decide the structural-only widening (option 1 vs. 2 above) and whether
+      dialects are a parameter or a registry. The entry shape itself is settled:
+      `{ dialect, schema }`, no functions, media type derived.
+- [ ] Implement in `fjs/media/module.f.ts`: parse once, then `validate(schema)`
+      per entry; keep a default wired to `[revision]` so current callers are
+      unaffected.
+- [ ] Require each entry's schema to pin its own `dialect` literal (how
+      `revisionSchema` already does it) — document it, and decide whether
+      `detect` checks it or the convention is enough.
 - [ ] Proof coverage in `fjs/media/proof.f.ts`: a second dialect is recognized;
       first-match-wins ordering; no match falls through to the `fjs/media/type`
       verdict unchanged; a `revision` blob still reports
-      `application/vnd.fjs.revision+json` through the default.
+      `application/vnd.fjs.revision+json` through the default; and — per the
+      widening decision — a structurally valid revision with a non-cbase32
+      `snapshot`, pinning whichever verdict was chosen.
 - [ ] Confirm `detectStream` is untouched and still dialect-unaware.
 - [ ] Check whether `DetectMeta` needs to carry the matched dialect itself, not
       only the derived `mime_type` — a caller that matched is usually about to
@@ -109,4 +149,9 @@ once and validate the parsed value against each schema — but note that
   `mediaType`, `dialect`; the reference implementation of the pattern and the de
   facto entry shape.
 - [`fjs/media/revision/README.md`](../revision/README.md) — the `vnd.fjs.<name>`
-  convention this gap makes only partially usable.
+  convention this gap makes only partially usable, and the mechanical media-type
+  derivation an entry relies on instead of naming its own.
+- [`fjs/types/rtti/module.f.ts`](../../types/rtti/module.f.ts) — `Type`, the
+  entry's schema half.
+- [`fjs/types/rtti/validate/module.f.ts`](../../types/rtti/validate/module.f.ts)
+  — `validate`, what detection runs per entry over the once-parsed value.

--- a/fjs/media/todo/dialect-registry.md
+++ b/fjs/media/todo/dialect-registry.md
@@ -45,20 +45,32 @@ Make the set of dialects a parameter rather than an import, and **limit what an
 entry can say to a dialect name plus an rtti schema** — nothing else:
 
 ```ts
-export type Dialect = {
-    readonly dialect: string
-    readonly schema: Type // `fjs/types/rtti` `Type`
-}
+// `Struct` from `fjs/types/rtti`: a struct schema whose `dialect` member is a
+// string const — the subset of `Type` that names its own dialect.
+export type Dialect = Struct & { readonly dialect: string }
 ```
 
-An entry is data, not code. That single restriction settles most of the open
-design questions:
+A dialect schema is already a struct whose `dialect` member is a string const —
+that is how `revisionSchema` is written, and it is what makes the schema
+self-discriminating. So the dialect name is *in* the schema, and a separate
+`dialect` field alongside it would be a second copy that can disagree with the
+first. An entry is one rtti schema and nothing else: the subset of `Type` that
+carries a string `dialect` member. `detect` reads `schema.dialect` and derives
+the media type from it.
+
+That an entry is data, not code, settles most of the open design questions:
 
 - **The media type is derived, not supplied.** `application/${dialect}+json`,
-  the same mechanical derivation `fjs/media/revision` already documents. An
-  entry cannot name an arbitrary `mime_type`, so a registered dialect can only
-  ever claim its own `vnd.fjs.<name>` type — no `mediaType` field to get wrong,
-  and nothing to allowlist after the fact.
+  the same mechanical derivation `fjs/media/revision` already documents, read
+  off the schema's own literal. An entry cannot name an arbitrary `mime_type`,
+  so a registered dialect can only ever claim its own `vnd.fjs.<name>` type —
+  no `mediaType` field to get wrong, and nothing to allowlist after the fact.
+  Under a generic `<S extends Dialect>` the literal survives into the type, so
+  the derived media type can stay a template-literal type the way `revision`'s
+  `mediaType` is today.
+- **The tag and the schema cannot disagree.** With one field there is no entry
+  that claims `vnd.fjs.foo` while validating `vnd.fjs.bar` blobs — no
+  consistency rule for `detect` to enforce, and none for a proof to cover.
 - **Parsing happens once.** Detection JSON-parses the text a single time and
   runs `rtti/validate`'s `validate(schema)` over the parsed value for each
   entry, so N dialects cost N structural validations, not N parses. The
@@ -68,13 +80,18 @@ design questions:
   pathological time — on bytes of unknown provenance, which is exactly the
   input `detect` exists to classify. Validating data against a schema cannot.
 
-Dialect schemas are self-discriminating, so this does not need a separate tag
-check: `revisionSchema` matches `dialect` as an exact string literal, so
-structural validation alone rejects every other dialect's blob. Require the
-same of any registered entry — a schema whose `dialect` field is the literal
-`dialect` of the entry — and disjointness is a property of the entries, not a
-rule `detect` has to enforce. First match still wins for entries that overlap
+Detection needs no separate tag check on top of validation: matching `dialect`
+as an exact string literal is what makes structural validation alone reject
+every other dialect's blob, so disjointness is a property of the entries rather
+than a rule `detect` enforces. First match still wins for entries that overlap
 anyway.
+
+One wrinkle to pin down: rtti admits both the direct const form
+(`dialect: 'vnd.fjs.revision'`) and the thunk form
+(`() => ['const', 'vnd.fjs.revision']`). The type above accepts only the direct
+form — what `revisionSchema` uses, and what keeps `schema.dialect` readable
+without evaluating anything. Either require it or unwrap the thunk when reading
+the name.
 
 Keep the current zero-argument `detect` as a binding over `[revision]`.
 Whether the list is a parameter (`detect(dialects)(bytes)`) or a module-level
@@ -121,13 +138,14 @@ while adding a registry:
 
 - [ ] Decide the structural-only widening (option 1 vs. 2 above) and whether
       dialects are a parameter or a registry. The entry shape itself is settled:
-      `{ dialect, schema }`, no functions, media type derived.
+      an rtti schema, nothing beside it — no functions, dialect and media type
+      both read off the schema.
 - [ ] Implement in `fjs/media/module.f.ts`: parse once, then `validate(schema)`
-      per entry; keep a default wired to `[revision]` so current callers are
-      unaffected.
-- [ ] Require each entry's schema to pin its own `dialect` literal (how
-      `revisionSchema` already does it) — document it, and decide whether
-      `detect` checks it or the convention is enough.
+      per entry, deriving the media type from `schema.dialect`; keep a default
+      wired to `[revisionSchema]` so current callers are unaffected.
+- [ ] Type `Dialect` so a schema without a string `dialect` member is rejected
+      at compile time, and decide the thunk-form question (require the direct
+      const, or unwrap when reading the name).
 - [ ] Proof coverage in `fjs/media/proof.f.ts`: a second dialect is recognized;
       first-match-wins ordering; no match falls through to the `fjs/media/type`
       verdict unchanged; a `revision` blob still reports
@@ -145,13 +163,14 @@ while adding a registry:
   import.
 - [`fjs/media/type/module.f.ts`](../type/module.f.ts) — `detectVec` /
   `detectStream`, the layer below.
-- [`fjs/media/revision/module.f.ts`](../revision/module.f.ts) — `decodeText`,
-  `mediaType`, `dialect`; the reference implementation of the pattern and the de
-  facto entry shape.
+- [`fjs/media/revision/module.f.ts`](../revision/module.f.ts) — `revisionSchema`
+  (the entry itself, `dialect` literal included), plus `decodeText`, `mediaType`
+  and the `checkReferences` semantics that stay outside detection.
 - [`fjs/media/revision/README.md`](../revision/README.md) — the `vnd.fjs.<name>`
   convention this gap makes only partially usable, and the mechanical media-type
   derivation an entry relies on instead of naming its own.
-- [`fjs/types/rtti/module.f.ts`](../../types/rtti/module.f.ts) — `Type`, the
-  entry's schema half.
+- [`fjs/types/rtti/module.f.ts`](../../types/rtti/module.f.ts) — `Struct` /
+  `Type` / `Const`; an entry is the subset of `Type` with a string `dialect`
+  member.
 - [`fjs/types/rtti/validate/module.f.ts`](../../types/rtti/validate/module.f.ts)
   — `validate`, what detection runs per entry over the once-parsed value.

--- a/fjs/media/todo/dialect-registry.md
+++ b/fjs/media/todo/dialect-registry.md
@@ -46,10 +46,8 @@ entry can say to an rtti schema plus a typed refinement predicate** — no
 decoder, no media type, no separate dialect name:
 
 ```ts
-// The dialect name a schema carries, and the schemas that carry one: an rtti
-// `Struct` whose `dialect` member is a direct string const.
-type DialectName<T extends Struct> = T['dialect'] extends string ? T['dialect'] : never
-type DialectSchema<T extends Struct> = T['dialect'] extends string ? T : never
+/** A schema that names its own dialect: `StringMap<'dialect', string>`. */
+export type DialectType = StringMap<'dialect', string>
 
 /** The registry entry: a dialect name and a predicate over a parsed value. */
 export type DialectEntry<S extends string> = {
@@ -58,10 +56,19 @@ export type DialectEntry<S extends string> = {
 }
 
 /** Registers a dialect for detection: its schema, plus whatever rtti can't say. */
-export const dialectEntry = <T extends Struct>(
-    type: DialectSchema<T>,
+export const dialectEntry = <T extends DialectType>(
+    type: T,
     extraValidate: (_: Ts<T>) => boolean = () => true,
-): DialectEntry<DialectName<T>> => /* … */
+): DialectEntry<T['dialect']> => {
+    const v = validate(type)
+    return {
+        dialect: type.dialect,
+        match: u => {
+            const [tag, value] = v(u)
+            return tag === 'ok' && extraValidate(value)
+        },
+    }
+}
 ```
 
 A dialect schema is already a struct whose `dialect` member is a string const —
@@ -70,25 +77,42 @@ self-discriminating. So the dialect name is *in* the schema, and a separate
 `dialect` field alongside it would be a second copy that can disagree with the
 first. `detect` reads `type.dialect` and derives the media type from it.
 
-The constraint is a conditional over rtti's own `Struct`, not a new record
-shape. Neither of the obvious spellings is allowed here: `Struct & { dialect:
-string }` is the intersection AGENTS.md rules out, and an inline
-`{ readonly [k: string]: Type | undefined, readonly dialect: string }` is the
-inline index signature it reserves for mutually-recursive types. The rule's
-usual remedy for the first — embed the record as a named field — cannot apply
-either, because an entry's schema *is* an rtti `Type`: nesting it
-(`{ struct: Struct, dialect: string }`) yields something `validate` cannot
-consume. Gating `T` on `T['dialect'] extends string` needs none of them; it
-reuses `Struct` (already `StringMap<string, Type>`) unchanged.
+The constraint is `StringMap<'dialect', string>` — the repo's spelling of
+`{ readonly dialect: string }` — and nothing more. Three other spellings were
+tried against the real `revisionSchema`, `Ts`, and `validate` with
+`tsc --strict`, and each fails:
 
-This encoding is checked, not assumed — `tsc --strict` against the real
-`revisionSchema` confirms all four properties it has to have:
-`dialectEntry(revisionSchema, r => r.generation > 0)` infers `r` as the decoded
-`Revision` with no annotation, the returned entry's `dialect` is the literal
-`'vnd.fjs.revision'` (assigning it to another literal type errors), and a
-schema with no `dialect` member or with a thunk-form one is rejected at the
-call site — the parameter resolves to `never` — rather than silently producing
-an entry whose name is `never`.
+- `Struct & { readonly dialect: string }` — the intersection AGENTS.md rules
+  out. (Its usual remedy, embedding the record as a named field, cannot apply
+  here either: an entry's schema *is* an rtti `Type`, so
+  `{ struct: Struct, dialect: string }` yields something `validate` cannot
+  consume.)
+- An inline `{ readonly [k: string]: Type | undefined, readonly dialect:
+  string }` — the inline index signature reserved for mutually-recursive types.
+- `<T extends Struct>` with the member gated by conditionals
+  (`type: DialectSchema<T>`, returning `DialectEntry<DialectName<T>>`). This
+  one type-checks at the *call site* but not in the body: `type.dialect` stays
+  `Type` (including `undefined`) rather than `DialectName<T>` (TS2322), and
+  `validate(type)` yields `Ts<DialectSchema<T>>`, which is not `Ts<T>` and so
+  cannot feed `extraValidate` (TS2345). Adding `Struct` to the constraint
+  alongside `StringMap<'dialect', string>` instead blows up with TS2589,
+  "type instantiation is excessively deep".
+
+The version above compiles end to end, body included, with no `as`. Checked,
+not assumed: `dialectEntry(revisionSchema, r => r.generation >= 0)` infers `r`
+as the decoded `Revision` with no annotation; the entry's `dialect` is the
+literal `'vnd.fjs.revision'`, so
+`revisionDialect: DialectEntry<typeof dialect>` type-checks and assigning it to
+a different literal errors; a schema with no `dialect` member is rejected at
+the call site; and a thunk-form `dialect` is rejected too, since a function is
+not a `string` — which is what makes the direct-const rule below
+compile-enforced rather than merely stated.
+
+What this constraint does *not* say is that the schema's other members are rtti
+`Type`s — `Struct` cannot be added back, per TS2589 above. In practice the gap
+is small: `Const` admits every primitive, array, and object literal, so almost
+any member is a valid schema; a genuinely malformed one (a function that is not
+a thunk) is caught by `validate`, not by registration.
 
 `extraValidate` closes the gap rtti leaves. Structural validation cannot say
 "this string is cbase32-decodable" or "this number is a non-negative safe
@@ -171,10 +195,14 @@ of the open design questions settle:
   that claims `vnd.fjs.foo` while validating `vnd.fjs.bar` blobs — no
   consistency rule for `detect` to enforce, and none for a proof to cover.
 - **Parsing happens once.** Detection JSON-parses the text a single time and
-  runs `rtti/validate`'s `validate(type)` over the parsed value for each entry,
-  with `extraValidate` on the same value when that succeeds. N dialects cost N
-  structural validations, not N parses — the "N decoders, N parses" cost of a
-  `decodeText`-shaped entry never arises.
+  calls each entry's `match` on the parsed value. Validation lives in the
+  entry, not the detector: `dialectEntry` closes over
+  `rtti/validate`'s `validate(type)` and its `extraValidate`, and `match` runs
+  the structural check followed by the refinement on the same value. `detect`
+  never sees `type` or `extraValidate` — it walks the list calling `match` and
+  takes the first `true`. N dialects therefore cost N structural validations,
+  not N parses; the "N decoders, N parses" cost of a `decodeText`-shaped entry
+  never arises.
 - **The one function an entry contributes is narrow.** A `decodeText`-shaped
   entry owns parsing, so it does arbitrary work on bytes of unknown provenance
   — exactly the input `detect` exists to classify. `extraValidate` never sees
@@ -192,8 +220,9 @@ anyway.
 
 **The `dialect` member must be a direct string const**, not a thunk. rtti
 admits both forms — `dialect: 'vnd.fjs.revision'` and
-`() => ['const', 'vnd.fjs.revision']` — and `DialectSchema` above accepts only
-the first. That is the decision, not an implementer's choice: the direct form
+`() => ['const', 'vnd.fjs.revision']` — and `DialectType` above accepts only
+the first, since a thunk is not a `string`. That is the decision, not an
+implementer's choice: the direct form
 is what `revisionSchema` already uses, it is what rtti's own docstring
 prescribes outside recursive definitions, it makes `type.dialect` readable
 without evaluating anything, and it is enforceable at compile time by the entry
@@ -274,15 +303,14 @@ while adding a registry:
 
 ### Tasks
 
-- [ ] Implement `dialectEntry(type, extraValidate?)` and the
-      `DialectEntry<T['dialect']>` it returns — generic in the name, so the
-      literal is not widened at the return boundary; confirm `Ts<T>` is
-      inferred at the call site so `extraValidate`'s parameter needs no
-      annotation (this is the reason registration is a function).
+- [ ] Implement `dialectEntry(type, extraValidate?)` as written above — it owns
+      validation, closing over `validate(type)` and `extraValidate` inside
+      `match`; the returned `DialectEntry<T['dialect']>` is generic in the name
+      so the literal is not widened at the return boundary.
 - [ ] Implement in `fjs/media/module.f.ts`: `detect(dialects)(bytes)` — parse
-      once, `validate(type)` per entry, then `extraValidate` on success,
-      appending `+json` to the matched entry's `dialect`. No dialect import
-      remains in this module.
+      once, call each entry's `match` on the parsed value, and append `+json`
+      to the first matching entry's `dialect`. `detect` handles no schemas and
+      no refinements of its own, and no dialect import remains in this module.
 - [ ] Add `revisionDialect` to `fjs/media/revision` —
       `dialectEntry(revisionSchema, r => checkReferences(r)[0] === 'ok')` —
       keeping the existing `dialect` string const untouched.
@@ -290,10 +318,11 @@ while adding a registry:
       `detectDialect` call sites) and `fjs/media/proof.f.ts` — and add a
       `**BREAKING CHANGES:**` CHANGELOG entry per AGENTS.md §8.4. No
       compatibility shim.
-- [ ] Carry the `DialectSchema` / `DialectName` conditionals over as written, so
-      a schema whose `dialect` member is absent, not a string, or a thunk-
-      wrapped const is rejected at the call site. Do **not** grammar-check or
-      allowlist the name — record why in the JSDoc, since the rule differs from
+- [ ] Keep the `DialectType = StringMap<'dialect', string>` constraint as
+      written — it is what rejects a schema with no `dialect` member or a
+      thunk-form one at the call site, and the alternatives above do not
+      compile. Do **not** grammar-check or allowlist the name — record why in
+      the JSDoc, since the rule differs from
       [detect-cbor](detect-cbor.md)'s blob-supplied names.
 - [ ] Proof coverage in `fjs/media/proof.f.ts`: a second dialect is recognized;
       first-match-wins ordering; no match falls through to the `fjs/media/type`
@@ -324,7 +353,9 @@ while adding a registry:
   `application/{dialect}+cbor`; its tier-2 names come from the blob, hence its
   allowlist and this module's lack of one.
 - [`fjs/types/rtti/module.f.ts`](../../types/rtti/module.f.ts) — `Struct` /
-  `Type` / `Const`; `Struct` is the entry schema's constraint, narrowed by a
-  conditional rather than by intersecting or re-spelling it.
+  `Type` / `Const`; `Struct` is what a dialect schema is, though the entry's
+  constraint is `StringMap<'dialect', string>` (see the compile notes above).
+- [`fjs/types/object/module.f.ts`](../../types/object/module.f.ts) —
+  `StringMap`, which spells that constraint.
 - [`fjs/types/rtti/validate/module.f.ts`](../../types/rtti/validate/module.f.ts)
   — `validate`, what detection runs per entry over the once-parsed value.

--- a/fjs/media/todo/dialect-registry.md
+++ b/fjs/media/todo/dialect-registry.md
@@ -46,6 +46,9 @@ entry can say to an rtti schema plus a typed refinement predicate** — no
 decoder, no media type, no separate dialect name:
 
 ```ts
+// `Struct`, `Ts` and `Unknown` are rtti's (`fjs/types/rtti`, `…/rtti/ts`),
+// `validate` is `…/rtti/validate`, `assert` is `fjs/asserts`.
+
 /** The registry entry: a dialect name and a predicate over a parsed value. */
 export type DialectEntry = {
     readonly dialect: string
@@ -195,7 +198,13 @@ of the open design questions settle:
   survive to.
 - **The entry names a dialect, not an encoding.** Erase to
   `{ dialect, match }`, not `{ mediaType, match }`: the `+json` suffix is the
-  JSON detector's to append. Nothing else is needed today — there is no CBOR
+  JSON detector's to append. `match`'s parameter is rtti's `Unknown`, not
+  `fjs/media/json`'s — the two are different types, and the JSON one excludes
+  `bigint` and `undefined`. Inside `fjs/media` the JSON one is the nearer
+  import, so this is easy to get wrong, and getting it wrong would make the
+  entries JSON-only: [detect-cbor](detect-cbor.md) leaves each dialect free to
+  admit CBOR-only values such as `bigint`, and those values have to reach the
+  same `match`. Nothing else is needed today — there is no CBOR
   codec yet, so `fjs/media/type` has no CBOR path to detect through — but the
   same entries are what [detect-cbor](detect-cbor.md) would validate against
   when there is one, deriving `application/{dialect}+cbor` from the same name.
@@ -369,5 +378,9 @@ while adding a registry:
   — `validate`, which each entry's `match` closes over; it throws rather than
   erroring on a schema member that is not a `Type`, which is why the constraint
   has to be `Struct`.
+- [`fjs/types/rtti/ts/module.f.ts`](../../types/rtti/ts/module.f.ts) — `Ts` and
+  the `Unknown` that `match` takes: the encoding-neutral one, admitting
+  `bigint` and `undefined`, unlike
+  [`fjs/media/json`](../json/module.f.ts)'s JSON-only `Unknown`.
 - [`fjs/asserts/module.f.ts`](../../asserts/module.f.ts) — `assert`, used once
   per registration to check the `dialect` member.

--- a/fjs/media/todo/dialect-registry.md
+++ b/fjs/media/todo/dialect-registry.md
@@ -1,0 +1,112 @@
+## dialect-registry. `media` `detect` recognizes only `vnd.fjs.revision`
+
+**Priority:** P2
+**Status:** open
+
+### Problem
+
+[`fjs/media/module.f.ts`](../module.f.ts) layers dialect-tagged JSON recognition
+on top of [`fjs/media/type`](../type/module.f.ts)'s byte-signature classifier:
+when a whole buffered `Vec` is valid UTF-8 text, `detect` parses it as JSON and
+validates it against a known dialect's rtti schema, reporting that dialect's
+derived media type on a match.
+
+"A known dialect" is exactly one, fixed at import time:
+
+```ts
+import { decodeText as decodeRevisionText, mediaType as revisionMediaType } from './revision/module.f.ts'
+// …
+const [tag] = decodeRevisionText(text)
+return tag === 'ok' ? { ...base, mime_type: revisionMediaType } : base
+```
+
+`vnd.fjs.revision` is therefore the only dialect `detect` can ever recognize,
+and there is no way for any other module — in this repo or downstream — to
+contribute one. The module's own docstring already anticipates this: it says the
+validation is against "a known dialect's rtti schema (currently just
+`vnd.fjs.revision`)".
+
+The naming convention makes the gap concrete.
+[`fjs/media/revision`'s README](../revision/README.md) establishes the pattern
+for new formats — JSON plus a `dialect` tag, named `vnd.fjs.<name>`, yielding
+`application/vnd.fjs.<name>+json` — and any format following it is structurally
+identical to `revision` from `detect`'s point of view. But a blob in such a
+format classifies as `text/plain`, because `detect` cannot be told about it. The
+convention invites new dialects; the detector recognizes exactly one.
+
+This is not urgent for a consumer that knows what it is validating — such a
+caller invokes its own dialect's `validate`/`decodeText` directly and needs
+nothing from `detect`. It bites when classifying a blob of *unknown*
+provenance, which is what `detect` exists for.
+
+### Proposal
+
+Make the set of dialects a parameter rather than an import.
+
+`fjs/media/revision` already exports exactly the pair an entry needs —
+`decodeText: (text: string) => Result<T, E>` and `mediaType: string` — so its
+own shape is the natural interface, and no new type has to be invented:
+
+```ts
+export type Dialect = {
+    readonly decodeText: (text: string) => Result<unknown, unknown>
+    readonly mediaType: string
+}
+```
+
+`detect` tries each in order and reports the first whose `decodeText` returns
+`ok`, falling through to the `fjs/media/type` verdict when none match. Keep the
+current zero-argument `detect` as a binding over `[revision]` so existing
+callers are unaffected.
+
+Whether the list is a parameter (`detect(dialects)(bytes)`) or a module-level
+registry is an API-taste call for this repo; a parameter keeps the module pure
+and avoids registration-order questions, at the cost of every caller naming the
+dialects it cares about.
+
+Two properties of the current implementation are deliberate and easy to lose
+while adding a registry:
+
+- **Detection is semantic, not syntactic.** Any JSON satisfying a dialect's
+  schema is recognized regardless of key order or whitespace — the docstring
+  calls this out and specifically rules out a byte-level `{"dialect":` prefix
+  check. A registry makes such a shortcut tempting as an optimization (test the
+  tag, then dispatch to one decoder); it would change the contract.
+- **Dialect detection is size-bounded by construction.** It runs only on a
+  single already-buffered `Vec` (capped at `maxLength`, 128 KiB) because schema
+  validation needs the whole parsed value. `fjs/media/type`'s `detectStream`
+  stays a pure byte-signature/UTF-8 classifier with no dialect awareness. A
+  registry must not push dialect validation into the streaming path.
+
+Trying N decoders is N JSON parses in the worst case. If that matters, parse
+once and validate the parsed value against each schema — but note that
+`decodeText` is the exported entry point today, so a parse-once design wants a
+`validate`-shaped member in the entry type instead of, or alongside,
+`decodeText`.
+
+### Tasks
+
+- [ ] Decide the entry shape (`{ decodeText, mediaType }` vs. a `validate`-based
+      one that parses once) and whether dialects are a parameter or a registry.
+- [ ] Implement in `fjs/media/module.f.ts`; keep a default wired to `[revision]`
+      so current callers and their results are unchanged.
+- [ ] Proof coverage in `fjs/media/proof.f.ts`: a second dialect is recognized;
+      first-match-wins ordering; no match falls through to the `fjs/media/type`
+      verdict unchanged; a `revision` blob still reports
+      `application/vnd.fjs.revision+json` through the default.
+- [ ] Confirm `detectStream` is untouched and still dialect-unaware.
+- [ ] Check whether `DetectMeta` needs to carry the matched dialect itself, not
+      only the derived `mime_type` — a caller that matched is usually about to
+      decode, and currently has to re-derive which dialect hit.
+
+### Related
+
+- [`fjs/media/module.f.ts`](../module.f.ts) — `detect`, the hardcoded `revision`
+  import.
+- [`fjs/media/type/module.f.ts`](../type/module.f.ts) — `detectVec` /
+  `detectStream`, the layer below.
+- [`fjs/media/revision/module.f.ts`](../revision/module.f.ts) — `decodeText`,
+  `mediaType`, `dialect`; the reference implementation of the pattern and the de
+  facto entry shape.
+- [`fjs/media/revision/README.md`](../revision/README.md) — the `vnd.fjs.<name>`
+  convention this gap makes only partially usable.


### PR DESCRIPTION
## Summary

This PR adds documentation of a known limitation in the `fjs/media` module's dialect detection system. The issue describes how the current `detect` function only recognizes a single hardcoded dialect (`vnd.fjs.revision`) and proposes a path forward to make dialect detection extensible.

## Changes

- **Added `fjs/media/todo/dialect-registry.md`**: A detailed issue document that:
  - Explains the current limitation: `detect` can only recognize `vnd.fjs.revision` because dialects are hardcoded at import time
  - Describes the gap between the naming convention (which invites new `vnd.fjs.<name>` dialects) and the implementation (which supports only one)
  - Proposes making dialects a parameter rather than a fixed import
  - Suggests a `Dialect` interface shape based on existing exports from `fjs/media/revision`
  - Outlines implementation considerations and a task list for future work
  - Highlights two important properties to preserve: semantic (not syntactic) detection and size-bounded validation

## Context

This is a design document capturing a known limitation and proposing a solution. No source code changes are made in this PR—it documents the issue for future implementation and serves as a reference for contributors interested in extending dialect support.

https://claude.ai/code/session_013emmWLiNEvnB1JnYwmJzS1