### PR TITLE
nanvm: document operator test follow-ups

### DIFF
--- a/nanvm-lib/todo/generated-rust-module-rustfmt-skip.md
+++ b/nanvm-lib/todo/generated-rust-module-rustfmt-skip.md
@@ -5,43 +5,65 @@
 
 ### Problem
 
-`fjs/nanvm/rust/module.f.mjs` currently emits `#[rustfmt::skip]` before every
-generated function in `nanvm-lib/tests/test/generated.rs`.
+`fjs/nanvm/rust/module.f.mjs` currently emits `#[rustfmt::skip]` before `eq`
+and each generated per-operation function in
+`nanvm-lib/tests/test/generated.rs`. The final `all` function is not currently
+annotated.
 
-The whole file is generated and intentionally uses one statement per test case.
-Formatting individual functions is therefore not useful, and repeating the
-attribute for every function adds generated noise and requires the printer to
-remember the same policy at each function-emission site.
+The whole module is generated and intentionally uses one statement per test
+case. Formatting those generated functions is therefore not useful, and
+repeating the attribute at every function-emission site adds generated noise.
+
+The per-function skips are still necessary today: removing them without a
+replacement causes `cargo fmt` to rewrap generated assertions and destroys the
+one-statement-per-case layout.
 
 This follows the post-merge review comment on #1489 to make the formatting skip
 global for the generated module.
 
 ### Proposal
 
-Emit one inner attribute at the top of the generated Rust module:
+Do not use an inner `#![rustfmt::skip]` attribute inside `generated.rs`.
+Custom tool attributes in inner position are unstable on stable Rust and make
+`cargo check --tests` fail.
+
+Instead, annotate the generated module declaration in the hand-written
+`nanvm-lib/tests/test/main.rs`:
 
 ```rust
-#![rustfmt::skip]
+#[rustfmt::skip]
+mod generated;
 ```
 
-Then remove the repeated outer `#[rustfmt::skip]` attributes from `eq` and the
-per-operation generated functions.
+Then stop emitting the repeated `#[rustfmt::skip]` attributes from
+`fjs/nanvm/rust/module.f.mjs`.
 
-The generated file should remain readable and deterministic, with one statement
-per case, while `cargo fmt -- --check` continues to accept the repository.
+This keeps one formatting-policy declaration for the whole generated module
+while remaining valid on stable Rust. The attribute belongs to `main.rs`, not
+to the generated file, so the generator should only stop emitting its
+per-function attributes; it should not try to emit a replacement inner
+attribute.
+
+A module-wide skip also covers `generated::all`, which is currently the one
+generated function without a `#[rustfmt::skip]` attribute. That broader skip is
+intentional: the entire module is generated and should be left byte-for-byte in
+the layout chosen by the generator.
 
 ### Tasks
 
-- [ ] Emit `#![rustfmt::skip]` once near the top of
-      `nanvm-lib/tests/test/generated.rs`.
-- [ ] Stop emitting `#[rustfmt::skip]` before individual generated functions.
+- [ ] Add `#[rustfmt::skip]` to the `mod generated;` declaration in
+      `nanvm-lib/tests/test/main.rs`.
+- [ ] Stop emitting `#[rustfmt::skip]` before `eq` and individual generated
+      operation functions.
+- [ ] Do not emit `#![rustfmt::skip]` inside `generated.rs`.
 - [ ] Update comments/documentation in `fjs/nanvm/rust/module.f.mjs` to describe
-      the module-wide formatting policy.
+      the module-level formatting policy owned by `main.rs`.
 - [ ] Update the Rust generator proof if its expected output covers these
       attributes.
 - [ ] Regenerate `nanvm-lib/tests/test/generated.rs` with `npm run ci-update`.
 - [ ] Verify a second `npm run ci-update` leaves the tree unchanged.
-- [ ] Run `fjs test`, `cargo test`, and `cargo fmt -- --check`.
+- [ ] Run `fjs test`, `cargo check --tests`, `cargo test`, and
+      `cargo fmt -- --check`.
 
 ### Related
 

