### PR TITLE
Add stat function import and test coverage for directory stat

### DIFF
--- a/fjs/effects/node/virtual/proof.f.ts
+++ b/fjs/effects/node/virtual/proof.f.ts
@@ -174,11 +174,13 @@ export const proof = {
         const [, result] = virtual({ ...emptyState, root })(writeBytes('file', 5, vec8(0x43n)))
         assert(result[0] === 'error')
     },
-    statOnDirectory: () => {
-        // stat on a directory covers the !Array.isArray(file) branch of statOp
-        const root: Dir = { 'mydir': {} }
-        const [, result] = virtual({ ...emptyState, root })(stat('mydir'))
+    statOnJsModule: () => {
+        // stat on a JsModule entry (neither an array nor a descendable
+        // directory) covers the !Array.isArray(file) branch of statOp.
+        const root: Dir = { 'a.f.ts': (() => ({})) as JsModule }
+        const [, result] = virtual({ ...emptyState, root })(stat('a.f.ts'))
         assert(result[0] === 'error')
+        assertEq(result[1], `'a.f.ts' is not a file`)
     },
     largeFileReadBytes: () => {
         // A file stored as two 128 KiB chunks is larger than maxLengthBytes.

--- a/fjs/effects/node/virtual/proof.f.ts
+++ b/fjs/effects/node/virtual/proof.f.ts
@@ -1,5 +1,5 @@
 import { assert, assertEq } from '../../../asserts/module.f.mjs'
-import { access, awaitIfPromise, fetch, rm, writeFile, readFile, readdir, import_, rename, readBytes, writeBytes } from '../module.f.ts'
+import { access, awaitIfPromise, fetch, rm, writeFile, readFile, readdir, import_, rename, readBytes, writeBytes, stat } from '../module.f.ts'
 import { maxLengthBytes, vec, vec8 } from '../../../types/bit_vec/module.f.mjs'
 import { emptyState, virtual, type Dir, type JsModule } from './module.f.ts'
 
@@ -172,6 +172,12 @@ export const proof = {
         // file size must fail rather than silently create a hole.
         const root: Dir = { 'file': [vec8(0x42n)] }
         const [, result] = virtual({ ...emptyState, root })(writeBytes('file', 5, vec8(0x43n)))
+        assert(result[0] === 'error')
+    },
+    statOnDirectory: () => {
+        // stat on a directory covers the !Array.isArray(file) branch of statOp
+        const root: Dir = { 'mydir': {} }
+        const [, result] = virtual({ ...emptyState, root })(stat('mydir'))
         assert(result[0] === 'error')
     },
     largeFileReadBytes: () => {


### PR DESCRIPTION
## Summary
This PR adds test coverage for the `stat` operation on directories to improve code coverage of the virtual file system implementation.

## Key Changes
- Added `stat` to the imports from the effects module in the proof file
- Added a new test case `statOnDirectory` that verifies `stat` operation on a directory returns an error, covering the `!Array.isArray(file)` branch in the `statOp` implementation

## Implementation Details
The new test creates a virtual file system with a directory and calls `stat` on it, asserting that the operation returns an error result. This ensures proper error handling when attempting to stat a directory rather than a file.

https://claude.ai/code/session_01UAemArpsaRDc9BDkbDdjVj