### PR TITLE
Clarify API design principles and versioning conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -515,6 +515,29 @@ independently constructed and consumed — and reads as plain data you destructu
 behind avoiding `as` and type predicates: make the structure explicit instead of
 deriving it.
 
+**Exception:** use `&` when every alternative is materially more complex — when
+composition would misdescribe the value or push real cost onto callers just to
+satisfy the rule. The cases in this repository:
+
+- **A type-level marker on a value that keeps its own runtime shape.**
+  `Nominal<N, R, B> = symbol & {…}` and
+  `Phantom<S, T> = S & { readonly[phantomKey]?: T }` exist precisely because the
+  value still *is* a `symbol` / an `S` at runtime. A named field would invent a
+  wrapper that never exists.
+- **Describing an object you don't own, or a flat serialized shape.**
+  `IncomingMessage = Readable & {…}` in `fjs/effects/node/module.ts` describes
+  Node's object, which really does carry both member sets on one level. Nesting
+  the base under a field there would describe something that isn't there — and
+  for a wire format it would change the encoding, not just the type.
+- **A facade adding a member to a generic interface.**
+  `FileCas = Cas<FileCasOperation> & { url: (v: Vec) => string }` — composition
+  would route every consumer through an extra hop (`fileCas.cas.read(…)`) to
+  express one added member.
+
+The exception is about cost to the reader or to the runtime, not about `&` being
+shorter to type. A composite assembled from record types you define and control —
+the `Signer` case above — is still the rule, not the exception.
+
 #### String literals instead of enum-like aliases
 
 Use string literals as strongly-typed values directly — don't introduce enum-like

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,16 +266,28 @@ format or contract for speed is not.
 ### 5.2 The API is the most important part of quality
 
 **Quality is the main priority, and the API is the most important part of it.**
-A clean, readable, simple API for the modules that consume it outweighs the cost
-of changing it. Never cut corners, hack, or bend a caller's input/output to fit
-an existing API's shape just to avoid touching that API.
+A clean, readable, simple API for the modules that consume it is worth more than
+any existing API's shape. **If the new version can have a better, simpler API,
+change it — never hesitate.** An API kept only because something already calls it
+is how a codebase ends up with a heap of legacy nobody is allowed to modify, and
+every later design is then bent around it. Never cut corners, hack, or bend a
+caller's input/output to fit an existing API's shape just to avoid touching that
+API.
 
 When the existing design is the obstacle, **fix the design**: rewrite the API and
