### PR TITLE
Add test for loadModuleMap default behavior when INIT_CWD is unset

### DIFF
--- a/fjs/dev/module.f.ts
+++ b/fjs/dev/module.f.ts
@@ -165,4 +165,12 @@ export const proof = {
         const [, result] = virtual({ ...emptyState, root })(allFiles('.', shouldLoad))
         assertEq(result.join(','), './a.f.ts')
     },
+    loadModuleMapDefaultsToCwdWhenInitCwdUnset: () => {
+        // With no `INIT_CWD` (e.g. `fjs t` invoked outside `npm run`), `env`
+        // lookup returns `undefined` and discovery falls back to `.`, so
+        // every path keeps its own `./`-prefix instead of having one stripped.
+        const root: Dir = { 'a.f.ts': () => ({}) }
+        const [, result] = virtual({ ...emptyState, root })(loadModuleMap({}))
+        assertEq(Object.keys(result).join(','), './a.f.ts')
+    },
 }


### PR DESCRIPTION
## Summary
Added a new test case to verify that `loadModuleMap` correctly defaults to the current working directory (`.`) when the `INIT_CWD` environment variable is not set.

## Changes
- Added `loadModuleMapDefaultsToCwdWhenInitCwdUnset` test case to the proof object
- Test verifies that when `INIT_CWD` is undefined (e.g., when `fjs t` is invoked outside of `npm run`), module discovery falls back to the current directory
- Confirms that module paths retain their `./` prefix in this scenario, as no path stripping occurs

## Implementation Details
The test creates a minimal virtual file system with a single module file (`a.f.ts`) and invokes `loadModuleMap({})` with an empty configuration object. It asserts that the resulting module key is `./a.f.ts`, demonstrating the expected fallback behavior when `INIT_CWD` is not available.

https://claude.ai/code/session_01XvcRNQqqPpig3KmT8853wQ