### PR TITLE
Update prose to reflect completion of TypeScript-to-JavaScript migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository is a monorepo with two code bases:
 
 | Directory    | Language                                | Notes                                       |
 | ------------ | --------------------------------------- | ------------------------------------------- |
-| `fjs/`       | FunctionalScript (`.f.ts`) / TypeScript | The language, its standard modules, and the `fjs` CLI |
+| `fjs/`       | FunctionalScript (`.f.mjs`) / TypeScript (`types.ts`) | The language, its standard modules, and the `fjs` CLI |
 | `nanvm-lib/` | Rust                                    | NaNVM, the native FunctionalScript VM       |
 
 Issues live in `todo/` directories, **not** on GitHub. Check them for existing
@@ -118,8 +118,8 @@ cargo fmt -- --check     # verify formatting
 
 1. Find or file the issue in `todo/` ([§7](#7-issues-todo)). For anything
    non-trivial, make sure it contains a concrete design first.
-2. Write the code, plus a co-located proof for every new `.f.ts` or `.f.mjs`
-   module ([§3](#3-testing-and-proof-coverage)).
+2. Write the code, plus a co-located proof for every new `.f.mjs` module
+   ([§3](#3-testing-and-proof-coverage)).
 3. Run `npm run update` after changing source code.
 4. Run the full check set before submitting:
    ```bash
@@ -142,44 +142,36 @@ cargo fmt -- --check     # verify formatting
 
 - `npx tsc` — type-check using the repository's version of TypeScript.
 - `fjs test` (or any equivalent from [§1.4](#14-ways-to-run-the-functionalscript-test-suite))
-  — test FunctionalScript (`.f.ts` / `.f.mjs`) files.
+  — test FunctionalScript (`.f.mjs`) files.
 - `cargo test`, `cargo clippy`, `cargo fmt -- --check` — the Rust crate.
 
 ### 3.2 Proof coverage is mandatory
 
 New FunctionalScript modules and functions must have **100% proof coverage**
 across every dimension: every exported function called, every line executed, and
-every branch (both sides of each conditional) taken. This applies to both
-authored FunctionalScript extensions, `.f.ts` and `.f.mjs`
-([`fjs/fsc/README.md`](./fjs/fsc/README.md) defines them). A new implementation
-module ships with a co-located proof (its `proof` export) that exercises all of
-its exports along all code paths — partial coverage of new code is not
-acceptable. If a line or branch genuinely cannot be reached, restructure the code
-so it isn't there rather than leaving it uncovered.
+every branch (both sides of each conditional) taken. This applies to authored
+FunctionalScript source, `.f.mjs`
+([`fjs/fsc/README.md`](./fjs/fsc/README.md) defines the extensions). A new
+implementation module ships with a co-located proof (its `proof` export) that
+exercises all of its exports along all code paths — partial coverage of new code
+is not acceptable. If a line or branch genuinely cannot be reached, restructure
+the code so it isn't there rather than leaving it uncovered.
 
-The implementation and proof extensions are independent during the incremental
-TypeScript-to-JavaScript migration:
+An implementation is `module.f.mjs` and its proof is `proof.f.mjs`. Stage 1 of
+the TypeScript-to-JavaScript migration is complete: no authored implementation or
+proof `.f.ts` remains, so write both files as JavaScript with JSDoc. Authored
+`types.ts` companions may remain permanently and hold the type-level API.
 
-| Implementation | Proof | When |
-|---|---|---|
-| `module.f.ts` | `proof.f.ts` | Both files are still authored TypeScript implementations/proofs. |
-| `module.f.mjs` | `proof.f.ts` | The implementation has migrated, while the proof temporarily remains TypeScript. |
-| `module.f.mjs` | `proof.f.mjs` | The proof is valid JavaScript/JSDoc and all authored runtime dependencies outside the migration group are already `.f.mjs`. Type-only APIs may remain in authored `types.ts` companions. Compiler readiness is not required. |
-
-Renaming an implementation to `.f.mjs` therefore never requires renaming its
-proof in the same change, and never removes it from proof discovery or from Node
-and Deno coverage: `shouldLoad` in [`fjs/dev/module.f.mjs`](./fjs/dev/module.f.mjs)
-matches both authored extensions, and both `npm run cov` and `deno task cov`
-include `module.f.ts` and `module.f.mjs`. Ordinary (non-FunctionalScript) `.mjs`
-files stay opt-in through the `proof.mjs` filename convention. Stage 1 ends with
-no authored implementation/proof `.f.ts`, so every remaining `proof.f.ts` must
-eventually migrate to `proof.f.mjs`; authored `types.ts` files may remain
-permanently.
+Proof discovery and coverage follow the same extension: `shouldLoad` in
+[`fjs/dev/module.f.mjs`](./fjs/dev/module.f.mjs) matches authored
+FunctionalScript source, and both `npm run cov` and `deno task cov` include
+`module.f.mjs`. Ordinary (non-FunctionalScript) `.mjs` files stay opt-in through
+the `proof.mjs` filename convention.
 
 A `proof.f.mjs` is authored `.f.mjs` like any other. Its relative **runtime**
-imports must target migrated `.f.mjs` modules. Type-only APIs may live in an
-authored `types.ts` companion and are referenced directly through that real
-source path. Its leading module JSDoc block may include, for example:
+imports must target `.f.mjs` modules. Type-only APIs may live in an authored
+`types.ts` companion and are referenced directly through that real source path.
+Its leading module JSDoc block may include, for example:
 
 ```js
 /**
@@ -191,21 +183,20 @@ source path. Its leading module JSDoc block may include, for example:
  */
 ```
 
-The same path is used by TypeScript `import type`; JSDoc `@import` introduces no
-runtime dependency. If a type needed by migrated JavaScript still lives only
-inside a remaining implementation `.f.ts`, split the type into `types.ts` before
-migrating the consumer instead of retaining a type-only edge to the implementation
-module. Never add a runtime value for a TypeScript-only declaration such as
-`declare const`. Compiler support remains independent of this JavaScript/JSDoc
-migration rule. See [`fjs/fsc/README.md`](./fjs/fsc/README.md) for the migration
-order and module policy.
+JSDoc `@import` introduces no runtime dependency; a `types.ts` file naming the
+same path from TypeScript uses `import type` instead. A type that several modules
+need independently of one implementation belongs in `types.ts`, not in a JSDoc
+typedef that consumers would have to reach into the implementation for. Never add
+a runtime value for a TypeScript-only declaration such as `declare const`.
+Compiler support remains independent of this JavaScript/JSDoc rule. See
+[`fjs/fsc/README.md`](./fjs/fsc/README.md) for the extension contract and module
+policy.
 
 ### 3.3 Use `assert` / `assertEq`, never a hand-written `if`/`throw`
 
-Assert results in `proof` code with `assert`/`assertEq` from the current authored
-`fjs/asserts/module.f.*` source, not a hand-written `if (cond) { throw ... }`.
-That helper has already migrated, so the current source is
-`fjs/asserts/module.f.mjs` and a `proof.f.mjs` may import it directly.
+Assert results in `proof` code with `assert`/`assertEq` from
+[`fjs/asserts/module.f.mjs`](./fjs/asserts/module.f.mjs), not a hand-written
+`if (cond) { throw ... }`.
 
 A local `if`/`throw` in a test is itself a new branch for the coverage tool to
 track, and its failure side is normally never exercised (the test is expected to
@@ -232,12 +223,12 @@ never counted as a test either.
 
 ### 3.5 Never use `try`/`catch`; test throwing with the `throw` key
 
-Never use `try`/`catch` in `.f.ts` files — FunctionalScript itself has no
+Never use `try`/`catch` in `.f.mjs` files — FunctionalScript itself has no
 `try`/`catch` and isn't planning to add it soon. To test that a call throws,
 nest the test function under a `throw` property key instead of wrapping it in
 `try`/`catch` (see `fjs/asserts/proof.f.mjs`).
 
-The test runner (`fjs/emergent_testing/module.f.ts`) treats `throw` as a
+The test runner (`fjs/emergent_testing/module.f.mjs`) treats `throw` as a
 structural marker: any function reachable under a `throw` key gets
 `throws: true`, and the runner inverts the sandboxed result so a thrown error
 counts as a pass — with no manual `caught`/`threw` flag or `assert` needed.
@@ -257,48 +248,21 @@ normally the part of the contract that matters.
 
 ## 4. Documentation
 
-Use JSDoc for module documentation in both TypeScript and JavaScript source.
-The `@module` tag belongs only to a package's entry-point file — `module.f.ts` /
-`module.f.mjs` / `module.ts` / `module.mjs` — not to `proof.f.ts` / `proof.f.mjs`,
-`types.ts`, or any other file. A `module.*` file starts with one module JSDoc
-block carrying `@module`, followed by one blank line before the first
-source-level import or declaration. A `proof.*` or other non-`module.*` file has
-no `@module` tag and no required leading documentation block; one is still
-needed if the file has `@import` tags to hold, per below.
+Use JSDoc for module documentation in both JavaScript and TypeScript source.
+The `@module` tag belongs only to a package's entry-point file — `module.f.mjs` /
+`module.mjs` — not to `proof.f.mjs`, `types.ts`, or any other file. A `module.*`
+file starts with one module JSDoc block carrying `@module`, followed by one blank
+line before the first source-level import or declaration. A `proof.*` or other
+non-`module.*` file has no `@module` tag and no required leading documentation
+block; one is still needed if the file has `@import` tags to hold, per below.
 
-For TypeScript, put type-only imports first, external or built-in runtime imports
-second, then repository-owned relative runtime imports: already-migrated
-JavaScript before remaining TypeScript. Separate the import groups with one blank
-line:
-
-```ts
-/**
- * <...Module documentation...>
- *
- * @module
- */
-
-import type ...
-import type ...
-
-import ... from 'node:...'
-import ... from 'package'
-
-import ... from '...mjs'
-import ... from '...mjs'
-
-import ... from '...ts'
-import ... from '...ts'
-```
-
-For JavaScript, group all module-level `@import` tags into one leading JSDoc
-comment block — the same block as `@module` in a `module.*` file, or a
-standalone block at the top of the file otherwise — then put one blank line
-before runtime imports. Do not scatter `@import` tags as separate comments
-between or after individual `import` statements. External or built-in runtime
-imports come first, followed by repository-owned relative `.mjs` runtime
-imports, matching the TypeScript order of type imports, then `.mjs` imports,
-then remaining `.ts` imports:
+Group all module-level `@import` tags into one leading JSDoc comment block — the
+same block as `@module` in a `module.*` file, or a standalone block at the top of
+the file otherwise — then put one blank line before runtime imports. Do not
+scatter `@import` tags as separate comments between or after individual `import`
+statements. External or built-in runtime imports come first, followed by
+repository-owned relative `.mjs` runtime imports, with one blank line between the
+groups:
 
 ```js
 /**
@@ -333,15 +297,22 @@ import ... from '...mjs'
 import ... from '...mjs'
 ```
 
-The `.mjs` / `.ts` grouping and the Stage 1 migration restriction apply to
-repository-owned relative runtime imports, not to external or built-in modules.
-During Stage 1, a migrated JavaScript module has no remaining relative runtime
-`.ts` / `.f.ts` import group: migrated JavaScript may depend at runtime on
-external modules and migrated repository JavaScript, but not on remaining
-authored TypeScript implementations. In a `module.*` file, the blank line after
-the leading JSDoc block is required even when the module has no `@import` tags;
-it keeps the `@module` header detached from the first import/declaration and
-preserves it through declaration emit.
+Authored TypeScript is limited to `types.ts`, whose imports are all type-only, so
+it needs no grouping: `import type` names the same real source paths, whether the
+type comes from another `types.ts` or from a `.f.mjs` module.
+
+```ts
+import type ... from '../other/types.ts'
+import type ... from './module.f.mjs'
+```
+
+The runtime-import grouping applies to repository-owned relative imports, not to
+external or built-in modules: a FunctionalScript module may depend at runtime on
+external modules and on repository `.mjs`, and there is no relative runtime `.ts`
+import group at all. In a `module.*` file, the blank line after the leading JSDoc
+block is required even when the module has no `@import` tags; it keeps the
+`@module` header detached from the first import/declaration and preserves it
+through declaration emit.
 
 Where each kind of documentation belongs:
 
@@ -559,11 +530,11 @@ cases remain explicit and independently testable.
 #### JavaScript/JSDoc type declarations
 
 Authored `.mjs` / `.f.mjs` files must remain valid JavaScript. Put named and
-generic static types in JSDoc rather than TypeScript syntax, and preserve the
-same public assignability and declaration-emission behavior when translating a
-`.ts` / `.f.ts` implementation file. A separately useful type-level API may live
-in an authored sibling `types.ts`; that file remains TypeScript type source and
-is outside the runtime implementation migration.
+generic static types in JSDoc rather than TypeScript syntax, and keep public
+assignability and declaration-emission behavior intact when a type's spelling
+changes. A separately useful type-level API may live in an authored sibling
+`types.ts`; that file remains TypeScript type source and holds no runtime
+implementation.
 
 Name implementation-only JSDoc typedefs with a leading `_`
 (`/** @typedef {number} _Type */`). Declaration emit cannot strip them yet, so
@@ -622,7 +593,8 @@ separate `@import` comment. For example:
  */
 ```
 
-The TypeScript implementation uses the same path:
+Another `types.ts` referring to the same file uses `import type` with that same
+path:
 
 ```ts
 import type { Types } from './types.ts'
@@ -631,22 +603,21 @@ import type { Types } from './types.ts'
 Both forms are type-only and introduce no runtime import. The `types.ts` file
 itself exists and is checked as ordinary TypeScript source, so this convention
 does not rely on `.d.ts` substitution and works with Deno's source resolver.
-Declaration-only `module.f.ts` files should normally become `types.ts` instead of
-acquiring an artificial JavaScript runtime representation. See [§4](#4-documentation)
+A declaration-only module belongs in `types.ts` rather than acquiring an
+artificial JavaScript runtime representation. See [§4](#4-documentation)
 for the complete module-header and import-order convention.
 
-Do not make migrated JavaScript point back to a remaining implementation `.ts` /
-`.f.ts` merely for a type. If that type should survive independently, split it
-into `types.ts` first; if it is naturally implementation-local and expressible in
-JSDoc, migrate it with the implementation. Never invent a runtime import,
-export, `Symbol()`, or other value solely to represent a TypeScript-only
-declaration such as `declare const`.
+Decide where a type lives by who needs it: one that must survive independently of
+a single implementation goes in `types.ts`, while one that is naturally
+implementation-local and expressible in JSDoc stays beside the code it describes.
+Never invent a runtime import, export, `Symbol()`, or other value solely to
+represent a TypeScript-only declaration such as `declare const`.
 
-When translating a public type that remains in JSDoc, verify both normal type
-checking and emitted `.d.ts` / `.d.mts` declarations. The JSDoc spelling may
-differ, but the public type contract must not become weaker just because the
-source moved to JavaScript. Types intentionally authored in `types.ts` use
-ordinary TypeScript syntax and declaration emit.
+When a public type is written in JSDoc, verify both normal type checking and the
+emitted `.d.ts` / `.d.mts` declarations. The JSDoc spelling may differ from the
+TypeScript one, but the public type contract must not become weaker for being
+written in JavaScript. Types authored in `types.ts` use ordinary TypeScript
+syntax and declaration emit.
 
 #### Prefer inference
 
@@ -707,10 +678,9 @@ mapSet(/** @type {ReadonlyMap<string, number>} */ (new Map()), 'a', 1)
 — because the declaration form documents the variable's intended type and lets
 the compiler check the initializer against it (closer to `satisfies`), while the
 inline form silently overrides whatever the compiler inferred, exactly like `as`.
-An exception applies when the original TypeScript source used `as`: a mechanical
-`.f.ts` → `.f.mjs` migration may carry the assertion over as an inline
-`@type`-cast rather than block on a redesign, but should still prefer the
-declaration form when it is a straightforward rewrite.
+Inline `@type` casts carried over from `as` assertions during the
+TypeScript-to-JavaScript migration still exist in the tree; converting one to the
+declaration form is a welcome cleanup wherever the rewrite is straightforward.
 
 `@type {const}` (the JSDoc equivalent of `as const`, see "Pin literal
 `const`s" above) is the one case where this preference inverts: it **must**
@@ -1116,28 +1086,22 @@ anywhere else as the rule being broken.
 
 ### 6.5 FunctionalScript module rules
 
-During Stage 1 of the TypeScript-to-JavaScript implementation migration,
-relative authored FunctionalScript **runtime** dependencies follow the asymmetric
-source rule:
+Authored FunctionalScript source is JavaScript with JSDoc. Relative
+repository-owned dependencies follow these source rules:
 
-- `.f.ts` is remaining authored TypeScript implementation/proof source and may
-  import `.f.ts` or already migrated `.f.mjs` at runtime;
-- `.f.mjs` runtime imports may target only migrated `.f.mjs` authored
-  FunctionalScript dependencies;
-- `types.ts` is authored type-only TypeScript source and does not participate in
-  the runtime implementation migration;
-- `.f.ts`, `.f.mjs`, and later `.f.js` may consume `types.ts` through `import type`
-  or JSDoc `@import`, always naming the real `types.ts` file;
-- migrated JavaScript must not retain a type-only reference to remaining
-  implementation `.ts` / `.f.ts`; split independently needed declarations into
-  `types.ts` first;
-- declaration-only `.f.ts` should normally become `types.ts` rather than
-  acquiring an artificial runtime representation;
+- `.f.mjs` is authored FunctionalScript implementation/proof source, and its
+  relative runtime imports target `.f.mjs`;
+- `types.ts` is authored type-only TypeScript source and carries no runtime
+  implementation;
+- `.f.mjs` — and later `.f.js` — consumes `types.ts` through JSDoc `@import`,
+  and TypeScript consumes it through `import type`, both always naming the real
+  `types.ts` file;
+- a declaration-only module belongs in `types.ts` rather than acquiring an
+  artificial runtime representation;
 - never add a runtime import/export or runtime value solely to represent a
   TypeScript-only type declaration;
-- compiler support does not gate an `.f.ts` / `proof.f.ts` -> `.f.mjs` /
-  `proof.f.mjs` rename; JavaScript/JSDoc validity and runtime dependency closure
-  do.
+- compiler support does not gate the later `.f.mjs` -> `.f.js` rename;
+  FunctionalScript parser coverage and package support do.
 
 Avoid references to built-in or external Node modules such as `node:path` in
 FunctionalScript source. No `try`/`catch` — see

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository is a monorepo with two code bases:
 
 | Directory    | Language                                | Notes                                       |
 | ------------ | --------------------------------------- | ------------------------------------------- |
-| `fjs/`       | FunctionalScript (`.f.mjs`) / TypeScript (`types.ts`) | The language, its standard modules, and the `fjs` CLI |
+| `fjs/`       | FunctionalScript (`.f.mjs`) / TypeScript (`types.ts`, plus the `emergent_testing` scenario fixtures) | The language, its standard modules, and the `fjs` CLI |
 | `nanvm-lib/` | Rust                                    | NaNVM, the native FunctionalScript VM       |
 
 Issues live in `todo/` directories, **not** on GitHub. Check them for existing
@@ -297,14 +297,21 @@ import ... from '...mjs'
 import ... from '...mjs'
 ```
 
-Authored TypeScript is limited to `types.ts`, whose imports are all type-only, so
-it needs no grouping: `import type` names the same real source paths, whether the
+Authored TypeScript you write is `types.ts`. Its imports are all type-only, so it
+needs no grouping: `import type` names the same real source paths, whether the
 type comes from another `types.ts` or from a `.f.mjs` module.
 
 ```ts
 import type ... from '../other/types.ts'
 import type ... from './module.f.mjs'
 ```
+
+The one exception is `fjs/emergent_testing/scenarios/*.ts`, `scenarios/all.ts`
+and `all.test.ts`, which do have runtime imports. Their `.ts` extension is
+load-bearing — `run.sh` dispatches on it to prove that Node, Bun and Deno execute
+a **TypeScript** proof natively — so they are deliberately not `types.ts` and
+must not be ported to `.mjs`. See the scenario-fixture item in
+[`todo/migrate-typescript-to-mjs.md`](./todo/migrate-typescript-to-mjs.md).
 
 The runtime-import grouping applies to repository-owned relative imports, not to
 external or built-in modules: a FunctionalScript module may depend at runtime on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,13 +65,12 @@ cargo fmt -- --check
 Bun, and published-CLI equivalents are listed in
 [AGENTS.md §1.4](./AGENTS.md#14-ways-to-run-the-functionalscript-test-suite).
 
-New `.f.ts` and `.f.mjs` modules need a co-located proof with 100% proof
-coverage — see [AGENTS.md §3](./AGENTS.md#3-testing-and-proof-coverage). During
-the TypeScript-to-JavaScript migration, a `module.f.mjs` may keep a
-`proof.f.ts`, or the proof may migrate to `proof.f.mjs` as soon as the proof
-itself is valid JavaScript/JSDoc and its authored FunctionalScript dependencies
-are already `.f.mjs`. Current FunctionalScript compiler support is not required
-for that proof rename.
+New `.f.mjs` modules need a co-located proof with 100% proof coverage — see
+[AGENTS.md §3](./AGENTS.md#3-testing-and-proof-coverage). Authored
+FunctionalScript is JavaScript with JSDoc: a `module.f.mjs` is accompanied by a
+`proof.f.mjs`, and a separately useful type-level API may live in a sibling
+`types.ts`. Current FunctionalScript compiler support is not required for either
+file.
 
 ### Updating dependencies
 

--- a/fjs/README.md
+++ b/fjs/README.md
@@ -97,7 +97,7 @@ This mirrors:
 Any arguments after `<module>` are forwarded to `main` via `options.args`:
 
 ```sh
-fjs run ./my-tool.f.ts foo bar   # options.args === ['foo', 'bar']
+fjs run ./my-tool.f.mjs foo bar   # options.args === ['foo', 'bar']
 ```
 
 

--- a/fjs/bnf/ll1/todo/stack-recursive-matching.md
+++ b/fjs/bnf/ll1/todo/stack-recursive-matching.md
@@ -55,14 +55,14 @@ grammar size, not input size — it does not need to change.
 - [ ] Replace per-step rest-spread with an index into the input array;
       materialize the `Remainder` slice only at the boundary.
 - [ ] Add a `longInput` proof group mirroring
-      `fjs/bnf/descent/proof.f.ts` — long `repeat0Plus` repetition (10,000+
+      `fjs/bnf/descent/proof.f.mjs` — long `repeat0Plus` repetition (10,000+
       code points) and deep bracket nesting via `deterministic()`.
 - [ ] `npx tsc`, `node ./fjs/module.mjs t`.
 
 ### Related
 
 - `fjs/bnf/descent/module.f.mjs` — the ported fix to mirror (explicit frame
-  stack; see the `longInput` proof group in its `proof.f.ts`), landed in PR
+  stack; see the `longInput` proof group in its `proof.f.mjs`), landed in PR
   [#1303](https://github.com/functionalscript/functionalscript/pull/1303),
   whose CHANGELOG entry records the history of the same bug in the descent
   backend and why the fix belongs in the matcher, not the grammar.

--- a/fjs/bnf/todo/207.md
+++ b/fjs/bnf/todo/207.md
@@ -351,7 +351,7 @@ const optD   = option(digit)        // Option<number>
 ```
 
 **Hypothesis 2 — real cyclic grammars cannot stay unannotated. ❌**
-Reproducing the JSON shape from `fjs/fsc/json.f.ts` *without* the `: Rule`
+Reproducing the JSON shape from `fjs/fsc/json.f.mjs` *without* the `: Rule`
 annotations fails to compile:
 
 ```ts
@@ -556,7 +556,7 @@ at instantiation independently.
 
 ### 6. Worked example: JSON
 
-Using the grammar from `fjs/fsc/json.f.ts` (`character`, `escape`, `string`,
+Using the grammar from `fjs/fsc/json.f.mjs` (`character`, `escape`, `string`,
 `member`, `object`, …) and the positional elision model:
 
 ```ts
@@ -665,4 +665,4 @@ a JSON action set exist as the first real consumer.
   `equal`/`subset` algebra; the predicate the instantiation-time boundary check
   (§5.3) depends on, and relevant if schemas are auto-derived from the BNF data
   form.
-- `fjs/fsc/json.f.ts`, `fjs/bnf/testlib.f.ts` — the grammars used in §6.
+- `fjs/fsc/json.f.mjs`, `fjs/bnf/testlib.f.mjs` — the grammars used in §6.

--- a/fjs/bnf/todo/665-bnf-data-fold-children.md
+++ b/fjs/bnf/todo/665-bnf-data-fold-children.md
@@ -103,7 +103,7 @@ removing the four mutated `let`s.
 
 - [ ] Add `foldChildren` (private) to `fjs/bnf/data/module.f.mjs`.
 - [ ] Rewrite `sequence` and `variant` as instantiations of it.
-- [ ] Confirm `fjs/bnf/data/proof.f.ts` coverage still exercises both result
+- [ ] Confirm `fjs/bnf/data/proof.f.mjs` coverage still exercises both result
       shapes (array and keyed) and the multi-child map-threading path.
 - [ ] `npm test` + `npx tsc` green.
 

--- a/fjs/bnf/todo/669-bnf-data-shared-helpers.md
+++ b/fjs/bnf/todo/669-bnf-data-shared-helpers.md
@@ -64,7 +64,7 @@ This is a local, single-module refactor with no cross-module coordination.
 ### Tasks
 
 - [ ] Hoist the shared `mr` constructor to module scope; update both `f` bodies.
-- [ ] Run `npx tsc`, `fjs t`, and confirm `fjs/bnf/data/proof.f.ts` still passes
+- [ ] Run `npx tsc`, `fjs t`, and confirm `fjs/bnf/data/proof.f.mjs` still passes
       with full coverage.
 
 ### Related

--- a/fjs/bnf/todo/data-tosequence-reuse.md
+++ b/fjs/bnf/todo/data-tosequence-reuse.md
@@ -13,7 +13,7 @@ The alphabet-specific BNF split intentionally removes that architecture instead:
 
 - `string` is removed from the generic `DataRule` / `Rule` representation;
 - `fjs/bnf/data/module.f.mjs` no longer interprets strings as Unicode code points;
-- `toSequence` moves to `fjs/bnf/unicode/module.f.ts` as an alphabet-specific
+- `toSequence` moves to `fjs/bnf/unicode/module.f.mjs` as an alphabet-specific
   construction helper;
 - Unicode helpers lower strings to ordinary generic rules before they reach
   `bnf/data`.

--- a/fjs/bnf/todo/new-parser.md
+++ b/fjs/bnf/todo/new-parser.md
@@ -205,7 +205,7 @@ The serializer and other independent parts of TODO 157 are unaffected.
 - [ ] Rebase [157](../../djs/todo/157.md) §1 according to which parser work lands
       first; do not recreate a shared DJS hand-written value machine after the BNF
       cutover.
-- [ ] `proof.f.ts` with full coverage; `npx tsc`, `fjs t`.
+- [ ] `proof.f.mjs` with full coverage; `npx tsc`, `fjs t`.
 
 ### Related
 

--- a/fjs/bnf/todo/proof-recognizer-and-fixtures.md
+++ b/fjs/bnf/todo/proof-recognizer-and-fixtures.md
@@ -7,17 +7,17 @@
 ### Problem
 
 `fjs/bnf` already has the right home for shared proof material —
-`fjs/bnf/testlib.f.ts`, which owns the two JSON grammars (`classic`,
+`fjs/bnf/testlib.f.mjs`, which owns the two JSON grammars (`classic`,
 `deterministic`) that four proof files import. Three smaller pieces of the same
 kind never made it there and are copy-pasted instead, across
-`fjs/bnf/descent/proof.f.ts`, `fjs/bnf/ll1/proof.f.ts`, and
+`fjs/bnf/descent/proof.f.mjs`, `fjs/bnf/ll1/proof.f.mjs`, and
 `fjs/djs/tokenizer/proof.f.mjs`.
 
 This design predates the alphabet split. Its shared `number` fixture currently
 constructs Unicode terminals with core `range('--')` / `range('09')`, and its
-import analysis assumes `fjs/bnf/testlib.f.ts` obtains text helpers from
-`./module.f.ts`. After the split, text/range construction belongs to
-`fjs/bnf/unicode/module.f.ts`. Do not implement the fixture extraction against
+import analysis assumes `fjs/bnf/testlib.f.mjs` obtains text helpers from
+`./module.f.mjs`. After the split, text/range construction belongs to
+`fjs/bnf/unicode/module.f.mjs`. Do not implement the fixture extraction against
 the old core API: rebase the fixture imports on `bnf/unicode` first while keeping
 the recognizer backends themselves generic.
 
@@ -28,7 +28,7 @@ and consume all of the input?* It is spelled out inline eight times, in two
 backend-specific shapes:
 
 ```ts
-// descent shape — fjs/bnf/descent/proof.f.ts:202, :228, :244
+// descent shape — fjs/bnf/descent/proof.f.mjs:202, :228, :244
 const expect = (s: string, expected: boolean) => {
     const cp = toArray(stringToCodePointList(s))
     const mr = descentParserCpOnly(m, '', cp)
@@ -36,7 +36,7 @@ const expect = (s: string, expected: boolean) => {
     assertEq(success, expected, mr)
 }
 
-// ll1 shape — fjs/bnf/ll1/proof.f.ts:198, :223, :238, :322
+// ll1 shape — fjs/bnf/ll1/proof.f.mjs:198, :223, :238, :322
 const expect = (s: string, success: boolean) => {
     const mr = m('', toArray(stringToCodePointList(s)))
     assertEq(mr[1] && mr[2]?.length === 0, success, mr)
@@ -74,7 +74,7 @@ const numberRule = [optionalMinusRule, digitRule]
 ```
 
 The fixture remains a Unicode/text fixture, so after the alphabet split the
-`range` used here must come from `fjs/bnf/unicode/module.f.ts` (or the equivalent
+`range` used here must come from `fjs/bnf/unicode/module.f.mjs` (or the equivalent
 final Unicode adapter API), **not** from core `fjs/bnf/module.f.mjs`. The produced
 rules are still ordinary generic BNF rules consumed by descent/LL1.
 
@@ -84,7 +84,7 @@ silently folded into the shared fixture.
 
 #### 3. The JSON acceptance corpus — 20 cases, 3 copies
 
-`fjs/bnf/descent/proof.f.ts` and `fjs/bnf/ll1/proof.f.ts` list the same 20 inputs
+`fjs/bnf/descent/proof.f.mjs` and `fjs/bnf/ll1/proof.f.mjs` list the same 20 inputs
 with the same verdicts; `fjs/djs/tokenizer/proof.f.mjs` repeats them plus DJS-token
 specific cases. Six JSON-rejecting rows are intentionally accepted by the JS
 /DJS token stream because tokenization leaves document structure to the parser.
@@ -92,7 +92,7 @@ That divergence should be an explicit override table rather than a copied corpus
 
 ### Proposal
 
-Move the shared harness and fixtures into `fjs/bnf/testlib.f.ts`, next to
+Move the shared harness and fixtures into `fjs/bnf/testlib.f.mjs`, next to
 `classic()` and `deterministic()`, after rebasing text construction on the Unicode
 adapter.
 
@@ -147,10 +147,10 @@ explicit named override list for the rows where token-stream acceptance differs.
 ### Tasks
 
 - [ ] Wait for [the alphabet split](./unicode-rules.md), then rebase
-      `fjs/bnf/testlib.f.ts` text/range imports on `fjs/bnf/unicode/module.f.ts`;
-      do not import Unicode `range` from core `./module.f.ts`.
+      `fjs/bnf/testlib.f.mjs` text/range imports on `fjs/bnf/unicode/module.f.mjs`;
+      do not import Unicode `range` from core `./module.f.mjs`.
 - [ ] Add `Case`, `Recognition`, `assertRecognizes`, and the two recognizer
-      adapters to `fjs/bnf/testlib.f.ts` (or per-backend testlibs if the import
+      adapters to `fjs/bnf/testlib.f.mjs` (or per-backend testlibs if the import
       direction argues for it); confirm no import cycle.
 - [ ] Carry each backend's `MatchResult` through as `Recognition.diagnostic` and
       report `[input, diagnostic]` from `assertRecognizes`.

--- a/fjs/bnf/todo/recognizer-backend.md
+++ b/fjs/bnf/todo/recognizer-backend.md
@@ -29,7 +29,7 @@ AST, which is the wrong shape (and wrong cost) for these.
 This TODO previously also assigned ownership of binary BNF authoring helpers to
 the recognizer work. That responsibility now belongs to
 [Separate alphabet-specific BNF helpers](./unicode-rules.md), which establishes
-`fjs/bnf/byte/module.f.ts` alongside `fjs/bnf/unicode/module.f.ts`. Implement the
+`fjs/bnf/byte/module.f.mjs` alongside `fjs/bnf/unicode/module.f.mjs`. Implement the
 alphabet split first so the recognizer can consume those helpers instead of
 creating a second byte-helper API or restoring alphabet-specific syntax in core
 BNF.
@@ -222,8 +222,8 @@ but generic `Rule` / `TerminalRange` semantics do not assign Unicode or byte
 meaning to it.
 
 After the alphabet split, text constructors such as `str` / `set` / `range` live
-in `fjs/bnf/unicode/module.f.ts`, while byte / hex literals, byte sequences, and
-byte-range helpers live in `fjs/bnf/byte/module.f.ts`. They are authoring adapters
+in `fjs/bnf/unicode/module.f.mjs`, while byte / hex literals, byte sequences, and
+byte-range helpers live in `fjs/bnf/byte/module.f.mjs`. They are authoring adapters
 that lower to ordinary generic BNF rules before automaton construction. The
 recognizer/DFA backends consume the resulting `RuleSet`; they do not define a
 second family of binary helpers.
@@ -290,7 +290,7 @@ Bigger automata are built from BNF pieces in two complementary ways:
       (no DFA exists) — do not fall back to another engine
 - [ ] AST-less LL(1) recognizer: derive from the existing `fjs/bnf/data` matcher
       by dropping `AstRule` accumulation; return accept/reject + final config
-- [ ] Consume binary terminal helpers from `fjs/bnf/byte/module.f.ts` after the
+- [ ] Consume binary terminal helpers from `fjs/bnf/byte/module.f.mjs` after the
       alphabet split for byte/hex literals, byte sequences, and byte ranges used
       by grammars such as magic-byte and UTF-8 recognizers; do **not** create a
       recognizer-local or second binary-helper family.

--- a/fjs/bnf/todo/unicode-rules.md
+++ b/fjs/bnf/todo/unicode-rules.md
@@ -28,13 +28,13 @@ Split alphabet-specific rule construction from the generic BNF module:
 - `fjs/bnf/module.f.mjs` defines generic symbols/ranges, rule types, and grammar
   combinators. It has no dependency on text/Unicode or byte-stream modules and
   does not give JavaScript `string` or byte-container values terminal meaning.
-- `fjs/bnf/unicode/module.f.ts` contains helpers for constructing generic BNF
+- `fjs/bnf/unicode/module.f.mjs` contains helpers for constructing generic BNF
   rules from Unicode code points and JavaScript strings.
-- `fjs/bnf/byte/module.f.ts` contains helpers for constructing generic BNF rules
+- `fjs/bnf/byte/module.f.mjs` contains helpers for constructing generic BNF rules
   over binary byte streams, including the byte range `0..255` and convenient
   byte sequence/set/range construction where useful.
 
-Move Unicode-specific APIs such as these to `fjs/bnf/unicode/module.f.ts`:
+Move Unicode-specific APIs such as these to `fjs/bnf/unicode/module.f.mjs`:
 
 - `unicodeRange`
 - `unicodeMax`
@@ -75,7 +75,7 @@ This split changes the public design assumptions used by older open TODOs:
 
 - [`fjs/media/json/todo/bnf-grammar-single-owner.md`](../../media/json/todo/bnf-grammar-single-owner.md)
   is blocked by this task. Its implementation must import Unicode-specific
-  construction from `fjs/bnf/unicode/module.f.ts` and lower text literals to
+  construction from `fjs/bnf/unicode/module.f.mjs` and lower text literals to
   generic rules before they reach core BNF.
 - [`fjs/bnf/todo/207.md`](./207.md) is blocked by this task. Its planned
   split/revision must remove `string` as a generic rule kind. Unicode text helpers
@@ -97,8 +97,8 @@ This split changes the public design assumptions used by older open TODOs:
   recognizer/DFA backends consume the generic rules produced by that adapter.
 - [`fjs/bnf/todo/proof-recognizer-and-fixtures.md`](./proof-recognizer-and-fixtures.md)
   is blocked by this task. Its shared `number` fixture currently constructs text
-  terminals with core `range('--')` / `range('09')` and assumes `testlib.f.ts`
-  obtains those helpers from `./module.f.ts`; after the split, fixture construction
+  terminals with core `range('--')` / `range('09')` and assumes `testlib.f.mjs`
+  obtains those helpers from `./module.f.mjs`; after the split, fixture construction
   must import the Unicode adapter while descent/LL1 remain generic consumers.
 - [`fjs/bnf/todo/data-tosequence-reuse.md`](./data-tosequence-reuse.md) is
   **irrelevant because it is superseded by this task**. It proposed preserving
@@ -113,8 +113,8 @@ new module boundary and final rule discriminants before implementation starts.
 
 ### Tasks
 
-- [ ] Add `fjs/bnf/unicode/module.f.ts` for Unicode code-point rule helpers.
-- [ ] Add `fjs/bnf/byte/module.f.ts` for binary byte-stream rule helpers.
+- [ ] Add `fjs/bnf/unicode/module.f.mjs` for Unicode code-point rule helpers.
+- [ ] Add `fjs/bnf/byte/module.f.mjs` for binary byte-stream rule helpers.
 - [ ] Move Unicode constants and string/code-point helper functions out of
       `fjs/bnf/module.f.mjs`.
 - [ ] Remove Unicode/text imports from `fjs/bnf/module.f.mjs`.
@@ -124,14 +124,14 @@ new module boundary and final rule discriminants before implementation starts.
 - [ ] Remove Unicode string expansion from `fjs/bnf/data/module.f.mjs`.
 - [ ] Make any core combinators that currently embed string/Unicode syntax
       alphabet-agnostic; keep optional Unicode conveniences in
-      `fjs/bnf/unicode/module.f.ts`.
+      `fjs/bnf/unicode/module.f.mjs`.
 - [ ] Update grammars and imports to construct text terminals through the Unicode
       helpers instead of relying on raw strings as generic rules.
 - [ ] Keep EOF generic and width-independent: use `EOF = -1` from
       [the EOF task](./eof-minus-one.md), and keep all alphabet adapters restricted
       to ordinary non-negative symbols without reserving the maximal value.
 - [ ] Update/block `fjs/media/json/todo/bnf-grammar-single-owner.md` so its JSON
-      grammar design imports Unicode helpers from `fjs/bnf/unicode/module.f.ts`
+      grammar design imports Unicode helpers from `fjs/bnf/unicode/module.f.mjs`
       and does not depend on raw string rules in core BNF.
 - [ ] Keep `fjs/bnf/todo/207.md` blocked until it is rebased/split so `string` is
       no longer described as a generic rule kind; Unicode text constructors lower
@@ -144,11 +144,11 @@ new module boundary and final rule discriminants before implementation starts.
       post-bigint `Rule` discriminants are settled; define its visitor against
       those semantic cases rather than the obsolete raw-string/number tests.
 - [ ] Keep `fjs/bnf/todo/recognizer-backend.md` blocked on this split and have it
-      consume byte helpers from `fjs/bnf/byte/module.f.ts` rather than defining
+      consume byte helpers from `fjs/bnf/byte/module.f.mjs` rather than defining
       another binary-helper family.
 - [ ] Keep `fjs/bnf/todo/proof-recognizer-and-fixtures.md` blocked on this split;
       rebase its shared text fixtures/testlib imports on
-      `fjs/bnf/unicode/module.f.ts` before implementing the extraction.
+      `fjs/bnf/unicode/module.f.mjs` before implementing the extraction.
 - [ ] Keep `fjs/bnf/todo/data-tosequence-reuse.md` irrelevant/superseded; do not
       implement its old generic-string reuse proposal.
 - [ ] Add byte helper proofs for byte boundaries and representative binary

--- a/fjs/cas/todo/66k-cas-cli-mcp-shared-core.md
+++ b/fjs/cas/todo/66k-cas-cli-mcp-shared-core.md
@@ -89,7 +89,7 @@ accepted as-is, the same as `cp`.
       streams and stages under `.cas/_stage`) — no new `KvStore.move` or
       `./cas/stage/` pipeline (both obsolete; see architecture note above).
 - [ ] Define a shared `casOps` (or similar) module/functions in
-      `fjs/cas/ops/module.f.ts` (or inline in `fjs/cas/module.f.mjs`) that
+      `fjs/cas/ops/module.f.mjs` (or inline in `fjs/cas/module.f.mjs`) that
       expose typed operations independent of transport. The inline
       (`text`/`base64`) `add` and the hash/store/error plumbing are shared; the
       file-path `add` is a CLI-only entry point, not part of the MCP surface.

--- a/fjs/ci/README.md
+++ b/fjs/ci/README.md
@@ -11,9 +11,9 @@ canonical Node job under `nix/generated/`.
   (`Setup` in `types.ts`) which returns an `Effect<NodeOp, number>` that writes
   the workflow file. Rust support is detected automatically by checking for
   `Cargo.toml` at the repository root via the `access` effect.
-- `proof.f.ts` — property-based proofs for the CI generator (Rust/no-Rust job presence,
+- `proof.f.mjs` — property-based proofs for the CI generator (Rust/no-Rust job presence,
   per-OS extra steps).
-- `common/module.f.ts` — shared RTTI schemas and types (`Step`, `Job`, `Jobs`,
+- `common/module.f.mjs` — shared RTTI schemas and types (`Step`, `Job`, `Jobs`,
   `GitHubAction`, `MetaStep`, `Os`, `Architecture`), and step-builder helpers
   (`test`, `install`, `uses`).
 - `config/module.f.mjs` — runner image matrix (OS × architecture → GitHub-hosted image name) and pinned tool/package versions, including the FunctionalScript package version used by generated smoke tests and the exact Nixpkgs commit the generated flakes pin.
@@ -89,7 +89,7 @@ and `ci-update`. A typical FunctionalScript project can define them like this:
 {
   "scripts": {
     "test": "tsc && fjs test",
-    "cov": "node --test --experimental-test-coverage --test-coverage-include=**/module.f.ts",
+    "cov": "node --test --experimental-test-coverage --test-coverage-include=**/module.f.mjs",
     "ci-update": "fjs ci"
   }
 }

--- a/fjs/ci/todo/669-ci-ubuntu-job-factory.md
+++ b/fjs/ci/todo/669-ci-ubuntu-job-factory.md
@@ -26,7 +26,7 @@ The same `{ 'runs-on': image, steps: toSteps(result) }` shape is also constructe
 `fjs/ci/module.f.mjs`, so there are currently three surviving copies of the same Job
 construction pattern.
 
-The former `fjs/ci/playwright/module.f.ts` consumer is intentionally excluded: that
+The former `fjs/ci/playwright/module.f.mjs` consumer is intentionally excluded: that
 module has already been deleted, and this refactoring must not resurrect it.
 
 ### Proposal
@@ -60,7 +60,7 @@ task must not add compatibility code for the deleted Playwright job.
 - [ ] Add the exported `job` factory in `fjs/ci/common/module.f.mjs`.
 - [ ] Re-express `ubuntu` and `ubuntuArm` in terms of `job`.
 - [ ] Migrate the surviving external construction in `fjs/ci/module.f.mjs`.
-- [ ] Confirm `proof.f.ts` still covers `job`, `ubuntu`, and `ubuntuArm`.
+- [ ] Confirm `proof.f.mjs` still covers `job`, `ubuntu`, and `ubuntuArm`.
 - [ ] Verify generated workflow output is unchanged.
 - [ ] Run `npx tsc` and `fjs t`.
 

--- a/fjs/ci/todo/66h-ci-npm-global-install.md
+++ b/fjs/ci/todo/66h-ci-npm-global-install.md
@@ -19,7 +19,7 @@ install({ run: `npm install -g @typescript/native-preview@${tsgo}` })
 The shape `install({ run: `npm install -g ${pkg}@${version}` })` is duplicated; only the
 package name and version differ.
 
-The former `fjs/ci/playwright/module.f.ts` call site is intentionally not a consumer of
+The former `fjs/ci/playwright/module.f.mjs` call site is intentionally not a consumer of
 this proposal. That job and its global install have already been deleted, and this task
 must not resurrect that obsolete path.
 

--- a/fjs/common/monoid/todo/balanced-fold.md
+++ b/fjs/common/monoid/todo/balanced-fold.md
@@ -128,5 +128,5 @@ finishing a walk over an already-doomed list.
   in-repo binary-counter accumulator this generalises.
 - `fjs/types/number/module.f.mjs` — `sum`, the reduction whose accuracy improves
   and whose output changes.
-- `fjs/types/bigint/module.f.mjs`, `fjs/types/string/module.f.ts` — `product` /
+- `fjs/types/bigint/module.f.mjs`, `fjs/types/string/module.f.mjs` — `product` /
   `sum` / `concat`, the reductions that gain the O(n log n) speedup.

--- a/fjs/crypto/sign/todo/computek-digest-param.md
+++ b/fjs/crypto/sign/todo/computek-digest-param.md
@@ -48,7 +48,7 @@ is a breaking API change — update all importers in the same PR per
 
 - [ ] Change `computeK`'s last parameter from message `m` to digest `h1`;
       update `sign` to pass `hm`.
-- [ ] Update `proof.f.ts` call sites and JSDoc.
+- [ ] Update `proof.f.mjs` call sites and JSDoc.
 - [ ] Run `npx tsc` and `fjs t`; verify the RFC 6979 test vectors still
       pass.
 

--- a/fjs/crypto/sign/todo/variadic-concat-to-bit-vec.md
+++ b/fjs/crypto/sign/todo/variadic-concat-to-bit-vec.md
@@ -17,8 +17,8 @@ export const concat = (...x: readonly Vec[]): Vec => listToVec(x)
 Nothing about it is signing-specific — it is the variadic sibling of the
 binary `msb.concat`, pure `bit_vec` logic living in (and widening the
 public API of) the ECDSA module. It has no external consumer besides the
-module's own `proof.f.ts`, which awkwardly imports this `concat` *and*
-separately reaches for the binary `msb.concat` (`proof.f.ts:7,72`).
+module's own `proof.f.mjs`, which awkwardly imports this `concat` *and*
+separately reaches for the binary `msb.concat` (`proof.f.mjs:7,72`).
 `AGENTS.md`: path-style logic belongs in its natural module even with a
 single consumer, and a declaration should only be `export`ed for a real
 external consumer.
@@ -48,7 +48,7 @@ readonly Vec[]): Vec => listToVec(x)` kept **private** in `crypto/sign`
 - [ ] Add `concatAll` to `BitOrder` in `fjs/types/bit_vec/module.f.mjs` with
       proof coverage (0, 1, n arguments; both bit orders).
 - [ ] Replace `concat` uses in `fjs/crypto/sign/module.f.mjs` and
-      `proof.f.ts`; delete the local export.
+      `proof.f.mjs`; delete the local export.
 - [ ] Run `npx tsc` and `fjs t`.
 
 ### Related

--- a/fjs/crypto/todo/666-crypto-sign-fromcurve.md
+++ b/fjs/crypto/todo/666-crypto-sign-fromcurve.md
@@ -117,7 +117,7 @@ co-locating the RFC rationale.
 - [ ] `sign` reads only from `fromCurve(c)` — no direct `c.nf`/`c.mul`/`c.g` access
 - [ ] add `bits2intModQ` to the RFC6979 record; express `bits2octets` and `sign`'s `h` through it
 - [ ] (optional) rename `All` → `Rfc6979` for clarity; split out if it churns proofjs/imports
-- [ ] confirm `proof.f.ts` still covers all of `all`/`fromCurve`/`sign`
+- [ ] confirm `proof.f.mjs` still covers all of `all`/`fromCurve`/`sign`
 
 ### Related
 

--- a/fjs/djs/todo/157.md
+++ b/fjs/djs/todo/157.md
@@ -35,11 +35,11 @@ leaf representation at the same boundary. This keeps one tokenizer and one
 container-building state machine without discarding `NumberToken.value` before
 extended JSON or RTTI validation can inspect it.
 
-`fjs/media/json/parser/module.f.ts` and `fjs/djs/parser/module.f.mjs` implement the
+`fjs/media/json/parser/module.f.mjs` and `fjs/djs/parser/module.f.mjs` implement the
 *same* container-building state machine. The value-state alphabet is identical:
 
 ```ts
-// json/parser/module.f.ts:32
+// json/parser/module.f.mjs:32
 status: '' | '[' | '[v' | '[,' | '{' | '{k' | '{:' | '{v' | '{,'
 // djs/parser/module.f.mjs:66
 valueState: '' | '[' | '[v' | '[,' | '{' | '{k' | '{:' | '{v' | '{,'
@@ -66,7 +66,7 @@ The differences are exactly the additive deltas DRY targets:
   `['object', …]` AST tuples instead of plain arrays/objects.
 
 The JSON value grammar (push/start/end/dispatch over the 9-state alphabet) is
-the same in both. A parameterized factory — e.g. `fjs/js/value_parser/module.f.ts`
+the same in both. A parameterized factory — e.g. `fjs/js/value_parser/module.f.mjs`
 — should take only the structural/container deltas. Numeric token materialization
 must happen after the shared structure has retained the exact token leaf.
 
@@ -97,7 +97,7 @@ id/ref hooks, then wraps the result in its module-level
 
 The same recursive `typeof`-dispatch walker is written three times:
 
-- `fjs/media/json/module.f.ts:49` (`serialize`)
+- `fjs/media/json/module.f.mjs:49` (`serialize`)
 - `fjs/djs/serializer/module.f.mjs:79` (`serializeWithoutConst`)
 - `fjs/djs/serializer/module.f.mjs:117` (`serializeWithConst`)
 

--- a/fjs/djs/todo/196.md
+++ b/fjs/djs/todo/196.md
@@ -36,7 +36,7 @@ The DJS tokenizer keeps `ws`/`nl`/`//`/`/*` in the stream on purpose
 then has to skip them at every state. That skipping is the same
 operation everywhere, but each handler hand-rolls it.
 
-`fjs/media/json/parser/module.f.ts` does **not** have this problem: its
+`fjs/media/json/parser/module.f.mjs` does **not** have this problem: its
 tokenizer drops `ws`/`nl` upstream (`mapToken` returns `empty` for
 them), and there are no `//` / `/*` tokens in JSON at all. So this is
 strictly a DJS-side concern and orthogonal to

--- a/fjs/djs/todo/197.md
+++ b/fjs/djs/todo/197.md
@@ -21,7 +21,7 @@ recursion or terminal handling):
 
 | # | Location | Purpose |
 |---|---|---|
-| 1 | `fjs/media/json/module.f.ts:67` — `serialize.f` | JSON `typeof` switch (a subset: no `bigint` / `undefined`). |
+| 1 | `fjs/media/json/module.f.mjs:67` — `serialize.f` | JSON `typeof` switch (a subset: no `bigint` / `undefined`). |
 | 2 | `fjs/djs/serializer/module.f.mjs:99` — `serializeWithoutConst.f` | DJS serialize (+`bigint` +`undefined`). |
 | 3 | `fjs/djs/serializer/module.f.mjs:135` — `serializeWithConst.f` | (2) + ref-counter short-circuit. |
 | 4 | `fjs/djs/serializer/module.f.mjs:36` — `getConstantsOp` | Collect constants for `const c{n} = …` block. |
@@ -76,7 +76,7 @@ ADT. The same factoring applies here.
 ### Proposed abstraction
 
 A `Visitor`-style walker for `Unknown`, e.g. in
-`fjs/djs/walk/module.f.ts`:
+`fjs/djs/walk/module.f.mjs`:
 
 ```ts
 export type Visitor<R> = {

--- a/fjs/djs/todo/663-json-djs-tree-type.md
+++ b/fjs/djs/todo/663-json-djs-tree-type.md
@@ -24,7 +24,7 @@ is therefore unsound for generic consumers: `object[key]` is typed as
 ### Proposal
 
 Define the recursive container once, parameterized over the leaf type, in
-`fjs/media/json/common/module.f.ts`:
+`fjs/media/json/common/module.f.mjs`:
 
 ```ts
 /** A recursive JSON-shaped tree over a leaf/primitive type `P`. */
@@ -43,7 +43,7 @@ a namespace where useful:
 
 ```ts
 // fjs/media/json/types.ts
-import type * as Tree from './common/module.f.ts'
+import type * as Tree from './common/module.f.mjs'
 export type Primitive = boolean | string | number | null
 export type Unknown = Tree.Unknown<Primitive>
 export type Object = Tree.Object<Primitive>
@@ -52,7 +52,7 @@ export type Array = Tree.Array<Primitive>
 
 ```ts
 // fjs/djs/module.f.mjs
-import type * as Tree from '../media/json/common/module.f.ts'
+import type * as Tree from '../media/json/common/module.f.mjs'
 import type { Primitive as JsonPrimitive } from '../media/json/types.ts'
 export type Primitive = JsonPrimitive | bigint | undefined
 export type Unknown = Tree.Unknown<Primitive>
@@ -90,7 +90,7 @@ serialization behavior.
 
 ### Tasks
 
-- [ ] Add `fjs/media/json/common/module.f.ts` with `Unknown<P>`, `Object<P>`, and
+- [ ] Add `fjs/media/json/common/module.f.mjs` with `Unknown<P>`, `Object<P>`, and
       `Array<P>`.
 - [ ] Define `Object<P>` with the optional recursive index signature
       `{ readonly [k in string]?: Unknown<P> }`.

--- a/fjs/djs/todo/66e-parser-container-stack-bookkeeping.md
+++ b/fjs/djs/todo/66e-parser-container-stack-bookkeeping.md
@@ -5,7 +5,7 @@
 
 ### Problem
 
-Both `fjs/media/json/parser/module.f.ts` and `fjs/djs/parser/module.f.mjs` build the
+Both `fjs/media/json/parser/module.f.mjs` and `fjs/djs/parser/module.f.mjs` build the
 container state machine out of four helpers — `startArray`, `startObject`,
 `endArray`, `endObject` — and within each module the two `start*` helpers and
 the two `end*` helpers share their *entire* stack-bookkeeping body. The only
@@ -15,7 +15,7 @@ finished container's value is extracted on the way out. Everything around that �
 pushing the current `top` onto the stack, popping it back off, and threading the
 result through `pushValue` — is repeated verbatim.
 
-#### JSON (`fjs/media/json/parser/module.f.ts:79-111`)
+#### JSON (`fjs/media/json/parser/module.f.mjs:79-111`)
 
 The stack-push line is byte-identical in both `start*` helpers:
 
@@ -159,7 +159,7 @@ one and can land independently of 157.
 
 ### Tasks
 
-- [ ] In `fjs/media/json/parser/module.f.ts`, add `pushStack` / `popState` (or
+- [ ] In `fjs/media/json/parser/module.f.mjs`, add `pushStack` / `popState` (or
       equivalently named) and `startContainer` / `endContainer`; derive
       `startArray` / `startObject` / `endArray` / `endObject` from them.
 - [ ] Apply the same shape to `fjs/djs/parser/module.f.mjs`, preserving the

--- a/fjs/djs/tokenizer/todo/error-message-specificity.md
+++ b/fjs/djs/tokenizer/todo/error-message-specificity.md
@@ -16,7 +16,7 @@ so the parser still saw whatever valid tokens came later.
 `fjs/djs/tokenizer/module.f.mjs`'s grammar (`descentParser`) has no
 cut/commit mechanism — it either parses the whole input as tokens or fails
 as one unit. This is why `numError`/`unterminated` exist at all (see
-`multilineContent`'s comment in `module.f.ts`): they turn what would be a
+`multilineContent`'s comment in `module.f.mjs`): they turn what would be a
 hard grammar failure into an always-succeeding, specially-tagged match, so
 the descent parser doesn't fall back to matching stray characters as
 unrelated operator tokens.
@@ -50,7 +50,7 @@ Two separable improvements, either could land independently:
    tagging to distinguish *why* a token is invalid — e.g. separate tags for
    "digits expected after `.`" vs. "digits expected after `e`" vs. "disallowed
    trailing char" (the `fracPart`/`expPart`/trailing-check branches in
-   `module.f.ts`'s `number` rule already structurally know which case fired;
+   `module.f.mjs`'s `number` rule already structurally know which case fired;
    right now they're all folded into one `numError` tag). Do the same for
    `string` (currently a hard grammar failure, not a tagged one — would need
    the same always-succeeds-but-tagged treatment `multilineContent` uses) and

--- a/fjs/djs/tokenizer/todo/vocabulary-single-source.md
+++ b/fjs/djs/tokenizer/todo/vocabulary-single-source.md
@@ -75,7 +75,7 @@ keys vs. downstream filter set), so it is tracked separately.
       `'<<<='`/`'<<<'` set entries; add a proof case showing `<<<`-containing
       input tokenizes old-tokenizer-compatibly (as `<<` + `<`, never as one
       token). Done — verified `<<<` → `<<`+`<` and `<<<=` → `<<`+`<=` via a
-      new `tokenizer/proof.f.ts` case.
+      new `tokenizer/proof.f.mjs` case.
 - [ ] Hoist `operator` to module scope; derive `operatorTags` from
       `Object.keys(operator)`.
 - [ ] Single-source the ws/newline character lists shared by the grammar rules,

--- a/fjs/effects/node/todo/ornotfound-combinator.md
+++ b/fjs/effects/node/todo/ornotfound-combinator.md
@@ -48,7 +48,7 @@ list: () => access(storePrefix).step(orNotFound<readonly Vec[]>([])(() =>
 
 - [ ] Add `orNotFound` beside `isNotFound` in `fjs/effects/node/module.f.mjs`
       (once a second consumer exists).
-- [ ] Rewrite `list` in `fjs/cas/module.f.ts` on top of it.
+- [ ] Rewrite `list` in `fjs/cas/module.f.mjs` on top of it.
 - [ ] Cover all three branches (`ok`, `ENOENT`, non-`ENOENT` throw) in `fjs/effects/node/proof.f.mjs`.
 
 ### Related

--- a/fjs/effects/node/todo/readjsonfile-writejsonfile-helpers.md
+++ b/fjs/effects/node/todo/readjsonfile-writejsonfile-helpers.md
@@ -9,7 +9,7 @@ Three modules independently open-code "read a file, UTF-8 decode it, JSON-parse 
 
 ### Proposed abstraction
 
-A small shared module (e.g. `fjs/effects/node/json/module.f.ts`) over the existing effects:
+A small shared module (e.g. `fjs/effects/node/json/module.f.mjs`) over the existing effects:
 
 Both sides go through `fjs/media/json`, not through the host's `JSON`: `parse`
 is total, so a malformed file is an `error` the caller destructures rather than

--- a/fjs/effects/node/virtual/todo/name-entity-kind-discrimination-once.md
+++ b/fjs/effects/node/virtual/todo/name-entity-kind-discrimination-once.md
@@ -3,7 +3,7 @@
 **Priority:** P3
 **Status:** open
 
-`module.f.ts` models filesystem nodes as `Entity = readonly Vec[] | Dir | JsModule`, but the three-way discrimination is re-derived inline at twelve call sites in at least four non-identical spellings. Define three predicate helpers next to the `Entity` type:
+`module.f.mjs` models filesystem nodes as `Entity = readonly Vec[] | Dir | JsModule`, but the three-way discrimination is re-derived inline at twelve call sites in at least four non-identical spellings. Define three predicate helpers next to the `Entity` type:
 
 ```ts
 const isBinFile  = (e: Entity): e is readonly Vec[] => e instanceof Array
@@ -17,7 +17,7 @@ These narrowing predicates are safe (each body is the exact structural check def
 
 - [ ] Add `isBinFile`, `isJsModule`, `isDir` next to the `Entity` type.
 - [ ] Rewrite the twelve inline kind-tests to use them; remove all `as Dir` / `as readonly Vec[]` casts.
-- [ ] Run `npx tsc` and `fjs t`; confirm `proof.f.ts` still passes.
+- [ ] Run `npx tsc` and `fjs t`; confirm `proof.f.mjs` still passes.
 
 ### Related
 

--- a/fjs/effects/todo/allvoid-combinator.md
+++ b/fjs/effects/todo/allvoid-combinator.md
@@ -8,13 +8,13 @@
 > `fjs/effects/node/module.f.mjs` because that is where `all`/`All` live today,
 > and notes that if `All` is ever lowered out of the node module `allVoid`
 > "moves down with it". [node-module-layering](./node-module-layering.md) is
-> that lowering: `All`/`all`/`both` go to `fjs/effects/all/module.f.ts`, and
+> that lowering: `All`/`all`/`both` go to `fjs/effects/all/module.f.mjs`, and
 > `allVoid` belongs there with them.
 >
 > Land the `All` move first, then add `allVoid` to `fjs/effects/all` — writing
 > it into the node module now would only earn it a second, breaking relocation.
 > The proposal's body is otherwise unchanged and still correct; substitute
-> `fjs/effects/all/module.f.ts` wherever it says `fjs/effects/node/module.f.mjs`.
+> `fjs/effects/all/module.f.mjs` wherever it says `fjs/effects/node/module.f.mjs`.
 
 ### Problem
 
@@ -83,7 +83,7 @@ duplicating the `all(...map)` core — whichever reads better.
 ### Tasks
 
 - [ ] Wait for [node-module-layering](./node-module-layering.md) to move
-      `All`/`all`/`both` to `fjs/effects/all/module.f.ts`.
+      `All`/`all`/`both` to `fjs/effects/all/module.f.mjs`.
 - [ ] Add `allVoid` there (next to `all`/`both`) with proof coverage — **not**
       to `fjs/effects/node/module.f.mjs`, per the note at the top of this issue.
 - [ ] Convert the three call sites in `fjs/emergent_testing/module.f.mjs`

--- a/fjs/effects/todo/effect-list-fold.md
+++ b/fjs/effects/todo/effect-list-fold.md
@@ -121,7 +121,7 @@ follow-up in `fjs/cas` (see *Related*), not part of this issue.
   `fjs/cas/evo/module.f.mjs:282` (`acc: Result<readonly Revision[], string>`);
   without it TypeScript fixes `S` to `Ok<…>` from `init` and the `'error'`
   branch goes dead. The retype should not change this, but re-check.
-- **Proof coverage.** `fjs/effects/list/` has no `proof.f.ts` at all today.
+- **Proof coverage.** `fjs/effects/list/` has no `proof.f.mjs` at all today.
   AGENTS.md requires 100% proof coverage across every dimension, so the move
   needs one created — covering `empty` and `nonEmpty` as well as the moved
   combinators and `fromList`.
@@ -141,7 +141,7 @@ follow-up in `fjs/cas` (see *Related*), not part of this issue.
 - [ ] Remove the now-unused `fjs/types/list` import from
       `fjs/effects/module.f.mjs`.
 - [ ] Migrate the six call sites; the four strict ones go through `fromList`.
-- [ ] Create `fjs/effects/list/proof.f.ts` with full coverage.
+- [ ] Create `fjs/effects/list/proof.f.mjs` with full coverage.
 - [ ] Re-scope or close [fold-stream-combinator](./fold-stream-combinator.md).
 - [ ] Run `npx tsc` and `fjs t`.
 

--- a/fjs/effects/todo/node-module-layering.md
+++ b/fjs/effects/todo/node-module-layering.md
@@ -50,10 +50,10 @@ provides*. Proposed destinations:
 
 | Moves to | Contents |
 |---|---|
-| `fjs/effects/all/module.f.ts` | `All`, `all`, `both`, and `allVoid`/`allReduce` when they land |
-| `fjs/effects/sandbox/module.f.ts` | `Sandbox`, `SandboxResult`, `sandbox`, `Await`, `awaitIfPromise` — the "run foreign code and observe what happened" pair |
-| `fjs/effects/console/module.f.ts` | `Read`, `Write`, `ReadConsoles`, `WriteConsoles`, `Console`, `log`, `error`, `readLine`, `errorExit`, and a **new named `Std`** (see below) |
-| `fjs/effects/test/module.f.ts` | `Test`, `TestFn`, `TestContext`, `test` — registration with an external framework, not I/O |
+| `fjs/effects/all/module.f.mjs` | `All`, `all`, `both`, and `allVoid`/`allReduce` when they land |
+| `fjs/effects/sandbox/module.f.mjs` | `Sandbox`, `SandboxResult`, `sandbox`, `Await`, `awaitIfPromise` — the "run foreign code and observe what happened" pair |
+| `fjs/effects/console/module.f.mjs` | `Read`, `Write`, `ReadConsoles`, `WriteConsoles`, `Console`, `log`, `error`, `readLine`, `errorExit`, and a **new named `Std`** (see below) |
+| `fjs/effects/test/module.f.mjs` | `Test`, `TestFn`, `TestContext`, `test` — registration with an external framework, not I/O |
 | stays in `fjs/effects/node` | `Fs` and its members, `Http`, `Fetch`, `Import`, `Forever`, `Now`, `RandomInt`, `IoResult`, `isNotFound`, `Env`, `Engine`, `NodeOp`, `NodeProgramOptions`, `Program`, `NodeProgram`, `NodeOperationMap` |
 
 `NodeOp` stays where it is and keeps unioning every family — it is the
@@ -105,7 +105,7 @@ Judgement calls worth deciding explicitly rather than by accident:
   are runner configuration and stay in `effects/node` — so `effects/node` would
   have to import `emergent_testing`, while `emergent_testing/module.f.mjs:21-24`
   keeps importing `NodeProgram`, `NodeProgramOptions` and `Program` back from
-  `effects/node`. `fjs/effects/test/module.f.ts` sits below both, so both may
+  `effects/node`. `fjs/effects/test/module.f.mjs` sits below both, so both may
   import it and the dependency stays a DAG. (The alternative — moving
   `NodeProgramOptions`' surviving test contexts up as well — would drag the
   whole program contract along and is not worth it.)
@@ -132,7 +132,7 @@ Judgement calls worth deciding explicitly rather than by accident:
   module and have `csiWrite` take *that*:
 
   ```ts
-  // fjs/effects/console/module.f.ts
+  // fjs/effects/console/module.f.mjs
   import type { RequiredMap } from '../../types/object/types.ts'
 
   export type Std = RequiredMap<WriteConsoles, { readonly isTTY: boolean }>
@@ -194,16 +194,16 @@ Judgement calls worth deciding explicitly rather than by accident:
 - [ ] Independent of the moves: replace `fjs/media/type`'s `IoResult` import
       with `Result<T, unknown>` from `fjs/types/result`, dropping its
       `effects/node` import. `IoResult` itself does **not** move.
-- [ ] Move `All` / `all` / `both` to `fjs/effects/all/module.f.ts`.
-- [ ] Move `Sandbox` / `Await` and helpers to `fjs/effects/sandbox/module.f.ts`.
-- [ ] Move the console family to `fjs/effects/console/module.f.ts`, add the
+- [ ] Move `All` / `all` / `both` to `fjs/effects/all/module.f.mjs`.
+- [ ] Move `Sandbox` / `Await` and helpers to `fjs/effects/sandbox/module.f.mjs`.
+- [ ] Move the console family to `fjs/effects/console/module.f.mjs`, add the
       named `Std` type there as `RequiredMap<WriteConsoles, …>`, point
       `NodeProgramOptions.std` at it, and narrow `csiWrite` to take `Std`
       (updating its one caller, `fjs/emergent_testing/module.f.mjs:360`). Verify
       `fjs/text/sgr` no longer imports `effects/node` at all — that is the test
       for this step.
 - [ ] Move `Test` / `TestFn` / `TestContext` / `test` to
-      `fjs/effects/test/module.f.ts` — **not** into `fjs/emergent_testing`, which
+      `fjs/effects/test/module.f.mjs` — **not** into `fjs/emergent_testing`, which
       would be a cycle (see the judgement call above). Confirm `effects/node`
       still compiles with `NodeOp` and `NodeProgramOptions` importing only the
       surviving process-runner test contexts from there; no Playwright context
@@ -215,7 +215,7 @@ Judgement calls worth deciding explicitly rather than by accident:
       restrict a currently unrestricted package. Whichever change introduces the
       complete map
       ([group-fs-subdirectories-by-concern](../../todo/group-fs-subdirectories-by-concern.md))
-      must enumerate these modules along with every other `module.f.ts`.
+      must enumerate these modules along with every other `module.f.mjs`.
 - [ ] `npx tsc` and `fjs t` after each move; one PR per concern.
 
 ### Related

--- a/fjs/emergent_testing/README.md
+++ b/fjs/emergent_testing/README.md
@@ -108,7 +108,7 @@ two tiers:
 
 | Language | Load gate |
 |----------|-----------|
-| FunctionalScript (`.f.ts` / `.f.js`) | **all** files are loaded — FS modules have no import side effects by construction |
+| FunctionalScript (`.f.mjs` / `.f.js`) | **all** files are loaded — FS modules have no import side effects by construction |
 | Vanilla TypeScript / JavaScript | opt-in by filename: names ending in `proof.ts`, `proof.js`, `proof.mts`, or `proof.mjs` (e.g. `math.proof.ts`) |
 
 A loaded module that does not export `proof` is silently skipped.

--- a/fjs/emergent_testing/todo/028-unit-test-examples-api.md
+++ b/fjs/emergent_testing/todo/028-unit-test-examples-api.md
@@ -26,7 +26,7 @@ Use these conventions:
 - **Executable proofs** use `export const proof = ...`.
   - Co-located `proof` values are white-box unit proofs and may test private
     implementation details.
-  - Separate `proof.f.ts` modules are black-box/API proofs and should import
+  - Separate `proof.f.mjs` modules are black-box/API proofs and should import
     only the public API.
 - **Examples** use `export const examples = ...` in the module that defines the
   public API.
@@ -36,7 +36,7 @@ simple invariant: every top-level example group describes a real public export,
 and renaming an export forces the matching example name to change too.
 
 ```ts
-import { assertEq } from '../asserts/module.f.ts'
+import { assertEq } from '../asserts/module.f.mjs'
 
 const normalizeRoot = (s: string): string => s === '' ? '.' : s
 

--- a/fjs/emergent_testing/todo/211.md
+++ b/fjs/emergent_testing/todo/211.md
@@ -9,7 +9,7 @@ reporter implementations follow naturally.
 
 ### GitHub Actions reporter
 
-`module.f.ts` currently reads `options.env['GITHUB_ACTIONS']` at startup and switches
+`module.f.mjs` currently reads `options.env['GITHUB_ACTIONS']` at startup and switches
 output format for the entire run:
 
 ```ts

--- a/fjs/emergent_testing/todo/65y-proof-asserteq-adoption.md
+++ b/fjs/emergent_testing/todo/65y-proof-asserteq-adoption.md
@@ -1,4 +1,4 @@
-## 65Y-proof-assertEq-adoption. Adopt `assert`/`assertEq` across `proof.f.ts` files
+## 65Y-proof-assertEq-adoption. Adopt `assert`/`assertEq` across `proof.f.mjs` files
 
 **Priority:** P4
 **Status:** open
@@ -14,7 +14,7 @@ export const assert: (v: boolean, msg?: unknown) => asserts v =
 export const assertEq = <T>(a: T, b: T): void => assert(a === b, [a, b])
 ```
 
-…but the codebase's `proof.f.ts` files mostly do not use them. The
+…but the codebase's `proof.f.mjs` files mostly do not use them. The
 prevailing pattern is hand-rolled per-line:
 
 ```ts
@@ -25,7 +25,7 @@ if (uint(s) !== 0x68656C6C_6F20776F_726C64n) { throw s }
 
 Counts in the current tree:
 
-- ~1,623 `if (...) { throw ... }` lines across `fjs/**/proof.f.ts` —
+- ~1,623 `if (...) { throw ... }` lines across `fjs/**/proof.f.mjs` —
   the dominant assertion style.
 - Only 4 files import `assertEq`: `fjs/sul/proof.f.mjs`,
   `fjs/sul/level/hash/proof.f.mjs`, `fjs/sul/id/proof.f.mjs`,
@@ -50,8 +50,8 @@ message.
 
 A migration that proceeds folder-by-folder, not all at once:
 
-1. **Pilot** — pick one moderately-sized `proof.f.ts` (e.g.
-   `fjs/types/string/proof.f.ts` or `fjs/types/array/proof.f.mjs`) and
+1. **Pilot** — pick one moderately-sized `proof.f.mjs` (e.g.
+   `fjs/types/string/proof.f.mjs` or `fjs/types/array/proof.f.mjs`) and
    rewrite every `if (x !== expected) { throw x }` to `assertEq(x, expected)`.
 2. **Validate** — run `npx tsc`, `npm test`, and `npm run fst` from
    that folder. Confirm test output is at least as useful on
@@ -90,7 +90,7 @@ it's by far the most common and the lowest-judgement case.
   decision and lives in one helper. Today each proof file re-makes
   that decision on every line. The helper already exists — it's just
   under-adopted.
-- **Lower bar for new contributors.** A new `proof.f.ts` writer
+- **Lower bar for new contributors.** A new `proof.f.mjs` writer
   copying the local style today copies the hand-rolled pattern; if
   the surrounding file uses `assertEq`, they pick that up by example.
   Adoption is self-reinforcing in either direction, so the first
@@ -111,12 +111,12 @@ it's by far the most common and the lowest-judgement case.
   tempted to add deep-equal support — see [i65X-async-test-functions](./README.md)
   and AGENTS.md: keep helpers minimal until a second consumer needs
   more.
-- **Import edge.** `proof.f.ts` files in `fjs/types/` currently avoid
+- **Import edge.** `proof.f.mjs` files in `fjs/types/` currently avoid
   importing from `fjs/dev/module.f.mjs` (only `fjs/types/patricia_trie/proof.f.mjs`
   pulls `assert` from there today). Verify there is no module-cycle
   problem before mass-importing from `fjs/dev` into the `fjs/types`
   subtree. If there is, hoist `assert`/`assertEq` into a small
-  `fjs/types/proof/module.f.ts` (or co-located leaf) that `fjs/dev` can
+  `fjs/types/proof/module.f.mjs` (or co-located leaf) that `fjs/dev` can
   re-export. The 4 existing `assertEq` consumers in `fjs/sul/` are a
   good existence proof that the import edge works from outside
   `fjs/types`.

--- a/fjs/emergent_testing/todo/65z-singleton-effect.md
+++ b/fjs/emergent_testing/todo/65z-singleton-effect.md
@@ -69,7 +69,7 @@ once and its exports are shared by all importers that resolve to the same URL.
 A dedicated registry module can exploit this:
 
 ```ts
-// ./fjs/emergent_testing/registry.f.ts
+// ./fjs/emergent_testing/registry.f.mjs
 export const seen = new Set<string>()
 ```
 
@@ -80,7 +80,7 @@ copies). No `globalThis` pollution needed.
 
 ```ts
 // all.ts
-import { seen } from './registry.f.ts'
+import { seen } from './registry.f.mjs'
 import { run } from './module.ts'
 
 if (!seen.has('all')) {
@@ -90,7 +90,7 @@ if (!seen.has('all')) {
 ```
 
 This is the simplest approach and requires no new effect type. The trade-off
-is that it only works when all copies share the same `registry.f.ts` URL —
+is that it only works when all copies share the same `registry.f.mjs` URL —
 which holds for hard links in the same directory tree, but not for copies in
 entirely separate trees.
 

--- a/fjs/emergent_testing/todo/665-proof-property-tests.md
+++ b/fjs/emergent_testing/todo/665-proof-property-tests.md
@@ -126,7 +126,7 @@ then show only the generated parameter values:
 
 ```
 seed: 42
-import("./fjs/math/proof.f.ts").proof.commutativity(3879392, 39002): error, 0.12 ms
+import("./fjs/math/proof.f.mjs").proof.commutativity(3879392, 39002): error, 0.12 ms
 ```
 
 Running with `--seed 42`, or opening the browser application with seed `42`,
@@ -148,7 +148,7 @@ adapter controls registration, an environment variable may provide the same
 escape hatch:
 
 ```
-FJS_TEST_ARGS='import("./fjs/math/proof.f.ts").proof.commutativity(3879392, 39002)'
+FJS_TEST_ARGS='import("./fjs/math/proof.f.mjs").proof.commutativity(3879392, 39002)'
 ```
 
 The adapter parses the path and arguments from the string and calls the function
@@ -176,7 +176,7 @@ the runner starts. One option is to register a synthetic always-passing test nam
 
 ```
 ✔ seed: 42 (0.00ms)
-✔ import("./fjs/math/proof.f.ts").proof.commutativity(3879392, 39002) (0.12ms)
+✔ import("./fjs/math/proof.f.mjs").proof.commutativity(3879392, 39002) (0.12ms)
 ```
 
 This appears in the external runner's own output and requires no special stdout

--- a/fjs/emergent_testing/todo/scenario-testing.md
+++ b/fjs/emergent_testing/todo/scenario-testing.md
@@ -36,11 +36,11 @@ The mock interpreter must be faithful to the real one. If they drift (e.g. file 
 
 ### Migration path
 
-Existing proof tests that use the virtual filesystem interpreter are already implicit scenarios — they have a state (`emptyState + root: dir`), an effect (`testAll(reporter)(options(...))`), and an expected result (exit code + events). Once the formal `Scenario` type is defined, these tests can be lifted into it directly, replacing the ad-hoc `run()` / `runMain()` helpers in `proof.f.ts` with typed scenario declarations.
+Existing proof tests that use the virtual filesystem interpreter are already implicit scenarios — they have a state (`emptyState + root: dir`), an effect (`testAll(reporter)(options(...))`), and an expected result (exit code + events). Once the formal `Scenario` type is defined, these tests can be lifted into it directly, replacing the ad-hoc `run()` / `runMain()` helpers in `proof.f.mjs` with typed scenario declarations.
 
 ### Plan
 
-- [ ] Define the `Scenario` type and `InitialState` effect in `fjs/testing/scenario/module.f.ts`.
+- [ ] Define the `Scenario` type and `InitialState` effect in `fjs/testing/scenario/module.f.mjs`.
 - [ ] Implement a mock interpreter for the scenario effect system.
 - [ ] Integrate scenarios with the existing unit test runner (`node --test`).
 - [ ] Define how CI integration jobs consume scenario modules (see [669-ci-integration-tests.md](669-ci-integration-tests.md)).

--- a/fjs/emergent_testing/todo/throw-payload-assertions.md
+++ b/fjs/emergent_testing/todo/throw-payload-assertions.md
@@ -7,7 +7,7 @@
 
 [PR #1295](https://github.com/functionalscript/functionalscript/pull/1295) replaced every
 hand-rolled `try`/`catch` throw-test with the structural [`throw`](../README.md#throw-tests)
-marker, and [AGENTS.md](../../../AGENTS.md) now flatly bans `try`/`catch` in `.f.ts` files
+marker, and [AGENTS.md](../../../AGENTS.md) now flatly bans `try`/`catch` in `.f.mjs` files
 (FunctionalScript itself has no `try`/`catch` and isn't planning one soon). Codex flagged the
 regression this causes on that PR
 ([`fjs/asserts/proof.f.mjs:17`](../../asserts/proof.f.mjs#L17)): `defaultTest` in
@@ -65,18 +65,18 @@ checks turn out to come up often enough to justify the framework work.
 
 No new rule or framework change needed — the distinction already exists and is documented in
 [fjs/todo/document-file-type-naming-conventions.md](../../todo/document-file-type-naming-conventions.md#proof--a-module-that-proves-other-modules):
-`proof.f.ts` is FunctionalScript (no `try`/`catch`, ever), `proof.ts` is vanilla TS and is
+`proof.f.mjs` is FunctionalScript (no `try`/`catch`, ever), `proof.ts` is vanilla TS and is
 already exempt from that rule — [`fjs/effects/node/memory/proof.mjs`](../../effects/node/memory/proof.mjs)
 is a live example (it isn't the shape we need here, since it captures a rejected `Promise` via
 `.then(onFulfilled, onRejected)` rather than `try`/`catch`, but it proves the file-type split
 already works and is already discovered by `fjs t` — `shouldLoad` in
 [`fjs/dev/module.f.mjs`](../../dev/module.f.mjs#L44) matches any `*proof.ts` filename alongside
-`*.f.ts`). AGENTS.md's `.f.ts` rule needs no change: it never applied to `proof.ts` in the first
+`*.f.ts` / `*.f.mjs`). AGENTS.md's `.f.mjs` rule needs no change: it never applied to `proof.ts` in the first
 place. The fix for `fjs/asserts/proof.f.mjs` and `fjs/types/result/proof.f.mjs` is simply to move
 just the payload-checking cases (`assertThrowsCustomMsg`, `assertEqThrowsOnUnequal`,
 `assertEqThrowsOnUnequal3`, `todoThrows`, `unwrapError`) into a sibling `proof.ts` in the same
 directory, using ordinary `try`/`catch`, while the rest of each module's coverage stays in
-`proof.f.ts`. `loadModuleMap` treats the two files as independent module-map entries, so both
+`proof.f.mjs`. `loadModuleMap` treats the two files as independent module-map entries, so both
 `proof` exports run.
 
 This is a workaround, not the destination: it splits one module's proof coverage across two
@@ -104,9 +104,9 @@ export const proof = {
 - If `try` throws, `catch` is called with the thrown value. `catch` is ordinary proof code —
   it can call `assert`/`assertEq`, and throwing (i.e. an assertion failing) is the leaf's real
   failure signal.
-- No raw `try`/`catch` is needed in `module.f.ts` to implement this: the module already routes
+- No raw `try`/`catch` is needed in `module.f.mjs` to implement this: the module already routes
   every leaf call through the `sandbox` effect (`fjs/effects/node/module.f.mjs`), which is
-  implemented in the host runtime (not `.f.ts`) and already exposes the thrown value as
+  implemented in the host runtime (not `.f.mjs`) and already exposes the thrown value as
   `SandboxResult.result`'s `error` case. `defaultTest` can sandbox `try`, and on an `error`
   result sandbox `() => catchFn(thrownValue)` as the leaf's real verdict — two effect calls,
   no bare `try`/`catch` written in FunctionalScript.
@@ -114,8 +114,8 @@ export const proof = {
   already encodes "expected to throw" on its own. Nesting one under `throw` should probably be
   a static error (redundant/contradictory expectation) rather than silently accepted.
 
-This keeps the flat "`.f.ts` never uses `try`/`catch`" rule intact, keeps payload checks
-inline in the same `proof.f.ts` and same structural-marker style as `throw`/`todo`/`skip`, and
+This keeps the flat "`.f.mjs` never uses `try`/`catch`" rule intact, keeps payload checks
+inline in the same `proof.f.mjs` and same structural-marker style as `throw`/`todo`/`skip`, and
 gives every proof author a supported way to check a thrown payload without reaching for a
 second file — the outcome A only approximates.
 
@@ -154,20 +154,20 @@ Playwright bridge.
 **Step 2 — long-term fix (B), only if payload checks prove common:**
 
 - [ ] Add the `{ try, catch }` leaf shape to `parseTestSet`/`collectTests`/`TestEntry` in
-      `fjs/emergent_testing/module.f.ts`, wire `defaultTest` to sandbox `catch` on a caught
+      `fjs/emergent_testing/module.f.mjs`, wire `defaultTest` to sandbox `catch` on a caught
       throw, and extend only the surviving process-framework registration paths.
 - [ ] Implement identical `{ try, catch }` behavior in the shared browser-side runner and
       include its result in the serializable browser report.
 - [ ] Document the `{ try, catch }` marker in `fjs/emergent_testing/README.md` next to
       [Throw tests](../README.md#throw-tests).
-- [ ] Migrate the `proof.ts` siblings from A back into `proof.f.ts` using the new marker, and
+- [ ] Migrate the `proof.ts` siblings from A back into `proof.f.mjs` using the new marker, and
       delete the now-empty `proof.ts` files.
 - [ ] Confirm `fjs t` proofs pass with full branch coverage and `npx tsc` is clean.
 
 ### Related
 
 - [PR #1295](https://github.com/functionalscript/functionalscript/pull/1295) — introduced the
-  `.f.ts` `try`/`catch` ban and, as a side effect, dropped the payload checks this issue
+  FunctionalScript `try`/`catch` ban and, as a side effect, dropped the payload checks this issue
   proposes to restore.
 - [todo-property](./todo-property.md), [skip-property](./skip-property.md) — the same
   structural-marker mechanism this proposal extends.

--- a/fjs/fsc/README.md
+++ b/fjs/fsc/README.md
@@ -8,10 +8,10 @@ FunctionalScript compiler.
 
 | Extension | Meaning |
 |---|---|
-| `.f.ts` | Authored FunctionalScript-intent TypeScript implementation/proof source that has not yet completed the repository TypeScript-to-JavaScript migration. |
+| `.f.ts` | Authored FunctionalScript-intent TypeScript implementation/proof source. **No longer used**: stage 1 removed the last one, and new source must not use this extension. It appears below only to describe that completed migration. |
 | `.f.mjs` | Authored FunctionalScript-intent ESM JavaScript with JSDoc types. It may use FunctionalScript features the current parser/compiler does not support yet. |
 | `.f.js` | During stage 1, generated JavaScript emitted from `.f.ts` and never authored. After stage 1 and authored-`.f.js` package support are complete, authored FunctionalScript that the current parser/compiler must accept. |
-| `types.ts` | Authored TypeScript source for a type-level API. It may coexist with `.f.ts`, `.f.mjs`, or `.f.js` and is outside the runtime implementation migration. |
+| `types.ts` | Authored TypeScript source for a type-level API. It may coexist with `.f.mjs` or later `.f.js` and holds no runtime implementation. |
 | `.d.ts`, `.d.mts` | Generated TypeScript declarations. |
 
 The migration is deliberately split into two implementation stages. The
@@ -21,6 +21,11 @@ and the package conventions are documented in
 [`fjs/ci/todo/publishing-packages.md`](../ci/todo/publishing-packages.md).
 
 ### Stage 1: remove authored TypeScript implementations
+
+**Stage 1 source conversion is complete** — no authored implementation or proof
+`.f.ts` remains, so every rename described in this section has already happened.
+It is kept as the record of what the extensions mean and why; write new source as
+`.f.mjs` plus, where a type-level API is separately useful, `types.ts`.
 
 Before the first real repository implementation conversion, complete both
 prerequisites in order:
@@ -113,11 +118,10 @@ files are required, and that TypeScript, Node, Deno, and Bun can consume the
 packed result. Do not simplify the TypeScript runtime-emission pass until that
 experiment establishes whether generated `types.js` remains necessary.
 
-Proofs follow the same runtime source-language rule. `proof.f.ts` may remain
-temporarily beside a migrated `module.f.mjs`, but it may move to `proof.f.mjs` as
-soon as the proof itself is valid JavaScript with JSDoc and its authored runtime
-dependencies are already `.f.mjs`. Type-only APIs may remain in `types.ts`.
-Current FunctionalScript compiler support is not a condition for that rename.
+Proofs followed the same runtime source-language rule and completed the same
+move, so a `module.f.mjs` is accompanied by a `proof.f.mjs`. Type-only APIs may
+remain in `types.ts`. Current FunctionalScript compiler support was never a
+condition for that rename.
 
 #### Private JSDoc typedefs
 

--- a/fjs/fsc/todo/66c-emit-literals-via-owner-modules.md
+++ b/fjs/fsc/todo/66c-emit-literals-via-owner-modules.md
@@ -128,7 +128,7 @@ but isn't exposed in a reusable (bare-string) form.
 
 ### Tasks
 
-- [ ] `fjs/types/ts`: import `serialize` from `../bigint/module.f.ts`; replace
+- [ ] `fjs/types/ts`: import `serialize` from `../bigint/module.f.mjs`; replace
       `case 'bigint': return \`${c}n\`` with `bigintSerialize(c)`.
 - [ ] `fjs/media/json/serializer`: export `stringLiteral`; redefine `stringSerialize`
       in terms of it (no behavior change).

--- a/fjs/fsm/README.md
+++ b/fjs/fsm/README.md
@@ -107,7 +107,7 @@ const b = { ...a, z: 7 }
 ## How to Add a Property # 2
 
 ```ts
-import map from './types/map/module.f.ts'
+import map from './types/map/module.f.mjs'
 const a = map.fromEntries(Object.entries({ x: 5, y: 6 }))
 const b = map.setReplace('z')(7)(a)
 ```

--- a/fjs/js/identifier/todo/lift-js-lexical-predicates-out-of-emergent-testing.md
+++ b/fjs/js/identifier/todo/lift-js-lexical-predicates-out-of-emergent-testing.md
@@ -5,10 +5,10 @@
 
 `fjs/emergent_testing/module.f.mjs` carries four predicates (`isAlpha`, `isDigit`, `isInteger`, `isIdentifier`) that encode JavaScript lexical rules, not test logic. They are even exported from the test module, polluting its public surface.
 
-Create `fjs/js/identifier/module.f.ts` with `isInteger` and `isIdentifier` (private `isAlpha`/`isDigit`), and have `emergent_testing` import them instead.
+Create `fjs/js/identifier/module.f.mjs` with `isInteger` and `isIdentifier` (private `isAlpha`/`isDigit`), and have `emergent_testing` import them instead.
 
 ```ts
-// fjs/js/identifier/module.f.ts
+// fjs/js/identifier/module.f.mjs
 const isAlpha = (c: string): boolean =>
     (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c === '_' || c === '$'
 
@@ -27,8 +27,8 @@ A future consumer: the DJS serializer currently quotes every object key; with `i
 
 ### Tasks
 
-- [ ] Create `fjs/js/identifier/module.f.ts` with the two exports.
-- [ ] Add co-located `proof.f.ts` with 100% coverage (reuse cases from `fjs/emergent_testing/proof.f.mjs:406-421`).
+- [ ] Create `fjs/js/identifier/module.f.mjs` with the two exports.
+- [ ] Add co-located `proof.f.mjs` with 100% coverage (reuse cases from `fjs/emergent_testing/proof.f.mjs:406-421`).
 - [ ] Register in `deno.json` `exports` map.
 - [ ] Remove the four definitions from `fjs/emergent_testing/module.f.mjs`; repoint `emergent_testing/proof.f.mjs` at the new module.
 - [ ] Run `npx tsc` and `fjs t`.

--- a/fjs/js/todo/174.md
+++ b/fjs/js/todo/174.md
@@ -3,7 +3,7 @@
 **Priority:** P3
 **Status:** open
 
-`fjs/fsc/module.f.mjs` and `fjs/js/tokenizer/module.f.ts` are the only two
+`fjs/fsc/module.f.mjs` and `fjs/js/tokenizer/module.f.mjs` are the only two
 code-point scanners in the tree, and both hand-roll the *same* Mealy machine
 over `range_map`: a state is a continuation `(codePoint) => [output, nextState]`,
 transitions are looked up in a `RangeMapArray` of continuations, and overlapping
@@ -38,7 +38,7 @@ const union
 
 The rest of the machinery is the same algorithm with the payload type swapped:
 
-| concern | `fsc` (`module.f.mjs`) | `js/tokenizer` (`module.f.ts`) |
+| concern | `fsc` (`module.f.mjs`) | `js/tokenizer` (`module.f.mjs`) |
 |---|---|---|
 | continuation | `ToResult = (cp) => [string[], ToResult]` | `ToToken = (cp) => [List<JsToken>, TokenizerState]` |
 | conflict merge | `union` :33 | `union` :330 |
@@ -52,7 +52,7 @@ Both `create` functions even end with the byte-identical dispatch shape
 
 ### Proposed abstraction
 
-A new module (e.g. `fjs/types/range_map/lexer/module.f.ts`) parameterized over
+A new module (e.g. `fjs/types/range_map/lexer/module.f.mjs`) parameterized over
 the continuation type `C` and the `def` continuation, exporting the
 range/range-set cell combinators and the `create` builder:
 

--- a/fjs/mcp/README.md
+++ b/fjs/mcp/README.md
@@ -265,6 +265,6 @@ remaining characters of the cBase32 hash. The `uri` field returned by
 ### Testing without a live process
 
 Because the adapter is generic in `O`, the same handlers run over an
-in-memory `Cas<MemOp>` in `proof.f.ts`, driven through a full
+in-memory `Cas<MemOp>` in `proof.f.mjs`, driven through a full
 `initialize` → `notifications/initialized` → `tools/call` sequence with no live
 process.

--- a/fjs/mcp/evo/README.md
+++ b/fjs/mcp/evo/README.md
@@ -88,5 +88,5 @@ Each tool's argument schema is an rtti struct declared once and used twice:
 ## Testing without a live process
 
 `evoToolRegistry` is generic in the store's operation type `O` and takes a
-plain `Evo<O>`, so `proof.f.ts` exercises each tool entry's `handle` directly
+plain `Evo<O>`, so `proof.f.mjs` exercises each tool entry's `handle` directly
 against an in-memory `Evo` — no MCP session or live process required.

--- a/fjs/mcp/todo/cas-get-mcp-resource-response.md
+++ b/fjs/mcp/todo/cas-get-mcp-resource-response.md
@@ -46,7 +46,7 @@ and the (future) resource view of a blob use the same terminology:
 ### Tasks
 
 - [x] Rename `mime_type` to `mimeType` in `Meta`, the `cas_get` handler, the tool
-      description string, `proof.f.ts`, and `README.md`
+      description string, `proof.f.mjs`, and `README.md`
 - [x] Replace `type`/`content` with `text`/`blob` for inline-content responses,
       keeping `type` as the metadata-only discriminator
 - [x] Rename `url` to `uri` and define its relation to the future resource URI

--- a/fjs/media/html/todo/665-json-html.md
+++ b/fjs/media/html/todo/665-json-html.md
@@ -11,7 +11,7 @@ booleans, null, structural symbols — wrapped in a `<span>` so CSS can colour i
 
 ### Proposal
 
-A module `fjs/media/json/html/module.f.ts` that converts a JSON `Unknown` value to a
+A module `fjs/media/json/html/module.f.mjs` that converts a JSON `Unknown` value to a
 syntax-highlighted HTML representation, using the project's existing virtual-DOM
 format (`['tag', {attrs}, ...children]`).
 
@@ -81,12 +81,12 @@ Which serialises to:
 
 ### Tasks
 
-- [ ] `fjs/media/json/html/module.f.ts` — `toHtml(value: Unknown): VDom` converter
-- [ ] `proof.f.ts` covering each value type and a nested example
+- [ ] `fjs/media/json/html/module.f.mjs` — `toHtml(value: Unknown): VDom` converter
+- [ ] `proof.f.mjs` covering each value type and a nested example
 - [ ] Register in `deno.json` exports
 
 ### Related
 
 - `fjs/media/json/types.ts` — the `Unknown` type
-- `fjs/media/json/module.f.ts` — `serialize`
+- `fjs/media/json/module.f.mjs` — `serialize`
 - `fjs/media/json/schema/module.f.mjs` — sibling JSON-dialect module

--- a/fjs/media/json/todo/bnf-grammar-single-owner.md
+++ b/fjs/media/json/todo/bnf-grammar-single-owner.md
@@ -9,7 +9,7 @@
 The JSON lexical grammar, written with `fjs/bnf` combinators, exists in two
 places, and neither copy is owned by `fjs/media/json`:
 
-- `fjs/bnf/testlib.f.ts` contains the deterministic JSON grammar used by BNF
+- `fjs/bnf/testlib.f.mjs` contains the deterministic JSON grammar used by BNF
   proofs plus the deliberately awkward `classic()` json.org fixture;
 - `fjs/djs/tokenizer/module.f.mjs` restates much of the JSON lexical grammar and
   extends it for DJS.
@@ -27,7 +27,7 @@ Do not implement this TODO against the old API.
 Give the canonical grammar an owner at:
 
 ```text
-fjs/media/json/grammar/module.f.ts
+fjs/media/json/grammar/module.f.mjs
 ```
 
 The dependency direction remains:
@@ -40,7 +40,7 @@ After the alphabet split:
 
 - generic grammar structure/combinators come from `fjs/bnf/module.f.mjs`;
 - all JavaScript-string / Unicode-code-point interpretation comes from
-  `fjs/bnf/unicode/module.f.ts`;
+  `fjs/bnf/unicode/module.f.mjs`;
 - raw strings are not generic BNF rules. Text literals such as `"`, `\`, `/`,
   punctuation, keywords, and character sets must be lowered through Unicode
   helpers before they enter the generic grammar.
@@ -54,7 +54,7 @@ import {
 } from '../../../bnf/module.f.mjs'
 import {
     range, set, str, unicodeMax,
-} from '../../../bnf/unicode/module.f.ts'
+} from '../../../bnf/unicode/module.f.mjs'
 ```
 
 The exact helper names should follow the API produced by the blocking Unicode
@@ -83,7 +83,7 @@ Only share what is actually common. DJS's number grammar is materially different
 is newline-sensitive. Keep those DJS-specific rules local rather than forcing a
 factory abstraction.
 
-`fjs/bnf/testlib.f.ts` may keep `classic()` as a BNF-local stress fixture, but the
+`fjs/bnf/testlib.f.mjs` may keep `classic()` as a BNF-local stress fixture, but the
 canonical deterministic JSON grammar should come from `fjs/media/json/grammar`.
 Document why `classic()` remains local if it stays.
 
@@ -93,7 +93,7 @@ Before implementing this TODO after the blocking split:
 
 - [ ] Replace every old core import of `range`, `set`, `unicodeMax`, `str`, or
       equivalent Unicode/text helpers with imports from
-      `fjs/bnf/unicode/module.f.ts`.
+      `fjs/bnf/unicode/module.f.mjs`.
 - [ ] Replace every raw string used as a generic BNF `Rule` with the appropriate
       Unicode helper construction.
 - [ ] Ensure generic combinators receive already-lowered rules/symbols and do not
@@ -104,13 +104,13 @@ Before implementing this TODO after the blocking split:
 
 - [ ] Wait for [Separate alphabet-specific BNF helpers](../../../bnf/todo/unicode-rules.md)
       and rebase this grammar on the resulting `bnf/unicode` API.
-- [ ] Create `fjs/media/json/grammar/module.f.ts` with the standard `@module`
+- [ ] Create `fjs/media/json/grammar/module.f.mjs` with the standard `@module`
       header and proof coverage.
 - [ ] Export the shared digit rules, parameterized JSON string rule, and complete
       canonical JSON grammar.
 - [ ] Keep JSON-specific Unicode construction in `fjs/media/json/grammar` using
       `fjs/bnf/unicode`; do not move it back into generic BNF.
-- [ ] Point `fjs/bnf/testlib.f.ts` deterministic JSON use at this module (or remove
+- [ ] Point `fjs/bnf/testlib.f.mjs` deterministic JSON use at this module (or remove
       that wrapper and update proof importers); document the role of `classic()`.
 - [ ] Point `fjs/djs/tokenizer/module.f.mjs` at the shared digit/string rules while
       keeping DJS-specific number/whitespace/token rules local.

--- a/fjs/media/json/todo/parser-unexpected-token.md
+++ b/fjs/media/json/todo/parser-unexpected-token.md
@@ -5,7 +5,7 @@
 
 ### Problem
 
-`fjs/media/json/parser/module.f.ts` builds `{ status: 'error', message:
+`fjs/media/json/parser/module.f.mjs` builds `{ status: 'error', message:
 'unexpected token' }` inline at nine sites (lines 146, 151, 162, 170, 178,
 185, 193, 202, 212), plus a stray `{ status: 'error', message: 'error' }`
 at line 68 (the `pushKey` fallthrough). Example:

--- a/fjs/media/json/todo/remove-native-json.md
+++ b/fjs/media/json/todo/remove-native-json.md
@@ -27,7 +27,7 @@ Three reasons to finish the job:
    deleted, and it is what the write side still looks like.
 2. **`JSON` is a host global with no FunctionalScript definition.** Nothing in
    `fjs/` defines it and NaNVM (`nanvm-lib/src`) has no `JSON` object, so a
-   `.f.ts` module reaching for it depends on the JS host rather than on
+   `.f.mjs` module reaching for it depends on the JS host rather than on
    FunctionalScript — and a "FunctionalScript JSON serializer" that calls the
    host to format its strings and numbers is not one.
 3. **It is the last host dependency in the pipeline.** With reading migrated,
@@ -39,7 +39,7 @@ Three reasons to finish the job:
 | Shape | Sites | Where | Replacement |
 | --- | --- | --- | --- |
 | **Leaf serializer** | 1 | `fjs/media/json/serializer/module.f.mjs` | FunctionalScript number formatting — blocks everything below |
-| Expected-output comparison | 73 | `fjs/bnf/ll1/proof.f.ts` (27), `fjs/bnf/descent/proof.f.ts` (22), `fjs/media/json/serializer/proof.f.mjs` (10), `fjs/djs/tokenizer/proof.f.mjs:886-921` (8), `fjs/bnf/data/proof.f.ts` (4), `fjs/media/revision/proof.f.mjs:177`, `fjs/cas/evo/proof.f.mjs:68` | `stringify(identity)` |
+| Expected-output comparison | 73 | `fjs/bnf/ll1/proof.f.mjs` (27), `fjs/bnf/descent/proof.f.mjs` (22), `fjs/media/json/serializer/proof.f.mjs` (10), `fjs/djs/tokenizer/proof.f.mjs:886-921` (8), `fjs/bnf/data/proof.f.mjs` (4), `fjs/media/revision/proof.f.mjs:177`, `fjs/cas/evo/proof.f.mjs:68` | `stringify(identity)` |
 | Assertion messages | 33 | `fjs/djs/tokenizer/proof.f.mjs` (31), `fjs/types/rtti/ts/proof.f.mjs:8,12` (2) | pass the value, or `fjs/djs`'s `stringify` |
 | Source-text quoting | 5 | `fjs/emergent_testing/module.f.mjs:282,303,318`, `fjs/types/ts/module.f.mjs:36,48` | `stringSerialize` — already designed in `66c-emit-literals-via-owner-modules.md` |
 | JSON line framing | 2 | `fjs/emergent_testing/proof.f.mjs:47`, `fjs/mcp/proof.f.mjs:128` | `stringify(identity)` |

--- a/fjs/media/json/todo/serializer-shared-atoms.md
+++ b/fjs/media/json/todo/serializer-shared-atoms.md
@@ -15,7 +15,7 @@ vocabulary were left behind and re-declared instead:
 `stringSerialize(k), colon, f(v)` property fragment:
 
 ```ts
-// fjs/media/json/module.f.ts:70
+// fjs/media/json/module.f.mjs:70
 const colon = [':']
 // fjs/djs/serializer/module.f.mjs:17
 const colon = [':']
@@ -25,7 +25,7 @@ const colon = [':']
 `Unknown` the entries carry:
 
 ```ts
-// fjs/media/json/module.f.ts:74-76
+// fjs/media/json/module.f.mjs:74-76
 type Entries = List<Entry>
 type MapEntries = (entries: Entries) => Entries
 // fjs/djs/serializer/module.f.mjs:23
@@ -47,7 +47,7 @@ export const colon: List<string> = [':']
 export type MapEntries<P> = (entries: List<ObjectEntry<P>>) => List<ObjectEntry<P>>
 ```
 
-`fjs/media/json/module.f.ts` imports `colon` and instantiates
+`fjs/media/json/module.f.mjs` imports `colon` and instantiates
 `MapEntries<Unknown>` (json's `Unknown`); `fjs/djs/serializer` imports both
 and instantiates `MapEntries<Unknown>` (djs's `Unknown`). The two local
 declarations are deleted. The leaf parameterization composes with
@@ -57,7 +57,7 @@ unifies the value types the same way but does not cover `MapEntries`.
 ### Tasks
 
 - [ ] Export `colon` and `MapEntries<P>` from `fjs/media/json/serializer`.
-- [ ] Delete the local copies in `fjs/media/json/module.f.ts` and
+- [ ] Delete the local copies in `fjs/media/json/module.f.mjs` and
       `fjs/djs/serializer/module.f.mjs`; import instead.
 - [ ] Run `npx tsc` and `fjs t`.
 

--- a/fjs/media/json/todo/streaming-recognizer.md
+++ b/fjs/media/json/todo/streaming-recognizer.md
@@ -11,7 +11,7 @@ without paying to build the value. Two independent costs make the existing
 pipeline unfit as a validity check for a size-independent streaming consumer:
 
 1. **The parser builds the whole value.** `parse`
-   (`fjs/media/json/parser/module.f.ts:232-238`) accumulates objects/arrays in
+   (`fjs/media/json/parser/module.f.mjs:232-238`) accumulates objects/arrays in
    `top`/`stack`, i.e. O(n) memory in the document size — even when the caller
    only wants a yes/no verdict.
 
@@ -69,7 +69,7 @@ parser; drop only the accumulation:
   drops object/array construction — one grammar, two builders.
 
 - **Value-free parsing.** Drive `fjs/media/json/parser`'s per-token control machine
-  (`foldOp` — `fjs/media/json/parser/module.f.ts:205-224`) with a no-op value builder,
+  (`foldOp` — `fjs/media/json/parser/module.f.mjs:205-224`) with a no-op value builder,
   keeping only `status` + a bracket stack. Space is **O(nesting depth)** — already
   strictly better than `parse`'s O(n) value. An **optional** max-depth cap
   (default: none) lets a consumer that needs a DoS guard bound the stack and
@@ -122,6 +122,6 @@ property, scoped to make it actually hold:
 
 ### Related
 
-- `fjs/media/json/parser/module.f.ts:205-238` — `foldOp` / `parse`; the control machine to reuse value-free.
+- `fjs/media/json/parser/module.f.mjs:205-238` — `foldOp` / `parse`; the control machine to reuse value-free.
 - `fjs/js/tokenizer/module.f.mjs:436-474,550-556` — string/number states that buffer payloads and must gain payload-free variants.
 - `fjs/media/type/todo/detect-json.md` — first consumer; needs O(depth), payload-free validity to keep `detectStream` size-independent.

--- a/fjs/media/json/todo/stringify-sorted-canonical.md
+++ b/fjs/media/json/todo/stringify-sorted-canonical.md
@@ -25,7 +25,7 @@ Proof files (each binds its own alias: `jsonStr`, `str`, `stringify`,
 - `fjs/text/ascii/proof.f.mjs:6`, `fjs/text/utf8/proof.f.mjs:8`,
   `fjs/text/utf16/proof.f.mjs:18`
 - `fjs/media/json/parser/proof.f.mjs:16`, `fjs/protocol/mcp/stdio/proof.f.mjs:20`
-- `fjs/bnf/data/proof.f.ts` (10 inline calls), `fjs/djs/parser/proof.f.mjs:309`,
+- `fjs/bnf/data/proof.f.mjs` (10 inline calls), `fjs/djs/parser/proof.f.mjs:309`,
   `fjs/djs/serializer/proof.f.mjs:47`
 
 Each site is one line, so no single site is a problem — the issue is that

--- a/fjs/media/nix/todo/serializer-validation-split.md
+++ b/fjs/media/nix/todo/serializer-validation-split.md
@@ -145,7 +145,7 @@ using `fjs/types/result`. Two details the shape has to respect:
 
 - **The trailing newline is part of the contract**, not incidental
   formatting: `nixToString` guarantees "exactly one trailing newline on
-  success" (`:261`) and ten proof cases assert it (`proof.f.ts:72-105`). A bare
+  success" (`:261`) and ten proof cases assert it (`proof.f.mjs:72-105`). A bare
   `mapOk(concat)` would silently turn `'{}\n'` into `'{}'`. The `ok` branch
   must append it, exactly as today.
 - **Do not route the branch through `nullable`'s `match`.** Its signature is
@@ -252,7 +252,7 @@ where it lands.
       `Nullable`" above; the caller migration below assumes `Result`'s
       `unwrap`.
 - [ ] Keep `nixToString`'s single trailing newline: the ten
-      `proof.f.ts:72-105` assertions must pass with only their `Result`
+      `proof.f.mjs:72-105` assertions must pass with only their `Result`
       wrapping changed, not their expected text.
 - [ ] Migrate the one production caller, `flakeText`
       (`fjs/ci/nix/module.f.mjs:71-72`): replace

--- a/fjs/media/todo/cbor.md
+++ b/fjs/media/todo/cbor.md
@@ -27,8 +27,8 @@ sibling of `media/json/` — same bucket, same reasons, different encoding.
 ### Proposal
 
 Create `fjs/media/cbor/` following the `fjs/media/json/` layout: a root
-`module.f.ts` re-exporting the pieces, `serializer/` (value → bytes) and
-`parser/` (bytes → value) submodules with their `proof.f.ts` tests, and a
+`module.f.mjs` re-exporting the pieces, `serializer/` (value → bytes) and
+`parser/` (bytes → value) submodules with their `proof.f.mjs` tests, and a
 README specifying the data-model mapping. Pure functions only, no store access,
 no effects; errors as result values, not exceptions — matching the sibling
 modules. (No `tokenizer/`: CBOR items are self-delimiting binary, so the
@@ -96,17 +96,17 @@ identity function, so encoding options would silently fork identities.
 
 - [ ] Create `fjs/media/cbor/README.md` — the data-model mapping table, the
       canonical-form rules (§4.2 deterministic encoding), and the strictness rules
-- [ ] `fjs/media/cbor/serializer/module.f.ts` — canonical encoder over the
+- [ ] `fjs/media/cbor/serializer/module.f.mjs` — canonical encoder over the
       data-model subset, `bigint` included; proof cases against the RFC 8949
       Appendix A test vectors that fall inside the model
-- [ ] `fjs/media/cbor/parser/module.f.ts` — strict decoder (well-formedness,
+- [ ] `fjs/media/cbor/parser/module.f.mjs` — strict decoder (well-formedness,
       single item, no duplicate keys, UTF-8-valid text, depth cap), result-typed
       errors; proof cases including truncated items, trailing bytes, duplicate
       keys, indefinite lengths (rejected), a tag-55799-wrapped item (accepted,
       unwrapped, reported non-canonical), and round trips through the serializer
 - [ ] `isCanonical` predicate (or a decode flag reporting canonicity) for
       consumers that require byte-identity
-- [ ] Root `fjs/media/cbor/module.f.ts` re-exporting serializer/parser and the
+- [ ] Root `fjs/media/cbor/module.f.mjs` re-exporting serializer/parser and the
       `application/cbor` constant; reference the module from `fjs/media` docs
 - [ ] Unblock [detect-cbor](detect-cbor.md) tier 2: the strict parser's full
       decode of a size-bounded (128 KiB) blob is the detection primitive — tier 2

--- a/fjs/media/todo/revision-lock-map.md
+++ b/fjs/media/todo/revision-lock-map.md
@@ -51,7 +51,7 @@ Use the existing recursive JSON serializer with lexicographically sorted object
 entries:
 
 ```ts
-import { stringify } from '../json/module.f.ts'
+import { stringify } from '../json/module.f.mjs'
 import { sort } from '../../types/object/module.f.mjs'
 
 const toJson = stringify(sort)

--- a/fjs/media/type/todo/detect-json.md
+++ b/fjs/media/type/todo/detect-json.md
@@ -175,6 +175,6 @@ exactly the path `cas_get` uses.
 - `fjs/media/type/module.f.mjs:157-178` — the UTF-8 factor whose decoded code points feed the JSON factor.
 - `fjs/media/json/todo/streaming-recognizer.md` — **blocks this**; the payload-free, O(depth) validity recognizer `A_json` wraps.
 - `fjs/js/tokenizer/module.f.mjs` — `parseStringStateOp`; already rejects raw U+0000–U+001F inside strings, so `A_json` inherits the correct verdict without re-deriving it.
-- `fjs/media/json/parser/module.f.ts:205-238` — `foldOp` / `parse`, the grammar the recognizer reuses value-free.
+- `fjs/media/json/parser/module.f.mjs:205-238` — `foldOp` / `parse`, the grammar the recognizer reuses value-free.
 - `fjs/mcp/cas/module.f.mjs:211-213` — `cas_get`, the consumer that gains `application/json` for free.
 - `fjs/media/type/todo/single-signature-table.md` — the sibling "one source of truth" cleanup; same single-classifier principle.

--- a/fjs/text/README.md
+++ b/fjs/text/README.md
@@ -38,7 +38,7 @@ Total error states:
 - 34_432
 - < 2^16
 
-### utf8/module.f.ts
+### utf8/module.f.mjs
 
 ```ts
 const toCodePointList: (input: List<u8|null>) => List<i32>
@@ -70,7 +70,7 @@ Requirement: no loss for UTF16 => codepoint => UTF16
 
 Total error states: 11 bit
 
-### utf16/module.f.ts
+### utf16/module.f.mjs
 
 ```ts
 const toCodePointList : List<u16|null>) => List<i32>

--- a/fjs/text/code_point/README.md
+++ b/fjs/text/code_point/README.md
@@ -20,7 +20,7 @@ distinct: a control byte such as NUL is perfectly valid UTF-8 yet not text, whic
 is exactly what `fjs/media/type` needs to split text from binary. `isValidCodePoint`
 gates decoding (`fromVec`); `isTextCodePoint` gates classification.
 
-`isValidCodePoint` was previously exported from `utf8/module.f.ts`; it now lives
+`isValidCodePoint` was previously exported from `utf8/module.f.mjs`; it now lives
 solely on `code_point`. Importers — `fjs/media/type` and `utf8`'s own `fromVec` — take
 it from `code_point` directly. This was a deliberate breaking change rather than
 a re-export, on the principle that the predicate's canonical home is the shared

--- a/fjs/text/sgr/todo/csi-edsl.md
+++ b/fjs/text/sgr/todo/csi-edsl.md
@@ -3,7 +3,7 @@
 **Priority:** P3
 **Status:** open
 
-Introduce a structured eDSL for composing ANSI CSI/SGR sequences in `module.f.ts`, analogous to the HTML eDSL in `fjs/media/html/module.f.mjs`.
+Introduce a structured eDSL for composing ANSI CSI/SGR sequences in `module.f.mjs`, analogous to the HTML eDSL in `fjs/media/html/module.f.mjs`.
 
 ### Motivation
 

--- a/fjs/text/sgr/todo/inplace-writer-split.md
+++ b/fjs/text/sgr/todo/inplace-writer-split.md
@@ -31,7 +31,7 @@ exists") discourages.
 ### Proposal
 
 When a real consumer appears, move the in-place rewriter to its own module
-(e.g. `fjs/text/console/module.f.ts`), leaving `sgr` focused on
+(e.g. `fjs/text/console/module.f.mjs`), leaving `sgr` focused on
 escape-sequence construction. Until then, at minimum stop exporting
 `createConsoleText`/`WriteText`/`Stdout` — or, if the writer has no planned
 consumer at all, delete it with its proof (speculative code per AGENTS.md).

--- a/fjs/text/todo/190.md
+++ b/fjs/text/todo/190.md
@@ -17,7 +17,7 @@ const fromCharCode = String.fromCharCode
 // fjs/js/tokenizer/module.f.mjs:114
 const { fromCharCode } = String
 
-// fjs/text/utf16/module.f.ts:401  — used inline
+// fjs/text/utf16/module.f.mjs:401  — used inline
 export const listToString: (input: List<U16>) => string
     = fn(map(String.fromCharCode)) /* … */
 
@@ -33,7 +33,7 @@ split:
 const r = s.codePointAt(i)
 if (r === void 0) { throw s }
 
-// fjs/text/utf16/module.f.ts:359
+// fjs/text/utf16/module.f.mjs:359
 const first = s.charCodeAt(i)
 return isNaN(first) ? empty : { first, tail: () => at(i + 1) }
 ```
@@ -52,7 +52,7 @@ relocates the backspace-based writer).
 `stringToCodePointList`, `listToString`, `codePointListToString`). What is missing
 is the *single-character* primitive, so every tokenizer/serializer re-binds
 `String.fromCharCode`/`fromCodePoint` itself. `AGENTS.md` explicitly discourages
-reaching into built-ins from `.f.ts` modules and asks that conceptually-distinct
+reaching into built-ins from `.f.mjs` modules and asks that conceptually-distinct
 logic live in its natural module.
 
 ### Proposed abstraction

--- a/fjs/text/todo/666-utf16-encode-errormask.md
+++ b/fjs/text/todo/666-utf16-encode-errormask.md
@@ -20,7 +20,7 @@ UTF-16 *encoder* does the opposite — it silently truncates to 16 bits, losing 
 error tag:
 
 ```ts
-// fjs/text/utf16/module.f.ts:109-118
+// fjs/text/utf16/module.f.mjs:109-118
 const codePointToUtf16 = (codePoint: CodePoint): List<U16> => {
     if (isBmpCodePoint(codePoint)) { return [codePoint] }
     if (isSupplementaryPlane(codePoint)) {
@@ -35,9 +35,9 @@ const codePointToUtf16 = (codePoint: CodePoint): List<U16> => {
 
 So two encoders that share one `errorMask` contract handle the invalid case with
 opposite philosophies: UTF-8 preserves+tags, UTF-16 discards. The UTF-16
-*decoder* (`fjs/text/utf16/module.f.ts:153` onward) does set `errorMask` on bad
+*decoder* (`fjs/text/utf16/module.f.mjs:153` onward) does set `errorMask` on bad
 input per its own JSDoc, so the encoder is the asymmetric side. `codePointToUtf16`
-is used internally at `fjs/text/utf16/module.f.ts:153` via `flatMap`.
+is used internally at `fjs/text/utf16/module.f.mjs:153` via `flatMap`.
 
 This is a separation-of-concerns / contract-consistency gap rather than code
 duplication: the rule for "what an encoder does with an invalid code point" should
@@ -61,7 +61,7 @@ resolution is to document *that* divergence in `code_point` instead).
 
 - [ ] decide and document the invalid-code-point encoder contract in `code_point`
 - [ ] align `codePointToUtf16`'s invalid branch (or document the deliberate divergence)
-- [ ] add/adjust a `utf16/proof.f.ts` case for an invalid (error-tagged) input round-trip
+- [ ] add/adjust a `utf16/proof.f.mjs` case for an invalid (error-tagged) input round-trip
 
 ### Related
 

--- a/fjs/text/todo/codec-eof-flush.md
+++ b/fjs/text/todo/codec-eof-flush.md
@@ -17,7 +17,7 @@ export const utf8EofToCodePointOp = state => [
 ]
 ```
 
-`fjs/text/utf16/module.f.ts:234-235`:
+`fjs/text/utf16/module.f.mjs:234-235`:
 
 ```ts
 const utf16EofToCodePointOp = (state: Utf16State): readonly[List<CodePoint>, Utf16State] =>

--- a/fjs/text/todo/surrogate-pair-in-code-point.md
+++ b/fjs/text/todo/surrogate-pair-in-code-point.md
@@ -18,7 +18,7 @@ const maxCodePoint = 0x10_ffff as const
 
 with the stated intent that "the surrogate bounds and the maximum appear
 exactly once". But the surrogate-pair *arithmetic* — the inverse of those
-predicates — re-hardcodes the same numbers in `fjs/text/utf16/module.f.ts`:
+predicates — re-hardcodes the same numbers in `fjs/text/utf16/module.f.mjs`:
 
 Encode (`:90-93`):
 
@@ -65,7 +65,7 @@ export const fromSurrogatePair = (high: number) => (low: number): number =>
     ((high - surrogateMin) << 10) + (low - lowSurrogateMin) + supplementaryBase
 ```
 
-`codePointToUtf16` (`fjs/text/utf16/module.f.ts:87-96`) and
+`codePointToUtf16` (`fjs/text/utf16/module.f.mjs:87-96`) and
 `utf16ByteToCodePointOp`'s low-surrogate branch (`:199-203`) then call these
 instead of re-deriving the constants. Every surrogate number then appears in
 exactly one module, and a future consumer (e.g. a WTF-8/CESU-8 codec or a JS

--- a/fjs/text/utf16/todo/decoder-oob-sentinel.md
+++ b/fjs/text/utf16/todo/decoder-oob-sentinel.md
@@ -17,7 +17,7 @@ export const utf8ByteToCodePointOp = (byte, state) => {
         return [[errorMask], state]
     }
 
-// fjs/text/utf16/module.f.ts:189-193 — bare magic literal
+// fjs/text/utf16/module.f.mjs:189-193 — bare magic literal
 const utf16ByteToCodePointOp: StateScan<U16, Utf16State, List<CodePoint>>
     = (word, state) => {
         if (!u16(word)) {

--- a/fjs/text/utf16/todo/word-classifier-dedup.md
+++ b/fjs/text/utf16/todo/word-classifier-dedup.md
@@ -5,7 +5,7 @@
 
 ### Problem
 
-`utf16ByteToCodePointOp` (`fjs/text/utf16/module.f.ts:188-207`) contains the
+`utf16ByteToCodePointOp` (`fjs/text/utf16/module.f.mjs:188-207`) contains the
 same three-way word classifier twice — once for the fresh-state dispatch and
 once for error recovery after an unpaired high surrogate:
 

--- a/fjs/todo/132.md
+++ b/fjs/todo/132.md
@@ -3,5 +3,5 @@
 **Priority:** P3
 **Status:** open
 
-1. Keep most implementation code in `module.f.ts` instead of `module.ts`
+1. Keep most implementation code in `module.f.mjs` instead of `module.ts`
 2. Use async functions and await instead of `.then`

--- a/fjs/todo/detect-unexported-types-referenced-by-exported-types.md
+++ b/fjs/todo/detect-unexported-types-referenced-by-exported-types.md
@@ -12,6 +12,6 @@ export type B = A | string
 
 We need to find a way to detect such cases. Notes:
 
-- FunctionalScript doesn't have RegEx, so an ad-hoc text-scan in `.f.ts` is not possible.
+- FunctionalScript doesn't have RegEx, so an ad-hoc text-scan in `.f.mjs` is not possible.
 - Requires emitting `.d.ts` via `tsc` and inspecting the output (or driving the TypeScript Compiler API) — an external tool, not a FunctionalScript module.
 - The proper place for this check is a FunctionalScript parser, which is not available yet.

--- a/fjs/todo/document-file-type-naming-conventions.md
+++ b/fjs/todo/document-file-type-naming-conventions.md
@@ -9,27 +9,27 @@ Document the file-type conventions in `fjs/README.md` (or a dedicated `CONVENTIO
 
 ### `module.*` — a module
 
-- `module.f.ts` / `module.f.js` — FunctionalScript module: pure by construction, safe to bulk-load.
-- `module.ts` / `module.js` — vanilla TS/JS: host integration that may run side effects at import time.
+- `module.f.mjs` / `module.f.js` — FunctionalScript module: pure by construction, safe to bulk-load.
+- `module.mjs` / `module.ts` — vanilla JS/TS: host integration that may run side effects at import time.
 
 ### `proof.*` — a module that proves other modules
 
 Tests other modules. Usually exports only `proof` (the proof tree). See [`fjs/emergent_testing/README.md`](emergent_testing/README.md).
 
-- `proof.f.ts` / `proof.f.js` — FunctionalScript proof.
+- `proof.f.mjs` / `proof.f.js` — FunctionalScript proof.
 - `proof.ts` / `proof.js` / `proof.mts` / `proof.mjs` — vanilla proof.
 
-### `node.app.f.ts` / `node.app.f.js` — a Node application
+### `node.app.f.mjs` / `node.app.f.js` — a Node application
 
 A module whose `export default` is a `NodeProgram` (`Program<NodeOp>`). The `.f.` infix is kept because the program is a pure effect description:
 
-```ts
-import app from './node.app.f.ts'
+```js
+import app from './node.app.f.mjs'
 import { run } from '../effects/node/module.mjs'
 await run(app)
 ```
 
 ### Open questions
 
-- Should existing entry points (`fjs/module.mjs`) be migrated to the `node.app.f.ts` convention, or only new entry points?
+- Should existing entry points (`fjs/module.mjs`) be migrated to the `node.app.f.mjs` convention, or only new entry points?
 - Canonical doc location: top-level `README.md`, `fjs/README.md`, or `CONVENTIONS.md`?

--- a/fjs/todo/group-fs-subdirectories-by-concern.md
+++ b/fjs/todo/group-fs-subdirectories-by-concern.md
@@ -3,7 +3,7 @@
 **Priority:** P4
 **Status:** open
 
-`fjs/` has 28 top-level directories mixing foundational data structures (`types`), byte/character encoders (`base64`, `base128`, `cbase32`), language tooling (`json`, `djs`, `fjs`, `fsc`, `bnf`, `js`, `html`), crypto, storage (`cas`, `sul`), and project infrastructure (`ci`, `dev`, `website`). Regroup incrementally — not a big-bang reorg, since every cross-module import is a relative `.f.ts` path.
+`fjs/` has 28 top-level directories mixing foundational data structures (`types`), byte/character encoders (`base64`, `base128`, `cbase32`), language tooling (`json`, `djs`, `fjs`, `fsc`, `bnf`, `js`, `html`), crypto, storage (`cas`, `sul`), and project infrastructure (`ci`, `dev`, `website`). Regroup incrementally — not a big-bang reorg, since every cross-module import is a relative `.f.mjs` path.
 
 ### 1. `fjs/basen/` — group base-N encoders
 
@@ -164,5 +164,5 @@ API (no `exports` map), so every move is a breaking change. The first wave is
 - [x] Rename `fjs/mime/` → `fjs/media/type/`.
 - [ ] Later: move `fjs/djs/` → `fjs/media/djs/`.
 - [x] Update all relative imports referencing the moved modules.
-- [ ] Update `deno.json` `exports` map and run `npm run update` (no `exports` map exists in `deno.json` currently; nothing to update). **When a map is first introduced it must enumerate every `module.f.ts` then present** — a partial map silently restricts a package that is unrestricted today. Modules proposed meanwhile are counting on this: `fjs/media/json/grammar` ([bnf-grammar-single-owner](../media/json/todo/bnf-grammar-single-owner.md)) and `fjs/effects/{all,sandbox,console,test}` ([node-module-layering](../effects/todo/node-module-layering.md)) each record that their registration lands here rather than in their own change.
+- [ ] Update `deno.json` `exports` map and run `npm run update` (no `exports` map exists in `deno.json` currently; nothing to update). **When a map is first introduced it must enumerate every `module.f.mjs` then present** — a partial map silently restricts a package that is unrestricted today. Modules proposed meanwhile are counting on this: `fjs/media/json/grammar` ([bnf-grammar-single-owner](../media/json/todo/bnf-grammar-single-owner.md)) and `fjs/effects/{all,sandbox,console,test}` ([node-module-layering](../effects/todo/node-module-layering.md)) each record that their registration lands here rather than in their own change.
 - [x] Verify `npx tsc` and `fjs t` pass.

--- a/fjs/types/bigint/README.md
+++ b/fjs/types/bigint/README.md
@@ -4,7 +4,7 @@ Bun has a `bigint` size limitation. It's `1_048_575` bits (`1024 ** 2`) or `131_
 
 ## Size Constraints
 
-The `module.f.ts` exports two constants documenting this limit:
+The `module.f.mjs` exports two constants documenting this limit:
 - `maxBits` = `1,048,575n` — the maximum number of bits in a bigint value
 - `maxBytes` = `131,072n` — the maximum file size in bytes (equivalent to maxBits ÷ 8)
 

--- a/fjs/types/btree/todo/proof-tree-corpus.md
+++ b/fjs/types/btree/todo/proof-tree-corpus.md
@@ -57,7 +57,7 @@ const set = (node: TNode<string>) => (value: string) =>
 Each also binds its own `jsonStr = stringify(sort)`, and **all four** open-code
 the squares loop `_map = set(_map)((i * i).toString())` — `set/proof.f.mjs` 31
 times, `remove/proof.f.mjs:22` (`n = 38`) and `:379` (`n = 10`),
-`find/proof.f.mjs:26` (`n = 10`), and `proof.f.ts:33-35` (`valuesTest2`,
+`find/proof.f.mjs:26` (`n = 10`), and `proof.f.mjs:33-35` (`valuesTest2`,
 `n = 10`).
 
 **`remove/proof.f.mjs:447-465` (`test3`) is not one of them.** Its loop inserts
@@ -69,7 +69,7 @@ comment: reaching the branch-merge-into-`Branch5`-sibling path in
 
 So "a string B-tree keyed by `cmp`", "serialize canonically", and "the squares
 corpus" — one fixture, shared by every proof in the directory — is stated four
-times with no single definition. `fjs/bnf/testlib.f.ts` is the precedent for
+times with no single definition. `fjs/bnf/testlib.f.mjs` is the precedent for
 where it should live instead.
 
 #### 3. The corpus itself is shared but unstated
@@ -82,7 +82,7 @@ shared starting state has to be verified by eye.
 
 ### Proposal
 
-**1. A `fjs/types/btree/testlib.f.ts`** — mirroring `fjs/bnf/testlib.f.ts` —
+**1. A `fjs/types/btree/testlib.f.mjs`** — mirroring `fjs/bnf/testlib.f.mjs` —
 holding the fixture the four proofs share:
 
 ```ts
@@ -191,17 +191,17 @@ are.
 
 ### Tasks
 
-- [ ] Add `fjs/types/btree/testlib.f.ts` with `set`, `squares`,
+- [ ] Add `fjs/types/btree/testlib.f.mjs` with `set`, `squares`,
       `expectedSquares`/`expectedSquares38`, and — until `stringifySorted` exists —
       the single `jsonStr` alias.
 - [ ] Convert `fjs/types/btree/set/proof.f.mjs` to `expectedSquares.map`; keep
       the two `replace` cases hand-written, sourced from `squares`.
 - [ ] Convert `fjs/types/btree/remove/proof.f.mjs`, `find/proof.f.mjs`, and
-      `proof.f.ts` to import the fixture; delete the four local `set` helpers
+      `proof.f.mjs` to import the fixture; delete the four local `set` helpers
       and `remove/proof.f.mjs`'s duplicate `n = 38` literal (`:25-32`).
 - [ ] Replace every squares loop with `squares(n)`, not just the local `set`
       helpers — `remove/proof.f.mjs:22` and `:379`, `find/proof.f.mjs:26`, and
-      `proof.f.ts:33-35` (`valuesTest2`). Importing `set` while leaving the
+      `proof.f.mjs:33-35` (`valuesTest2`). Importing `set` while leaving the
       loop in place would satisfy the previous task and still leave the corpus
       with four owners.
 - [ ] Leave `remove/proof.f.mjs`'s `test3` loop (`:447-465`) alone — it builds
@@ -214,8 +214,8 @@ are.
       exercise, and a corpus swap there would keep the proof green while
       silently dropping it.
 - [ ] Add a CHANGELOG entry (`AGENTS.md` §8.3). The documentation-only
-      exemption does not apply: this adds `testlib.f.ts` and rewrites four
-      `proof.f.ts` files, which are code changes even though nothing in
+      exemption does not apply: this adds `testlib.f.mjs` and rewrites four
+      `proof.f.mjs` files, which are code changes even though nothing in
       production moves.
 - [ ] Run `npx tsc` and `fjs t`.
 
@@ -234,7 +234,7 @@ are.
   — a `btree/remove` *implementation* refactor; it would be reviewed against
   these proofs, so landing the fixture first makes that diff readable.
 - [proof-recognizer-and-fixtures](../../../bnf/todo/proof-recognizer-and-fixtures.md)
-  — the same "shared harness and fixtures belong in a `testlib.f.ts`" move for
+  — the same "shared harness and fixtures belong in a `testlib.f.mjs`" move for
   the bnf proofs.
-- `fjs/bnf/testlib.f.ts` — the existing precedent for a proof-only fixture
+- `fjs/bnf/testlib.f.mjs` — the existing precedent for a proof-only fixture
   module living beside the code it exercises.

--- a/fjs/types/function/operator/todo/derive-concat-from-join.md
+++ b/fjs/types/function/operator/todo/derive-concat-from-join.md
@@ -18,4 +18,4 @@ Worth doing if the file is touched anyway, not on its own.
 ### Tasks
 
 - [ ] Replace `concat`'s body with `join('')`.
-- [ ] Confirm `proof.f.ts` still passes and `npx tsc` is clean.
+- [ ] Confirm `proof.f.mjs` still passes and `npx tsc` is clean.

--- a/fjs/types/object/todo/structurally-same.md
+++ b/fjs/types/object/todo/structurally-same.md
@@ -49,7 +49,7 @@ the object module to reuse `structurallySame` without creating the runtime cycle
 Define the recursive comparison in a cycle-free leaf module:
 
 ```ts
-// fjs/types/object/structurally_same/module.f.ts
+// fjs/types/object/structurally_same/module.f.mjs
 export const structurallySame = (a: unknown, b: unknown): boolean => ...
 ```
 
@@ -155,8 +155,8 @@ These cases can be added later when a concrete consumer requires them.
 ## Tasks
 
 - [ ] Add the dependency-free implementation to
-      `fjs/types/object/structurally_same/module.f.ts`.
-- [ ] Add the co-located `fjs/types/object/structurally_same/proof.f.ts` module,
+      `fjs/types/object/structurally_same/module.f.mjs`.
+- [ ] Add the co-located `fjs/types/object/structurally_same/proof.f.mjs` module,
       export `proof`, and exercise every branch of `structurallySame` there.
 - [ ] Re-export `structurallySame` from `fjs/types/object/module.f.mjs`.
 - [ ] Add `assertStructurallySame` to `fjs/asserts/module.f.mjs`, importing

--- a/fjs/types/ordered_map/todo/at-nullable-map.md
+++ b/fjs/types/ordered_map/todo/at-nullable-map.md
@@ -8,7 +8,7 @@
 The codebase has a canonical null-projection combinator —
 `map` in `fjs/types/nullable/module.f.mjs` (`f => value => value === null ?
 null : f(value)`) — and `array`'s safe accessors already route through it.
-`ordered_map.at` (`fjs/types/ordered_map/module.f.ts:23-28`) re-inlines the
+`ordered_map.at` (`fjs/types/ordered_map/module.f.mjs:23-28`) re-inlines the
 same shape by hand:
 
 ```ts

--- a/fjs/types/rtti/README.md
+++ b/fjs/types/rtti/README.md
@@ -6,13 +6,13 @@ A type-safe schema system for describing TypeScript types at runtime and validat
 
 ## Modules
 
-- `module.f.ts` — schema construction: defines `Type`, `Info`, and schema builder values
-- `ts/module.f.ts` — type-level transformer: `Ts<T>` maps a schema to its TypeScript type
-- `common/module.f.ts` — shared kernel for runtime consumers: error shape, path
+- `module.f.mjs` — schema construction: defines `Type`, `Info`, and schema builder values
+- `ts/module.f.mjs` — type-level transformer: `Ts<T>` maps a schema to its TypeScript type
+- `common/module.f.mjs` — shared kernel for runtime consumers: error shape, path
   bookkeeping, primitive checks, and `match` (the flat `Kind` recognizer)
-- `validate/module.f.ts` — runtime validation: `validate(schema)(value)` returns
+- `validate/module.f.mjs` — runtime validation: `validate(schema)(value)` returns
   the original value (or `Result` on error)
-- `parse/module.f.ts` — runtime deserialization: `parse(schema)(value)` returns
+- `parse/module.f.mjs` — runtime deserialization: `parse(schema)(value)` returns
   a freshly constructed value containing only the declared fields/elements
 
 ## Schema types

--- a/fjs/types/rtti/ts/README.md
+++ b/fjs/types/rtti/ts/README.md
@@ -1,6 +1,6 @@
 # `rtti/ts` — TypeScript type inference for RTTI schemas
 
-`Ts<T>` (`module.f.ts`) maps an RTTI schema `Type` to its TypeScript type at
+`Ts<T>` (`module.f.mjs`) maps an RTTI schema `Type` to its TypeScript type at
 compile time. It works by walking the schema's structural shape with a chain of
 conditional types and `infer`.
 
@@ -100,7 +100,7 @@ schema structure. Option 2 was reverted.
 
 ## Remaining open problems
 
-Three `as any` casts in `validate/module.f.ts` and `parse/module.f.ts` cannot
+Three `as any` casts in `validate/module.f.mjs` and `parse/module.f.mjs` cannot
 be removed without language features TypeScript does not yet have:
 
 **Problem A — visitor rank-2 erasure.** `Visitor<R>` requires a uniform `R`

--- a/fjs/types/todo/161.md
+++ b/fjs/types/todo/161.md
@@ -3,10 +3,10 @@
 **Priority:** P3
 **Status:** open
 
-`fjs/types/string_set/module.f.mjs` and `fjs/types/ordered_map/module.f.ts` are
+`fjs/types/string_set/module.f.mjs` and `fjs/types/ordered_map/module.f.mjs` are
 parallel thin wrappers over the same B-tree primitives
 (`btree/find`, `btree/set`, `btree/remove`, `btree/module`) keyed by the same
-string comparator (`string/module.f.ts` `cmp`). A set is logically a map whose
+string comparator (`string/module.f.mjs` `cmp`). A set is logically a map whose
 key *is* its value, and that relationship shows up directly in the code.
 
 ```ts

--- a/fjs/types/todo/169.md
+++ b/fjs/types/todo/169.md
@@ -23,7 +23,7 @@ export const mapDelete = (map, k)    => new Map(filter(map, ([xk]) => xk !== k))
 These are the *only* hand-written `Symbol.iterator` generators in the `fs` tree
 outside `fjs/types/list/module.f.mjs`, which already exports lazy `iterable`,
 `concat`, and `filter` over its own `List` type
-(`list/module.f.ts:80`, and its `concat`/`filter` combinators). The `map`
+(`list/module.f.mjs:80`, and its `concat`/`filter` combinators). The `map`
 helpers re-implement the same two concepts (sequence concatenation and
 predicate filtering) against raw `Iterable<T>`.
 

--- a/fjs/types/todo/bit-set-factory.md
+++ b/fjs/types/todo/bit-set-factory.md
@@ -29,7 +29,7 @@ base-N codecs with a parameterized factory.
 
 ### Proposal
 
-Introduce a factory, e.g. `fjs/types/bit_set/module.f.ts`:
+Introduce a factory, e.g. `fjs/types/bit_set/module.f.mjs`:
 
 ```ts
 export type BitSetOps<T> = {
@@ -63,7 +63,7 @@ generic `has`.
 
 ### Tasks
 
-- [ ] Add `fjs/types/bit_set/module.f.ts` (+ `proof.f.ts`, register in
+- [ ] Add `fjs/types/bit_set/module.f.mjs` (+ `proof.f.mjs`, register in
       `deno.json` exports) with the parameterized algebra.
 - [ ] Rewrite `byte_set` and `nibble_set` as instantiations, preserving
       their public APIs and JSDoc (including nibble_set's

--- a/fjs/website/todo/generate-website.md
+++ b/fjs/website/todo/generate-website.md
@@ -8,5 +8,5 @@
 - [ ] Convert `README.md` files into HTML and publish them
 - [ ] Source code highlighting
 - [ ] One `main.css`
-- [ ] Convention for `page.f.ts` — generates a demo webpage for the module in the same directory
+- [ ] Convention for `page.f.mjs` — generates a demo webpage for the module in the same directory
 - [ ] Browser test runner (requires switching test framework to Effects first)

--- a/fjs/website/todo/publish-deno-doc-to-website.md
+++ b/fjs/website/todo/publish-deno-doc-to-website.md
@@ -5,6 +5,6 @@
 
 Before or after dropping JSR, publish `deno doc`-generated API documentation to the FunctionalScript website so users have an up-to-date reference.
 
-- [ ] Run `deno doc --html **/module.f.ts` and review the output.
+- [ ] Run `deno doc --html **/module.f.mjs` and review the output.
 - [ ] Integrate the `deno doc` build step into the website generation pipeline (see [Generate website](#generate-website)).
 - [ ] Publish the generated docs alongside the existing website content.

--- a/nanvm-lib/todo/65y-nanvm-conversion-macros.md
+++ b/nanvm-lib/todo/65y-nanvm-conversion-macros.md
@@ -185,7 +185,7 @@ The natural endpoint of C, if it pays off: write a small
 FunctionalScript program that consumes the variant table and emits
 Rust source. `fjs/djs/transpiler` already turns DJS into JS; a
 parallel Rust emitter would let the variant table live in
-`fjs/nanvm/conversions.f.ts` (or similar) as plain data, with the
+`fjs/nanvm/conversions.f.mjs` (or similar) as plain data, with the
 emitter as the only Rust-aware piece. This is large enough that it
 should be filed separately if and when there is appetite — flagging
 it here only because PR feedback asked.

--- a/todo/140.md
+++ b/todo/140.md
@@ -1,6 +1,6 @@
-## 140. 100% test coverage for all `module.f.ts` files.
+## 140. 100% test coverage for all `module.f.mjs` files.
 
 **Priority:** P3
 **Status:** open
 
-We should have 100% test coverage for all `module.f.ts` files.
+We should have 100% test coverage for all `module.f.mjs` files.

--- a/todo/flow.md
+++ b/todo/flow.md
@@ -36,7 +36,7 @@ are checked by TypeScript.
 
 ### Module
 
-`fjs/flow/module.f.ts` defines `Flow<E, O>`: a node of the graph, describing
+`fjs/flow/module.f.mjs` defines `Flow<E, O>`: a node of the graph, describing
 a sequence of `O` computed from an environment of type `E`. A `Flow` is
 *cold* — an immutable description, not a running computation (cf. Kotlin's
 `Flow`, which is also a cold, later-bound stream description). The
@@ -222,10 +222,10 @@ Planned engine work, each a separate change:
 
 ## Tasks
 
-- [ ] `fjs/flow/module.f.ts` — `Flow<E, O>`, `Transducer`/`Step`/`Terminal`,
+- [ ] `fjs/flow/module.f.mjs` — `Flow<E, O>`, `Transducer`/`Step`/`Terminal`,
   primitives `input` and `transduce`, derived operations, naive `run`
   engine over `types/list`
-- [ ] `fjs/flow/proof.f.ts` — full proof coverage, including early
+- [ ] `fjs/flow/proof.f.mjs` — full proof coverage, including early
   termination, pre-pull termination (`take(0)` pulls nothing), `end`
   flush, and a fallible stage using `A = Result`
 - [ ] memoizing engine (shared node evaluated once per run)

--- a/todo/lang/3240-export.md
+++ b/todo/lang/3240-export.md
@@ -56,7 +56,7 @@ A module **must not** export a zero-argument (or one-or-two-argument) function n
 export const then = () => { ... }
 ```
 
-When a module namespace object has a callable `.then` property, JavaScript's `await` (and `Promise.resolve()`) treats the entire namespace as a *thenable*. A dynamic import `await import('./module.f.ts')` would call `.then()` on the namespace instead of resolving to it — causing the import to hang, resolve to an unexpected value, or never complete, depending on what `then` does.
+When a module namespace object has a callable `.then` property, JavaScript's `await` (and `Promise.resolve()`) treats the entire namespace as a *thenable*. A dynamic import `await import('./module.f.mjs')` would call `.then()` on the namespace instead of resolving to it — causing the import to hang, resolve to an unexpected value, or never complete, depending on what `then` does.
 
 Since FunctionalScript modules are loaded via dynamic import in the test framework and the runtime, this would silently corrupt module loading. The FunctionalScript compiler/validator must reject any module that exports a function named `then`.
 

--- a/todo/lang/README.md
+++ b/todo/lang/README.md
@@ -14,19 +14,19 @@ File Types:
 |File Type|Extension|Notes|
 |---------|---------|-----|
 |JSON|`.json`|Tree.|
-|FJS source|`.f.ts`, `.f.mjs`, `.f.js`|Graph with functions; extension meaning follows the repository migration stage below.|
+|FJS source|`.f.mjs`, `.f.js`|Graph with functions; extension meaning follows the repository migration stage below.|
 
 Repository source migration has two separate stages:
 
-1. `.f.ts -> .f.mjs` removes authored TypeScript. `.f.mjs` is authored ESM
-   JavaScript with JSDoc types and does **not** imply that the current
-   FunctionalScript parser/compiler accepts the module.
+1. `.f.ts -> .f.mjs` removed authored TypeScript, and is complete. `.f.mjs` is
+   authored ESM JavaScript with JSDoc types and does **not** imply that the
+   current FunctionalScript parser/compiler accepts the module.
 2. After authored TypeScript is gone and authored `.f.js` package support is
    complete, compiler-supported `.f.mjs` modules may move to authored `.f.js`.
    `.f.js` is then the compiler-compatibility marker.
 
-During Stage 1, `.f.js` remains generated output from `.f.ts` and must not be
-authored. Stage 1 is independent of parser coverage; Stage 2 grows incrementally
+Until Stage 2 begins, `.f.js` remains generated output and must not be authored.
+Stage 1 was independent of parser coverage; Stage 2 grows incrementally
 as compiler support grows. See [`fjs/fsc/README.md`](../../fjs/fsc/README.md) for
 the authoritative extension contract and
 [`todo/migrate-typescript-to-mjs.md`](../migrate-typescript-to-mjs.md) for the

--- a/todo/migrate-typescript-to-mjs.md
+++ b/todo/migrate-typescript-to-mjs.md
@@ -897,31 +897,60 @@ person can re-check rather than re-derive. Counts are as of
       whose history is correctly left alone); that measurement now returns **9**,
       and all 9 are the rename arrows (`module.f.ts -> module.f.mjs`) and
       completed `[x]` items in this file and `fjs/fsc/README.md`, where the
-      `.f.ts` spelling *is* the subject. Across the whole tree the same sweep
-      took non-`CHANGELOG.md` `.f.ts` mentions from 294 to 51. `AGENTS.md` went
-      from 24 mentions to 1 — the sentence recording that stage 1 is complete —
-      and its guidance now leads with the JavaScript/JSDoc form, keeping
-      `import type` only for `types.ts`.
+      `.f.ts` spelling *is* the subject.
+
+      Two other rulers get quoted for this and are easy to mix up, so name the
+      one you mean. A **path-like mention** is one module-path token ending in
+      the old extension; a **line** may hold several. Whole tree, `CHANGELOG.md`
+      excluded:
+
+      | ruler | `main` | after the sweep |
+      | --- | --- | --- |
+      | path-like mentions | 294 | 52 |
+      | lines containing `.f.ts` | 398 | 145 |
+
+      `AGENTS.md` went from 10 mentions on 24 lines to 0 on 1 — the one
+      line left records that stage 1 is complete — and its guidance now leads
+      with the JavaScript/JSDoc form, keeping `import type` for `types.ts` and
+      for the scenario fixtures whose `.ts` extension is load-bearing.
 
       Beyond renaming references to files that moved, the sweep also fixed
       forward-looking plans that told a contributor to *create* a `.f.ts`
       (`fjs/bnf/todo/unicode-rules.md`, `fjs/effects/todo/node-module-layering.md`
       and ~40 others), since no such file may be authored any more.
 
-      The 51 that remain are deliberate and should stay: this file,
-      [`fjs/fsc/README.md`](../fjs/fsc/README.md), the package-support and
-      publishing plans, `todo/plan/roadmap.md`,
-      `nanvm-lib/todo/mvp-roadmap.md` and
+      All 22 files that still contain the old extension anywhere are listed
+      below, and each one is deliberate. Describing the migration or the
+      extension itself: this file, `AGENTS.md`,
+      [`fjs/fsc/README.md`](../fjs/fsc/README.md),
+      [`f-mjs-package-support.md`](../fjs/ci/todo/f-mjs-package-support.md),
+      [`f-js-package-support.md`](../fjs/ci/todo/f-js-package-support.md),
+      [`publishing-packages.md`](../fjs/ci/todo/publishing-packages.md),
+      [`f-mjs-test-and-coverage.md`](../fjs/emergent_testing/todo/f-mjs-test-and-coverage.md),
+      [`fjs-nanvm-integration.md`](./fjs-nanvm-integration.md),
+      [`plan/roadmap.md`](./plan/roadmap.md), [`lang/README.md`](./lang/README.md),
+      [`demo/README.md`](./demo/README.md),
+      [`nanvm-lib/todo/mvp-roadmap.md`](../nanvm-lib/todo/mvp-roadmap.md),
       [`blocked/js-extension-type-annotations.md`](./blocked/js-extension-type-annotations.md)
-      describe the migration or the extension itself;
-      `fjs/emergent_testing/todo/664-emergent-testing-module-files.md`,
-      `todo/205.md` and `todo/skip-property.md` quote `shouldLoad`, which still
-      matches `.f.ts`; and `fjs/types/rtti/todo/serializable-data.md` is the
-      separate broken-link item below. Re-measure with the same resolve-against-
-      the-tree method before claiming a number.
+      and [`formatter-for-f-js-and-f-ts-files.md`](../fjs/todo/formatter-for-f-js-and-f-ts-files.md).
+      Quoting `shouldLoad`, which still matches `.f.ts`:
+      [`664-emergent-testing-module-files.md`](../fjs/emergent_testing/todo/664-emergent-testing-module-files.md),
+      [`205.md`](../fjs/emergent_testing/todo/205.md) and
+      [`skip-property.md`](../fjs/emergent_testing/todo/skip-property.md).
+      Recording a superseded convention or a completed move:
+      [`028-unit-test-examples-api.md`](../fjs/emergent_testing/todo/028-unit-test-examples-api.md),
+      [`throw-payload-assertions.md`](../fjs/emergent_testing/todo/throw-payload-assertions.md)
+      and [`group-fs-subdirectories-by-concern.md`](../fjs/todo/group-fs-subdirectories-by-concern.md).
+      Plus [`browser-testing.md`](../fjs/emergent_testing/todo/browser-testing.md)
+      and [`serializable-data.md`](../fjs/types/rtti/todo/serializable-data.md),
+      each its own item below. Re-measure with the same resolve-against-the-tree
+      method, at the final commit, before claiming a number — prose that
+      enumerates survivors can itself add mentions, which is how a stale count
+      got published the first time.
 - [ ] **Redesign or retire `browser-testing.md`.**
       [`fjs/emergent_testing/todo/browser-testing.md`](../fjs/emergent_testing/todo/browser-testing.md)
-      holds 23 of the 51 surviving `.f.ts` mentions, and they were left alone on
+      holds 10 of the surviving path-like mentions on 23 lines — the largest
+      single concentration — and they were left alone on
       purpose: its whole design is a transpile step from `.f.ts` to `.f.js`
       because browsers cannot load TypeScript. Authored source is now `.f.mjs`,
       which a browser loads directly, so the premise is gone and a sweep would

--- a/todo/migrate-typescript-to-mjs.md
+++ b/todo/migrate-typescript-to-mjs.md
@@ -389,11 +389,11 @@ rediscovered by each migration.
 
 #### Module header and import ordering
 
-The `@module` tag belongs only to a package's entry-point file — `module.f.ts` /
-`module.f.mjs` / `module.ts` / `module.mjs`. It is not required on `proof.f.ts` /
-`proof.f.mjs`, `types.ts`, or any other file. A `module.*` file starts with one
-leading JSDoc block carrying `@module`; always put one blank line after that
-block before the first source-level import or declaration.
+The `@module` tag belongs only to a package's entry-point file — `module.f.mjs` /
+`module.mjs`. It is not required on `proof.f.mjs`, `types.ts`, or any other file.
+A `module.*` file starts with one leading JSDoc block carrying `@module`; always
+put one blank line after that block before the first source-level import or
+declaration.
 
 For TypeScript, put type-only imports first, external or built-in runtime imports
 second, then repository-owned relative runtime imports: already-migrated
@@ -796,11 +796,12 @@ blocking, plus the prose sweep. The remaining items are listed under
       without weakening public type semantics.
 - [ ] Update imports, proofs, tests, coverage globs, scripts, generated CI, and
       documentation for every migrated group.
-- [ ] Sweep prose references to already-migrated modules: `AGENTS.md`, README
+- [x] Sweep prose references to already-migrated modules: `AGENTS.md`, README
       files, and `todo/*.md` still name `.f.ts` paths that no longer exist, so
       snippets copied from them produce broken imports and links. Include
       type-only renames such as `module.f.ts -> types.ts` and any typedef renames
-      in this sweep.
+      in this sweep. Done together with the measured sweep under
+      [Remaining after stage 1](#remaining-after-stage-1).
 - [ ] Preserve Node, Deno, Bun, proof, coverage, type-checking, declaration, and
       CI package behavior throughout the migration.
 - [ ] Add required `**BREAKING CHANGES:**` changelog entries for every public
@@ -890,17 +891,48 @@ person can re-check rather than re-derive. Counts are as of
       Porting them to `.mjs` would delete that coverage rather than move it, so
       this is a decision about whether native-TypeScript execution should still
       be tested — keep them, replace the coverage some other way, or drop it.
-- [ ] **Sweep the remaining stale prose.** 88 mentions across 42 `.md` files
-      name an `X.f.ts` whose `X.f.mjs` now exists (measured by resolving each
-      mention against the tree, excluding `CHANGELOG.md`, whose history is
-      correctly left alone). The largest are
-      `fjs/bnf/todo/proof-recognizer-and-fixtures.md` (11), `fjs/fsc/README.md`
-      (5) and `fjs/types/rtti/README.md` (5); this file itself has 6. Snippets
-      copied out of these produce broken imports. Separately, `AGENTS.md` has 24
-      `.f.ts` mentions and 5 `import type` references whose guidance should now
-      lead with the JavaScript/JSDoc form and keep the TypeScript form only
-      where it still applies (`types.ts`). This subsumes the existing sweep task
-      above; the numbers are here so progress is measurable.
+- [x] **Sweep the remaining stale prose.** Done. The measured set was 88
+      mentions across 42 `.md` files naming an `X.f.ts` whose `X.f.mjs` now
+      exists (resolving each mention against the tree, excluding `CHANGELOG.md`,
+      whose history is correctly left alone); that measurement now returns **9**,
+      and all 9 are the rename arrows (`module.f.ts -> module.f.mjs`) and
+      completed `[x]` items in this file and `fjs/fsc/README.md`, where the
+      `.f.ts` spelling *is* the subject. Across the whole tree the same sweep
+      took non-`CHANGELOG.md` `.f.ts` mentions from 294 to 51. `AGENTS.md` went
+      from 24 mentions to 1 — the sentence recording that stage 1 is complete —
+      and its guidance now leads with the JavaScript/JSDoc form, keeping
+      `import type` only for `types.ts`.
+
+      Beyond renaming references to files that moved, the sweep also fixed
+      forward-looking plans that told a contributor to *create* a `.f.ts`
+      (`fjs/bnf/todo/unicode-rules.md`, `fjs/effects/todo/node-module-layering.md`
+      and ~40 others), since no such file may be authored any more.
+
+      The 51 that remain are deliberate and should stay: this file,
+      [`fjs/fsc/README.md`](../fjs/fsc/README.md), the package-support and
+      publishing plans, `todo/plan/roadmap.md`,
+      `nanvm-lib/todo/mvp-roadmap.md` and
+      [`blocked/js-extension-type-annotations.md`](./blocked/js-extension-type-annotations.md)
+      describe the migration or the extension itself;
+      `fjs/emergent_testing/todo/664-emergent-testing-module-files.md`,
+      `todo/205.md` and `todo/skip-property.md` quote `shouldLoad`, which still
+      matches `.f.ts`; and `fjs/types/rtti/todo/serializable-data.md` is the
+      separate broken-link item below. Re-measure with the same resolve-against-
+      the-tree method before claiming a number.
+- [ ] **Redesign or retire `browser-testing.md`.**
+      [`fjs/emergent_testing/todo/browser-testing.md`](../fjs/emergent_testing/todo/browser-testing.md)
+      holds 23 of the 51 surviving `.f.ts` mentions, and they were left alone on
+      purpose: its whole design is a transpile step from `.f.ts` to `.f.js`
+      because browsers cannot load TypeScript. Authored source is now `.f.mjs`,
+      which a browser loads directly, so the premise is gone and a sweep would
+      have produced a plan that no longer describes anything. Decide whether the
+      transpile step survives for `types.ts`-only reasons, shrinks to a bundling
+      concern, or goes away — then rewrite the document to match.
+- [ ] **Retitle `formatter-for-f-js-and-f-ts-files.md`.**
+      [`fjs/todo/formatter-for-f-js-and-f-ts-files.md`](../fjs/todo/formatter-for-f-js-and-f-ts-files.md)
+      names `.f.ts` in its filename and title. A formatter no longer needs to
+      handle that extension; renaming the file is a trivial follow-up left out of
+      the prose sweep because it changes a path rather than prose.
 - [ ] **Fix the one broken doc link that is not a rename artifact.**
       `fjs/types/rtti/todo/serializable-data.md` links to `../data/module.f.ts`;
       `fjs/types/rtti/data/` has never existed, so this needs an author decision

--- a/todo/plan/architecture.md
+++ b/todo/plan/architecture.md
@@ -52,7 +52,7 @@ The HTTP effect infrastructure (`CreateServer`, `Listen`, `Fetch`) already exist
 ## Content encoding
 
 **Current:** content crosses the MCP wire as **cBase32** (same encoding as hashes).
-**Target (Layer 2):** switch content to **base64** (MCP-idiomatic for binary data); hashes stay as cBase32. The base64 codec (`fjs/base64/module.f.ts`) is already implemented — only the MCP wiring remains.
+**Target (Layer 2):** switch content to **base64** (MCP-idiomatic for binary data); hashes stay as cBase32. The base64 codec (`fjs/base64/module.f.mjs`) is already implemented — only the MCP wiring remains.
 
 ## Addressing
 

--- a/todo/samples.md
+++ b/todo/samples.md
@@ -56,7 +56,7 @@ Candidate samples, from #233:
 - consuming a FunctionalScript module from an existing TypeScript project;
 - consuming a FunctionalScript module from an existing JavaScript project.
 
-The last two are the ones that answer #485 directly — the claim that `.f.ts`
+The last two are the ones that answer #485 directly — the claim that `.f.mjs`
 modules import into ordinary TS/JS with no build step is the project's main
 selling point and is currently unillustrated.
 
@@ -85,6 +85,6 @@ delete it.
 - [GitHub issue #485](https://github.com/functionalscript/functionalscript/issues/485)
   — README does not explain how the library is used.
 - [fjs/website/todo/generate-website.md](../fjs/website/todo/generate-website.md)
-  — the `page.f.ts` convention and README→HTML publishing; samples should
+  — the `page.f.mjs` convention and README→HTML publishing; samples should
   feed the website rather than duplicate it.
 - [demo/README.md](./demo/README.md) — existing examples to salvage.


### PR DESCRIPTION
This PR updates documentation and prose throughout the repository to reflect the completion of Stage 1 of the TypeScript-to-JavaScript migration. All authored FunctionalScript source now uses `.f.mjs` (JavaScript with JSDoc) instead of `.f.ts` (TypeScript).

## Summary of Changes

The migration from `.f.ts` to `.f.mjs` for all FunctionalScript source code is complete. This PR sweeps through documentation, TODOs, READMEs, and code comments to:

1. **Remove references to `.f.ts`** as an active extension for new code
2. **Update guidance** to lead with JavaScript/JSDoc patterns
3. **Clarify that `types.ts`** is the only remaining authored TypeScript file type (for type-only APIs)
4. **Simplify documentation** that previously described the migration path

## Key Changes

- **AGENTS.md**: Updated file extension references and import ordering guidance to reflect JavaScript-first approach; removed migration-stage-specific rules that no longer apply
- **fjs/fsc/README.md**: Marked `.f.ts` as no longer used; clarified that new source must use `.f.mjs`
- **Contributing guidelines**: Simplified proof coverage requirements to reference only `.f.mjs` modules
- **TODO files**: Updated 40+ TODO and planning documents to use `.f.mjs` paths instead of `.f.ts`
- **README files**: Corrected code examples and module references across `fjs/` subdirectories
- **Migration tracking**: Marked the "sweep stale prose" task as complete with updated metrics (9 remaining references vs. original 88)

## Implementation Details

- All changes are documentation-only; no source code logic was modified
- The sweep covered 42+ markdown files across the repository
- Import ordering guidance now assumes JavaScript/JSDoc as the primary form, with `types.ts` for type-only APIs
- Proof file naming is now consistently `proof.f.mjs` (no more `proof.f.ts`)

https://claude.ai/code/session_019W41JHMkoiHpLcdHJjoSwr