### PR TITLE
Document native JavaScript syntax for eDSLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,6 +423,30 @@ have the caller check the `null` result rather than a precomputed bound.
 CLI parameters are preferred over environment variables when adding new
 features.
 
+### 5.8 Reuse JavaScript syntax in embedded DSLs
+
+**An embedded DSL should reuse ordinary JavaScript values and constructions when
+their JavaScript meaning already matches the DSL meaning.** Prefer a number,
+string, boolean, `null`, array, or object literal directly over wrapping the same
+value in a tagged representation such as `['number', 3.14]` or
+`['array', [...]]`. The host language already supplies syntax, tooling, type
+inference, and reader intuition for those concepts; duplicating that vocabulary
+adds ceremony without adding semantics.
+
+Introduce a constructor, function, or tagged union only when the DSL needs a
+concept that JavaScript cannot express directly or when the ordinary JavaScript
+shape would be ambiguous. The authoring eDSL and its internal normalized form do
+not need to be identical: a convenient JavaScript-facing representation may
+normalize to a tagged AST when that is useful for parsing, hashing, compilation,
+or pattern matching.
+
+Apply this principle to existing and future FunctionalScript eDSLs, including
+HTML, BNF, RTTI, generated-code/test descriptions, and especially the future
+FunctionalScript function AST. The function AST should preserve ordinary
+JavaScript/FunctionalScript literals and structures wherever they already carry
+the intended meaning, and add explicit AST constructors or tags only for syntax
+or semantics that require discrimination.
+
 ---
 
 ## 6. Coding style


### PR DESCRIPTION
## Summary

Document a general FunctionalScript eDSL design principle in `AGENTS.md`:

- reuse ordinary JavaScript literals and structures when their JavaScript meaning already matches the DSL meaning;
- introduce constructors/tags only for concepts that JavaScript cannot express directly or where the ordinary shape would be ambiguous;
- allow the ergonomic authoring representation to normalize to a different internal tagged AST when useful;
- apply the same principle to the future FunctionalScript function AST.

This captures the direction already visible in RTTI and the shared NaNVM operator-test data, where ordinary values are more readable than tagging every primitive and collection.

## Impact

Documentation/design guidance only. No runtime or public API changes, so no CHANGELOG entry is needed.

## Validation

Compared the branch against `main`: only `AGENTS.md` changes, with 24 added lines and no deletions.