### PR TITLE
Add reduceValue2DefaultBranch test case to btree remove proof

### DIFF
--- a/fjs/types/btree/remove/module.f.mjs
+++ b/fjs/types/btree/remove/module.f.mjs
@@ -177,6 +177,9 @@ export const proof = {
         reduceValue0DefaultBranch: () => {
             reduceValue0([['leaf']])([['x'], 's', ['y']])
         },
+        reduceValue2DefaultBranch: () => {
+            reduceValue2([['leaf']])([['x'], 's', ['y']])
+        },
         initValue1DefaultBranch: () => {
             initValue1(null)([[['a'], 'b', ['c']], 'd', ['e']])
         },


### PR DESCRIPTION
## Summary
Added a missing test case for the `reduceValue2DefaultBranch` function in the btree remove module's proof suite.

## Key Changes
- Added `reduceValue2DefaultBranch` test case that verifies `reduceValue2` correctly handles a leaf node with a default branch structure `[['x'], 's', ['y']]`

## Implementation Details
The new test follows the same pattern as the existing `reduceValue0DefaultBranch` test case, ensuring consistent test coverage for the reduce value functions in the btree removal proof suite.

https://claude.ai/code/session_01VAUANGNZv3GnL65EbNZ5D6