### PR TITLE
Document opening record types to dynamic keys with intersections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -533,6 +533,39 @@ satisfy the rule. The cases in this repository:
   `FileCas = Cas<FileCasOperation> & { url: (v: Vec) => string }` — composition
   would route every consumer through an extra hop (`fileCas.cas.read(…)`) to
   express one added member.
+- **Opening a record type to dynamic keys.** A record type restricts its fields:
+  unknown keys are neither writable in a literal nor readable off a value.
+  Intersecting it with `StringMap<string, unknown>` keeps the declared fields
+  checked while allowing arbitrary keys:
+
+  ```ts
+  type A = {
+      readonly x: number
+  }
+
+  // `a` doesn't have access to other fields.
+  const a: A = {
+      x: 5,
+      // b: null, // compilation error
+  }
+  // const aB = a.b // compilation error
+
+  // `AM` is a `StringMap` but with restricted fields.
+  type AM = StringMap<string, unknown> & A
+
+  // `am` has access to all fields, with `A`'s restrictions still applied.
+  const am: AM = {
+      x: 5,
+      b: null,
+      // x: 'no', // compilation error: `x` is still `number`
+  }
+  const amB = am.b // `unknown`
+  ```
+
+  Reach for this only when the composite type itself must carry both. To hand a
+  record to something that expects a map, widen at the use site instead — `A` is
+  already assignable to `StringMap<string, unknown>`, so
+  `const m: StringMap<string, unknown> = a` needs no intersection (and no `as`).
 
 The exception is about cost to the reader or to the runtime, not about `&` being
 shorter to type. A composite assembled from record types you define and control —


### PR DESCRIPTION
## Summary
Added documentation to AGENTS.md explaining how to use type intersections to extend record types with dynamic key support while preserving field type safety.

## Changes
- Added a new section documenting the pattern of intersecting a record type with `StringMap<string, unknown>` to allow arbitrary keys while maintaining type checking for declared fields
- Included a practical TypeScript example showing:
  - A basic record type `A` with restricted field access
  - An intersection type `AM` that combines `StringMap` with `A`
  - Demonstration of how `AM` allows dynamic keys while enforcing type constraints on declared fields
- Added guidance recommending this pattern only when the composite type itself must carry both capabilities, with a note that widening at the use site is preferred when passing a record to something expecting a map

## Implementation Details
The documentation clarifies that this intersection approach is useful for cases where a type needs to support both:
1. Strict typing for known fields (from the record type)
2. Dynamic key access (from the StringMap)

The example demonstrates that the intersection preserves type safety—attempting to assign an incorrect type to a declared field still results in a compilation error, while unknown keys are accessible as `unknown`.

https://claude.ai/code/session_01MGUw6kqWEBa3Lsh7BTrUhB