-make a breaking change (update every importer in the same PR — see
-[§8.4](#84-breaking-changes-and-versioning)), or, when a hard cutover is
-impractical, introduce a clean transitional API alongside the old one and migrate
-callers to it. Adjusting a call site to work around a poor API, instead of
+make a breaking change, updating every importer in the same PR (see
+[§8.4](#84-breaking-changes-and-versioning)). Every consumer inside this
+repository is visible and updatable, so a hard cutover is nearly always
+available — take it. Adjusting a call site to work around a poor API, instead of
 improving the API, is the wrong trade-off here.
+
+Keeping the old API alongside the new one is a **last resort**, not the
+convenient middle path: two shapes for one concept doubles what a reader has to
+understand and, in practice, the old one never leaves. If a rewrite is genuinely
+too large for one PR, split it by **scope** — module by module, each step its own
+complete breaking change — rather than by **time**. If a transitional API is
+still unavoidable, file a `todo/` issue for removing the old one as part of the
+same change; the work isn't done until that issue is deleted.
 
 **If you see a way to improve an API — or a new API that would make consuming
 modules simpler and more readable — propose it as soon as you notice it.** Don't
@@ -802,9 +814,13 @@ Only add CHANGELOG entries for code changes — PRs that only touch `todo/`,
 
 ### 8.4 Breaking changes and versioning
 
-- Make breaking changes when they are the right design — don't preserve a worse
-  API (e.g. a stale re-export or a non-canonical export location) just to avoid
-  churn. When a change breaks the public API, prefix its CHANGELOG entry with
+- Make breaking changes whenever they are the right design — don't preserve a
+  worse API (e.g. a stale re-export or a non-canonical export location) just to
+  avoid churn, and don't treat "it's already published" as a reason to keep a
+  shape ([§5.2](#52-the-api-is-the-most-important-part-of-quality)). The version
+  number is what lets consumers stay on the old API; a released version is
+  immutable, so nothing is taken away from anyone by improving the next one.
+  When a change breaks the public API, prefix its CHANGELOG entry with
   `**BREAKING CHANGES:**` and update every importer in the same PR rather than
   keeping a compatibility shim.
 - When the version is bumped in `deno.json`/`package.json`, create a new

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -832,14 +832,25 @@ Only add CHANGELOG entries for code changes — PRs that only touch `todo/`,
   | `## Unreleased` contains                    | Pre-1.0 — `0.Y.Z` | 1.0 and later — `X.Y.Z` |
   | ------------------------------------------- | ----------------- | ----------------------- |
   | at least one `**BREAKING CHANGES:**` entry  | `0.(Y+1).0`       | `(X+1).0.0`             |
-  | new features, nothing breaking              | `0.(Y+1).0`       | `X.(Y+1).0`             |
+  | new features, nothing breaking              | `0.Y.(Z+1)`       | `X.(Y+1).0`             |
   | fixes only                                  | `0.Y.(Z+1)`       | `X.Y.(Z+1)`             |
 
-  Pre-1.0 the first two rows collapse into the same bump, which is why `0.32.0`
-  (a breaking CLI change) and `0.35.0` (new features only) are both minor bumps
-  while `0.35.1` and `0.35.2` (pure fixes) are patches. A bigger bump is a number,
-  not a cost — it never argues for holding back a breaking change, it only records
-  that one happened.
+  Pre-1.0 the leading `0.` costs one position, and the distinction it costs is
+  feature-vs-fix, not the break signal: `0.Y` moves **only** for a breaking
+  change, and everything else — new features included — is a patch. That is
+  deliberate. `^0.41.0` and `~0.41.0` both resolve to `>=0.41.0 <0.42.0` under
+  npm (Cargo's bare `0.41.0` and JSR/Deno agree), so while the package is pre-1.0
+  the minor is the only upgrade boundary a resolver enforces. Reserving it for
+  breaking changes makes crossing it mean "something broke, read the entries" and
+  makes every patch release a safe upgrade that still delivers features — the
+  same contract the 1.0-and-later column gives, one position to the left. SemVer
+  §4 leaves `0.y.z` undefined ("Anything MAY change at any time"), so this is a
+  convention chosen inside the spec rather than a departure from it.
+
+  A bigger bump is a number, not a cost — it never argues for holding back a
+  breaking change, it only records that one happened. Releases through `0.41.0`
+  predate this convention and took a minor bump for feature-only releases too
+  (`0.35.0`, `0.33.0`); they are published, so leave their numbers alone.
 - Releasing is its own commit: the version lives in `package.json` (`"version"`)
   — `deno.json` holds tasks and formatting only. When it's bumped, create a new
   `## X.Y.Z` section in `CHANGELOG.md` immediately after `## Unreleased` and move

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -823,6 +823,24 @@ Only add CHANGELOG entries for code changes — PRs that only touch `todo/`,
   When a change breaks the public API, prefix its CHANGELOG entry with
   `**BREAKING CHANGES:**` and update every importer in the same PR rather than
   keeping a compatibility shim.
-- When the version is bumped in `deno.json`/`package.json`, create a new
+- **The project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html),
+  and the CHANGELOG decides which number moves.** A `**BREAKING CHANGES:**` entry
+  in `## Unreleased` means the release shipping it cannot be a patch. The package
+  is still pre-1.0, where the leading `0.` is pinned and the *minor* position
+  plays the role the major one plays after 1.0:
+
+  | `## Unreleased` contains                    | Pre-1.0 — `0.Y.Z` | 1.0 and later — `X.Y.Z` |
+  | ------------------------------------------- | ----------------- | ----------------------- |
+  | at least one `**BREAKING CHANGES:**` entry  | `0.(Y+1).0`       | `(X+1).0.0`             |
+  | new features, nothing breaking              | `0.(Y+1).0`       | `X.(Y+1).0`             |
+  | fixes only                                  | `0.Y.(Z+1)`       | `X.Y.(Z+1)`             |
+
+  Pre-1.0 the first two rows collapse into the same bump, which is why `0.32.0`
+  (a breaking CLI change) and `0.35.0` (new features only) are both minor bumps
+  while `0.35.1` and `0.35.2` (pure fixes) are patches. A bigger bump is a number,
+  not a cost — it never argues for holding back a breaking change, it only records
+  that one happened.
+- Releasing is its own commit: the version lives in `package.json` (`"version"`)
+  — `deno.json` holds tasks and formatting only. When it's bumped, create a new
   `## X.Y.Z` section in `CHANGELOG.md` immediately after `## Unreleased` and move
   all entries from `## Unreleased` into it, leaving `## Unreleased` empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+While the package is pre-1.0, the minor position carries the meaning the major
+one will carry after 1.0: `0.Y` is bumped **only** by a release containing
+`**BREAKING CHANGES:**`, and every other release — new features included — is a
+patch bump. So `0.Y` is the API-compatibility boundary, which is also the
+boundary `^0.Y.Z` and `~0.Y.Z` ranges already enforce: a patch upgrade is always
+safe, and crossing `0.Y` always means reading the entries below. Releases through
+`0.41.0` predate this convention and used a minor bump for feature-only releases
+as well.
+
 New entries are at most a few lines and link only to their pull request. A few
 older entries predate that convention and have no PR link — they are kept as
 history.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ history.
   the generated Deno CI step include `module.f.mjs` alongside `module.f.ts`
   [#1422](https://github.com/functionalscript/functionalscript/pull/1422)
 
-### 0.41.0
+## 0.41.0
 
 - `fjs/effects`: `match` resolves a command's handler with an own-property
   lookup, so a `command` naming an `Object.prototype` member (`constructor`,
@@ -27,7 +27,7 @@ history.
   least one current head that is not archived — instead of every subject
   [#1415](https://github.com/functionalscript/functionalscript/pull/1415)
 
-### 0.40.0
+## 0.40.0
 
 - **BREAKING CHANGES:** remove the Playwright integration, which ran proofs in a
   Node worker rather than in a browser: no `@playwright/test` dependency, no

--- a/fjs/djs/todo/json-bigint-serialization.md
+++ b/fjs/djs/todo/json-bigint-serialization.md
@@ -170,7 +170,8 @@ logic; JS's single `number` type is what makes it necessary here.
   is naturally a third instantiation of that generic if the narrower-type
   option is chosen.
 - [parse-text-pipeline.md](../../media/json/todo/parse-text-pipeline.md) —
-  adds a `parseText` (string → `Result`) entry point to `fjs/media/json`; the
+  adds a `parse` (string → `Result`) entry point to `fjs/media/json`, moving
+  native `JSON.parse` aside as `parseNative`; the
   `parseWith` generalization here is the same shape of change (a new
   parameterized entry point, existing behavior preserved as the default),
   just on the token-list parser rather than the string-to-tokens pipeline.

--- a/fjs/media/json/todo/parse-text-pipeline.md
+++ b/fjs/media/json/todo/parse-text-pipeline.md
@@ -44,25 +44,41 @@ import { parse as parseTokens } from './parser/module.f.ts'
 import { tokenize } from './tokenizer/module.f.ts'
 import { stringToList } from '../../text/utf16/module.f.ts'
 
-export const parseText: (text: string) => Result<Unknown, string> =
+export const parse: (text: string) => Result<Unknown, string> =
     text => parseTokens(tokenize(stringToList(text)))
 ```
 
+The new entry point takes the name **`parse`**, and the existing
+`parse = JSON.parse` becomes `parseNative`. The Problem above is that `parse` is
+the concept consumers want and the module spends that name on the export they
+all avoid; moving the native one aside only to park the pipeline under a
+qualified name like `parseText` would leave the best name unused and keep the
+naming compromise in place, which is the trade-off `AGENTS.md` §5.2 rejects.
+`parseNative` also reads as what it is — the escape hatch, qualified because it
+is the special case. There is no clash with `parser/module.f.ts`'s own `parse`
+(over a token list): different module, and this one already imports it as
+`parseTokens`.
+
 Then `revision`'s `parseJson`, `package_json`'s `parseJsonText`, and
-`mcp/stdio`'s inline call import `parseText` and delete their local copies.
-Separately, the existing `parse = JSON.parse` export needs renaming: its name
-collides with the concept consumers actually want, and its throwing/native
-behavior is the reason they avoid it. Rename it (e.g. `parseNative`) as a
-breaking change with importers updated in the same PR — keeping the misleading
-name and documenting the split around it is the trade-off `AGENTS.md` §5.2
-rejects.
+`mcp/stdio`'s inline call import `parse` and delete their local copies.
+
+This is the strongest form of breaking change — a surviving name with a new
+contract — so the CHANGELOG entry must state both shapes: `parse` goes from
+`(string) => Unknown` (throwing) to `(string) => Result<Unknown, string>`
+(total), and the old behavior is available as `parseNative`. In-repo the type
+change is caught by `tsc`, and there is exactly one importer to update:
+`fjs/ci/proof.f.ts:11` (`import { parse as jsonParse }`). An untyped external
+caller would see the change only at runtime, which is what the entry has to warn
+about.
 
 ### Tasks
 
-- [ ] Add `parseText` to `fjs/media/json/module.f.ts` with proof coverage.
+- [ ] Rename `parse = JSON.parse` to `parseNative`; update `fjs/ci/proof.f.ts`.
+- [ ] Add the Result-returning `parse` to `fjs/media/json/module.f.ts` with
+      proof coverage.
 - [ ] Migrate the three consumers; delete their local copies.
-- [ ] Rename the `parse = JSON.parse` export and update all importers in the
-      same PR (**BREAKING CHANGES** entry).
+- [ ] Ship both renames in one PR with a **BREAKING CHANGES** entry naming the
+      old and new shapes of `parse`.
 - [ ] `npx tsc`, `fjs t`.
 
 ### Related

--- a/fjs/media/json/todo/parse-text-pipeline.md
+++ b/fjs/media/json/todo/parse-text-pipeline.md
@@ -50,18 +50,19 @@ export const parseText: (text: string) => Result<Unknown, string> =
 
 Then `revision`'s `parseJson`, `package_json`'s `parseJsonText`, and
 `mcp/stdio`'s inline call import `parseText` and delete their local copies.
-Separately, decide what to do about the existing `parse = JSON.parse` export:
-its name collides with the concept consumers actually want, and its
-throwing/native behavior is the reason they avoid it — rename (e.g.
-`parseNative`) as a breaking change with importers updated in the same PR, or
-keep and document the split.
+Separately, the existing `parse = JSON.parse` export needs renaming: its name
+collides with the concept consumers actually want, and its throwing/native
+behavior is the reason they avoid it. Rename it (e.g. `parseNative`) as a
+breaking change with importers updated in the same PR — keeping the misleading
+name and documenting the split around it is the trade-off `AGENTS.md` §5.2
+rejects.
 
 ### Tasks
 
 - [ ] Add `parseText` to `fjs/media/json/module.f.ts` with proof coverage.
 - [ ] Migrate the three consumers; delete their local copies.
-- [ ] Decide the fate of the `parse = JSON.parse` export; if renamed, update
-      all importers in the same PR (**BREAKING CHANGES** entry).
+- [ ] Rename the `parse = JSON.parse` export and update all importers in the
+      same PR (**BREAKING CHANGES** entry).
 - [ ] `npx tsc`, `fjs t`.
 
 ### Related

--- a/fjs/text/utf8/todo/vec-to-code-point-pipeline.md
+++ b/fjs/text/utf8/todo/vec-to-code-point-pipeline.md
@@ -50,9 +50,11 @@ export const vecToCodePointList = (v: Vec): List<I32> => toCodePointList(u8List(
 `text/module.f.ts`'s `utf8ToString` becomes
 `codePointListToString(vecToCodePointList(msbV))`. Consider going further and
 moving `utf8ToString` into `fjs/text/utf8/module.f.ts` as the unchecked
-sibling of `fromVec` (re-exported from `fjs/text/module.f.ts` for existing
-importers, or migrated as a breaking change) — mirroring how the encode
-direction already pairs `tryUtf8`/`utf8` in one place.
+sibling of `fromVec` — mirroring how the encode direction already pairs
+`tryUtf8`/`utf8` in one place. If it moves, migrate it as a breaking change
+with every importer updated in the same PR; a re-export left in
+`fjs/text/module.f.ts` for existing importers is the stale-re-export case
+`AGENTS.md` §8.4 rules out.
 
 ### Tasks
 


### PR DESCRIPTION
This PR strengthens the guidance in `AGENTS.md` around API design and breaking changes, and documents the project's semantic versioning convention for pre-1.0 releases.

## Summary

The changes reinforce that **API quality is the primary concern** and that breaking changes should be made whenever they improve the design, rather than preserved for backward compatibility. The PR also formalizes the versioning strategy used by the project while pre-1.0, where the minor version (`0.Y`) is reserved exclusively for breaking changes, making it the API-compatibility boundary that npm's version range operators already enforce.

## Key Changes

- **§5.2 (API Quality)**: Expanded guidance to emphasize that a better API always justifies a breaking change, and that keeping a poor API "because something already calls it" leads to unmaintainable legacy code. Added explicit guidance against using transitional APIs as a convenient middle path — if a rewrite is too large for one PR, split by scope (module-by-module) rather than by time.

- **§8.4 (Breaking Changes & Versioning)**: 
  - Clarified that "it's already published" is not a reason to preserve a worse API shape
  - Added a detailed versioning table documenting the pre-1.0 convention: `0.Y` bumps only for breaking changes, all other releases (including features) are patch bumps
  - Explained the rationale: this makes `0.Y` the only upgrade boundary that npm resolvers enforce, so crossing it signals "something broke, read the entries"
  - Noted that releases through `0.41.0` predate this convention and should be left unchanged
  - Clarified that version bumps live in `package.json` only, not `deno.json`

- **CHANGELOG.md**: Added a preamble explaining the pre-1.0 versioning convention and its relationship to npm's version range operators

- **Todo items** (`parse-text-pipeline.md`, `vec-to-code-point-pipeline.md`): Updated to reflect the stronger stance on breaking changes — removed language about "deciding" whether to keep misleading APIs and instead directed to rename/migrate as breaking changes in a single PR

## Notable Details

The versioning convention is not a departure from SemVer but a deliberate choice within it: SemVer §4 leaves `0.y.z` undefined, so this documents the convention chosen inside the spec. The approach ensures that patch upgrades are always safe while making the minor version the signal for API-breaking changes during the pre-1.0 phase.

https://claude.ai/code/session_01PGKvP7tP6n1SX1NEumKDW2