--- a/nanvm-lib/todo/generated-rust-module-rustfmt-skip.md
+++ b/nanvm-lib/todo/generated-rust-module-rustfmt-skip.md
@@ -1,0 +1,49 @@
+## generated-rust-module-rustfmt-skip. Skip rustfmt once for the generated module
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`fjs/nanvm/rust/module.f.mjs` currently emits `#[rustfmt::skip]` before every
+generated function in `nanvm-lib/tests/test/generated.rs`.
+
+The whole file is generated and intentionally uses one statement per test case.
+Formatting individual functions is therefore not useful, and repeating the
+attribute for every function adds generated noise and requires the printer to
+remember the same policy at each function-emission site.
+
+This follows the post-merge review comment on #1489 to make the formatting skip
+global for the generated module.
+
+### Proposal
+
+Emit one inner attribute at the top of the generated Rust module:
+
+```rust
+#![rustfmt::skip]
+```
+
+Then remove the repeated outer `#[rustfmt::skip]` attributes from `eq` and the
+per-operation generated functions.
+
+The generated file should remain readable and deterministic, with one statement
+per case, while `cargo fmt -- --check` continues to accept the repository.
+
+### Tasks
+
+- [ ] Emit `#![rustfmt::skip]` once near the top of
+      `nanvm-lib/tests/test/generated.rs`.
+- [ ] Stop emitting `#[rustfmt::skip]` before individual generated functions.
+- [ ] Update comments/documentation in `fjs/nanvm/rust/module.f.mjs` to describe
+      the module-wide formatting policy.
+- [ ] Update the Rust generator proof if its expected output covers these
+      attributes.
+- [ ] Regenerate `nanvm-lib/tests/test/generated.rs` with `npm run ci-update`.
+- [ ] Verify a second `npm run ci-update` leaves the tree unchanged.
+- [ ] Run `fjs test`, `cargo test`, and `cargo fmt -- --check`.
+
+### Related
+
+- #1489 — introduced the generated shared operator tests.
+- #1489 review: https://github.com/functionalscript/functionalscript/pull/1489#discussion_r3770843238

--- a/nanvm-lib/todo/operator-test-operation-model.md
+++ b/nanvm-lib/todo/operator-test-operation-model.md
@@ -18,7 +18,8 @@ given two arguments, or a binary operation one argument, without a type error.
 
 The shared corpus should describe the JavaScript operation itself rather than
 the identifier chosen by a particular proof or code generator. Consumer-specific
-names such as a Rust function name belong in the consumer.
+names such as Rust function names and diagnostic case labels belong in the
+consumer.
 
 This follows the post-merge review discussion on #1489:
 
@@ -55,12 +56,17 @@ number of arguments:
 
 ```ts
 export type Case<N extends number> = {
-    readonly name: string
     readonly args: Tuple<N, Value>
     readonly expected: Value
     readonly rust?: string
 }
 ```
+
+Do not store a `name` on each case. Case names are diagnostic metadata and can
+be generated deterministically by the proof and Rust test generator from the
+case position (and argument order where needed). The shared corpus should contain
+only the inputs, expected result, and any representation override needed to
+construct the value.
 
 Groups must preserve the operation's literal arity so their cases are typed as
 `Case<O[1]>`, where element `1` is the operation's `argsN`. The exact TypeScript
@@ -78,22 +84,26 @@ when needed, generated function name.
 
 Do not broaden this task into making strict equality (`===`) use the generic
 `Group` representation. `Eq` has shared-reference requirements today; it can be
-unified later if doing so becomes clearly useful.
+unified later if doing so becomes clearly useful. Its existing case representation
+is therefore outside this task as well.
 
 ### Tasks
 
 - [ ] Replace the current string-union `Op` model with `readonly [name, argsN]`
       operations carrying a semantic name and literal argument count.
-- [ ] Make `Case` generic over argument count and type `args` as a fixed-length
-      tuple.
+- [ ] Make `Case` generic over argument count, remove its stored `name`, and
+      type `args` as a fixed-length tuple.
+- [ ] Generate diagnostic case names in consumers instead of storing them in
+      the shared operator corpus.
 - [ ] Make each group's cases derive their argument count from `operation[1]`.
 - [ ] Restrict `commutative` to binary groups.
-- [ ] Update `fjs/nanvm/module.f.mjs` to use semantic operation descriptions.
+- [ ] Update `fjs/nanvm/module.f.mjs` to use semantic operation descriptions and
+      unnamed cases.
 - [ ] Update `fjs/nanvm/proof.f.mjs` to dispatch on the semantic operation and
-      arity.
+      arity and generate its own leaf names.
 - [ ] Update `fjs/nanvm/rust/module.f.mjs` to map semantic operations to Rust
