### PR TITLE
Make `StringMap` a one-parameter open-key-set record; add `RequiredMap`/`OptionalMap`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -474,31 +474,35 @@ silently stop matching its asserted type and narrow incorrectly with no compile
 error. Keep such predicates next to the type they discriminate, and revisit them
 whenever that type changes.
 
-#### `StringMap` for string-keyed records
+#### `StringMap` / `RequiredMap` / `OptionalMap` for string-keyed records
 
 Use the record types from `fjs/types/object/module.f.ts` for all string-keyed
 record types. The key set picks the type:
 
-- **Open key set:** `StringMap<T>` is `{ readonly[k in string]?: T }` — any key,
-  every value optional, because "the key may be missing" is what an open key set
-  means at runtime.
+- **Open key set:** `StringMap<T>` is `{ readonly[k in string]?: T }` — any
+  key, every value optional, because "the key may be missing" is what an open
+  key set means at runtime.
 - **Finite key set:** `RequiredMap<'a' | 'b', T>` is
-  `{ readonly a: T; readonly b: T }`, and `OptionalMap<'a' | 'b', T>` is the same
-  record with optional values.
+  `{ readonly a: T; readonly b: T }`, and `OptionalMap<'a' | 'b', T>` is that
+  same record with optional values.
 
 `RequiredMap<string, T>` is `never`: no object can carry every string as a
-required key, so an open key set fails to compile there. Reach for `StringMap<T>`
-instead.
+required key, so an open key set fails to compile there. Reach for
+`StringMap<T>` instead.
 
-Do not write inline `{ readonly[k in string]: T }` without `?` — TypeScript types
-every access as `T` but the value can be `undefined` at runtime. **Exception:**
-mutually-recursive types (e.g. `type Obj = { readonly[k in string]?: Obj }`) must
-use the inline form because TypeScript's circular-reference detection cannot
-resolve through conditional types.
+Do not write inline `{ readonly[k in string]: T }` without `?` — TypeScript
+types every access as `T` but the value can be `undefined` at runtime.
+**Exception:** mutually-recursive types (e.g.
+`type Obj = { readonly[k in string]?: Obj }`) must use the inline form. A type
+alias may not reference itself through *another* alias's instantiation, so
+`type Obj = StringMap<Obj>` is TS2456 ("Type alias 'Obj' circularly references
+itself") even though it expands to the inline spelling, which resolves. That is
+a property of aliasing, not of any one definition — writing the record as a
+mapped type rather than a conditional one does not lift it.
 
-When iterating all defined entries of a `StringMap<T>`, use
-`definedEntries` from `fjs/types/object/module.f.ts` instead of `Object.entries`;
-use `definedValues` instead of `Object.values`.
+When iterating all defined entries of a `StringMap<T>`, use `definedEntries`
+from `fjs/types/object/module.f.ts` instead of `Object.entries`; use
+`definedValues` instead of `Object.values`.
 
 #### `flatMap` over a filtering type predicate
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -474,12 +474,19 @@ silently stop matching its asserted type and narrow incorrectly with no compile
 error. Keep such predicates next to the type they discriminate, and revisit them
 whenever that type changes.
 
-#### `StringMap` for string-keyed records
+#### `Map` / `StringMap` for string-keyed records
 
-Use `StringMap<K, T>` from `fjs/types/object/module.f.ts` for all string-keyed
-record types. `StringMap<string, T>` resolves to `{ readonly[k in string]?: T }`
-(infinite key set, optional) and `StringMap<'a' | 'b', T>` resolves to
-`{ readonly a: T; readonly b: T }` (finite key set, required).
+Use the record types from `fjs/types/object/module.f.ts` for all string-keyed
+record types. The key set picks the type:
+
+- **Open key set:** `Map<T>` is `{ readonly[k in string]?: T }` — any key, every
+  value optional, because "the key may be missing" is what an open key set means
+  at runtime.
+- **Finite key set:** `StringMap<'a' | 'b', T>` is
+  `{ readonly a: T; readonly b: T }` — every key required.
+
+`StringMap<string, T>` is `never`, so handing an open key set to the finite type
+fails to compile at every use of the result. Reach for `Map<T>` there instead.
 
 Do not write inline `{ readonly[k in string]: T }` without `?` — TypeScript types
 every access as `T` but the value can be `undefined` at runtime. **Exception:**
@@ -487,7 +494,7 @@ mutually-recursive types (e.g. `type Obj = { readonly[k in string]?: Obj }`) mus
 use the inline form because TypeScript's circular-reference detection cannot
 resolve through conditional types.
 
-When iterating all defined entries of a `StringMap<string, T>`, use
+When iterating all defined entries of a `Map<T>`, use
 `definedEntries` from `fjs/types/object/module.f.ts` instead of `Object.entries`;
 use `definedValues` instead of `Object.values`.
 
@@ -535,7 +542,7 @@ satisfy the rule. The cases in this repository:
   express one added member.
 - **Opening a record type to dynamic keys.** A record type restricts its fields:
   unknown keys are neither writable in a literal nor readable off a value.
-  Intersecting it with `StringMap<string, unknown>` keeps the declared fields
+  Intersecting it with `Map<unknown>` keeps the declared fields
   checked while allowing arbitrary keys:
 
   ```ts
@@ -550,8 +557,8 @@ satisfy the rule. The cases in this repository:
   }
   // const aB = a.b // compilation error
 
-  // `AM` is a `StringMap` but with restricted fields.
-  type AM = StringMap<string, unknown> & A
+  // `AM` is a `Map` but with restricted fields.
+  type AM = Map<unknown> & A
 
   // `am` has access to all fields, with `A`'s restrictions still applied.
   const am: AM = {
@@ -564,8 +571,8 @@ satisfy the rule. The cases in this repository:
 
   Reach for this only when the composite type itself must carry both. To hand a
   record to something that expects a map, widen at the use site instead — `A` is
-  already assignable to `StringMap<string, unknown>`, so
-  `const m: StringMap<string, unknown> = a` needs no intersection (and no `as`).
+  already assignable to `Map<unknown>`, so
+  `const m: Map<unknown> = a` needs no intersection (and no `as`).
 
 The exception is about cost to the reader or to the runtime, not about `&` being
 shorter to type. A composite assembled from record types you define and control —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -504,7 +504,10 @@ record types. The key set picks the type:
 
 `RequiredMap<string, T>` is `never`: no object can carry every string as a
 required key, so an open key set fails to compile there. Reach for
-`StringMap<T>` instead.
+`StringMap<T>` instead. That guard is `string extends K`, which holds exactly
+when `K` is `string` — TypeScript cannot be asked whether a type is finite, so
+give `RequiredMap` a union of string literals and nothing else. A template
+literal like `` `x-${string}` `` is infinite but passes the guard.
 
 Do not write inline `{ readonly[k in string]: T }` without `?` — TypeScript
 types every access as `T` but the value can be `undefined` at runtime.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,7 +193,23 @@ close coverage gaps. `assert`/`assertEq` push that branch into a shared helper
 whose own branches are already fully covered elsewhere, so the call site adds no
 new uncovered branch.
 
-### 3.4 Never use `try`/`catch`; test throwing with the `throw` key
+### 3.4 Assert type-level facts with `Assert<Equal<…>>`
+
+To prove that a type resolves to what you claim, write
+`type _Name = Assert<Equal<Actual, Expected>>` — `Assert` from
+`fjs/asserts/module.f.ts`, `Equal` from `fjs/types/ts/module.f.ts`. A wrong
+claim is then a compile error (TS2344, "Type 'false' does not satisfy the
+constraint 'true'"), and the check costs nothing at runtime.
+
+Do **not** state the claim as `true as _Predicate`, where `_Predicate` is a
+conditional type resolving to `true` or `false`. That proves nothing:
+TypeScript compares an assertion against the *widened* type of its operand, so
+`true as false` — and `true as never` — are both legal, and the assertion
+compiles no matter what the predicate resolved to. Such an entry in a `proof`
+object is doubly inert: the runner only invokes functions, so a boolean leaf is
+never counted as a test either.
+
+### 3.5 Never use `try`/`catch`; test throwing with the `throw` key
 
 Never use `try`/`catch` in `.f.ts` files — FunctionalScript itself has no
 `try`/`catch` and isn't planning to add it soon. To test that a call throws,
@@ -786,7 +802,7 @@ anywhere else as the rule being broken.
 
 - Only import other `.f.ts` files from FunctionalScript modules. Avoid references
   to built-in or external Node modules such as `node:path` in `.f.ts` files.
-- No `try`/`catch` — see [§3.4](#34-never-use-trycatch-test-throwing-with-the-throw-key).
+- No `try`/`catch` — see [§3.5](#35-never-use-trycatch-test-throwing-with-the-throw-key).
 
 ### 6.6 Formatting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -474,19 +474,21 @@ silently stop matching its asserted type and narrow incorrectly with no compile
 error. Keep such predicates next to the type they discriminate, and revisit them
 whenever that type changes.
 
-#### `Map` / `StringMap` for string-keyed records
+#### `StringMap` for string-keyed records
 
 Use the record types from `fjs/types/object/module.f.ts` for all string-keyed
 record types. The key set picks the type:
 
-- **Open key set:** `Map<T>` is `{ readonly[k in string]?: T }` — any key, every
-  value optional, because "the key may be missing" is what an open key set means
-  at runtime.
-- **Finite key set:** `StringMap<'a' | 'b', T>` is
-  `{ readonly a: T; readonly b: T }` — every key required.
+- **Open key set:** `StringMap<T>` is `{ readonly[k in string]?: T }` — any key,
+  every value optional, because "the key may be missing" is what an open key set
+  means at runtime.
+- **Finite key set:** `RequiredMap<'a' | 'b', T>` is
+  `{ readonly a: T; readonly b: T }`, and `OptionalMap<'a' | 'b', T>` is the same
+  record with optional values.
 
-`StringMap<string, T>` is `never`, so handing an open key set to the finite type
-fails to compile at every use of the result. Reach for `Map<T>` there instead.
+`RequiredMap<string, T>` is `never`: no object can carry every string as a
+required key, so an open key set fails to compile there. Reach for `StringMap<T>`
+instead.
 
 Do not write inline `{ readonly[k in string]: T }` without `?` — TypeScript types
 every access as `T` but the value can be `undefined` at runtime. **Exception:**
@@ -494,7 +496,7 @@ mutually-recursive types (e.g. `type Obj = { readonly[k in string]?: Obj }`) mus
 use the inline form because TypeScript's circular-reference detection cannot
 resolve through conditional types.
 
-When iterating all defined entries of a `Map<T>`, use
+When iterating all defined entries of a `StringMap<T>`, use
 `definedEntries` from `fjs/types/object/module.f.ts` instead of `Object.entries`;
 use `definedValues` instead of `Object.values`.
 
@@ -542,7 +544,7 @@ satisfy the rule. The cases in this repository:
   express one added member.
 - **Opening a record type to dynamic keys.** A record type restricts its fields:
   unknown keys are neither writable in a literal nor readable off a value.
-  Intersecting it with `Map<unknown>` keeps the declared fields
+  Intersecting it with `StringMap<unknown>` keeps the declared fields
   checked while allowing arbitrary keys:
 
   ```ts
@@ -557,8 +559,8 @@ satisfy the rule. The cases in this repository:
   }
   // const aB = a.b // compilation error
 
