### PR TITLE
Add test case for consecutive dots in number tokenization

### DIFF
--- a/fjs/js/tokenizer/proof.f.ts
+++ b/fjs/js/tokenizer/proof.f.ts
@@ -255,6 +255,11 @@ export const proof = {
             if (result !== '[{"kind":"error","message":"invalid number"},{"kind":"]"},{"kind":"eof"}]') { throw result }
         },
         () => {
+            // a second "." after the fraction has started (covers fullStopToToken's default branch)
+            const result = stringify(tokenizeString('1..'))
+            if (result !== '[{"kind":"error","message":"invalid number"},{"kind":"eof"}]') { throw result }
+        },
+        () => {
             const result = stringify(tokenizeString('0e1'))
             if (result !== '[{"bf":[0n,1],"kind":"number","value":"0e1"},{"kind":"eof"}]') { throw result }
         },


### PR DESCRIPTION
## Summary
Added a test case to the tokenizer proof suite to verify proper error handling when consecutive dots appear in a number literal.

## Key Changes
- Added a new test case in `fjs/js/tokenizer/proof.f.ts` that validates the tokenizer's behavior when parsing `'1..'`
- The test verifies that consecutive dots in a number are correctly identified as an error with the message "invalid number"
- This test case specifically covers the default branch of `fullStopToToken`, ensuring comprehensive coverage of the number parsing logic

## Implementation Details
The test follows the existing pattern in the proof suite, using `tokenizeString()` and `stringify()` to verify that the input `'1..'` produces the expected token sequence: an error token followed by an EOF token.

https://claude.ai/code/session_01SoyAcK28QErpNH5znXEo9r