-      syntax and generated identifiers without leaking those identifiers into
-      the shared data.
+      syntax, generated identifiers, and case diagnostics without leaking those
+      identifiers into the shared data.
 - [ ] Add type-level coverage proving that wrong argument counts are rejected.
 - [ ] Regenerate `nanvm-lib/tests/test/generated.rs` and keep the generated test
       behavior unchanged.

--- a/nanvm-lib/todo/operator-test-operation-model.md
+++ b/nanvm-lib/todo/operator-test-operation-model.md
@@ -18,8 +18,7 @@ given two arguments, or a binary operation one argument, without a type error.
 
 The shared corpus should describe the JavaScript operation itself rather than
 the identifier chosen by a particular proof or code generator. Consumer-specific
-names such as Rust function names and diagnostic case labels belong in the
-consumer.
+names such as Rust function names belong in the consumer.
 
 This follows the post-merge review discussion on #1489:
 
@@ -47,8 +46,8 @@ The corpus can then describe operations along these lines:
 ```
 
 The arity disambiguates operations that share syntax, such as unary `+` and a
-future binary `+`. The tuple also keeps the shared data compact: an operation is
-just a semantic descriptor, not an object with independently mutable fields.
+future binary `+`. The tuple keeps the shared data compact and makes the arity
+available directly as `O[1]` for types such as `Case<O[1]>`.
 
 Make `Case` generic over the argument count and use the existing fixed-length
 array machinery (`Tuple<N, T>`) so an operation's cases have exactly the right
@@ -56,37 +55,27 @@ number of arguments:
 
 ```ts
 export type Case<N extends number> = {
+    readonly name: string
     readonly args: Tuple<N, Value>
     readonly expected: Value
     readonly rust?: string
 }
 ```
 
-Do not store a `name` on each case. The inputs, operation, and expected result
-already contain enough information to generate a useful semantic diagnostic.
-For example, an ordinary binary case can be rendered as:
+Keep the case `name`. It is diagnostic metadata and a stable proof key, not part
+of the operation semantics. The arguments and expected result are not sufficient
+as a unique key: for a commutative operation, a case with equal arguments is
+identical to its swapped form, so an expression such as `2 * 2 === 4` cannot
+distinguish the two entries. The current proof uses the case name and derives a
+`Swapped` suffix for the reversed order; preserve that explicit disambiguation
+rather than relying on `fromEntries` to silently collapse duplicate keys.
 
-```text
-2 + 2 === 4
-```
-
-Prefer such semantic expressions over positional labels such as `case17`.
-The renderer must still describe the comparison truthfully for special values:
-when the proof relies on `Object.is` semantics (for example `NaN` or `-0`), use
-an explicit `Object.is(...)` form rather than a misleading `===` expression.
-Throwing cases should likewise get an explicit generated form such as
+Semantic expressions may still be generated as supplemental diagnostics. When
+doing so, render operands as faithful source literals so distinct values remain
+distinct (`123` versus `123n`, `0` versus `-0`, quoted strings, and so on), and
+use an explicit `Object.is(...)` form when `===` would describe the comparison
+incorrectly. Throwing cases should likewise use an explicit form such as
 `+0n throws`.
-
-FunctionalScript can use this generated expression directly as the emergent-test
-proof key. The Rust generator should reuse the same semantic expression in
-assertion diagnostics so a failure identifies the exact case without a stored
-name. Under the current Rust test layout, generated cases are statements inside
-generic group functions rather than individual `#[test]` functions, and Rust
-function identifiers cannot literally be expressions such as `2 + 2 === 4`.
-Do not restructure the Rust harness solely to turn each expression into a test
-function name; keep the exact expression in the assertion diagnostic. A future
-test-layout change may additionally derive a valid Rust identifier from it if
-that becomes useful.
 
 Groups must preserve the operation's literal arity so their cases are typed as
 `Case<O[1]>`, where element `1` is the operation's `argsN`. The exact TypeScript
@@ -111,22 +100,22 @@ is therefore outside this task as well.
 
 - [ ] Replace the current string-union `Op` model with `readonly [name, argsN]`
       operations carrying a semantic name and literal argument count.
