### PR TITLE
Document private JSDoc typedef convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,16 +481,6 @@ When translating a public type, verify both normal type checking and emitted
 type contract must not become weaker just because the source moved to
 JavaScript.
 
-Preserve private type intent as well. An implementation-only JSDoc typedef must
-use a leading `_`, for example `/** @typedef {number} _Node */`. TypeScript
-currently emits JSDoc typedefs as exported aliases even when they are intended to
-be private, so `_` is the repository's temporary private-API marker: consumers
-must not depend on these names, and changing, renaming, or removing them is not a
-breaking change. Public typedefs use ordinary names without the `_` prefix. See
-[`fjs/fsc/README.md`](./fjs/fsc/README.md) for the migration contract and
-[`todo/blocked/jsdoc-typedef-strip-internal.md`](./todo/blocked/jsdoc-typedef-strip-internal.md)
-for replacing this workaround with `@internal` when TypeScript supports it.
-
 #### Prefer inference
 
 Let TypeScript infer the type of private constants, local variables, and return

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,6 +481,16 @@ When translating a public type, verify both normal type checking and emitted
 type contract must not become weaker just because the source moved to
 JavaScript.
 
+Preserve private type intent as well. An implementation-only JSDoc typedef must
+use a leading `_`, for example `/** @typedef {number} _Node */`. TypeScript
+currently emits JSDoc typedefs as exported aliases even when they are intended to
+be private, so `_` is the repository's temporary private-API marker: consumers
+must not depend on these names, and changing, renaming, or removing them is not a
+breaking change. Public typedefs use ordinary names without the `_` prefix. See
+[`fjs/fsc/README.md`](./fjs/fsc/README.md) for the migration contract and
+[`todo/blocked/jsdoc-typedef-strip-internal.md`](./todo/blocked/jsdoc-typedef-strip-internal.md)
+for replacing this workaround with `@internal` when TypeScript supports it.
+
 #### Prefer inference
 
 Let TypeScript infer the type of private constants, local variables, and return

--- a/fjs/ci/todo/f-mjs-package-support.md
+++ b/fjs/ci/todo/f-mjs-package-support.md
@@ -95,6 +95,20 @@ Update `AGENTS.md` with that asymmetric source-migration policy. Compiler
 compatibility is a later `.f.mjs` -> `.f.js` migration and is not part of this
 package prerequisite.
 