-  // `AM` is a `Map` but with restricted fields.
-  type AM = Map<unknown> & A
+  // `AM` is a `StringMap` but with restricted fields.
+  type AM = StringMap<unknown> & A
 
   // `am` has access to all fields, with `A`'s restrictions still applied.
   const am: AM = {
@@ -571,8 +573,8 @@ satisfy the rule. The cases in this repository:
 
   Reach for this only when the composite type itself must carry both. To hand a
   record to something that expects a map, widen at the use site instead — `A` is
-  already assignable to `Map<unknown>`, so
-  `const m: Map<unknown> = a` needs no intersection (and no `as`).
+  already assignable to `StringMap<unknown>`, so
+  `const m: StringMap<unknown> = a` needs no intersection (and no `as`).
 
 The exception is about cost to the reader or to the runtime, not about `&` being
 shorter to type. A composite assembled from record types you define and control —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,8 @@ history.
 ## Unreleased
 
 - **BREAKING CHANGES:** `fjs/types/object`: `StringMap<T>` takes one type
-  argument and is the open-key-set record; a finite key set is now
-  `RequiredMap<K, T>` or `OptionalMap<K, T>`, and `RequiredMap<string, T>` is
-  `never`. `Map<T>` is removed — it was `StringMap<T>`
+  argument, the open-key-set record; a finite key set is `RequiredMap<K, T>` or
+  `OptionalMap<K, T>`. `Map<T>` is removed — it was `StringMap<T>`
   [#1442](https://github.com/functionalscript/functionalscript/pull/1442)
 
 ## 0.42.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,11 @@ history.
 
 ## Unreleased
 
-- **BREAKING CHANGES:** `fjs/types/object`: `StringMap<T>` takes one parameter
-  and is the open-key-set record (`{ readonly[k in string]?: T }`) — the old
-  `StringMap<string, T>` spelling no longer compiles. A finite key set is
+- **BREAKING CHANGES:** `fjs/types/object`: `StringMap<T>` takes one type
+  argument and is the open-key-set record; a finite key set is now
   `RequiredMap<K, T>` or `OptionalMap<K, T>`, and `RequiredMap<string, T>` is
-  `never`. `Map<T>` is gone; it was `StringMap<T>` under a name that shadowed the
-  global `Map`
+  `never`. `Map<T>` is removed — it was `StringMap<T>`
+  [#1442](https://github.com/functionalscript/functionalscript/pull/1442)
 
 ## 0.42.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ history.
 
 ## Unreleased
 
+- **BREAKING CHANGES:** `fjs/types/object`: `StringMap<K, T>` accepts only a
+  finite union of string literals — `StringMap<string, T>` is now `never`, so an
+  open key set no longer compiles. Use `Map<T>`, which is again a type of its
+  own (`{ readonly[k in string]?: T }`); all 24 sites in this repository moved
+
 ## 0.42.0
 
 - `fjs/media/json`: `stringSerialize` escapes in FunctionalScript instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,12 @@ history.
 
 ## Unreleased
 
-- **BREAKING CHANGES:** `fjs/types/object`: `StringMap<K, T>` accepts only a
-  finite union of string literals — `StringMap<string, T>` is now `never`, so an
-  open key set no longer compiles. Use `Map<T>`, which is again a type of its
-  own (`{ readonly[k in string]?: T }`); all 24 sites in this repository moved
+- **BREAKING CHANGES:** `fjs/types/object`: `StringMap<T>` takes one parameter
+  and is the open-key-set record (`{ readonly[k in string]?: T }`) — the old
+  `StringMap<string, T>` spelling no longer compiles. A finite key set is
+  `RequiredMap<K, T>` or `OptionalMap<K, T>`, and `RequiredMap<string, T>` is
+  `never`. `Map<T>` is gone; it was `StringMap<T>` under a name that shadowed the
+  global `Map`
 
 ## 0.42.0
 

--- a/fjs/bnf/data/module.f.ts
+++ b/fjs/bnf/data/module.f.ts
@@ -18,7 +18,7 @@ import {
     type Rule as FRule,
     type Sequence as FSequence,
 } from '../module.f.ts'
-import { definedEntries, type Map } from '../../types/object/module.f.ts'
+import { definedEntries, type StringMap } from '../../types/object/module.f.ts'
 
 /**
  * Encoded terminal range value used by BNF data rules.
@@ -33,7 +33,7 @@ export type TerminalRange = number
 export type Sequence = readonly string[]
 
 /** A variant of rule names. */
-export type Variant = Map<string>
+export type Variant = StringMap<string>
 
 /**
  * Grammar rule definition.
@@ -55,7 +55,7 @@ export type RuleSet = Readonly<Record<string, Rule>>
  */
 export type EmptyTag = string | true | undefined
 
-type EmptyTagMap = Map<EmptyTag>
+type EmptyTagMap = StringMap<EmptyTag>
 
 const emptyTagOf = (map: EmptyTagMap) => (rule: Rule): EmptyTag => {
     if (typeof rule === 'number') {
@@ -110,7 +110,7 @@ export const emptyTagMap = (ruleSet: RuleSet): EmptyTagMap => {
 
 //
 
-type FRuleMap = Map<FRule>
+type FRuleMap = StringMap<FRule>
 
 const { entries } = Object
 

--- a/fjs/bnf/data/module.f.ts
+++ b/fjs/bnf/data/module.f.ts
@@ -18,7 +18,7 @@ import {
     type Rule as FRule,
     type Sequence as FSequence,
 } from '../module.f.ts'
-import { definedEntries, type StringMap } from '../../types/object/module.f.ts'
+import { definedEntries, type Map } from '../../types/object/module.f.ts'
 
 /**
  * Encoded terminal range value used by BNF data rules.
@@ -33,7 +33,7 @@ export type TerminalRange = number
 export type Sequence = readonly string[]
 
 /** A variant of rule names. */
-export type Variant = StringMap<string, string>
+export type Variant = Map<string>
 
 /**
  * Grammar rule definition.
@@ -55,7 +55,7 @@ export type RuleSet = Readonly<Record<string, Rule>>
  */
 export type EmptyTag = string | true | undefined
 
-type EmptyTagMap = StringMap<string, EmptyTag>
+type EmptyTagMap = Map<EmptyTag>
 
 const emptyTagOf = (map: EmptyTagMap) => (rule: Rule): EmptyTag => {
     if (typeof rule === 'number') {
@@ -110,7 +110,7 @@ export const emptyTagMap = (ruleSet: RuleSet): EmptyTagMap => {
 
 //
 
-type FRuleMap = StringMap<string, FRule>
+type FRuleMap = Map<FRule>
 
 const { entries } = Object
 

--- a/fjs/bnf/ll1/module.f.ts
+++ b/fjs/bnf/ll1/module.f.ts
@@ -16,7 +16,7 @@ import { toArray } from '../../types/list/module.f.ts'
 import { rangeMap, type RangeMapArray } from '../../types/range_map/module.f.ts'
 import { contains, set, type StringSet } from '../../types/string_set/module.f.ts'
 import { rangeDecode } from '../module.f.ts'
-import { definedEntries, type StringMap } from '../../types/object/module.f.ts'
+import { definedEntries, type Map } from '../../types/object/module.f.ts'
 import { emptyTagMap, type EmptyTag, type RuleSet, toData } from '../data/module.f.ts'
 import { type Rule as FRule } from '../module.f.ts'
 
@@ -36,7 +36,7 @@ type DispatchRuleCollection = {
     readonly rules: DispatchRuleOrName[]
 }
 
-type DispatchMap = StringMap<string, DispatchRule>
+type DispatchMap = Map<DispatchRule>
 
 /**
  * Represents a parsed AST sequence.

--- a/fjs/bnf/ll1/module.f.ts
+++ b/fjs/bnf/ll1/module.f.ts
@@ -16,7 +16,7 @@ import { toArray } from '../../types/list/module.f.ts'
 import { rangeMap, type RangeMapArray } from '../../types/range_map/module.f.ts'
 import { contains, set, type StringSet } from '../../types/string_set/module.f.ts'
 import { rangeDecode } from '../module.f.ts'
-import { definedEntries, type Map } from '../../types/object/module.f.ts'
+import { definedEntries, type StringMap } from '../../types/object/module.f.ts'
 import { emptyTagMap, type EmptyTag, type RuleSet, toData } from '../data/module.f.ts'
 import { type Rule as FRule } from '../module.f.ts'
 
@@ -36,7 +36,7 @@ type DispatchRuleCollection = {
     readonly rules: DispatchRuleOrName[]
 }
 
-type DispatchMap = Map<DispatchRule>
+type DispatchMap = StringMap<DispatchRule>
 
 /**
  * Represents a parsed AST sequence.

--- a/fjs/bnf/module.f.ts
+++ b/fjs/bnf/module.f.ts
@@ -7,7 +7,7 @@
  * @module
  */
 import { codePointListToString, stringToCodePointList } from '../text/utf16/module.f.ts'
-import { definedValues, type StringMap } from '../types/object/module.f.ts'
+import { definedValues, type Map } from '../types/object/module.f.ts'
 import { type Array2, isArray2 } from '../types/array/module.f.ts'
 import { map, toArray, repeat as listRepeat } from '../types/list/module.f.ts'
 import { contains } from '../types/range/module.f.ts'
@@ -155,7 +155,7 @@ type RangeList = readonly TerminalRange[]
 /**
  * A set of terminal ranges compatible with the `Variant` rule.
  */
-export type RangeVariant = StringMap<string, TerminalRange>
+export type RangeVariant = Map<TerminalRange>
 
 const rangeToEntry = (r: TerminalRange): readonly [string, TerminalRange] =>
     ['0x' + r.toString(16), r]

--- a/fjs/bnf/module.f.ts
+++ b/fjs/bnf/module.f.ts
@@ -7,7 +7,7 @@
  * @module
  */
 import { codePointListToString, stringToCodePointList } from '../text/utf16/module.f.ts'
-import { definedValues, type Map } from '../types/object/module.f.ts'
+import { definedValues, type StringMap } from '../types/object/module.f.ts'
 import { type Array2, isArray2 } from '../types/array/module.f.ts'
 import { map, toArray, repeat as listRepeat } from '../types/list/module.f.ts'
 import { contains } from '../types/range/module.f.ts'
@@ -155,7 +155,7 @@ type RangeList = readonly TerminalRange[]
 /**
  * A set of terminal ranges compatible with the `Variant` rule.
  */
-export type RangeVariant = Map<TerminalRange>
+export type RangeVariant = StringMap<TerminalRange>
 
 const rangeToEntry = (r: TerminalRange): readonly [string, TerminalRange] =>
     ['0x' + r.toString(16), r]

--- a/fjs/cas/evo/module.f.ts
+++ b/fjs/cas/evo/module.f.ts
@@ -54,7 +54,7 @@ import { stringify } from '../../media/json/module.f.ts'
 import { identity } from '../../types/function/module.f.ts'
 import { ok, error, type Ok, type Result } from '../../types/result/module.f.ts'
 import { nonEmpty, empty as elEmpty } from '../../effects/list/module.f.ts'
-import { at, definedEntries, type Map } from '../../types/object/module.f.ts'
+import { at, definedEntries, type StringMap } from '../../types/object/module.f.ts'
 import { unwrap } from '../../types/nullable/module.f.ts'
 import type { Vec } from '../../types/bit_vec/module.f.ts'
 import { isNotFound, type IoResult } from '../../effects/node/module.f.ts'
@@ -133,7 +133,7 @@ export type SubjectState = {
 
 /** In-memory index: subject → its {@link SubjectState}. */
 export type Cache = {
-    readonly bySubject: Map<SubjectState>
+    readonly bySubject: StringMap<SubjectState>
 }
 
 /** A cache with no known subjects yet — the starting point for {@link buildCache}. */

--- a/fjs/cas/evo/module.f.ts
+++ b/fjs/cas/evo/module.f.ts
@@ -54,7 +54,7 @@ import { stringify } from '../../media/json/module.f.ts'
 import { identity } from '../../types/function/module.f.ts'
 import { ok, error, type Ok, type Result } from '../../types/result/module.f.ts'
 import { nonEmpty, empty as elEmpty } from '../../effects/list/module.f.ts'
-import { at, definedEntries, type StringMap } from '../../types/object/module.f.ts'
+import { at, definedEntries, type Map } from '../../types/object/module.f.ts'
 import { unwrap } from '../../types/nullable/module.f.ts'
 import type { Vec } from '../../types/bit_vec/module.f.ts'
 import { isNotFound, type IoResult } from '../../effects/node/module.f.ts'
@@ -133,7 +133,7 @@ export type SubjectState = {
 
 /** In-memory index: subject → its {@link SubjectState}. */
 export type Cache = {
-    readonly bySubject: StringMap<string, SubjectState>
+    readonly bySubject: Map<SubjectState>
 }
 
 /** A cache with no known subjects yet — the starting point for {@link buildCache}. */

--- a/fjs/dev/module.f.ts
+++ b/fjs/dev/module.f.ts
@@ -14,7 +14,7 @@ import {
     type Readdir
 } from '../effects/node/module.f.ts'
 import { cmp as strCmp } from '../types/string/module.f.ts'
-import type { Map } from '../types/object/module.f.ts'
+import type { StringMap } from '../types/object/module.f.ts'
 import { unwrap } from '../types/result/module.f.ts'
 import { pure, step, type Effect } from '../effects/module.f.ts'
 import { join, relativize, toPosix } from '../path/module.f.ts'
@@ -26,7 +26,7 @@ export type Module = {
     readonly [k: string]: unknown
 }
 
-export type ModuleMap = Map<Module>
+export type ModuleMap = StringMap<Module>
 
 /**
  * Returns `true` if the file should be loaded for proof discovery.

--- a/fjs/dev/module.f.ts
+++ b/fjs/dev/module.f.ts
@@ -14,7 +14,7 @@ import {
     type Readdir
 } from '../effects/node/module.f.ts'
 import { cmp as strCmp } from '../types/string/module.f.ts'
-import type { StringMap } from '../types/object/module.f.ts'
+import type { Map } from '../types/object/module.f.ts'
 import { unwrap } from '../types/result/module.f.ts'
 import { pure, step, type Effect } from '../effects/module.f.ts'
 import { join, relativize, toPosix } from '../path/module.f.ts'
@@ -26,7 +26,7 @@ export type Module = {
     readonly [k: string]: unknown
 }
 
-export type ModuleMap = StringMap<string, Module>
+export type ModuleMap = Map<Module>
 
 /**
  * Returns `true` if the file should be loaded for proof discovery.

--- a/fjs/effects/node/module.f.ts
+++ b/fjs/effects/node/module.f.ts
@@ -16,7 +16,7 @@ import { length, type Vec } from '../../types/bit_vec/module.f.ts'
 import type { MemOp } from '../memory/module.f.ts'
 import type { Nominal } from '../../types/nominal/module.f.ts'
 import { ok, error as resultError, mapOk, type Result } from '../../types/result/module.f.ts'
-import type { StringMap } from '../../types/object/module.f.ts'
+import type { Map } from '../../types/object/module.f.ts'
 import { type Effect, type Func, type Operation, type ToAsyncOperationMap, do_, mapStep, okStep, pure, step } from '../module.f.ts'
 import type { List } from '../list/module.f.ts'
 
@@ -246,7 +246,7 @@ export type Server =
 
 // createServer
 
-export type Headers = StringMap<string, string>
+export type Headers = Map<string>
 
 export type IncomingMessage = {
     readonly method: string
@@ -289,7 +289,7 @@ export const forever: Func<Forever> =
 
 // import
 
-export type Module = StringMap<string, unknown>
+export type Module = Map<unknown>
 
 export type Import = ['import', (path: string) => IoResult<Module>]
 

--- a/fjs/effects/node/module.f.ts
+++ b/fjs/effects/node/module.f.ts
@@ -16,7 +16,7 @@ import { length, type Vec } from '../../types/bit_vec/module.f.ts'
 import type { MemOp } from '../memory/module.f.ts'
 import type { Nominal } from '../../types/nominal/module.f.ts'
 import { ok, error as resultError, mapOk, type Result } from '../../types/result/module.f.ts'
-import type { Map } from '../../types/object/module.f.ts'
+import type { StringMap } from '../../types/object/module.f.ts'
 import { type Effect, type Func, type Operation, type ToAsyncOperationMap, do_, mapStep, okStep, pure, step } from '../module.f.ts'
 import type { List } from '../list/module.f.ts'
 
@@ -246,7 +246,7 @@ export type Server =
 
 // createServer
 
-export type Headers = Map<string>
+export type Headers = StringMap<string>
 
 export type IncomingMessage = {
     readonly method: string
@@ -289,7 +289,7 @@ export const forever: Func<Forever> =
 
 // import
 
-export type Module = Map<unknown>
+export type Module = StringMap<unknown>
 
 export type Import = ['import', (path: string) => IoResult<Module>]
 

--- a/fjs/effects/node/module.ts
+++ b/fjs/effects/node/module.ts
@@ -42,7 +42,7 @@ import { asBase, asNominal } from '../../types/nominal/module.f.ts'
 import { error, ok, type Result } from '../../types/result/module.f.ts'
 import { asyncTryCatch } from '../../types/result/module.ts'
 import { fromVec, listToVec, toVec } from '../../types/uint8array/module.f.ts'
-import type { Map } from '../../types/object/module.f.ts'
+import type { StringMap } from '../../types/object/module.f.ts'
 import { maxLengthBytes } from '../../types/bit_vec/module.f.ts'
 
 type Server = {
@@ -58,7 +58,7 @@ type IncomingMessage = Readable & {
 }
 
 type ServerResponse = {
-    readonly writeHead: (status: number, headers: Map<string>) => ServerResponse
+    readonly writeHead: (status: number, headers: StringMap<string>) => ServerResponse
     readonly end: (body: Uint8Array) => void
 }
 

--- a/fjs/effects/node/module.ts
+++ b/fjs/effects/node/module.ts
@@ -42,7 +42,7 @@ import { asBase, asNominal } from '../../types/nominal/module.f.ts'
 import { error, ok, type Result } from '../../types/result/module.f.ts'
 import { asyncTryCatch } from '../../types/result/module.ts'
 import { fromVec, listToVec, toVec } from '../../types/uint8array/module.f.ts'
-import type { StringMap } from '../../types/object/module.f.ts'
+import type { Map } from '../../types/object/module.f.ts'
 import { maxLengthBytes } from '../../types/bit_vec/module.f.ts'
 
 type Server = {
@@ -58,7 +58,7 @@ type IncomingMessage = Readable & {
 }
 
 type ServerResponse = {
-    readonly writeHead: (status: number, headers: StringMap<string, string>) => ServerResponse
+    readonly writeHead: (status: number, headers: Map<string>) => ServerResponse
     readonly end: (body: Uint8Array) => void
 }
 

--- a/fjs/effects/todo/node-module-layering.md
+++ b/fjs/effects/todo/node-module-layering.md
@@ -141,13 +141,14 @@ Judgement calls worth deciding explicitly rather than by accident:
   export const csiWrite = (std: Std) => (stream: WriteConsoles) => …
   ```
 
-  Note the `StringMap` spelling: `AGENTS.md` requires it for *all* string-keyed
-  record types, and over a finite key union `StringMap<WriteConsoles, T>`
-  resolves to the same required-field record the inline mapped type produces.
+  Note the `StringMap` spelling: `AGENTS.md` requires the `fjs/types/object`
+  record types for *all* string-keyed record types, and over a finite key union
+  `StringMap<WriteConsoles, T>` resolves to the same required-field record the
+  inline mapped type produces.
   `NodeProgramOptions.std` (`fjs/effects/node/module.f.ts:535`) writes that
   inline form by hand today — a pre-existing deviation from the rule, in a
-  module that already imports `StringMap` at `:19` and uses it for `Headers`
-  and `Module`. Pointing `std` at the named `Std` fixes that deviation as a side
+  module that already imports the open-key-set `Map` at `:19` and uses it for
+  `Headers` and `Module`. Pointing `std` at the named `Std` fixes that as a side
   effect and keeps the runner contract in sync with the console module by
   construction.
 

--- a/fjs/effects/todo/node-module-layering.md
+++ b/fjs/effects/todo/node-module-layering.md
@@ -133,22 +133,22 @@ Judgement calls worth deciding explicitly rather than by accident:
 
   ```ts
   // fjs/effects/console/module.f.ts
-  import type { StringMap } from '../../types/object/module.f.ts'
+  import type { RequiredMap } from '../../types/object/module.f.ts'
 
-  export type Std = StringMap<WriteConsoles, { readonly isTTY: boolean }>
+  export type Std = RequiredMap<WriteConsoles, { readonly isTTY: boolean }>
 
   // fjs/text/sgr/module.f.ts
   export const csiWrite = (std: Std) => (stream: WriteConsoles) => …
   ```
 
-  Note the `StringMap` spelling: `AGENTS.md` requires the `fjs/types/object`
+  Note the `RequiredMap` spelling: `AGENTS.md` requires the `fjs/types/object`
   record types for *all* string-keyed record types, and over a finite key union
-  `StringMap<WriteConsoles, T>` resolves to the same required-field record the
-  inline mapped type produces.
+  `RequiredMap<WriteConsoles, T>` is the same required-field record the inline
+  mapped type produces.
   `NodeProgramOptions.std` (`fjs/effects/node/module.f.ts:535`) writes that
   inline form by hand today — a pre-existing deviation from the rule, in a
-  module that already imports the open-key-set `Map` at `:19` and uses it for
-  `Headers` and `Module`. Pointing `std` at the named `Std` fixes that as a side
+  module that already imports the open-key-set `StringMap` at `:19` and uses it
+  for `Headers` and `Module`. Pointing `std` at the named `Std` fixes that deviation as a side
   effect and keeps the runner contract in sync with the console module by
   construction.
 
@@ -197,7 +197,7 @@ Judgement calls worth deciding explicitly rather than by accident:
 - [ ] Move `All` / `all` / `both` to `fjs/effects/all/module.f.ts`.
 - [ ] Move `Sandbox` / `Await` and helpers to `fjs/effects/sandbox/module.f.ts`.
 - [ ] Move the console family to `fjs/effects/console/module.f.ts`, add the
-      named `Std` type there as `StringMap<WriteConsoles, …>`, point
+      named `Std` type there as `RequiredMap<WriteConsoles, …>`, point
       `NodeProgramOptions.std` at it, and narrow `csiWrite` to take `Std`
       (updating its one caller, `fjs/emergent_testing/module.f.ts:370`). Verify
       `fjs/text/sgr` no longer imports `effects/node` at all — that is the test

--- a/fjs/fsm/module.f.ts
+++ b/fjs/fsm/module.f.ts
@@ -4,7 +4,7 @@
  * @module
  */
 import { equal, isEmpty, fold, toArray, scan, foldScan, empty as emptyList, type List } from '../types/list/module.f.ts'
-import type { StringMap } from '../types/object/module.f.ts'
+import type { Map } from '../types/object/module.f.ts'
 import { toRangeMap, union as byteSetUnion, one, empty, range, type ByteSet } from '../types/byte_set/module.f.ts'
 import { intersect, type SortedSet, union as sortedSetUnion } from '../types/sorted_set/module.f.ts'
 import {
@@ -25,7 +25,7 @@ type Rule = readonly [string, ByteSet, string]
 
 export type Grammar = List<Rule>
 
-type Dfa = StringMap<string, RangeMapArray<string>>
+type Dfa = Map<RangeMapArray<string>>
 
 const stringifyIdentity = stringify(identity)
 

--- a/fjs/fsm/module.f.ts
+++ b/fjs/fsm/module.f.ts
@@ -4,7 +4,7 @@
  * @module
  */
 import { equal, isEmpty, fold, toArray, scan, foldScan, empty as emptyList, type List } from '../types/list/module.f.ts'
-import type { Map } from '../types/object/module.f.ts'
+import type { StringMap } from '../types/object/module.f.ts'
 import { toRangeMap, union as byteSetUnion, one, empty, range, type ByteSet } from '../types/byte_set/module.f.ts'
 import { intersect, type SortedSet, union as sortedSetUnion } from '../types/sorted_set/module.f.ts'
 import {
@@ -25,7 +25,7 @@ type Rule = readonly [string, ByteSet, string]
 
 export type Grammar = List<Rule>
 
-type Dfa = Map<RangeMapArray<string>>
+type Dfa = StringMap<RangeMapArray<string>>
 
 const stringifyIdentity = stringify(identity)
 

--- a/fjs/media/html/module.f.ts
+++ b/fjs/media/html/module.f.ts
@@ -6,7 +6,7 @@
  */
 import { map, flatMap, flat, concat as listConcat, type List } from '../../types/list/module.f.ts'
 import { concat, concat as stringConcat } from '../../types/string/module.f.ts'
-import { definedEntries, type Entry, type Map } from '../../types/object/module.f.ts'
+import { definedEntries, type Entry, type StringMap } from '../../types/object/module.f.ts'
 import { compose } from '../../types/function/module.f.ts'
 import { stringToList } from '../../text/utf16/module.f.ts'
 import { includes } from '../../types/array/module.f.ts'
@@ -61,7 +61,7 @@ type Element2 = readonly [Tag, Attributes, ...Node[]]
  */
 export type Element = Element1 | Element2
 
-type Attributes = Map<string>
+type Attributes = StringMap<string>
 
 export type Node = Element | string
 

--- a/fjs/media/html/module.f.ts
+++ b/fjs/media/html/module.f.ts
@@ -6,7 +6,7 @@
  */
 import { map, flatMap, flat, concat as listConcat, type List } from '../../types/list/module.f.ts'
 import { concat, concat as stringConcat } from '../../types/string/module.f.ts'
-import { definedEntries, type Entry, type StringMap } from '../../types/object/module.f.ts'
+import { definedEntries, type Entry, type Map } from '../../types/object/module.f.ts'
 import { compose } from '../../types/function/module.f.ts'
 import { stringToList } from '../../text/utf16/module.f.ts'
 import { includes } from '../../types/array/module.f.ts'
@@ -61,7 +61,7 @@ type Element2 = readonly [Tag, Attributes, ...Node[]]
  */
 export type Element = Element1 | Element2
 
-type Attributes = StringMap<string, string>
+type Attributes = Map<string>
 
 export type Node = Element | string
 

--- a/fjs/types/object/module.f.ts
+++ b/fjs/types/object/module.f.ts
@@ -23,6 +23,13 @@ export type OptionalMap<K extends string, T> = { readonly[k in K]?: T }
  * `never`, because no object can carry every string as a key. Use `StringMap<T>`
  * for an open key set — its values are optional, which is what such a key set
  * means at runtime.
+ *
+ * There is no known way to ask TypeScript whether `K` is finite, so the guard
+ * approximates it with `string extends K`, which holds exactly when `K` is
+ * `string`. Other infinite key sets are not caught: a template literal such as
+ * `x-${string}` yields a template index signature instead of `never`, and its
+ * reads are typed `T` while the runtime value is `undefined`. Keep `K` a union
+ * of string literals.
  */
 export type RequiredMap<K extends string, T> =
     string extends K

--- a/fjs/types/object/module.f.ts
+++ b/fjs/types/object/module.f.ts
@@ -1,7 +1,7 @@
 /**
- * Plain-object helpers and types: `Map<T>`/`Entry<T>` shapes, safe property
- * lookup via `at`, conversions between entries and `OrderedMap`, and the
- * `OneKey`/`SingleProperty`/`NotUnion` utility types.
+ * Plain-object helpers and types: the `Map<T>`/`StringMap<K, T>`/`Entry<T>`
+ * shapes, safe property lookup via `at`, conversions between entries and
+ * `OrderedMap`, and the `OneKey`/`SingleProperty`/`NotUnion` utility types.
  *
  * @module
  */
@@ -12,7 +12,20 @@ import { entries as mapEntries, fromEntries as mapFromEntries, type OrderedMap }
 
 const { getOwnPropertyDescriptor, fromEntries: objectFromEntries } = Object
 
-export type Map<T> = StringMap<string, T>
+/** A record with an open key set. Every value can be missing at runtime. */
+export type Map<T> = { readonly[k in string]?: T }
+
+/**
+ * A record with a finite key set. Every key of `K` is required.
+ *
+ * `K` has to be a union of string literals: `StringMap<string, T>` is `never`,
+ * so an open key set is a compilation error here. Use `Map<T>` for that case —
+ * its values are optional, which is what an open key set means at runtime.
+ */
+export type StringMap<K extends string, T> =
+    string extends K
+    ? never
+    : { readonly[k in K]: T }
 
 export type Entry<T> = readonly[string, T]
 
@@ -52,7 +65,7 @@ export type NotUnion<T, U = T> =
     : never
   : never;
 
-export type SingleProperty<T extends StringMap<string, never>> =
+export type SingleProperty<T extends Map<never>> =
   keyof T extends NotUnion<keyof T> ? T
   : never;
 
@@ -64,14 +77,9 @@ const { values, entries } = Object
 
 /** Returns only the defined (non-undefined) values of a partial record. */
 export const definedValues =
-    <T>(map: StringMap<string, Exclude<T, undefined>>): readonly Exclude<T, undefined>[] =>
+    <T>(map: Map<Exclude<T, undefined>>): readonly Exclude<T, undefined>[] =>
     values(map).filter(v => v !== undefined)
 
-export type StringMap<K extends string, T> =
-    string extends K
-    ? { readonly[k in string]?: T }
-    : { readonly[k in K]: T }
-
 export const definedEntries =
-    <T>(cmd: StringMap<string, Exclude<T, undefined>>): readonly (readonly[string, Exclude<T, undefined>])[] =>
+    <T>(cmd: Map<Exclude<T, undefined>>): readonly (readonly[string, Exclude<T, undefined>])[] =>
     entries(cmd).flatMap(([a, b]) => b === undefined ? [] : [[a, b]])

--- a/fjs/types/object/module.f.ts
+++ b/fjs/types/object/module.f.ts
@@ -1,7 +1,8 @@
 /**
- * Plain-object helpers and types: the `Map<T>`/`StringMap<K, T>`/`Entry<T>`
- * shapes, safe property lookup via `at`, conversions between entries and
- * `OrderedMap`, and the `OneKey`/`SingleProperty`/`NotUnion` utility types.
+ * Plain-object helpers and types: the `OptionalMap`/`RequiredMap`/`StringMap`
+ * record shapes and `Entry<T>`, safe property lookup via `at`, conversions
+ * between entries and `OrderedMap`, and the `OneKey`/`SingleProperty`/`NotUnion`
+ * utility types.
  *
  * @module
  */
@@ -12,24 +13,28 @@ import { entries as mapEntries, fromEntries as mapFromEntries, type OrderedMap }
 
 const { getOwnPropertyDescriptor, fromEntries: objectFromEntries } = Object
 
-/** A record with an open key set. Every value can be missing at runtime. */
-export type Map<T> = { readonly[k in string]?: T }
+/** A record over the keys of `K`, each value possibly missing at runtime. */
+export type OptionalMap<K extends string, T> = { readonly[k in K]?: T }
 
 /**
- * A record with a finite key set. Every key of `K` is required.
+ * A record over the keys of `K`, each value required.
  *
- * `K` has to be a union of string literals: `StringMap<string, T>` is `never`,
- * so an open key set is a compilation error here. Use `Map<T>` for that case —
- * its values are optional, which is what an open key set means at runtime.
+ * `K` has to be a finite union of string literals: `RequiredMap<string, T>` is
+ * `never`, because no object can carry every string as a key. Use `StringMap<T>`
+ * for an open key set — its values are optional, which is what such a key set
+ * means at runtime.
  */
-export type StringMap<K extends string, T> =
+export type RequiredMap<K extends string, T> =
     string extends K
     ? never
     : { readonly[k in K]: T }
 
+/** A record with an open key set. Every value can be missing at runtime. */
+export type StringMap<T> = OptionalMap<string, T>
+
 export type Entry<T> = readonly[string, T]
 
-export const at: (name: string) => <T>(object: Map<T>) => Nullable<Exclude<T, undefined>>
+export const at: (name: string) => <T>(object: StringMap<T>) => Nullable<Exclude<T, undefined>>
     = name => object => {
         const d = getOwnPropertyDescriptor(object, name)
         return d === undefined ? null : fromUndefined(d.value)
@@ -38,10 +43,10 @@ export const at: (name: string) => <T>(object: Map<T>) => Nullable<Exclude<T, un
 export const sort: <T>(e: List<Entry<T>>) => List<Entry<T>>
     = e => mapEntries(mapFromEntries(e))
 
-export const fromEntries: <T>(e: List<Entry<T>>) => Map<T>
+export const fromEntries: <T>(e: List<Entry<T>>) => StringMap<T>
     = e => objectFromEntries(iterable(e))
 
-export const fromMap: <T>(m: OrderedMap<T>) => Map<T>
+export const fromMap: <T>(m: OrderedMap<T>) => StringMap<T>
     = m => fromEntries(mapEntries(m))
 
 /**
@@ -51,7 +56,7 @@ export const fromMap: <T>(m: OrderedMap<T>) => Map<T>
  * https://stackoverflow.com/questions/57571664/typescript-type-for-an-object-with-only-one-key-no-union-type-allowed-as-a-key
  */
 export type OneKey<K extends string, V> = {
-    [P in K]: (StringMap<P, V> & Partial<StringMap<Exclude<K, P>, never>>) extends infer O
+    [P in K]: (RequiredMap<P, V> & OptionalMap<Exclude<K, P>, never>) extends infer O
         ? { [Q in keyof O]: O[Q] }
         : never
 }[K];
@@ -65,7 +70,7 @@ export type NotUnion<T, U = T> =
     : never
   : never;
 
-export type SingleProperty<T extends Map<never>> =
+export type SingleProperty<T extends StringMap<never>> =
   keyof T extends NotUnion<keyof T> ? T
   : never;
 
@@ -77,9 +82,9 @@ const { values, entries } = Object
 
 /** Returns only the defined (non-undefined) values of a partial record. */
 export const definedValues =
-    <T>(map: Map<Exclude<T, undefined>>): readonly Exclude<T, undefined>[] =>
+    <T>(map: StringMap<Exclude<T, undefined>>): readonly Exclude<T, undefined>[] =>
     values(map).filter(v => v !== undefined)
 
 export const definedEntries =
-    <T>(cmd: Map<Exclude<T, undefined>>): readonly (readonly[string, Exclude<T, undefined>])[] =>
+    <T>(cmd: StringMap<Exclude<T, undefined>>): readonly (readonly[string, Exclude<T, undefined>])[] =>
     entries(cmd).flatMap(([a, b]) => b === undefined ? [] : [[a, b]])

--- a/fjs/types/object/proof.f.ts
+++ b/fjs/types/object/proof.f.ts
@@ -1,24 +1,23 @@
 import { at } from './module.f.ts'
 import type { OptionalMap, RequiredMap, StringMap } from './module.f.ts'
-import { assertEq } from '../../asserts/module.f.ts'
+import { assertEq, type Assert } from '../../asserts/module.f.ts'
+import type { Equal } from '../ts/module.f.ts'
 
-type E<A, B> = A extends B ? B extends A ? true : false : false
+type _StringMapIsOptional = Assert<Equal<
+    StringMap<bigint>,
+    { readonly[k in string]?: bigint }>>
 
-// `[T]` keeps the conditional from distributing, so `never` stays `never`.
-type IsNever<T> = [T] extends [never] ? true : false
+type _OptionalIsPartial = Assert<Equal<
+    OptionalMap<'a'|'b', bigint>,
+    { readonly a?: bigint; readonly b?: bigint }>>
 
-type _StringMapIsOptional = E<StringMap<bigint>, { readonly[k in string]?: bigint }>
-type _OptionalIsPartial = E<OptionalMap<'a'|'b', bigint>, { readonly a?: bigint; readonly b?: bigint }>
-type _RequiredIsRequired = E<RequiredMap<'a'|'b', bigint>, { readonly a: bigint; readonly b: bigint }>
-type _RequiredOverAnyStringIsNever = IsNever<RequiredMap<string, bigint>>
+type _RequiredIsRequired = Assert<Equal<
+    RequiredMap<'a'|'b', bigint>,
+    { readonly a: bigint; readonly b: bigint }>>
+
+type _RequiredOverAnyStringIsNever = Assert<Equal<RequiredMap<string, bigint>, never>>
 
 export const proof = {
-    stringMap: {
-        stringMapIsOptional: true as _StringMapIsOptional,
-        optionalIsPartial: true as _OptionalIsPartial,
-        requiredIsRequired: true as _RequiredIsRequired,
-        requiredOverAnyStringIsNever: true as _RequiredOverAnyStringIsNever,
-    },
     ctor: () => {
         const a = {}
         const value = at('constructor')(a)

--- a/fjs/types/object/proof.f.ts
+++ b/fjs/types/object/proof.f.ts
@@ -1,5 +1,5 @@
 import { at } from './module.f.ts'
-import type { Map, StringMap } from './module.f.ts'
+import type { OptionalMap, RequiredMap, StringMap } from './module.f.ts'
 import { assertEq } from '../../asserts/module.f.ts'
 
 type E<A, B> = A extends B ? B extends A ? true : false : false
@@ -7,15 +7,17 @@ type E<A, B> = A extends B ? B extends A ? true : false : false
 // `[T]` keeps the conditional from distributing, so `never` stays `never`.
 type IsNever<T> = [T] extends [never] ? true : false
 
-type _MapIsOptional = E<Map<bigint>, { readonly[k in string]?: bigint }>
-type _FiniteIsRequired = E<StringMap<'a'|'b', bigint>, { readonly a: bigint; readonly b: bigint }>
-type _OpenKeySetIsNever = IsNever<StringMap<string, bigint>>
+type _StringMapIsOptional = E<StringMap<bigint>, { readonly[k in string]?: bigint }>
+type _OptionalIsPartial = E<OptionalMap<'a'|'b', bigint>, { readonly a?: bigint; readonly b?: bigint }>
+type _RequiredIsRequired = E<RequiredMap<'a'|'b', bigint>, { readonly a: bigint; readonly b: bigint }>
+type _RequiredOverAnyStringIsNever = IsNever<RequiredMap<string, bigint>>
 
 export const proof = {
     stringMap: {
-        mapIsOptional: true as _MapIsOptional,
-        finiteIsRequired: true as _FiniteIsRequired,
-        openKeySetIsNever: true as _OpenKeySetIsNever,
+        stringMapIsOptional: true as _StringMapIsOptional,
+        optionalIsPartial: true as _OptionalIsPartial,
+        requiredIsRequired: true as _RequiredIsRequired,
+        requiredOverAnyStringIsNever: true as _RequiredOverAnyStringIsNever,
     },
     ctor: () => {
         const a = {}

--- a/fjs/types/object/proof.f.ts
+++ b/fjs/types/object/proof.f.ts
@@ -1,16 +1,21 @@
 import { at } from './module.f.ts'
-import type { StringMap } from './module.f.ts'
+import type { Map, StringMap } from './module.f.ts'
 import { assertEq } from '../../asserts/module.f.ts'
 
 type E<A, B> = A extends B ? B extends A ? true : false : false
 
-type _InfiniteIsOptional = E<StringMap<string, bigint>, { readonly[k in string]?: bigint }>
+// `[T]` keeps the conditional from distributing, so `never` stays `never`.
+type IsNever<T> = [T] extends [never] ? true : false
+
+type _MapIsOptional = E<Map<bigint>, { readonly[k in string]?: bigint }>
 type _FiniteIsRequired = E<StringMap<'a'|'b', bigint>, { readonly a: bigint; readonly b: bigint }>
+type _OpenKeySetIsNever = IsNever<StringMap<string, bigint>>
 
 export const proof = {
     stringMap: {
-        infiniteIsOptional: true as _InfiniteIsOptional,
+        mapIsOptional: true as _MapIsOptional,
         finiteIsRequired: true as _FiniteIsRequired,
+        openKeySetIsNever: true as _OpenKeySetIsNever,
     },
     ctor: () => {
         const a = {}

--- a/fjs/types/object/todo/defined-values-from-entries.md
+++ b/fjs/types/object/todo/defined-values-from-entries.md
@@ -10,11 +10,11 @@ entries" twice, with two different idioms:
 
 ```ts
 export const definedValues =
-    <T>(map: Map<Exclude<T, undefined>>): readonly Exclude<T, undefined>[] =>
+    <T>(map: StringMap<Exclude<T, undefined>>): readonly Exclude<T, undefined>[] =>
     values(map).filter(v => v !== undefined)
 
 export const definedEntries =
-    <T>(cmd: Map<Exclude<T, undefined>>): readonly (readonly[string, Exclude<T, undefined>])[] =>
+    <T>(cmd: StringMap<Exclude<T, undefined>>): readonly (readonly[string, Exclude<T, undefined>])[] =>
     entries(cmd).flatMap(([a, b]) => b === undefined ? [] : [[a, b]])
 ```
 
@@ -28,7 +28,7 @@ Derive one from the other so the predicate lives once:
 
 ```ts
 export const definedValues =
-    <T>(map: Map<Exclude<T, undefined>>): readonly Exclude<T, undefined>[] =>
+    <T>(map: StringMap<Exclude<T, undefined>>): readonly Exclude<T, undefined>[] =>
     definedEntries(map).map(([, v]) => v)
 ```
 
@@ -40,5 +40,5 @@ export const definedValues =
 ### Related
 
 - AGENTS.md — `definedEntries`/`definedValues` are the mandated iteration
-  helpers for `Map`; their own definitions should model the preferred
+  helpers for `StringMap`; their own definitions should model the preferred
   idiom once, not twice.

--- a/fjs/types/object/todo/defined-values-from-entries.md
+++ b/fjs/types/object/todo/defined-values-from-entries.md
@@ -10,11 +10,11 @@ entries" twice, with two different idioms:
 
 ```ts
 export const definedValues =
-    <T>(map: StringMap<string, Exclude<T, undefined>>): readonly Exclude<T, undefined>[] =>
+    <T>(map: Map<Exclude<T, undefined>>): readonly Exclude<T, undefined>[] =>
     values(map).filter(v => v !== undefined)
 
 export const definedEntries =
-    <T>(cmd: StringMap<string, Exclude<T, undefined>>): readonly (readonly[string, Exclude<T, undefined>])[] =>
+    <T>(cmd: Map<Exclude<T, undefined>>): readonly (readonly[string, Exclude<T, undefined>])[] =>
     entries(cmd).flatMap(([a, b]) => b === undefined ? [] : [[a, b]])
 ```
 
@@ -28,7 +28,7 @@ Derive one from the other so the predicate lives once:
 
 ```ts
 export const definedValues =
-    <T>(map: StringMap<string, Exclude<T, undefined>>): readonly Exclude<T, undefined>[] =>
+    <T>(map: Map<Exclude<T, undefined>>): readonly Exclude<T, undefined>[] =>
     definedEntries(map).map(([, v]) => v)
 ```
 
@@ -40,5 +40,5 @@ export const definedValues =
 ### Related
 
 - AGENTS.md — `definedEntries`/`definedValues` are the mandated iteration
-  helpers for `StringMap`; their own definitions should model the preferred
+  helpers for `Map`; their own definitions should model the preferred
   idiom once, not twice.

--- a/fjs/types/rtti/common/module.f.ts
+++ b/fjs/types/rtti/common/module.f.ts
@@ -40,7 +40,7 @@ import {
 import { error, ok, type Error, type Result as CommonResult } from '../../result/module.f.ts'
 import type { Ts } from '../ts/module.f.ts'
 import { isArray as commonIsArray } from '../../array/module.f.ts'
-import { isObject as commonIsObject, type Map } from '../../object/module.f.ts'
+import { isObject as commonIsObject, type StringMap } from '../../object/module.f.ts'
 
 /** A path to a sub-value within the validated structure. Each step is an object key or stringified array index. */
 export type Path = readonly string[]
@@ -107,14 +107,14 @@ export type IsContainer<C extends Unknown> = (value: Unknown) => value is C
 /** Maps a `Tag1` to its runtime container type. */
 export type Container<K extends Tag1> = K extends 'array'
     ? ReadonlyArray<Unknown>
-    : Map<Unknown>
+    : StringMap<Unknown>
 
 /** `IsContainer` guard for arrays, shared by `validate` and `parse`. */
 export const isArray: IsContainer<ReadonlyArray<Unknown>> =
     value => commonIsArray(value)
 
 /** `IsContainer` guard for records/structs, shared by `validate` and `parse`. */
-export const isObject: IsContainer<Map<Unknown>> =
+export const isObject: IsContainer<StringMap<Unknown>> =
     value => commonIsObject(value)
 
 /**

--- a/fjs/types/rtti/common/module.f.ts
+++ b/fjs/types/rtti/common/module.f.ts
@@ -40,7 +40,7 @@ import {
 import { error, ok, type Error, type Result as CommonResult } from '../../result/module.f.ts'
 import type { Ts } from '../ts/module.f.ts'
 import { isArray as commonIsArray } from '../../array/module.f.ts'
-import { isObject as commonIsObject, type StringMap } from '../../object/module.f.ts'
+import { isObject as commonIsObject, type Map } from '../../object/module.f.ts'
 
 /** A path to a sub-value within the validated structure. Each step is an object key or stringified array index. */
 export type Path = readonly string[]
@@ -107,14 +107,14 @@ export type IsContainer<C extends Unknown> = (value: Unknown) => value is C
 /** Maps a `Tag1` to its runtime container type. */
 export type Container<K extends Tag1> = K extends 'array'
     ? ReadonlyArray<Unknown>
-    : StringMap<string, Unknown>
+    : Map<Unknown>
 
 /** `IsContainer` guard for arrays, shared by `validate` and `parse`. */
 export const isArray: IsContainer<ReadonlyArray<Unknown>> =
     value => commonIsArray(value)
 
 /** `IsContainer` guard for records/structs, shared by `validate` and `parse`. */
-export const isObject: IsContainer<StringMap<string, Unknown>> =
+export const isObject: IsContainer<Map<Unknown>> =
     value => commonIsObject(value)
 
 /**

--- a/fjs/types/rtti/module.f.ts
+++ b/fjs/types/rtti/module.f.ts
@@ -39,7 +39,7 @@
 import type { Assert } from '../../asserts/module.f.ts'
 import { includes, type Includes } from '../array/module.f.ts'
 import type { Equal } from '../ts/module.f.ts'
-import type { StringMap } from '../object/module.f.ts'
+import type { Map } from '../object/module.f.ts'
 
 /** A constant schema: a primitive literal, a struct object, or a tuple. */
 export type Const =
@@ -59,7 +59,7 @@ export type Const =
 export type ConstObject = Struct | Tuple
 
 /** A struct schema: plain object whose values are nested `Type`s. */
-export type Struct = StringMap<string, Type>
+export type Struct = Map<Type>
 
 /** A tuple schema: readonly array whose elements are nested `Type`s. */
 export type Tuple = readonly Type[]

--- a/fjs/types/rtti/module.f.ts
+++ b/fjs/types/rtti/module.f.ts
@@ -39,7 +39,7 @@
 import type { Assert } from '../../asserts/module.f.ts'
 import { includes, type Includes } from '../array/module.f.ts'
 import type { Equal } from '../ts/module.f.ts'
-import type { Map } from '../object/module.f.ts'
+import type { StringMap } from '../object/module.f.ts'
 
 /** A constant schema: a primitive literal, a struct object, or a tuple. */
 export type Const =
@@ -59,7 +59,7 @@ export type Const =
 export type ConstObject = Struct | Tuple
 
 /** A struct schema: plain object whose values are nested `Type`s. */
-export type Struct = Map<Type>
+export type Struct = StringMap<Type>
 
 /** A tuple schema: readonly array whose elements are nested `Type`s. */
 export type Tuple = readonly Type[]

--- a/fjs/types/rtti/parse/module.f.ts
+++ b/fjs/types/rtti/parse/module.f.ts
@@ -34,7 +34,7 @@ import {
     type Type,
 } from '../module.f.ts'
 import { ok, type Result as CommonResult } from '../../result/module.f.ts'
-import type { StringMap } from '../../object/module.f.ts'
+import type { Map } from '../../object/module.f.ts'
 import { reverse, toArray, type List } from '../../list/module.f.ts'
 import {
     constPrimitiveValidate,
@@ -147,7 +147,7 @@ const tupleParse = constContainerParse<ReadonlyArray<Unknown>>(
     arrayRebuild,
 )
 
-const structParse = constContainerParse<StringMap<string, Unknown>>(
+const structParse = constContainerParse<Map<Unknown>>(
     isObject,
     (value, k) => value[k],
     recordRebuild,

--- a/fjs/types/rtti/parse/module.f.ts
+++ b/fjs/types/rtti/parse/module.f.ts
@@ -34,7 +34,7 @@ import {
     type Type,
 } from '../module.f.ts'
 import { ok, type Result as CommonResult } from '../../result/module.f.ts'
-import type { Map } from '../../object/module.f.ts'
+import type { StringMap } from '../../object/module.f.ts'
 import { reverse, toArray, type List } from '../../list/module.f.ts'
 import {
     constPrimitiveValidate,
@@ -147,7 +147,7 @@ const tupleParse = constContainerParse<ReadonlyArray<Unknown>>(
     arrayRebuild,
 )
 
-const structParse = constContainerParse<Map<Unknown>>(
+const structParse = constContainerParse<StringMap<Unknown>>(
     isObject,
     (value, k) => value[k],
     recordRebuild,

--- a/fjs/types/rtti/proof.f.ts
+++ b/fjs/types/rtti/proof.f.ts
@@ -1,6 +1,6 @@
-import type { StringMap } from '../object/module.f.ts'
+import type { Map } from '../object/module.f.ts'
 
-type Tests = StringMap<string, readonly unknown[]>
+type Tests = Map<readonly unknown[]>
 
 const tests: Tests = {
     undefined: [undefined],

--- a/fjs/types/rtti/proof.f.ts
+++ b/fjs/types/rtti/proof.f.ts
@@ -1,6 +1,6 @@
-import type { Map } from '../object/module.f.ts'
+import type { StringMap } from '../object/module.f.ts'
 
-type Tests = Map<readonly unknown[]>
+type Tests = StringMap<readonly unknown[]>
 
 const tests: Tests = {
     undefined: [undefined],

--- a/fjs/types/rtti/ts/module.f.ts
+++ b/fjs/types/rtti/ts/module.f.ts
@@ -11,7 +11,7 @@ import { type Equal, primitive, union, printer as tsPrinter } from '../../ts/mod
 import type { Tag0, Tag1, Const, Or, String as RttiString, Struct, Tuple, Type, ConstObject } from '../module.f.ts'
 import type { Assert } from '../../../asserts/module.f.ts'
 import type { phantomKey } from '../../phantom/module.f.ts'
-import type { StringMap } from '../../object/module.f.ts'
+import type { Map } from '../../object/module.f.ts'
 
 /**
  * The set of primitive literal types representable as rtti `Const` values.
@@ -56,7 +56,7 @@ export type Info0Ts<T extends Tag0> =
 /** Maps a `Const` schema to its TypeScript type. */
 export type ConstTs<T> =
     T extends readonly Type[] ? TupleTs<T> :
-    T extends StringMap<string, Type> ? StructTs<T> :
+    T extends Map<Type> ? StructTs<T> :
     T
 
 /** Maps a `Tag1` and inner type to its TypeScript type. */
@@ -230,7 +230,7 @@ type _array = Assert<Equal<Ts<
 >>
 type _record = Assert<Equal<
     Ts<() => readonly['record', () => readonly['boolean']]>,
-    StringMap<string, boolean>
+    Map<boolean>
 >>
 
 type _tupleString = Assert<Equal<

--- a/fjs/types/rtti/ts/module.f.ts
+++ b/fjs/types/rtti/ts/module.f.ts
@@ -11,7 +11,7 @@ import { type Equal, primitive, union, printer as tsPrinter } from '../../ts/mod
 import type { Tag0, Tag1, Const, Or, String as RttiString, Struct, Tuple, Type, ConstObject } from '../module.f.ts'
 import type { Assert } from '../../../asserts/module.f.ts'
 import type { phantomKey } from '../../phantom/module.f.ts'
-import type { Map } from '../../object/module.f.ts'
+import type { StringMap } from '../../object/module.f.ts'
 
 /**
  * The set of primitive literal types representable as rtti `Const` values.
@@ -56,7 +56,7 @@ export type Info0Ts<T extends Tag0> =
 /** Maps a `Const` schema to its TypeScript type. */
 export type ConstTs<T> =
     T extends readonly Type[] ? TupleTs<T> :
-    T extends Map<Type> ? StructTs<T> :
+    T extends StringMap<Type> ? StructTs<T> :
     T
 
 /** Maps a `Tag1` and inner type to its TypeScript type. */
@@ -230,7 +230,7 @@ type _array = Assert<Equal<Ts<
 >>
 type _record = Assert<Equal<
     Ts<() => readonly['record', () => readonly['boolean']]>,
-    Map<boolean>
+    StringMap<boolean>
 >>
 
 type _tupleString = Assert<Equal<

--- a/fjs/types/rtti/validate/module.f.ts
+++ b/fjs/types/rtti/validate/module.f.ts
@@ -36,7 +36,7 @@ import {
     type Type,
 } from '../module.f.ts'
 import { ok } from '../../result/module.f.ts'
-import type { StringMap } from '../../object/module.f.ts'
+import type { Map } from '../../object/module.f.ts'
 import {
     constPrimitiveValidate,
     eachEntry,
@@ -126,7 +126,7 @@ const tupleValidate = constContainerValidate<ReadonlyArray<Unknown>>(
     (value, k) => value[Number(k)]
 )
 
-const structValidate = constContainerValidate<StringMap<string, Unknown>>(
+const structValidate = constContainerValidate<Map<Unknown>>(
     isObject,
     (value, k) => value[k]
 )

--- a/fjs/types/rtti/validate/module.f.ts
+++ b/fjs/types/rtti/validate/module.f.ts
@@ -36,7 +36,7 @@ import {
     type Type,
 } from '../module.f.ts'
 import { ok } from '../../result/module.f.ts'
-import type { Map } from '../../object/module.f.ts'
+import type { StringMap } from '../../object/module.f.ts'
 import {
     constPrimitiveValidate,
     eachEntry,
@@ -126,7 +126,7 @@ const tupleValidate = constContainerValidate<ReadonlyArray<Unknown>>(
     (value, k) => value[Number(k)]
 )
 
-const structValidate = constContainerValidate<Map<Unknown>>(
+const structValidate = constContainerValidate<StringMap<Unknown>>(
     isObject,
     (value, k) => value[k]
 )


### PR DESCRIPTION
`fjs/types/object`: `StringMap<T>` takes one type argument and is the open-key-set record; a finite key set is now `RequiredMap<K, T>` or `OptionalMap<K, T>`, and `RequiredMap<string, T>` is `never`. `Map<T>` is removed — it was `StringMap<T>`.