-- [ ] Make `Case` generic over argument count, remove its stored `name`, and
-      type `args` as a fixed-length tuple.
-- [ ] Generate semantic case expressions from the operation, arguments, and
-      expected result instead of storing case names in the shared corpus.
-- [ ] Use generated semantic expressions as FunctionalScript proof keys and in
-      Rust assertion diagnostics; handle `Object.is`-sensitive and throwing
+- [ ] Make `Case` generic over argument count while keeping its stable `name`,
+      and type `args` as a fixed-length tuple.
+- [ ] Keep case names as FunctionalScript proof keys and Rust assertion
+      diagnostics; keep the explicit `Swapped` disambiguation for reversed
+      commutative cases.
+- [ ] If semantic expressions are generated for diagnostics, render values as
+      faithful source literals and handle `Object.is`-sensitive and throwing
       cases explicitly.
 - [ ] Make each group's cases derive their argument count from `operation[1]`.
 - [ ] Restrict `commutative` to binary groups.
-- [ ] Update `fjs/nanvm/module.f.mjs` to use semantic operation descriptions and
-      unnamed cases.
+- [ ] Update `fjs/nanvm/module.f.mjs` to use semantic operation descriptions.
 - [ ] Update `fjs/nanvm/proof.f.mjs` to dispatch on the semantic operation and
-      arity and generate semantic leaf names.
+      arity while preserving unique case proof keys.
 - [ ] Update `fjs/nanvm/rust/module.f.mjs` to map semantic operations to Rust
-      syntax, generated identifiers, and assertion diagnostics without leaking
-      those identifiers into the shared data.
+      syntax and generated identifiers without leaking those identifiers into
+      the shared data.
 - [ ] Add type-level coverage proving that wrong argument counts are rejected.
 - [ ] Regenerate `nanvm-lib/tests/test/generated.rs` and keep the generated test
       behavior unchanged.

--- a/nanvm-lib/todo/operator-test-operation-model.md
+++ b/nanvm-lib/todo/operator-test-operation-model.md
@@ -62,11 +62,31 @@ export type Case<N extends number> = {
 }
 ```
 
-Do not store a `name` on each case. Case names are diagnostic metadata and can
-be generated deterministically by the proof and Rust test generator from the
-case position (and argument order where needed). The shared corpus should contain
-only the inputs, expected result, and any representation override needed to
-construct the value.
+Do not store a `name` on each case. The inputs, operation, and expected result
+already contain enough information to generate a useful semantic diagnostic.
+For example, an ordinary binary case can be rendered as:
+
+```text
+2 + 2 === 4
+```
+
+Prefer such semantic expressions over positional labels such as `case17`.
+The renderer must still describe the comparison truthfully for special values:
+when the proof relies on `Object.is` semantics (for example `NaN` or `-0`), use
+an explicit `Object.is(...)` form rather than a misleading `===` expression.
+Throwing cases should likewise get an explicit generated form such as
+`+0n throws`.
+
+FunctionalScript can use this generated expression directly as the emergent-test
+proof key. The Rust generator should reuse the same semantic expression in
+assertion diagnostics so a failure identifies the exact case without a stored
+name. Under the current Rust test layout, generated cases are statements inside
+generic group functions rather than individual `#[test]` functions, and Rust
+function identifiers cannot literally be expressions such as `2 + 2 === 4`.
+Do not restructure the Rust harness solely to turn each expression into a test
+function name; keep the exact expression in the assertion diagnostic. A future
+test-layout change may additionally derive a valid Rust identifier from it if
+that becomes useful.
 
 Groups must preserve the operation's literal arity so their cases are typed as
 `Case<O[1]>`, where element `1` is the operation's `argsN`. The exact TypeScript
@@ -93,17 +113,20 @@ is therefore outside this task as well.
       operations carrying a semantic name and literal argument count.
 - [ ] Make `Case` generic over argument count, remove its stored `name`, and
       type `args` as a fixed-length tuple.
-- [ ] Generate diagnostic case names in consumers instead of storing them in
-      the shared operator corpus.
+- [ ] Generate semantic case expressions from the operation, arguments, and
+      expected result instead of storing case names in the shared corpus.
+- [ ] Use generated semantic expressions as FunctionalScript proof keys and in
+      Rust assertion diagnostics; handle `Object.is`-sensitive and throwing
+      cases explicitly.
 - [ ] Make each group's cases derive their argument count from `operation[1]`.
 - [ ] Restrict `commutative` to binary groups.
 - [ ] Update `fjs/nanvm/module.f.mjs` to use semantic operation descriptions and
       unnamed cases.
 - [ ] Update `fjs/nanvm/proof.f.mjs` to dispatch on the semantic operation and
