### PR TITLE
Fix parser call-stack overflow on sibling containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ history.
 
 ## Unreleased
 
+- `fjs/media/json`: `parse` no longer overflows the call stack on documents
+  with ~5000 or more sibling containers; the parser stack is popped eagerly
+  instead of through a lazy `drop(1)` chain
+  [#1435](https://github.com/functionalscript/functionalscript/pull/1435)
 - `nanvm-lib`: add native-JS multiplication proofs matching the Rust coercion
   cases [#1429](https://github.com/functionalscript/functionalscript/pull/1429)
 - **BREAKING CHANGES:** `fjs/media` `detect` takes the dialects to recognize —

--- a/fjs/media/json/parser/module.f.ts
+++ b/fjs/media/json/parser/module.f.ts
@@ -4,7 +4,7 @@
  * @module
  */
 import { error, ok, type Result } from '../../../types/result/module.f.ts'
-import { type List, fold, first, drop, toArray, concat } from '../../../types/list/module.f.ts'
+import { type List, fold, next, toArray, concat } from '../../../types/list/module.f.ts'
 import { type Fold } from '../../../types/function/operator/module.f.ts'
 import { type JsonToken } from '../tokenizer/module.f.ts'
 import { setReplace, type OrderedMap } from '../../../types/ordered_map/module.f.ts'
@@ -84,13 +84,24 @@ const startArray
         return { status: '[', top: { kind: 'array', values: null }, stack: newStack }
     }
 
+// Pops the enclosing container off `stack`. `next` is forced here rather than
+// left as a `drop(1)` thunk: the stack is written only by startArray/startObject,
+// always as a literal cons, and a lazy pop would leave one unforced thunk per
+// closed container — a chain that overflows the stack when it is finally forced.
+const popStack
+    : (stack: JsonStack) => StateParse
+    = stack => {
+        const ne = next(stack)
+        return ne === null
+            ? { status: '', top: null, stack: null }
+            : { status: '', top: ne.first, stack: ne.tail }
+    }
+
 const endArray
     : (state: StateParse) => JsonState
     = state => {
         const array = state.top !== null ? toArray(state.top.values) : null
-        const newState
-            : StateParse
-            = { status: '', top: first(null)(state.stack), stack: drop(1)(state.stack) }
+        const newState = popStack(state.stack)
         return pushValue(newState)(array)
     }
 
@@ -105,9 +116,7 @@ const endObject
     : (state: StateParse) => JsonState
     = state => {
         const obj = state.top?.kind === 'object' ? fromMap(state.top.values) : null
-        const newState
-            : StateParse
-            = { status: '', top: first(null)(state.stack), stack: drop(1)(state.stack) }
+        const newState = popStack(state.stack)
         return pushValue(newState)(obj)
     }
 

--- a/fjs/media/json/parser/proof.f.ts
+++ b/fjs/media/json/parser/proof.f.ts
@@ -271,5 +271,39 @@ export const proof = {
             const result = stringify(obj)
             assertEq(result, '["error","unexpected token"]')
         },
-    ]
+    ],
+    // Regression: closing a container used to pop the parser stack lazily
+    // (`drop(1)`), leaving one unforced thunk per closed container. The chain
+    // was only forced at the end, overflowing the call stack at roughly 5000
+    // sibling containers while the same count of primitives was fine. See
+    // `fjs/media/json/todo/parser-sibling-container-overflow.md`.
+    siblingContainers: [
+        () => {
+            const [tag, value] = parse(tokenizeString(`[${Array(6000).fill('{}').join(',')}]`))
+            assertEq(tag, 'ok')
+            assertEq(Array.isArray(value) ? value.length : -1, 6000)
+        },
+        () => {
+            const [tag, value] = parse(tokenizeString(`[${Array(6000).fill('[]').join(',')}]`))
+            assertEq(tag, 'ok')
+            assertEq(Array.isArray(value) ? value.length : -1, 6000)
+        },
+        () => {
+            const keys = Array.from({ length: 6000 }, (_, i) => `"k${i}":{}`)
+            const [tag, value] = parse(tokenizeString(`{${keys.join(',')}}`))
+            assertEq(tag, 'ok')
+            assertEq(typeof value === 'object' && value !== null ? Object.keys(value).length : -1, 6000)
+        },
+        () => {
+            // deep nesting shares the same stack path and overflowed at 5000
+            const [tag] = parse(tokenizeString('['.repeat(5000) + ']'.repeat(5000)))
+            assertEq(tag, 'ok')
+        },
+        () => {
+            // baseline that always worked: primitives never touch the stack
+            const [tag, value] = parse(tokenizeString(`[${Array.from({ length: 12000 }, (_, i) => i).join(',')}]`))
+            assertEq(tag, 'ok')
+            assertEq(Array.isArray(value) ? value.length : -1, 12000)
+        },
+    ],
 }


