### PR TITLE
Add object parameter dispatch example to RTTI validate proofs

### DIFF
--- a/fjs/types/rtti/validate/proof.f.ts
+++ b/fjs/types/rtti/validate/proof.f.ts
@@ -398,8 +398,8 @@ export const proof = {
             throw 'unreachable: args did not match any parameter set'
         }
 
-        const f0 = (args: Ts<Param0>): number => Number(args.b) + args.a.length
-        const f1 = (args: Ts<Param1>): number => args.c
+        const f0 = (args: Param0): number => Number(args.b) + args.a.length
+        const f1 = (args: Param1): number => args.c
 
         const x: (args: Param01) => number = func(f0, f1)
 

--- a/fjs/types/rtti/validate/proof.f.ts
+++ b/fjs/types/rtti/validate/proof.f.ts
@@ -399,6 +399,13 @@ export const proof = {
         }
 
         const f0 = (args: Ts<Param0>): number => Number(args.b) + args.a.length
-        const f1 = (args: Ts<Param1>): number => 13
+        const f1 = (args: Ts<Param1>): number => args.c
+
+        const x: (args: Param01) => number = func(f0, f1)
+
+        return () => {
+            assertEq(x({ a: 'hello', b: 42n }), 47)
+            assertEq(x({ a: 'goodbye', b: 'world', c: 43 }), 43)
+        }
     }
 }

--- a/fjs/types/rtti/validate/proof.f.ts
+++ b/fjs/types/rtti/validate/proof.f.ts
@@ -365,5 +365,40 @@ export const proof = {
             assertEq(x('hello', 42n), 42)
             assertEq(x('goodbye', 'world', 43), 13)
         }
+    },
+    funcObj: () => {
+        const param0 = { a: 'hello', b: bigint }
+        const param1 = { a: 'goodbye', b: string, c: 43 }
+
+        const param01 = or(param0, param1)
+
+        type Param0 = Ts<typeof param0>
+        type Param1 = Ts<typeof param1>
+        type Param01 = Ts<typeof param01>
+
+        const v0 = validate(param0)
+        const v1 = validate(param1)
+
+        type F0<T> = (args: Param0) => T
+        type F1<T> = (args: Param1) => T
+
+        const func = <T>(f0: F0<T>, f1: F1<T>) => (args: Param01): T => {
+            {
+                const [t, r] = v0(args)
+                if (t === 'ok') {
+                    return f0(r)
+                }
+            }
+            {
+                const [t, r] = v1(args)
+                if (t === 'ok') {
+                    return f1(r)
+                }
+            }
+            throw 'unreachable: args did not match any parameter set'
+        }
+
+        const f0 = (args: Ts<Param0>): number => Number(args.b) + args.a.length
+        const f1 = (args: Ts<Param1>): number => 13
     }
 }


### PR DESCRIPTION
Adds a `funcObj` proof to [`fjs/types/rtti/validate/proof.f.ts`](fjs/types/rtti/validate/proof.f.ts), the object-shaped counterpart to the existing `funcParam` proof from #1431.

Where `funcParam` dispatches on a positional argument tuple, `funcObj` describes each overload as a record (`{ a: 'hello', b: bigint }` and `{ a: 'goodbye', b: string, c: 43 }`), combines them with `or`, and wraps two implementations behind a single function taking the union. At runtime each validator is tried in turn and the first `ok` result selects the implementation, so the static type and the dispatch both come from the same RTTI description.

Test plan: `npx tsc` is clean and the proof runner passes (2317 pass, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