-      arity and generate its own leaf names.
+      arity and generate semantic leaf names.
 - [ ] Update `fjs/nanvm/rust/module.f.mjs` to map semantic operations to Rust
-      syntax, generated identifiers, and case diagnostics without leaking those
-      identifiers into the shared data.
+      syntax, generated identifiers, and assertion diagnostics without leaking
+      those identifiers into the shared data.
 - [ ] Add type-level coverage proving that wrong argument counts are rejected.
 - [ ] Regenerate `nanvm-lib/tests/test/generated.rs` and keep the generated test
       behavior unchanged.

--- a/nanvm-lib/todo/operator-test-operation-model.md
+++ b/nanvm-lib/todo/operator-test-operation-model.md
@@ -1,0 +1,107 @@
+## operator-test-operation-model. Describe operations by syntax and arity
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+The shared operator corpus in `fjs/nanvm/` currently uses implementation-style
+names such as `unaryPlus`, `unaryMinus`, and `mul`:
+
+```ts
+export type Op = 'unaryPlus' | 'unaryMinus' | 'mul' | 'stringCoercion'
+```
+
+`Case.args` is also just `readonly Value[]`, so the type system does not connect
+an operation with its number of arguments. A unary operation can therefore be
+given two arguments, or a binary operation one argument, without a type error.
+
+The shared corpus should describe the JavaScript operation itself rather than
+the identifier chosen by a particular proof or code generator. Consumer-specific
+names such as a Rust function name belong in the consumer.
+
+This follows the post-merge review discussion on #1489:
+
+- use operation spellings such as `+`, `-`, and `*` instead of `unaryPlus`,
+  `unaryMinus`, and `mul`;
+- associate every operation with its arity and use that arity to type its cases.
+
+### Proposal
+
+Represent an operation with its semantic name and argument count. For example:
+
+```ts
+export type Operation<N extends number = number> = {
+    readonly name: string
+    readonly argsN: N
+}
+```
+
+The corpus can then describe operations along these lines:
+
+```ts
+{ name: '+', argsN: 1 }
+{ name: '-', argsN: 1 }
+{ name: '*', argsN: 2 }
+{ name: 'String', argsN: 1 }
+```
+
+The arity disambiguates operations that share syntax, such as unary `+` and a
+future binary `+`.
+
+Make `Case` generic over the argument count and use the existing fixed-length
+array machinery (`Tuple<N, T>`) so an operation's cases have exactly the right
+number of arguments:
+
+```ts
+export type Case<N extends number> = {
+    readonly name: string
+    readonly args: Tuple<N, Value>
+    readonly expected: Value
+    readonly rust?: string
+}
+```
+
+Groups must preserve the operation's literal arity so their cases are typed as
+`Case<O['argsN']>`. The exact TypeScript shape may use generic groups or separate
+unary/binary group types; the important invariant is that invalid case arity is
+rejected statically.
+
+`commutative` only makes sense for binary operations. Prefer a type shape where
+it is available only for binary groups rather than a general optional property.
+
+The JavaScript proof and Rust printer should translate the semantic operation
+into their own implementation. In particular, the Rust printer must not derive
+Rust identifiers by applying `snakeCase` to punctuation such as `+`; it should
+own an explicit mapping from an operation plus arity to the Rust expression and,
+when needed, generated function name.
+
+Do not broaden this task into making strict equality (`===`) use the generic
+`Group` representation. `Eq` has shared-reference requirements today; it can be
+unified later if doing so becomes clearly useful.
+
+### Tasks
+
+- [ ] Replace the current string-union `Op` model with operations that carry a
+      semantic name and literal argument count.
+- [ ] Make `Case` generic over argument count and type `args` as a fixed-length
+      tuple.
+- [ ] Make each group's cases derive their argument count from its operation.
+- [ ] Restrict `commutative` to binary groups.
+- [ ] Update `fjs/nanvm/module.f.mjs` to use semantic operation descriptions.
+- [ ] Update `fjs/nanvm/proof.f.mjs` to dispatch on the semantic operation and
+      arity.
+- [ ] Update `fjs/nanvm/rust/module.f.mjs` to map semantic operations to Rust
+      syntax and generated identifiers without leaking those identifiers into
+      the shared data.
+- [ ] Add type-level coverage proving that wrong argument counts are rejected.
+- [ ] Regenerate `nanvm-lib/tests/test/generated.rs` and keep the generated test
+      behavior unchanged.
+- [ ] Run `npx tsc`, `fjs test`, `npm run ci-update`, `cargo test`,
+      `cargo clippy -- -D warnings`, and `cargo fmt -- --check`.
+
+### Related
+
+- #1489 — introduced the shared operator corpus.
+- #1489 review: https://github.com/functionalscript/functionalscript/pull/1489#discussion_r3770780551
+- #1489 review: https://github.com/functionalscript/functionalscript/pull/1489#discussion_r3770797058

