### PR TITLE
Add initValue1DefaultBranch test case to btree remove module

### DIFF
--- a/fjs/types/btree/remove/module.f.mjs
+++ b/fjs/types/btree/remove/module.f.mjs
@@ -177,5 +177,8 @@ export const proof = {
         reduceValue0DefaultBranch: () => {
             reduceValue0([['leaf']])([['x'], 's', ['y']])
         },
+        initValue1DefaultBranch: () => {
+            initValue1(null)([[['a'], 'b', ['c']], 'd', ['e']])
+        },
     },
 }


### PR DESCRIPTION
## Summary
Added a new test case to the btree remove module's proof object to verify the default branch behavior of the `initValue1` function.

## Key Changes
- Added `initValue1DefaultBranch` test case that validates `initValue1` with a null initial value and a nested array structure containing three elements with separators

## Implementation Details
The new test case follows the existing pattern in the proof object and tests the `initValue1` function with:
- A null initial value
- A complex nested structure: `[[['a'], 'b', ['c']], 'd', ['e']]`

This complements the existing `reduceValue0DefaultBranch` test case and ensures comprehensive coverage of default branch scenarios in the btree removal logic.

https://claude.ai/code/session_015FZ8jonsa3mBCwrJaB3FQJ