### PR TITLE
Add function parameter dispatch example to RTTI validate proofs

### DIFF
--- a/fjs/types/rtti/validate/proof.f.ts
+++ b/fjs/types/rtti/validate/proof.f.ts
@@ -340,7 +340,7 @@ export const proof = {
         type F0<T> = (...args: Param0) => T
         type F1<T> = (...args: Param1) => T
 
-        const func = <T>(f0: F0<T>, f1: F1<T>) =>(...args: Param01): T => {
+        const func = <T>(f0: F0<T>, f1: F1<T>) => (...args: Param01): T => {
             {
                 const [t, r] = v0(args)
                 if (t === 'ok') {
@@ -353,7 +353,7 @@ export const proof = {
                     return f1(...r)
                 }
             }
-            throw new Error('Invalid arguments')
+            throw 'unreachable: args did not match any parameter set'
         }
 
         const f0 = (a: 'hello', b: bigint): number => 42

--- a/fjs/types/rtti/validate/proof.f.ts
+++ b/fjs/types/rtti/validate/proof.f.ts
@@ -324,4 +324,46 @@ export const proof = {
             assertError(v({ a: 42 }))
         },
     },
+    funcParam: () => {
+        const paramSet0 = ['hello', bigint] as const
+        const paramSet1 = ['goodbye', string, 43] as const
+
+        const paramSet01 = or(paramSet0, paramSet1)
+
+        type Param0 = Ts<typeof paramSet0>
+        type Param1 = Ts<typeof paramSet1>
+        type Param01 = Ts<typeof paramSet01>
+
+        const v0 = validate(paramSet0)
+        const v1 = validate(paramSet1)
+
+        type F0<T> = (...args: Param0) => T
+        type F1<T> = (...args: Param1) => T
+
+        const func = <T>(f0: F0<T>, f1: F1<T>) =>(...args: Param01): T => {
+            {
+                const [t, r] = v0(args)
+                if (t === 'ok') {
+                    return f0(...r)
+                }
+            }
+            {
+                const [t, r] = v1(args)
+                if (t === 'ok') {
+                    return f1(...r)
+                }
+            }
+            throw new Error('Invalid arguments')
+        }
+
+        const f0 = (a: 'hello', b: bigint): number => 42
+        const f1 = (a: 'goodbye', b: string, c: 43): number => 13
+
+        const x: (...args: Param01) => number = func(f0, f1)
+
+        return () => {
+            assertEq(x('hello', 42n), 42)
+            assertEq(x('goodbye', 'world', 43), 13)
+        }
+    }
 }


### PR DESCRIPTION
Adds a `funcParam` proof to [`fjs/types/rtti/validate/proof.f.ts`](fjs/types/rtti/validate/proof.f.ts) demonstrating how RTTI validators can drive overload-style dispatch on function parameters.

The example builds two parameter tuple types (`["hello", bigint]` and `["goodbye", string, 43]`), combines them with `or`, and wraps two implementations behind a single function whose argument type is the union. At call time each validator is tried in turn and the first `ok` result selects the implementation, so both the static types and the runtime dispatch come from the same RTTI description.

Test plan: the proof asserts `x("hello", 42n) === 42` and `x("goodbye", "world", 43) === 13`, and runs as part of the existing proof suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
