### PR TITLE
Serialize JSON strings in FunctionalScript, not `JSON.stringify`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ history.
 
 ## Unreleased
 
+- `fjs/media/json`: `stringSerialize` escapes in FunctionalScript instead of
+  calling the host's `JSON.stringify`, matching it exactly down to `\uXXXX` for
+  unpaired surrogates; `fjs/text/utf16` gains `codePointToString`
+  [#1438](https://github.com/functionalscript/functionalscript/pull/1438)
 - `fjs/djs`: the parser no longer spends a call-stack frame per container —
   the same lazy `drop(1)` pop that #1435 fixed in `fjs/media/json`
   [#1436](https://github.com/functionalscript/functionalscript/pull/1436)

--- a/fjs/media/json/serializer/module.f.ts
+++ b/fjs/media/json/serializer/module.f.ts
@@ -1,19 +1,79 @@
 /**
  * JSON serializer for deterministic string output.
  *
+ * `stringSerialize` is FunctionalScript, not the host's `JSON.stringify`: it
+ * escapes over this repository's own UTF-16 decoder and reproduces the
+ * ECMAScript `QuoteJSONString` result exactly, lone surrogates included.
+ *
  * @module
  */
-import { flat, reduce, empty, type List } from '../../../types/list/module.f.ts'
+import { flat, map, reduce, empty, type List } from '../../../types/list/module.f.ts'
 import { type Reduce } from '../../../types/function/operator/module.f.ts'
+import { concat } from '../../../types/string/module.f.ts'
+import {
+    codePointToString,
+    stringToCodePointList,
+    type CodePoint,
+} from '../../../text/utf16/module.f.ts'
+import { errorMask } from '../../../text/code_point/module.f.ts'
+import {
+    backspace,
+    cr,
+    digit0,
+    ff,
+    ht,
+    latinSmallLetterA,
+    lf,
+    quotationMark,
+    reverseSolidus,
+    space,
+} from '../../../text/ascii/module.f.ts'
 
 const jsonStringify = JSON.stringify
+
+const { fromCharCode } = String
+
+/**
+ * The code points JSON gives a two-character escape. Every other code point
+ * below `space` has no short form and goes through `unicodeEscape` instead.
+ */
+const escapeTable = {
+    [backspace]: '\\b',
+    [ht]: '\\t',
+    [lf]: '\\n',
+    [ff]: '\\f',
+    [cr]: '\\r',
+    [quotationMark]: '\\"',
+    [reverseSolidus]: '\\\\',
+} as const
+
+const hexDigit = (value: number): string =>
+    fromCharCode(value < 10 ? digit0 + value : latinSmallLetterA + value - 10)
+
+/**
+ * `\uXXXX` with lowercase hex digits, matching ECMAScript's `UnicodeEscape`.
+ */
+const unicodeEscape = (unit: number): string =>
+    `\\u${hexDigit(unit >> 12 & 0xf)}${hexDigit(unit >> 8 & 0xf)}${hexDigit(unit >> 4 & 0xf)}${hexDigit(unit & 0xf)}`
+
+/**
+ * Escapes one decoded code point. A code point tagged with `errorMask` is an
+ * unpaired surrogate, which well-formed JSON stringification (ES2019) emits as
+ * its `\uXXXX` escape rather than as a code unit; everything else is either a
+ * named escape, a `\u00XX` control escape, or the character itself.
+ */
+const escapeCodePoint = (codePoint: CodePoint): string =>
+    (codePoint & errorMask) !== 0
+        ? unicodeEscape(codePoint & 0xffff)
+        : escapeTable[codePoint]
+            ?? (codePoint < space ? unicodeEscape(codePoint) : codePointToString(codePoint))
 
 /**
  * Serializes a string as a JSON string literal.
  */
 export const stringSerialize
     : (_: string) => List<string>
-    = input => [jsonStringify(input)]
+    = input => [`"${concat(map(escapeCodePoint)(stringToCodePointList(input)))}"`]
 
 /**
  * Serializes a number as a JSON number literal.

--- a/fjs/media/json/serializer/proof.f.ts
+++ b/fjs/media/json/serializer/proof.f.ts
@@ -1,8 +1,14 @@
 import { arrayWrap, boolSerialize, numberSerialize, objectWrap, stringSerialize } from './module.f.ts'
 import * as list from '../../../types/list/module.f.ts'
+import { concat } from '../../../types/string/module.f.ts'
 import { assertEq } from '../../../asserts/module.f.ts'
 
 const { toArray } = list
+
+// The expected literals below are what the host's `JSON.stringify` produces for
+// the same input; `stringSerialize` has to reproduce them exactly, so any
+// divergence in the FunctionalScript escaping shows up here as a failure.
+const serialized = (input: string): string => concat(stringSerialize(input))
 
 export const proof = {
     arrayWrap: [
@@ -34,14 +40,33 @@ export const proof = {
         }
     ],
     stringSerialize: [
-        () => {
-            const result = JSON.stringify(toArray(stringSerialize('abc')))
-            assertEq(result, '["\\"abc\\""]')
-        },
-        () => {
-            const result = JSON.stringify(toArray(stringSerialize('123')))
-            assertEq(result, '["\\"123\\""]')
-        }
+        () => { assertEq(serialized('abc'), '"abc"') },
+        () => { assertEq(serialized('123'), '"123"') },
+        () => { assertEq(serialized(''), '""') },
+        // one chunk, like every other leaf serializer in this module
+        () => { assertEq(toArray(stringSerialize('a"')).length, 1) },
+        // the two escapes JSON requires outside the control block
+        () => { assertEq(serialized('a"b'), '"a\\"b"') },
+        () => { assertEq(serialized('a\\b'), '"a\\\\b"') },
+        // every named control escape
+        () => { assertEq(serialized('\b\f\n\r\t'), '"\\b\\f\\n\\r\\t"') },
+        // control code points without a named escape, covering both hex-digit
+        // halves: '0'-'9' and 'a'-'f'
+        () => { assertEq(serialized('\u0000'), '"\\u0000"') },
+        () => { assertEq(serialized('\u000b'), '"\\u000b"') },
+        () => { assertEq(serialized('\u001f'), '"\\u001f"') },
+        // `space` is the first code point copied through unescaped, and DEL is
+        // not a JSON escape at all
+        () => { assertEq(serialized(' \u007f'), '" \u007f"') },
+        // a surrogate pair decodes to one code point and survives unchanged
+        () => { assertEq(serialized('😀'), '"😀"') },
+        // unpaired surrogates, well-formed-stringify escaped: leading, trailing,
+        // in the middle, doubled, and left over at end of input
+        () => { assertEq(serialized('\ud800'), '"\\ud800"') },
+        () => { assertEq(serialized('\udfff'), '"\\udfff"') },
+        () => { assertEq(serialized('a\udc00b'), '"a\\udc00b"') },
+        () => { assertEq(serialized('\ud800\ud800'), '"\\ud800\\ud800"') },
+        () => { assertEq(serialized('a\ud83d'), '"a\\ud83d"') },
     ],
     numberSerialize: [
         () => {

--- a/fjs/media/json/todo/remove-native-json.md
+++ b/fjs/media/json/todo/remove-native-json.md
@@ -8,14 +8,16 @@
 `fjs/media/json` owns a complete JSON pipeline written in FunctionalScript —
 `tokenize` → `parse` for reading, `serialize` / `stringify` for writing. The
 reading half is done: `parseNative` is gone and every call site goes through
-the total, `Result`-returning `parse`. The writing half is still the host's:
+the total, `Result`-returning `parse`. The writing half is still mostly the
+host's:
 
-- **117 call sites call `JSON.stringify` directly** — and one of them is
-  `fjs/media/json/serializer/module.f.ts:9`, so the FunctionalScript serializer
-  itself bottoms out in the host. `stringSerialize` and `numberSerialize` are
-  `JSON.stringify` with a different name, and `fjs/djs/serializer/module.f.ts:15`
-  imports both, so *every* value this repository serializes — JSON and DJS
-  alike — is ultimately formatted by the host.
+- **115 call sites call `JSON.stringify` directly** — and one of them is
+  `fjs/media/json/serializer/module.f.ts`, so the FunctionalScript serializer
+  itself still bottoms out in the host. `numberSerialize` is `JSON.stringify`
+  with a different name, and `fjs/djs/serializer/module.f.ts:15` imports it, so
+  *every number* this repository serializes — JSON and DJS alike — is still
+  formatted by the host. `stringSerialize` no longer is: phase 1 below has
+  shipped.
 
 Three reasons to finish the job:
 
@@ -32,12 +34,12 @@ Three reasons to finish the job:
    `serialize`'s two leaves are the only thing between this module and being
    self-hosted end to end.
 
-#### `JSON.stringify` — 117 sites in six shapes
+#### `JSON.stringify` — 115 sites in six shapes
 
 | Shape | Sites | Where | Replacement |
 | --- | --- | --- | --- |
-| **Leaf serializers** | 1 | `fjs/media/json/serializer/module.f.ts:9` | FunctionalScript escaping + number formatting — blocks everything below |
-| Expected-output comparison | 75 | `fjs/bnf/ll1/proof.f.ts` (27), `fjs/bnf/descent/proof.f.ts` (22), `fjs/media/json/serializer/proof.f.ts` (12), `fjs/djs/tokenizer/proof.f.ts:795-829` (8), `fjs/bnf/data/proof.f.ts` (4), `fjs/media/revision/proof.f.ts:138`, `fjs/cas/evo/proof.f.ts:57` | `stringify(identity)` |
+| **Leaf serializer** | 1 | `fjs/media/json/serializer/module.f.ts` | FunctionalScript number formatting — blocks everything below |
+| Expected-output comparison | 73 | `fjs/bnf/ll1/proof.f.ts` (27), `fjs/bnf/descent/proof.f.ts` (22), `fjs/media/json/serializer/proof.f.ts` (10), `fjs/djs/tokenizer/proof.f.ts:795-829` (8), `fjs/bnf/data/proof.f.ts` (4), `fjs/media/revision/proof.f.ts:138`, `fjs/cas/evo/proof.f.ts:57` | `stringify(identity)` |
 | Assertion messages | 33 | `fjs/djs/tokenizer/proof.f.ts` (31), `fjs/types/rtti/ts/proof.f.ts:8,12` (2) | pass the value, or `fjs/djs`'s `stringify` |
 | Source-text quoting | 5 | `fjs/emergent_testing/module.f.ts:305,322,335`, `fjs/types/ts/module.f.ts:36,48` | `stringSerialize` — already designed in `66c-emit-literals-via-owner-modules.md` |
 | JSON line framing | 2 | `fjs/emergent_testing/proof.f.ts:42`, `fjs/mcp/proof.f.ts:128` | `stringify(identity)` |
@@ -65,13 +67,25 @@ Three semantic differences to respect while migrating, none of them blocking:
 Four phases. They are separable and each is a complete change on its own, so
 they should ship as separate PRs (§8.1); phases 1 and 2 gate the migration.
 
-**1. `stringSerialize` in FunctionalScript.** Escape `"`, `\`, the short forms
-`\b \f \n \r \t`, and every other code point below `0x20` as `\u00XX`, over
-`fjs/text/utf16`. It must match the host exactly, including well-formed
-`JSON.stringify` (ES2019) escaping of lone surrogates as `\uD800` — the
-migrated proofs compare against literals the host produced, so any divergence
-surfaces as a test failure rather than silently. This is ordinary
-FunctionalScript work and unblocks the source-text-quoting sites too.
+**1. `stringSerialize` in FunctionalScript — done.** Escapes `"`, `\`, the short
+forms `\b \f \n \r \t`, and every other code point below `0x20` as `\u00XX`,
+over `fjs/text/utf16`; lone surrogates come out as `\ud800` the way well-formed
+`JSON.stringify` (ES2019) emits them, because `stringToCodePointList` already
+tags them with `errorMask`. Verified against the host over every code unit and
+every surrogate pair, and the proof pins the host's literals so a divergence
+fails a test.
+
+Two things that fell out of it, worth knowing before phase 2:
+
+- `fjs/text/utf16` gained `codePointToString`, the scalar counterpart of
+  `codePointListToString`. Wrapping one code point in a list to call the list
+  version cost about half of the escape loop's time.
+- A FunctionalScript leaf is roughly 5× the host's on a serialize-heavy
+  benchmark (a 20k-key object: ~130 ms → ~700 ms end to end), which is what
+  replacing a C++ builtin with an interpreted decode pipeline costs. That is
+  the price of self-hosting, not a defect; if it ever becomes a real problem the
+  generic fix is a faster `text/utf16` scan, not a special case in the
+  serializer.
 
 **2. `numberSerialize` in FunctionalScript — its own issue.** This is the one
 genuinely hard piece: `JSON.stringify(x)` on a finite number is ECMAScript
@@ -112,7 +126,7 @@ Consider a guard so it does not come back — the cheapest is a proof in
 
 ### Tasks
 
-- [ ] Phase 1: FunctionalScript `stringSerialize`, with proof coverage for
+- [x] Phase 1: FunctionalScript `stringSerialize`, with proof coverage for
       every escape class including lone surrogates.
 - [ ] Phase 2: file the shortest-round-trip number-formatting issue under
       `fjs/types/bigfloat/todo/`, then implement `numberSerialize` on it.
@@ -123,7 +137,9 @@ Consider a guard so it does not come back — the cheapest is a proof in
 ### Related
 
 - [`fjs/media/json/serializer/module.f.ts`](../serializer/module.f.ts) — the
-  leaf `JSON.stringify` phases 1 and 2 replace.
+  leaf `JSON.stringify` phases 1 and 2 replace; only `numberSerialize` is left.
+- [`fjs/text/utf16/module.f.ts`](../../../text/utf16/module.f.ts) — where the
+  escaping reads code points, and where phase 1 added `codePointToString`.
 - [`fjs/fsc/todo/66c-emit-literals-via-owner-modules.md`](../../../fsc/todo/66c-emit-literals-via-owner-modules.md)
   — already owns the source-text-quoting sites (`fjs/types/ts`,
   `fjs/emergent_testing`); phase 3 defers to it rather than re-deciding.

--- a/fjs/media/json/todo/remove-native-json.md
+++ b/fjs/media/json/todo/remove-native-json.md
@@ -67,7 +67,9 @@ Three semantic differences to respect while migrating, none of them blocking:
 Four phases. They are separable and each is a complete change on its own, so
 they should ship as separate PRs (§8.1); phases 1 and 2 gate the migration.
 
-**1. `stringSerialize` in FunctionalScript — done.** Escapes `"`, `\`, the short
+**1. `stringSerialize` in FunctionalScript — done in
+[#1438](https://github.com/functionalscript/functionalscript/pull/1438).**
+Escapes `"`, `\`, the short
 forms `\b \f \n \r \t`, and every other code point below `0x20` as `\u00XX`,
 over `fjs/text/utf16`; lone surrogates come out as `\ud800` the way well-formed
 `JSON.stringify` (ES2019) emits them, because `stringToCodePointList` already

--- a/fjs/text/utf16/module.f.ts
+++ b/fjs/text/utf16/module.f.ts
@@ -84,7 +84,7 @@ export type CodePoint = number
  * })
  * ```
  */
-const codePointToUtf16 = (codePoint: CodePoint): List<U16> => {
+const codePointToUtf16 = (codePoint: CodePoint): readonly U16[] => {
     if (isBmpCodePoint(codePoint)) { return [codePoint] }
     if (isSupplementaryPlane(codePoint)) {
         const n = codePoint - 0x1_0000
@@ -334,3 +334,21 @@ export const listToString: (input: List<U16>) => string
  */
 export const codePointListToString = (input: List<CodePoint>): string =>
     listToString(fromCodePointList(input))
+
+/**
+ * Converts a single Unicode code point to a string — the scalar counterpart of
+ * {@link codePointListToString}, for callers that hold one code point rather
+ * than a list of them and would otherwise wrap it in a single-element list.
+ *
+ * @param codePoint - A Unicode code point (`CodePoint`).
+ * @returns The one- or two-code-unit string encoding it.
+ *
+ * @example
+ *
+ * ```ts
+ * codePointToString(0x48)     // 'H'
+ * codePointToString(0x1F600)  // the 😀 surrogate pair
+ * ```
+ */
+export const codePointToString = (codePoint: CodePoint): string =>
+    String.fromCharCode(...codePointToUtf16(codePoint))

--- a/fjs/text/utf16/module.f.ts
+++ b/fjs/text/utf16/module.f.ts
@@ -340,14 +340,22 @@ export const codePointListToString = (input: List<CodePoint>): string =>
  * {@link codePointListToString}, for callers that hold one code point rather
  * than a list of them and would otherwise wrap it in a single-element list.
  *
+ * Input outside the assignable range — a surrogate, a value above
+ * `0x10FFFF`, or a negative one — is truncated to its low 16 bits and encoded
+ * as that code unit, rather than rejected. This matches
+ * {@link codePointListToString}, which reports malformed input through the
+ * decoder's `errorMask` on the way *in* rather than through a failure on the
+ * way out.
+ *
  * @param codePoint - A Unicode code point (`CodePoint`).
  * @returns The one- or two-code-unit string encoding it.
  *
  * @example
  *
  * ```ts
- * codePointToString(0x48)     // 'H'
- * codePointToString(0x1F600)  // the 😀 surrogate pair
+ * codePointToString(0x48)      // 'H'
+ * codePointToString(0x1F600)   // the 😀 surrogate pair
+ * codePointToString(0x110000)  // '\u0000' — out of range, low 16 bits kept
  * ```
  */
 export const codePointToString = (codePoint: CodePoint): string =>

--- a/fjs/text/utf16/proof.f.ts
+++ b/fjs/text/utf16/proof.f.ts
@@ -4,7 +4,8 @@ import {
     stringToList,
     listToString,
     stringToCodePointList,
-    codePointListToString
+    codePointListToString,
+    codePointToString
 } from './module.f.ts'
 import { stringify as jsonStringify, type Unknown } from '../../media/json/module.f.ts'
 import { sort } from '../../types/object/module.f.ts'
@@ -141,5 +142,14 @@ export const proof = {
             const codePoints = [0x48, 0x65, 0x6C, 0x6C, 0x6F]
             const outputString = codePointListToString(codePoints)
         }
+    ],
+    codePointToString: [
+        () => { assertEq(codePointToString(0x48), 'H') },
+        // supplementary plane: one code point, two code units
+        () => { assertEq(codePointToString(0x1f600), '😀') },
+        // a surrogate is not a code point; it round-trips as its own code unit
+        () => { assertEq(codePointToString(0xd800), '\ud800') },
+        // above the maximum code point, the low 16 bits are kept
+        () => { assertEq(codePointToString(0x110000), '\u0000') },
     ]
 }


### PR DESCRIPTION
Phase 1 of [`fjs/media/json/todo/remove-native-json.md`](https://github.com/functionalscript/functionalscript/blob/main/fjs/media/json/todo/remove-native-json.md).

The reading half of `fjs/media/json` stopped depending on the host when `parseNative` went away (#1433). The writing half still bottomed out in `JSON.stringify`: `stringSerialize` and `numberSerialize` were the host under a different name, and `fjs/djs/serializer` imports both — so every string this repository serialized, JSON and DJS alike, was formatted by the host.

This PR replaces the string leaf. `numberSerialize` stays as it is; shortest-round-trip number formatting is phase 2 and belongs next to the numeric code, per the issue.

## What it does

`stringSerialize` decodes its input with `stringToCodePointList` and escapes each code point:

- the named escapes `\b \t \n \f \r \" \\`, as a table keyed by the `fjs/text/ascii` constants;
- every other code point below `space` as `\u00XX`, lowercase hex, matching ECMAScript's `UnicodeEscape`;
- unpaired surrogates as `\ud800` — this is well-formed `JSON.stringify` (ES2019) behavior, and it falls out for free because `stringToCodePointList` already tags lone surrogates with `errorMask`;
- everything else through unchanged.

The output is still a single chunk, like `numberSerialize`, `nullSerialize`, and `boolSerialize`, so no consumer sees a shape change.

## Correctness

The contract is "identical to the host", so it was checked that way before the proof was written: every single code unit `0x0000`–`0xFFFF`, every surrogate × surrogate pair, surrogates adjacent to BMP characters, and 50k random strings — all byte-identical to `JSON.stringify`. The proof itself pins the host's literals (rather than calling the host at test time) so a future divergence fails a test instead of being papered over.

## `codePointToString`

`fjs/text/utf16` gains `codePointToString`, the scalar counterpart of `codePointListToString`. The escape loop holds one code point at a time, and wrapping it in a single-element list to reach the list version cost about half of the loop's total time. It is a primitive the module was missing, not a fast path in the serializer.

## Cost

Replacing a C++ builtin with an interpreted decode pipeline is not free. On a 20k-key object (~1.3 MB of JSON) end-to-end `stringify` goes from ~130 ms to ~700 ms; the full FunctionalScript suite goes from ~67–69 s to ~72 s. The naive version — per-code-point chunks and `codePointListToString` per character — was ~1520 ms on the same benchmark, so this is already 2× better than the first working shape. If the remaining gap ever matters, the generic fix is a faster scan in `text/utf16`, not a special case here; the issue file records the measurement.

## Checks

- `npx tsc` — clean
- `node ./fjs/module.ts t` — 2340 pass, 0 fail
- `npm run cov` — `fjs/media/json/serializer/module.f.ts` at 100% line / branch / function
- `bun fjs/module.ts t` — 2338 pass, 2 fail; both failures (`fjs/fsc/proof.f.ts` `f1`/`f2`) reproduce unchanged on `main`

Rust untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199JaXVTAGvky4bhP6c1eJZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0199JaXVTAGvky4bhP6c1eJZ)_