### PR TITLE
Update dependencies and Node.js versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "26.6.0"
+            "node-version": "26.7.0"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.41.0"
+          "run": "npm install -g functionalscript@0.43.1"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -77,11 +77,11 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "26.6.0"
+            "node-version": "26.7.0"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.41.0"
+          "run": "npm install -g functionalscript@0.43.1"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -118,11 +118,11 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "26.6.0"
+            "node-version": "26.7.0"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.41.0"
+          "run": "npm install -g functionalscript@0.43.1"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -159,11 +159,11 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "26.6.0"
+            "node-version": "26.7.0"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.41.0"
+          "run": "npm install -g functionalscript@0.43.1"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -201,11 +201,11 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "26.6.0"
+            "node-version": "26.7.0"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.41.0"
+          "run": "npm install -g functionalscript@0.43.1"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -254,11 +254,11 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "26.6.0"
+            "node-version": "26.7.0"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.41.0"
+          "run": "npm install -g functionalscript@0.43.1"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -385,17 +385,17 @@
         {
           "uses": "denoland/setup-deno@v2.0.5",
           "with": {
-            "deno-version": "2.9.4"
+            "deno-version": "2.9.5"
           }
         },
         {
-          "run": "deno install -g -A --minimum-dependency-age=0 npm:functionalscript@0.41.0"
+          "run": "deno install -g -A --minimum-dependency-age=0 npm:functionalscript@0.43.1"
         },
         {
           "uses": "actions/checkout@v7.0.1"
         },
         {
-          "run": "deno run -A --minimum-dependency-age=0 npm:functionalscript@0.41.0 test"
+          "run": "deno run -A --minimum-dependency-age=0 npm:functionalscript@0.43.1 test"
         },
         {
           "run": "deno install --frozen"
@@ -415,7 +415,7 @@
           }
         },
         {
-          "run": "bun install -g functionalscript@0.41.0"
+          "run": "bun install -g functionalscript@0.43.1"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -424,7 +424,7 @@
           "run": "bun install --frozen-lockfile"
         },
         {
-          "run": "bunx functionalscript@0.41.0 test"
+          "run": "bunx functionalscript@0.43.1 test"
         },
         {
           "run": "bun test --coverage"
@@ -441,7 +441,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.41.0"
+          "run": "npm install -g functionalscript@0.43.1"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -463,7 +463,7 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "24.18.0"
+            "node-version": "24.18.1"
           }
         },
         {
@@ -483,7 +483,7 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "26.6.0"
+            "node-version": "26.7.0"
           }
         },
         {
@@ -522,10 +522,10 @@
           "run": "test \"$(nix develop ./nix/generated/node22 --command node --version)\" = v22.23.2"
         },
         {
-          "run": "test \"$(nix develop ./nix/generated/node24 --command node --version)\" = v24.18.0"
+          "run": "test \"$(nix develop ./nix/generated/node24 --command node --version)\" = v24.18.1"
         },
         {
-          "run": "test \"$(nix develop ./nix/generated/node26 --command node --version)\" = v26.6.0"
+          "run": "test \"$(nix develop ./nix/generated/node26 --command node --version)\" = v26.7.0"
         }
       ]
     }

--- a/fjs/ci/config/module.f.ts
+++ b/fjs/ci/config/module.f.ts
@@ -24,13 +24,13 @@ export const images = {
 // published FunctionalScript release; do not tie it to package.json's current
 // in-repo version.
 // https://www.npmjs.com/package/functionalscript
-export const functionalscript = '0.41.0' as const
+export const functionalscript = '0.43.1' as const
 
 // https://bun.sh/
 export const bun = '1.3.14'
 
 // https://deno.com/
-export const deno = '2.9.4'
+export const deno = '2.9.5'
 
 // The Node versions the pinned Nixpkgs snapshot below provides — read from
 // `pkgs/development/web/nodejs/v{22,24,26}.nix` at that commit. Every runtime
@@ -40,9 +40,9 @@ export const deno = '2.9.4'
 // it offers rather than the latest release.
 // https://nodejs.org/en/download
 export const node = {
-    default: '26.6.0',
+    default: '26.7.0',
     node22: '22.23.2',
-    node24: '24.18.0',
+    node24: '24.18.1',
 } as const
 
 // Official Nixpkgs snapshot used by the generated CI flakes. `ref` is the
@@ -52,7 +52,7 @@ export const node = {
 // https://channels.nixos.org/nixos-26.05/git-revision
 export const nixpkgs = {
     ref: 'nixos-26.05',
-    commit: '04607e1165ac22c5fde6dcc54c9e0b3c0487c555',
+    commit: 'fcb8fcd6bf2d0adecae5bd491afaaaf8311b758d',
 } as const
 
 // https://github.com/bytecodealliance/wasmtime/releases

--- a/nix/generated/node22/flake.nix
+++ b/nix/generated/node22/flake.nix
@@ -1,5 +1,5 @@
 {
-    inputs.nixpkgs.url = "github:NixOS/nixpkgs/04607e1165ac22c5fde6dcc54c9e0b3c0487c555";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/fcb8fcd6bf2d0adecae5bd491afaaaf8311b758d";
     outputs = { nixpkgs, ... }: {
         devShells.aarch64-linux.default = let
             pkgs = import nixpkgs {

--- a/nix/generated/node24/flake.nix
+++ b/nix/generated/node24/flake.nix
@@ -1,5 +1,5 @@
 {
-    inputs.nixpkgs.url = "github:NixOS/nixpkgs/04607e1165ac22c5fde6dcc54c9e0b3c0487c555";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/fcb8fcd6bf2d0adecae5bd491afaaaf8311b758d";
     outputs = { nixpkgs, ... }: {
         devShells.aarch64-linux.default = let
             pkgs = import nixpkgs {

--- a/nix/generated/node26/flake.nix
+++ b/nix/generated/node26/flake.nix
@@ -1,5 +1,5 @@
 {
-    inputs.nixpkgs.url = "github:NixOS/nixpkgs/04607e1165ac22c5fde6dcc54c9e0b3c0487c555";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/fcb8fcd6bf2d0adecae5bd491afaaaf8311b758d";
     outputs = { nixpkgs, ... }: {
         devShells.aarch64-linux.default = let
             pkgs = import nixpkgs {


### PR DESCRIPTION
## Summary
This PR updates various development dependencies and runtime versions across the CI configuration and Nix flakes.

## Key Changes
- **FunctionalScript**: Updated from `0.41.0` to `0.43.1` across all CI workflows and configuration
- **Node.js versions**:
  - Default Node.js: `26.6.0` → `26.7.0`
  - Node 24: `24.18.0` → `24.18.1`
- **Deno**: Updated from `2.9.4` to `2.9.5`
- **Nixpkgs**: Updated commit reference from `04607e1165ac22c5fde6dcc54c9e0b3c0487c555` to `fcb8fcd6bf2d0adecae5bd491afaaaf8311b758d` (nixos-26.05 channel)
- **Nix flakes**: Updated all generated Nix flake files (node22, node24, node26) to reference the new Nixpkgs commit

## Implementation Details
- Updates are applied consistently across all CI workflow jobs (6 separate workflow configurations)
- Changes cover npm, deno, and bun package managers
- Nix development environment flakes are regenerated with the updated Nixpkgs snapshot
- All version updates are pinned to specific releases for reproducibility

https://claude.ai/code/session_01EfbrXbhQxV9cmjp8HXBWhW