### PR DESCRIPTION
Fixes the `RangeError: Maximum call stack size exceeded` that `fjs/media/json`'s `parse` throws on well-formed JSON with roughly 5000 or more sibling containers. Found by @sergey-shandar while migrating `fjs/djs/tokenizer/proof.f.ts` off `JSON.parse` in #1433, and written up there in `fjs/media/json/todo/parser-sibling-container-overflow.md`.

## Root cause

`endArray`/`endObject` popped the enclosing container with `first(null)(state.stack)` / `drop(1)(state.stack)`. `drop` is `apply(dropStep(n))`, which returns a **`Thunk`** — so each closed container replaced the stack with an unforced thunk wrapping the previous one. After N containers the stack was a `drop(1)(drop(1)(…))` chain N deep, logically still shallow but structurally nested, and forcing it recursed `apply` → `next` → `trampoline` once per link.

That explains the shape of the bug: the threshold tracked *container* count, not value count. Primitives never push or pop the stack, so 12000 of them were always fine, while ~5000 sibling `{}` or `[]` blew up. It also explains why deep nesting failed at the same size — same code path.

The parser stack is written only by `startArray`/`startObject`, and always as a literal cons (`{ first, tail }`). Popping it therefore needs no list combinator at all: force a single `next` and take `first`/`tail` directly. O(1), nothing accumulates.

## Correction to the todo's analysis

`parser-sibling-container-overflow.md` says "**Not a depth limit.** 5000 levels of nesting parse fine." That holds on Node 22 (as the file states) but not on Node v23.11.0, where I measure nesting depth 4000 `ok` / 5000 `RangeError` — the same band as sibling containers, because it is the same lazy-pop chain. The distinction that actually matters is containers vs. primitives, which this PR preserves as a test.

## Verification

| | before | after |
| --- | --- | --- |
| 6000 sibling `{}` / `[]` | `RangeError` | `ok` |
| 6000 one-field objects | `RangeError` | `ok` |
| 6000 objects in an object | `RangeError` | `ok` |
| nesting depth 5000 | `RangeError` | `ok` |
| 100000 sibling containers | `RangeError` | `ok` |
| nesting depth 20000 | `RangeError` | `ok` |
| 12000 primitives (baseline) | `ok` | `ok` |

Round-trip correctness spot-checked: `[{},{}]` and `{"a":[1,{"b":2}],"c":null}` both parse to the same value they did before.

`npx tsc --noEmit` clean. Full suite **2316 pass / 0 fail**. The five new `siblingContainers` proofs are a genuine regression test — reverting the parser change while keeping them gives **4 fail** (all `RangeError`), with the 12000-primitive baseline still passing.

## Notes

- This makes the `Tasks` list in `parser-sibling-container-overflow.md` (landing in #1433) largely done; that file should be updated or deleted when both land. I left it untouched here to avoid conflicting with #1433.
- Worth checking whether `fjs/djs`'s parser shares the lazy-pop shape — the todo raises this and I have not looked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9JGBQacxZPLJGmuHUaEzV