### PR TITLE
Add test for DFA with missing states fallback behavior

### DIFF
--- a/fjs/fsm/proof.f.ts
+++ b/fjs/fsm/proof.f.ts
@@ -131,6 +131,16 @@ export const proof = {
             ]
             const expectedResult = stringifyIdentity(expectedOutput)
             assertEq(result, expectedResult)
+        },
+        () => {
+            // `run` accepts any `Dfa` (a `StringMap`, so entries may be
+            // missing), not only one built by `dfa()`. A state absent from
+            // the map falls back to the empty transition table.
+            const result = stringifyIdentity(toArray(run({})(stringToList('a'))))
+
+            const expectedOutput = ['[]']
+            const expectedResult = stringifyIdentity(expectedOutput)
+            assertEq(result, expectedResult)
         }
     ]
 }


### PR DESCRIPTION
## Summary
Added a test case to verify that the `run` function correctly handles DFAs with missing states by falling back to an empty transition table.

## Key Changes
- Added a new test case in the proof suite that validates `run` accepts any `Dfa` (a `StringMap`), not only those built by the `dfa()` constructor
- The test verifies that when a state is absent from the DFA map, it falls back to an empty transition table, resulting in no transitions being available
- Test case passes an empty object `{}` as the DFA and verifies it produces an empty array `[]` when processing input

## Implementation Details
- The test uses the existing test infrastructure (`stringifyIdentity`, `toArray`, `run`, `stringToList`, `assertEq`)
- Demonstrates that the `run` function is flexible enough to work with incomplete DFA definitions, which is useful for partial or dynamically constructed state machines

https://claude.ai/code/session_017WMju3jw7xPWz59gktNGDm