+JSDoc declaration emit currently exposes every top-level `@typedef` as an
+exported type alias. During the migration, implementation-only typedefs use the
+repository's leading-`_` convention, for example `_Node`; see
+[`todo/migrate-typescript-to-mjs.md`](../../../todo/migrate-typescript-to-mjs.md).
+An emitted `export type _Node = ...` is therefore package-private by contract,
+not public API. Clean-consumer tests must exercise documented public types and
+must not turn `_`-prefixed declaration artifacts into supported API merely
+because TypeScript emitted them.
+
+The eventual replacement is `@internal` plus `stripInternal`, blocked on
+[microsoft/TypeScript#46407](https://github.com/microsoft/TypeScript/issues/46407)
+and tracked in
+[`todo/blocked/jsdoc-typedef-strip-internal.md`](../../../todo/blocked/jsdoc-typedef-strip-internal.md).
+
 Package selection does not need to distinguish every authored `.mjs` by public
 API status during this transition. Incidental authored files such as
 `fjs/types/bigint/benchmark.mjs` may be present in the archive; because they are
@@ -135,13 +149,16 @@ the clean-consumer type-check, or the rejected `.mjs`→`.ts` import direction.
 - [ ] Keep package/publish jobs on a clean CI checkout; do not add generated
       output tracking or cleanup for artifacts from previous revisions.
 - [ ] Add a mixed authored `.ts` + JSDoc `.mjs` package fixture.
+- [ ] Include an implementation-only `_`-prefixed JSDoc typedef in the fixture;
+      tolerate its current exported declaration form without treating it as
+      clean-consumer public API.
 - [ ] Test the allowed `.ts` -> `.mjs` dependency direction in a clean checkout
       and CI-built package archive.
 - [ ] Reject authored `.mjs` runtime imports and declaration-retained references
       to remaining relative `.ts` or generated `.js`.
 - [ ] Verify emitted `.d.mts` contains no references to omitted package files.
 - [ ] Type-check a clean consumer using exported/transitive types from the
-      authored `.mjs` fixture.
+      authored `.mjs` fixture, without importing `_`-prefixed private typedefs.
 - [ ] Verify the CI-built archive contains authored `.mjs`, generated `.js`,
       `.d.ts`, and `.d.mts` in the expected paths during stage 1.
 - [x] Update `AGENTS.md` to the asymmetric `.f.ts` / `.f.mjs` migration policy.
@@ -158,6 +175,9 @@ the clean-consumer type-check, or the rejected `.mjs`→`.ts` import direction.
   present; PR #1451 provides the initial repository validation of this behavior.
 - Package emission produces `.d.ts` for `.ts`, `.d.mts` for `.mjs`, `.js` only
   for `.ts`, and preserves authored `.mjs` unchanged.
+- `_`-prefixed JSDoc typedefs are treated as private API even if declaration
+  emission currently writes them as exported aliases; clean-consumer tests do
+  not depend on those names.
 - Non-public authored `.mjs` files do not require special package exclusions.
 - No separate user-facing `emit:*` scripts are required.
 - Package/publish runs start from a clean CI checkout, so ignored generated
@@ -190,6 +210,11 @@ prepares authored `.f.js` before compiler-compatibility migration starts.
   two-pass `prepack`.
 - [`todo/migrate-typescript-to-mjs.md`](../../../todo/migrate-typescript-to-mjs.md)
   — repository-wide stage-1 source migration.
+- [`todo/blocked/jsdoc-typedef-strip-internal.md`](../../../todo/blocked/jsdoc-typedef-strip-internal.md)
+  — replace the temporary `_` convention with `@internal` when declaration emit
+  supports it.
+- [microsoft/TypeScript#46407](https://github.com/microsoft/TypeScript/issues/46407)
+  — upstream blocker for stripping private JSDoc typedefs.
 - [`publishing-packages.md`](./publishing-packages.md) — broader package roadmap.
 - [`f-js-package-support.md`](./f-js-package-support.md) — stage-2 authored
   `.f.js` package prerequisite.

--- a/fjs/fsc/README.md
+++ b/fjs/fsc/README.md
@@ -75,8 +75,11 @@ leading `_` for implementation-only typedefs created during the migration:
 The underscore is an API contract, not declaration-level visibility. Generated
 `.d.ts` / `.d.mts` may still contain `export type _Type = number`, but names that
 begin with `_` are private FunctionalScript implementation details. Consumers
-must not rely on them, and changing, renaming, or removing them is not a breaking
-change and does not require a `**BREAKING CHANGES:**` changelog entry.
+must not rely on those names directly, so renaming or removing a `_`-prefixed
+alias is not a breaking change solely because TypeScript emitted it. The public
+contract still governs transitive effects: if a public type depends on `_Type`,
+changing `_Type` in a way that changes that public type's assignability is a
+breaking change and requires the normal `**BREAKING CHANGES:**` treatment.
 
 Public typedefs keep ordinary names without the `_` prefix. When upstream
 support is ready, replace this workaround with `@internal`; that cleanup is

--- a/fjs/fsc/README.md
+++ b/fjs/fsc/README.md
@@ -81,6 +81,33 @@ contract still governs transitive effects: if a public type depends on `_Type`,
 changing `_Type` in a way that changes that public type's assignability is a
 breaking change and requires the normal `**BREAKING CHANGES:**` treatment.
 
+For example, suppose the generated declaration initially contains:
+
+```ts
+export type _Internal = number
+export type Public = readonly [_Internal]
+```
+
+Changing it to this is **not** a breaking change:
+
+```ts
+export type Public = readonly [number]
+```
+
+`_Internal` disappeared, but the expanded public contract of `Public` is still
+`readonly [number]`. A consumer that imported `_Internal` directly was depending
+on a private implementation detail.
+
+By contrast, changing it to this **is** a breaking change:
+
+```ts
+export type _Internal = string
+export type Public = readonly [_Internal]
+```
+
+The emitted private alias is still private, but the expanded public contract of
+`Public` changed from `readonly [number]` to `readonly [string]`.
+
 Public typedefs keep ordinary names without the `_` prefix. When upstream
 support is ready, replace this workaround with `@internal`; that cleanup is
 tracked by

--- a/fjs/fsc/README.md
+++ b/fjs/fsc/README.md
@@ -58,6 +58,31 @@ proof itself is valid JavaScript with JSDoc and its authored runtime and type
 dependencies are already `.f.mjs`. Current FunctionalScript compiler support is
 not a condition for that rename.
 
+#### Private JSDoc typedefs
+
+TypeScript declaration emit currently turns JSDoc `@typedef`s into exported type
+aliases, including typedefs that exist only as implementation details. This is
+tracked upstream by
+[microsoft/TypeScript#46407](https://github.com/microsoft/TypeScript/issues/46407).
+
+Until JSDoc typedefs can be stripped with `@internal` and `stripInternal`, use a
+leading `_` for implementation-only typedefs created during the migration:
+
+```js
+/** @typedef {number} _Type */
+```
+
+The underscore is an API contract, not declaration-level visibility. Generated
+`.d.ts` / `.d.mts` may still contain `export type _Type = number`, but names that
+begin with `_` are private FunctionalScript implementation details. Consumers
+must not rely on them, and changing, renaming, or removing them is not a breaking
+change and does not require a `**BREAKING CHANGES:**` changelog entry.
+
+Public typedefs keep ordinary names without the `_` prefix. When upstream
+support is ready, replace this workaround with `@internal`; that cleanup is
+tracked by
+[`todo/blocked/jsdoc-typedef-strip-internal.md`](../../todo/blocked/jsdoc-typedef-strip-internal.md).
+
 When the last authored `.ts` / `.f.ts` file is gone, remove the
 TypeScript-to-JavaScript emit path, remove obsolete generated `.js` from the
 working tree for that transition, and remove the blanket `**/*.js` rule from

--- a/todo/blocked/jsdoc-typedef-strip-internal.md
+++ b/todo/blocked/jsdoc-typedef-strip-internal.md
@@ -72,6 +72,21 @@ Do not strip a private typedef if a public declaration still depends on its name
 refactor the public declaration first so emitted declarations remain
 self-contained and preserve the same public assignability contract.
 
+### Tasks
+
+- [ ] Enable or retain `stripInternal` for declaration emission once the trigger
+      is satisfied.
+- [ ] Mark implementation-only JSDoc typedefs with `@internal`.
+- [ ] Remove leading `_` from private typedef names where the prefix exists only
+      as the temporary visibility workaround.
+- [ ] Refactor public declarations that refer to private typedef names so they
+      remain self-contained and preserve the same public assignability contract
+      before those private typedefs are stripped.
+- [ ] Add a package/declaration fixture proving that private typedefs are absent
+      from emitted declarations while public declarations remain valid.
+- [ ] Update migration, compiler, package, and contributor documentation to
+      remove the underscore workaround.
+
 ### Acceptance criteria
 
 - `@internal` on a JSDoc `@typedef` is honored by the repository's TypeScript

--- a/todo/blocked/jsdoc-typedef-strip-internal.md
+++ b/todo/blocked/jsdoc-typedef-strip-internal.md
@@ -29,6 +29,11 @@ The canonical blocker is
 which is still open and specifically requests `stripInternal` support for types
 defined with JSDoc.
 
+Another open TypeScript declaration/comment-emission issue,
+[microsoft/TypeScript#62453](https://github.com/microsoft/TypeScript/issues/62453),
+demonstrates the same JSDoc typedef-to-`export type` emission path while tracking
+duplicated typedef comments. It is related context, not the visibility blocker.
+
 A separate equivalent TypeScript 7 / Go issue was not found in
 `microsoft/typescript-go`. The native compiler does implement `stripInternal`
 in general, but the known JSDoc declaration-emission reports still show
@@ -83,3 +88,5 @@ self-contained.
   — declaration-emission and clean-consumer validation.
 - [microsoft/TypeScript#46407](https://github.com/microsoft/TypeScript/issues/46407)
   — canonical upstream feature request.
+- [microsoft/TypeScript#62453](https://github.com/microsoft/TypeScript/issues/62453)
+  — related JSDoc typedef declaration/comment emission bug.

--- a/todo/blocked/jsdoc-typedef-strip-internal.md
+++ b/todo/blocked/jsdoc-typedef-strip-internal.md
@@ -13,7 +13,11 @@ to be public API.
 Until the declaration emitter can strip private JSDoc typedefs, the repository
 uses a leading `_` as an API convention: a typedef such as `_Node` is private by
 contract even if the generated `.d.ts` / `.d.mts` contains `export type _Node`.
-Changing, renaming, or removing such a type is therefore not a breaking change.
+Consumers must not depend on that emitted name directly, so renaming or removing
+the alias is not a breaking change solely because it was emitted. This does not
+exempt changes propagated into public types: if a public declaration depends on
+`_Node`, any change that alters that public declaration's assignability remains
+a breaking API change.
 
 The desired long-term representation is `@internal` plus `stripInternal`, so the
 generated declaration does not expose the private type at all.
@@ -66,7 +70,7 @@ Once the trigger is satisfied:
 
 Do not strip a private typedef if a public declaration still depends on its name;
 refactor the public declaration first so emitted declarations remain
-self-contained.
+self-contained and preserve the same public assignability contract.
 
 ### Acceptance criteria
 
@@ -74,6 +78,8 @@ self-contained.
   declaration emitter when `stripInternal` is enabled.
 - Generated `.d.ts` / `.d.mts` files omit implementation-only typedefs.
 - Public emitted declarations never reference a stripped private type.
+- Removing the `_` workaround does not weaken or otherwise change public
+  assignability unless that change is explicitly treated as breaking.
 - The `_`-prefix workaround is removed from repository documentation and from
   private typedefs that used it solely for visibility.
 - Clean package-consumer type checking still passes.

--- a/todo/blocked/jsdoc-typedef-strip-internal.md
+++ b/todo/blocked/jsdoc-typedef-strip-internal.md
@@ -1,0 +1,85 @@
+# Use `@internal` for private JSDoc typedefs
+
+**Priority:** P3
+**Status:** blocked
+
+### Problem
+
+During the TypeScript-to-JavaScript migration, implementation-only TypeScript
+types become JSDoc `@typedef`s. TypeScript currently emits those typedefs as
+exported type aliases in generated declarations even when they are not intended
+to be public API.
+
+Until the declaration emitter can strip private JSDoc typedefs, the repository
+uses a leading `_` as an API convention: a typedef such as `_Node` is private by
+contract even if the generated `.d.ts` / `.d.mts` contains `export type _Node`.
+Changing, renaming, or removing such a type is therefore not a breaking change.
+
+The desired long-term representation is `@internal` plus `stripInternal`, so the
+generated declaration does not expose the private type at all.
+
+### Trigger
+
+Unblocked when the TypeScript compiler used by this repository supports applying
+`@internal` to JSDoc `@typedef` declarations and `stripInternal` reliably omits
+those typedefs from generated `.d.ts` / `.d.mts` files.
+
+The canonical blocker is
+[microsoft/TypeScript#46407](https://github.com/microsoft/TypeScript/issues/46407),
+which is still open and specifically requests `stripInternal` support for types
+defined with JSDoc.
+
+A separate equivalent TypeScript 7 / Go issue was not found in
+`microsoft/typescript-go`. The native compiler does implement `stripInternal`
+in general, but the known JSDoc declaration-emission reports still show
+`@typedef`s becoming exported aliases. Related TypeScript-Go issues are:
+
+- [microsoft/typescript-go#4363](https://github.com/microsoft/typescript-go/issues/4363)
+  — open; emitted JSDoc typedef aliases and their documentation ordering.
+- [microsoft/typescript-go#4235](https://github.com/microsoft/typescript-go/issues/4235)
+  — closed; JSDoc typedef/property documentation in declaration emit.
+- [microsoft/typescript-go#4011](https://github.com/microsoft/typescript-go/issues/4011)
+  — closed; correctness of generated declaration syntax for JSDoc typedefs.
+
+These TypeScript-Go issues are adjacent declaration-emitter bugs, not substitutes
+for #46407. Re-check the current TypeScript tracker when this task is unblocked,
+especially as the native compiler work is consolidated with the main TypeScript
+project.
+
+### Proposal
+
+Once the trigger is satisfied:
+
+1. enable or retain `stripInternal` for declaration emission;
+2. mark implementation-only JSDoc typedefs with `@internal`;
+3. remove leading `_` from private typedef names where the prefix exists only as
+   the current visibility workaround;
+4. add a package/declaration fixture proving that private typedefs are absent
+   from emitted declarations while public declarations remain valid;
+5. update migration, compiler, package, and contributor documentation to remove
+   the underscore workaround.
+
+Do not strip a private typedef if a public declaration still depends on its name;
+refactor the public declaration first so emitted declarations remain
+self-contained.
+
+### Acceptance criteria
+
+- `@internal` on a JSDoc `@typedef` is honored by the repository's TypeScript
+  declaration emitter when `stripInternal` is enabled.
+- Generated `.d.ts` / `.d.mts` files omit implementation-only typedefs.
+- Public emitted declarations never reference a stripped private type.
+- The `_`-prefix workaround is removed from repository documentation and from
+  private typedefs that used it solely for visibility.
+- Clean package-consumer type checking still passes.
+
+### Related
+
+- [`../migrate-typescript-to-mjs.md`](../migrate-typescript-to-mjs.md) — Stage 1
+  TypeScript-to-JSDoc migration and the temporary `_` convention.
+- [`../../fjs/fsc/README.md`](../../fjs/fsc/README.md) — source migration and
+  JSDoc visibility contract.
+- [`../../fjs/ci/todo/f-mjs-package-support.md`](../../fjs/ci/todo/f-mjs-package-support.md)
+  — declaration-emission and clean-consumer validation.
+- [microsoft/TypeScript#46407](https://github.com/microsoft/TypeScript/issues/46407)
+  — canonical upstream feature request.

--- a/todo/migrate-typescript-to-mjs.md
+++ b/todo/migrate-typescript-to-mjs.md
@@ -126,6 +126,40 @@ Use `@template out T`, `@template in T`, or constrained forms such as
 `@template {Operation} out O`. Variance modifiers belong to a JSDoc type alias
 (`@typedef`), not to an ordinary function's `@template`.
 
+#### Preserve private type intent with `_`
+
+A non-exported TypeScript type can become externally visible merely by being
+translated to a JSDoc `@typedef`: TypeScript currently emits JSDoc typedefs as
+exported aliases in generated declarations. The upstream request to make
+`@internal` plus `stripInternal` work for JSDoc typedefs is
+[microsoft/TypeScript#46407](https://github.com/microsoft/TypeScript/issues/46407).
+
+Until that support is available, prefix implementation-only typedef names with
+`_` during migration. For example:
+
+```ts
+type Node = number
+export type Tree = readonly Node[]
+```
+
+becomes conceptually:
+
+```js
+/** @typedef {number} _Node */
+/** @typedef {readonly _Node[]} Tree */
+```
+
+The leading `_` is the FunctionalScript API visibility convention. It does not
+prevent declaration emission, so generated declarations may contain
+`export type _Node = number`. Nevertheless, `_Node` remains private by contract:
+consumers must not depend on it, and changing, renaming, or removing it is not a
+breaking change and does not require a `**BREAKING CHANGES:**` changelog entry.
+Public typedefs keep ordinary names without a leading `_`.
+
+This convention is temporary. Once TypeScript can strip `@internal` JSDoc
+typedefs correctly, replace the underscore workaround as tracked by
+[`blocked/jsdoc-typedef-strip-internal.md`](./blocked/jsdoc-typedef-strip-internal.md).
+
 #### Known TypeScript-to-JSDoc hard cases
 
 Do not require the migration plan to pre-design every TypeScript-only type
@@ -151,6 +185,8 @@ For each migration group:
 
 - replace TypeScript-only syntax with equivalent JavaScript plus JSDoc types;
 - preserve public assignability semantics, not only runtime behavior;
+- preserve type visibility intent: public typedefs retain public names and
+  implementation-only typedefs use the `_` prefix;
 - if a TypeScript-only construct has no established semantics-preserving JSDoc
   translation, record it as a focused hard case and postpone that group rather
   than inventing a redesign inside the mechanical migration;
@@ -209,6 +245,10 @@ compiler-compatibility rename.
       compiler support.
 - [ ] Translate TypeScript generic constraints and `in` / `out` variance to
       JSDoc `@template` syntax without changing assignability.
+- [ ] Prefix implementation-only JSDoc typedefs with `_` when converting
+      non-exported TypeScript types; keep public typedef names unprefixed.
+- [ ] Do not treat changes to `_`-prefixed typedefs as breaking API changes or
+      require a `**BREAKING CHANGES:**` entry solely for those changes.
 - [ ] Continue upward through the dependency graph in reviewable groups until no
       authored TypeScript remains.
 - [ ] Translate `.ts` to `.mjs` and `.f.ts` to `.f.mjs`, moving static type
@@ -225,7 +265,7 @@ compiler-compatibility rename.
 - [ ] Preserve Node, Deno, Bun, proof, coverage, type-checking, declaration, and
       CI package behavior throughout the migration.
 - [ ] Add required `**BREAKING CHANGES:**` changelog entries for public runtime
-      import paths that change.
+      import paths that change; `_`-prefixed private typedef changes are exempt.
 - [ ] After the last authored TypeScript file is gone, simplify `prepack` to its
       declaration-only command and remove the TS-to-JS emit path and obsolete
       generated `.js` outputs.
@@ -251,6 +291,10 @@ compiler-compatibility rename.
   never by current FunctionalScript compiler support.
 - TypeScript generic constraints and variance annotations are preserved with
   their JSDoc `@template` equivalents; public assignability is not weakened.
+- Implementation-only JSDoc typedefs use `_`-prefixed names and are treated as
+  private API even when TypeScript emits them as exported declaration aliases.
+- Changing, renaming, or removing an `_`-prefixed typedef is not a breaking
+  change; public typedefs remain unprefixed.
 - `.f.mjs` means FunctionalScript-intent JavaScript, not current-compiler
   compatibility.
 - Migrated JavaScript never depends on remaining authored TypeScript during the
@@ -277,6 +321,11 @@ compiler-compatibility rename.
   — broader package-publishing plan.
 - [`../fjs/fsc/README.md`](../fjs/fsc/README.md) — authoritative FunctionalScript
   extension and migration contract.
+- [`blocked/jsdoc-typedef-strip-internal.md`](./blocked/jsdoc-typedef-strip-internal.md)
+  — replace the temporary `_` convention with `@internal` when upstream
+  declaration emit supports it.
+- [microsoft/TypeScript#46407](https://github.com/microsoft/TypeScript/issues/46407)
+  — upstream request for `stripInternal` support on JSDoc typedefs.
 - [`fjs-nanvm-integration.md`](./fjs-nanvm-integration.md) — existing compiler
   integration and compiler-compatibility migration.
 - [`plan/roadmap.md`](./plan/roadmap.md) — project roadmap.

--- a/todo/migrate-typescript-to-mjs.md
+++ b/todo/migrate-typescript-to-mjs.md
@@ -151,10 +151,16 @@ becomes conceptually:
 
 The leading `_` is the FunctionalScript API visibility convention. It does not
 prevent declaration emission, so generated declarations may contain
-`export type _Node = number`. Nevertheless, `_Node` remains private by contract:
-consumers must not depend on it, and changing, renaming, or removing it is not a
-breaking change and does not require a `**BREAKING CHANGES:**` changelog entry.
-Public typedefs keep ordinary names without a leading `_`.
+`export type _Node = number`. `_Node` is still private by contract: consumers
+must not depend on that emitted name directly, so renaming or removing `_Node`
+is not a breaking change solely because TypeScript exposed the alias.
+
+The public contract still governs transitive effects. In the example above,
+`Tree` is public and depends on `_Node`; changing `_Node` from `number` to
+`string` changes `Tree`'s public assignability and is therefore a breaking
+change. The underscore exempts only the private alias itself, never a change to
+the expanded public API. Public typedefs keep ordinary names without a leading
+`_`.
 
 This convention is temporary. Once TypeScript can strip `@internal` JSDoc
 typedefs correctly, replace the underscore workaround as tracked by
@@ -247,8 +253,9 @@ compiler-compatibility rename.
       JSDoc `@template` syntax without changing assignability.
 - [ ] Prefix implementation-only JSDoc typedefs with `_` when converting
       non-exported TypeScript types; keep public typedef names unprefixed.
-- [ ] Do not treat changes to `_`-prefixed typedefs as breaking API changes or
-      require a `**BREAKING CHANGES:**` entry solely for those changes.
+- [ ] Treat `_`-prefixed typedef names as private even when declarations emit
+      them as exports, but still require `**BREAKING CHANGES:**` whenever a
+      change to one alters the assignability of a public declaration.
 - [ ] Continue upward through the dependency graph in reviewable groups until no
       authored TypeScript remains.
 - [ ] Translate `.ts` to `.mjs` and `.f.ts` to `.f.mjs`, moving static type
@@ -264,8 +271,9 @@ compiler-compatibility rename.
       `.f.ts`-reference check at least at the end of stage 1.
 - [ ] Preserve Node, Deno, Bun, proof, coverage, type-checking, declaration, and
       CI package behavior throughout the migration.
-- [ ] Add required `**BREAKING CHANGES:**` changelog entries for public runtime
-      import paths that change; `_`-prefixed private typedef changes are exempt.
+- [ ] Add required `**BREAKING CHANGES:**` changelog entries for every public
+      runtime or type-contract change; direct changes to an emitted `_` alias
+      are exempt only when the expanded public contract is unchanged.
 - [ ] After the last authored TypeScript file is gone, simplify `prepack` to its
       declaration-only command and remove the TS-to-JS emit path and obsolete
       generated `.js` outputs.
@@ -293,8 +301,9 @@ compiler-compatibility rename.
   their JSDoc `@template` equivalents; public assignability is not weakened.
 - Implementation-only JSDoc typedefs use `_`-prefixed names and are treated as
   private API even when TypeScript emits them as exported declaration aliases.
-- Changing, renaming, or removing an `_`-prefixed typedef is not a breaking
-  change; public typedefs remain unprefixed.
+- Renaming or removing an emitted `_`-prefixed alias is not breaking solely due
+  to that alias being emitted; any resulting change to a public declaration's
+  assignability is still a breaking change.
 - `.f.mjs` means FunctionalScript-intent JavaScript, not current-compiler
   compatibility.
 - Migrated JavaScript never depends on remaining authored TypeScript during the

--- a/todo/rename-private-jsdoc-typedefs.md
+++ b/todo/rename-private-jsdoc-typedefs.md
@@ -1,0 +1,125 @@
+# Rename private JSDoc typedefs in migrated modules
+
+**Priority:** P1
+**Status:** open
+
+### Problem
+
+The first Stage-1 `.f.ts` -> `.f.mjs` migrations landed before the repository
+adopted the leading-`_` convention for implementation-only JSDoc typedefs.
+TypeScript emits module-scope JSDoc `@typedef`s as exported declaration aliases,
+so an implementation-only type that kept its old unprefixed name now appears to
+be public in generated `.d.mts` even though it was not public before migration.
+
+Audit the already migrated `.f.mjs` modules against the `.f.ts` source immediately
+before each migration. A type is private when either:
+
+- the corresponding module-scope TypeScript alias was not exported before the
+  migration; or
+- the JSDoc migration introduced a new alias solely as an implementation helper
+  for another type.
+
+This cleanup restores the intended visibility contract; it must not redesign or
+weaken public types. Renaming a private alias is not a breaking change when the
+expanded/structural contract of every public declaration remains unchanged.
+
+### Audit
+
+The audit covers all 14 current `.f.mjs` FunctionalScript modules. Historical
+visibility was checked against the parent revision of the migration that created
+each `.f.mjs` file: PRs
+[#1452](https://github.com/functionalscript/functionalscript/pull/1452),
+[#1453](https://github.com/functionalscript/functionalscript/pull/1453),
+[#1454](https://github.com/functionalscript/functionalscript/pull/1454),
+[#1456](https://github.com/functionalscript/functionalscript/pull/1456),
+[#1458](https://github.com/functionalscript/functionalscript/pull/1458), and
+[#1460](https://github.com/functionalscript/functionalscript/pull/1460).
+
+| Migrated module | Migration | Private typedef cleanup |
+|---|---|---|
+| `fjs/asserts/module.f.mjs` | #1452 | None; `Assert` was public. |
+| `fjs/types/function/module.f.mjs` | #1453 | `Fn` -> `_Fn` (the old `Fn` alias was not exported). |
+| `fjs/types/option/module.f.mjs` | #1453 | None; `Option` was public. |
+| `fjs/types/nullable/module.f.mjs` | #1453 | None; `Nullable` was public. |
+| `fjs/types/array/module.f.mjs` | #1454 | `TupleX` -> `_TupleX`, `IndexX` -> `_IndexX`; both are migration-introduced recursive helpers. Existing `_X0`, `_X1`, `_X2` already follow the private convention. |
+| `fjs/types/ts/module.f.mjs` | #1454 | None; `Equal` and `Printer` were public. |
+| `fjs/types/function/compare/module.f.mjs` | #1456 | None; all module-scope type aliases were public. |
+| `fjs/types/function/operator/module.f.mjs` | #1456 | None; all module-scope type aliases were public. |
+| `fjs/types/list/module.f.mjs` | #1458 | `NotLazy` -> `_NotLazy`, `Empty` -> `_Empty`, `Concat` -> `_Concat`; all three old aliases were non-exported. |
+| `fjs/types/result/module.f.mjs` | #1458 | None; `Ok`, `Error`, and `Result` were public. |
+| `fjs/common/monoid/module.f.mjs` | #1458 | None; `Monoid` was public. |
+| `fjs/types/bigint/module.f.mjs` | #1458 | None; `Unary` and `Reduce` were public. |
+| `fjs/types/nominal/module.f.mjs` | #1458 | None; `Nominal` was public. |
+| `fjs/types/bit_vec/module.f.mjs` | #1460 | `Revision` -> `_Revision` (migration-introduced helper); `Norm` -> `_Norm`, `NormOp` -> `_NormOp`, `Base` -> `_Base`, `UnpackConcat` -> `_UnpackConcat`, `ListToVecState` -> `_ListToVecState`, `ListToVecOp` -> `_ListToVecOp` (all corresponding old aliases were non-exported). |
+
+This gives 13 aliases to rename across four modules.
+
+Function-local JSDoc aliases such as the local `T` typedefs used inside functions
+are not part of this cleanup: they correspond to local TypeScript aliases and do
+not define module-level package API. If declaration emission ever promotes one
+of them to a module-level alias, add it to this task using the same visibility
+rule.
+
+### Proposal
+
+Rename only the audited private module-scope typedefs and all references to those
+names. Keep every public typedef name unchanged.
+
+For aliases referenced by public declarations, preserve the expanded public
+contract. For example, changing a public declaration from
+`readonly [Private]` to `readonly [_Private]` is only a visibility cleanup when
+`Private` and `_Private` denote the same type. A change to the underlying type
+that changes public assignability is a separate breaking API change.
+
+The cleanup should not add a `**BREAKING CHANGES:**` entry solely because an
+accidentally emitted implementation alias changes name: those aliases were
+non-public before migration or were introduced only as private migration
+helpers. Add normal breaking-change documentation if implementation of this task
+also changes an expanded public contract.
+
+### Tasks
+
+- [x] Audit every current `.f.mjs` FunctionalScript module against its
+      pre-migration `.f.ts` source.
+- [ ] In `fjs/types/function/module.f.mjs`, rename `Fn` to `_Fn` and update its
+      recursive/self references and the `fn` annotation.
+- [ ] In `fjs/types/array/module.f.mjs`, rename `TupleX` to `_TupleX` and
+      `IndexX` to `_IndexX`, updating the public `Tuple` / `Index` definitions
+      without changing their resulting types.
+- [ ] In `fjs/types/list/module.f.mjs`, rename `NotLazy` to `_NotLazy`, `Empty`
+      to `_Empty`, and `Concat` to `_Concat`, updating all internal and public
+      references without changing expanded public types.
+- [ ] In `fjs/types/bit_vec/module.f.mjs`, rename `Revision`, `Norm`, `NormOp`,
+      `Base`, `UnpackConcat`, `ListToVecState`, and `ListToVecOp` to their
+      leading-`_` forms and update all references.
+- [ ] Search all `.mjs` / `.f.mjs` sources and JSDoc imports for references to
+      the old private names; update internal references and confirm no supported
+      consumer API depends on them.
+- [ ] Emit `.d.mts` declarations before/after the cleanup and verify that public
+      declaration assignability is unchanged after expanding private aliases.
+- [ ] Run type checking, tests/proofs, declaration emission, and package consumer
+      validation required by the Stage-1 migration.
+
+### Acceptance criteria
+
+- Every audited implementation-only module-scope JSDoc typedef uses a leading
+  `_`.
+- Public aliases that existed before migration retain their public names.
+- Migration-introduced helper aliases are `_`-prefixed unless intentionally
+  promoted to documented public API.
+- Generated declarations may still emit `_` aliases, but public declarations
+  preserve the same expanded/structural type contracts as before this cleanup.
+- No source or test imports an old private alias as supported package API.
+- No `**BREAKING CHANGES:**` entry is required solely for these visibility
+  renames; any actual public assignability change is treated separately as
+  breaking.
+
+### Related
+
+- [`migrate-typescript-to-mjs.md`](./migrate-typescript-to-mjs.md) — Stage-1
+  TypeScript-to-JSDoc migration and the leading-`_` visibility convention.
+- [`../fjs/fsc/README.md`](../fjs/fsc/README.md) — authoritative migration and
+  private-JSDoc typedef contract.
+- [`blocked/jsdoc-typedef-strip-internal.md`](./blocked/jsdoc-typedef-strip-internal.md)
+  — eventual replacement of the `_` workaround with `@internal` and
+  `stripInternal`.


### PR DESCRIPTION
## Summary

- document `_`-prefixed JSDoc typedefs as private FunctionalScript API during the TypeScript-to-JavaScript migration
- state that consumers must not depend on emitted `_` alias names directly, so renaming/removing such an alias is not breaking solely because TypeScript emitted it as `export type`
- preserve the normal breaking-change rule for transitive effects: if changing a private alias changes a public declaration's assignability, that public type change is breaking
- add concrete breaking/non-breaking `.d.ts` examples based on the expanded public type contract
- update the migration and `.mjs` package-validation TODOs to preserve that API intent
- add `todo/rename-private-jsdoc-typedefs.md`: audit all 14 already migrated `.f.mjs` modules against their pre-migration `.f.ts` sources and track 13 private-alias renames across `function`, `array`, `list`, and `bit_vec`
- add `todo/blocked/jsdoc-typedef-strip-internal.md` to replace the workaround with `@internal` + `stripInternal` once upstream support is available

## Upstream tracking

The direct blocker is microsoft/TypeScript#46407 (`Support stripInternal for types in JSDoc`).

I did not find a dedicated equivalent issue in `microsoft/typescript-go`. The blocked TODO records the adjacent native declaration-emitter issues #4363, #4235, and #4011, and also references microsoft/TypeScript#62453 as related typedef declaration/comment-emission context.

## Validation

Documentation/TODO-only change. The private-type cleanup audit compares each existing `.f.mjs` module with the `.f.ts` source immediately before its migration; no runtime source is changed by this PR, so no runtime checks are required.