### PR TITLE
Upgrade Node.js to 26.6.0 and update nixpkgs commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "26.5.1"
+            "node-version": "26.6.0"
           }
         },
         {
@@ -77,7 +77,7 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "26.5.1"
+            "node-version": "26.6.0"
           }
         },
         {
@@ -118,7 +118,7 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "26.5.1"
+            "node-version": "26.6.0"
           }
         },
         {
@@ -159,7 +159,7 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "26.5.1"
+            "node-version": "26.6.0"
           }
         },
         {
@@ -201,7 +201,7 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "26.5.1"
+            "node-version": "26.6.0"
           }
         },
         {
@@ -254,7 +254,7 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "26.5.1"
+            "node-version": "26.6.0"
           }
         },
         {
@@ -483,7 +483,7 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "26.5.1"
+            "node-version": "26.6.0"
           }
         },
         {
@@ -525,7 +525,7 @@
           "run": "test \"$(nix develop ./nix/generated/node24 --command node --version)\" = v24.18.0"
         },
         {
-          "run": "test \"$(nix develop ./nix/generated/node26 --command node --version)\" = v26.5.1"
+          "run": "test \"$(nix develop ./nix/generated/node26 --command node --version)\" = v26.6.0"
         }
       ]
     }

--- a/fjs/ci/config/module.f.ts
+++ b/fjs/ci/config/module.f.ts
@@ -40,7 +40,7 @@ export const deno = '2.9.4'
 // it offers rather than the latest release.
 // https://nodejs.org/en/download
 export const node = {
-    default: '26.5.1',
+    default: '26.6.0',
     node22: '22.23.2',
     node24: '24.18.0',
 } as const
@@ -52,7 +52,7 @@ export const node = {
 // https://channels.nixos.org/nixos-26.05/git-revision
 export const nixpkgs = {
     ref: 'nixos-26.05',
-    commit: '531670d871c0e29724a02f3cbcac170adc65b58c',
+    commit: '04607e1165ac22c5fde6dcc54c9e0b3c0487c555',
 } as const
 
 // https://github.com/bytecodealliance/wasmtime/releases

--- a/nix/generated/node22/flake.nix
+++ b/nix/generated/node22/flake.nix
@@ -1,5 +1,5 @@
 {
-    inputs.nixpkgs.url = "github:NixOS/nixpkgs/531670d871c0e29724a02f3cbcac170adc65b58c";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/04607e1165ac22c5fde6dcc54c9e0b3c0487c555";
     outputs = { nixpkgs, ... }: {
         devShells.aarch64-linux.default = let
             pkgs = import nixpkgs {

--- a/nix/generated/node24/flake.nix
+++ b/nix/generated/node24/flake.nix
@@ -1,5 +1,5 @@
 {
-    inputs.nixpkgs.url = "github:NixOS/nixpkgs/531670d871c0e29724a02f3cbcac170adc65b58c";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/04607e1165ac22c5fde6dcc54c9e0b3c0487c555";
     outputs = { nixpkgs, ... }: {
         devShells.aarch64-linux.default = let
             pkgs = import nixpkgs {

--- a/nix/generated/node26/flake.nix
+++ b/nix/generated/node26/flake.nix
@@ -1,5 +1,5 @@
 {
-    inputs.nixpkgs.url = "github:NixOS/nixpkgs/531670d871c0e29724a02f3cbcac170adc65b58c";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/04607e1165ac22c5fde6dcc54c9e0b3c0487c555";
     outputs = { nixpkgs, ... }: {
         devShells.aarch64-linux.default = let
             pkgs = import nixpkgs {


### PR DESCRIPTION
## Summary
This PR updates the default Node.js version from 26.5.1 to 26.6.0 across the project configuration and CI workflows, along with updating the nixpkgs commit reference.

## Key Changes
- Updated default Node.js version from 26.5.1 to 26.6.0 in `fjs/ci/config/module.f.ts`
- Updated Node.js version in all CI workflow job configurations (`.github/workflows/ci.yml`)
- Updated nixpkgs commit reference from `531670d871c0e29724a02f3cbcac170adc65b58c` to `04607e1165ac22c5fde6dcc54c9e0b3c0487c555` in:
  - `fjs/ci/config/module.f.ts`
  - `nix/generated/node22/flake.nix`
  - `nix/generated/node24/flake.nix`
  - `nix/generated/node26/flake.nix`
- Updated Node.js version assertion in CI workflow test from v26.5.1 to v26.6.0

## Implementation Details
The changes maintain consistency across all CI job configurations and Nix flake files, ensuring that all environments use the same Node.js version and nixpkgs commit. The nixpkgs update aligns with the Node.js version upgrade to ensure compatibility.

https://claude.ai/code/session_015qNmRRuZrsaNUEKYdVJ243