### PR TITLE
Update nixpkgs commit to 9f78f44a87948854445dae0b6bf82b2e87e4efb5

### DIFF
--- a/fjs/ci/config/module.f.mjs
+++ b/fjs/ci/config/module.f.mjs
@@ -53,7 +53,7 @@ export const node = /** @type {const} */({
 // https://channels.nixos.org/nixos-26.05/git-revision
 export const nixpkgs = /** @type {const} */({
     ref: 'nixos-26.05',
-    commit: 'fcb8fcd6bf2d0adecae5bd491afaaaf8311b758d',
+    commit: '9f78f44a87948854445dae0b6bf82b2e87e4efb5',
 })
 
 // https://github.com/bytecodealliance/wasmtime/releases

--- a/nix/generated/node22/flake.nix
+++ b/nix/generated/node22/flake.nix
@@ -1,5 +1,5 @@
 {
-    inputs.nixpkgs.url = "github:NixOS/nixpkgs/fcb8fcd6bf2d0adecae5bd491afaaaf8311b758d";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/9f78f44a87948854445dae0b6bf82b2e87e4efb5";
     outputs = { nixpkgs, ... }: {
         devShells.aarch64-linux.default = let
             pkgs = import nixpkgs {

--- a/nix/generated/node24/flake.nix
+++ b/nix/generated/node24/flake.nix
@@ -1,5 +1,5 @@
 {
-    inputs.nixpkgs.url = "github:NixOS/nixpkgs/fcb8fcd6bf2d0adecae5bd491afaaaf8311b758d";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/9f78f44a87948854445dae0b6bf82b2e87e4efb5";
     outputs = { nixpkgs, ... }: {
         devShells.aarch64-linux.default = let
             pkgs = import nixpkgs {

--- a/nix/generated/node26/flake.nix
+++ b/nix/generated/node26/flake.nix
@@ -1,5 +1,5 @@
 {
-    inputs.nixpkgs.url = "github:NixOS/nixpkgs/fcb8fcd6bf2d0adecae5bd491afaaaf8311b758d";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/9f78f44a87948854445dae0b6bf82b2e87e4efb5";
     outputs = { nixpkgs, ... }: {
         devShells.aarch64-linux.default = let
             pkgs = import nixpkgs {


### PR DESCRIPTION
## Summary
Updates the nixpkgs reference across the configuration to a newer commit within the nixos-26.05 channel.

## Changes
- Updated the nixpkgs commit hash in the module configuration from `fcb8fcd6bf2d0adecae5bd491afaaaf8311b758d` to `9f78f44a87948854445dae0b6bf82b2e87e4efb5`
- Regenerated flake.nix files for Node.js 22, 24, and 26 with the updated nixpkgs reference

## Details
The nixpkgs reference remains on the `nixos-26.05` channel while updating to a newer commit. The generated flake.nix files are automatically updated to reflect this change across all Node.js version configurations.

https://claude.ai/code/session_01Jx3U5vFKxd2mhXNo3XDumT