--- a/nanvm-lib/todo/operator-test-operation-model.md
+++ b/nanvm-lib/todo/operator-test-operation-model.md
@@ -28,26 +28,26 @@ This follows the post-merge review discussion on #1489:
 
 ### Proposal
 
-Represent an operation with its semantic name and argument count. For example:
+Represent an operation as a small immutable tuple containing its semantic name
+and argument count:
 
 ```ts
-export type Operation<N extends number = number> = {
-    readonly name: string
-    readonly argsN: N
-}
+export type Operation<N extends number = number> =
+    readonly [name: string, argsN: N]
 ```
 
 The corpus can then describe operations along these lines:
 
 ```ts
-{ name: '+', argsN: 1 }
-{ name: '-', argsN: 1 }
-{ name: '*', argsN: 2 }
-{ name: 'String', argsN: 1 }
+['+', 1]
+['-', 1]
+['*', 2]
+['String', 1]
 ```
 
 The arity disambiguates operations that share syntax, such as unary `+` and a
-future binary `+`.
+future binary `+`. The tuple also keeps the shared data compact: an operation is
+just a semantic descriptor, not an object with independently mutable fields.
 
 Make `Case` generic over the argument count and use the existing fixed-length
 array machinery (`Tuple<N, T>`) so an operation's cases have exactly the right
@@ -63,9 +63,9 @@ export type Case<N extends number> = {
 ```
 
 Groups must preserve the operation's literal arity so their cases are typed as
-`Case<O['argsN']>`. The exact TypeScript shape may use generic groups or separate
-unary/binary group types; the important invariant is that invalid case arity is
-rejected statically.
+`Case<O[1]>`, where element `1` is the operation's `argsN`. The exact TypeScript
+shape may use generic groups or separate unary/binary group types; the important
+invariant is that invalid case arity is rejected statically.
 
 `commutative` only makes sense for binary operations. Prefer a type shape where
 it is available only for binary groups rather than a general optional property.
@@ -82,11 +82,11 @@ unified later if doing so becomes clearly useful.
 
 ### Tasks
 
-- [ ] Replace the current string-union `Op` model with operations that carry a
-      semantic name and literal argument count.
+- [ ] Replace the current string-union `Op` model with `readonly [name, argsN]`
+      operations carrying a semantic name and literal argument count.
 - [ ] Make `Case` generic over argument count and type `args` as a fixed-length
       tuple.
-- [ ] Make each group's cases derive their argument count from its operation.
+- [ ] Make each group's cases derive their argument count from `operation[1]`.
 - [ ] Restrict `commutative` to binary groups.
 - [ ] Update `fjs/nanvm/module.f.mjs` to use semantic operation descriptions.
 - [ ] Update `fjs/nanvm/proof.f.mjs` to dispatch on the semantic operation and


### PR DESCRIPTION
Follow up on the three post-merge review comments on #1489 with two focused TODOs.

## What changed

- Add a TODO to replace implementation-style operator names with semantic `readonly [name, argsN]` operation descriptions and make case argument counts type-safe.
- Keep `Case.name` as a stable FunctionalScript proof key and Rust diagnostic label. This avoids silent key collisions for symmetric commutative cases; reversed cases retain explicit `Swapped` disambiguation. Semantic expressions may still be generated as supplemental diagnostics using source-faithful literal rendering.
- Add a TODO to put one outer `#[rustfmt::skip]` on `mod generated;` in `nanvm-lib/tests/test/main.rs`, instead of emitting repeated per-function attributes. The TODO explicitly avoids unstable inner `#![rustfmt::skip]`.

The first TODO intentionally keeps strict-equality (`Eq`) unification out of scope; its shared-reference behavior can be reconsidered separately.

## Validation

Documentation-only change. Review feedback verified the stable Rust module-level rustfmt form and identified the case-key collision risk; both points are now captured explicitly in the TODOs.

Related: #1489