### PR TITLE
Upgrade FunctionalScript to 0.44.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.43.1"
+          "run": "npm install -g functionalscript@0.44.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -81,7 +81,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.43.1"
+          "run": "npm install -g functionalscript@0.44.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -122,7 +122,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.43.1"
+          "run": "npm install -g functionalscript@0.44.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -163,7 +163,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.43.1"
+          "run": "npm install -g functionalscript@0.44.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -205,7 +205,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.43.1"
+          "run": "npm install -g functionalscript@0.44.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -258,7 +258,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.43.1"
+          "run": "npm install -g functionalscript@0.44.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -389,13 +389,13 @@
           }
         },
         {
-          "run": "deno install -g -A --minimum-dependency-age=0 npm:functionalscript@0.43.1"
+          "run": "deno install -g -A --minimum-dependency-age=0 npm:functionalscript@0.44.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
         },
         {
-          "run": "deno run -A --minimum-dependency-age=0 npm:functionalscript@0.43.1 test"
+          "run": "deno run -A --minimum-dependency-age=0 npm:functionalscript@0.44.0 test"
         },
         {
           "run": "deno install --frozen"
@@ -415,7 +415,7 @@
           }
         },
         {
-          "run": "bun install -g functionalscript@0.43.1"
+          "run": "bun install -g functionalscript@0.44.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -424,7 +424,7 @@
           "run": "bun install --frozen-lockfile"
         },
         {
-          "run": "bunx functionalscript@0.43.1 test"
+          "run": "bunx functionalscript@0.44.0 test"
         },
         {
           "run": "bun test --coverage"
@@ -441,7 +441,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.43.1"
+          "run": "npm install -g functionalscript@0.44.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"

--- a/fjs/ci/config/module.f.mjs
+++ b/fjs/ci/config/module.f.mjs
@@ -25,7 +25,7 @@ export const images = /** @type {const} */({
 // published FunctionalScript release; do not tie it to package.json's current
 // in-repo version.
 // https://www.npmjs.com/package/functionalscript
-export const functionalscript = /** @type {const} */ '0.43.1'
+export const functionalscript = /** @type {const} */ '0.44.0'
 
 // https://bun.sh/
 export const bun = '1.3.14'


### PR DESCRIPTION
## Summary
Updates the FunctionalScript dependency version from 0.43.1 to 0.44.0 across all CI workflows and configuration files.

## Changes
- Updated FunctionalScript version in CI configuration from 0.43.1 to 0.44.0
- Updated version references in all npm, deno, and bun installation commands across 6 CI workflow jobs
- Updated the source configuration file (`fjs/ci/config/module.f.mjs`) to reflect the new FunctionalScript version

## Details
The version bump is applied consistently across:
- npm global installations (6 occurrences)
- Deno installations and runtime commands (2 occurrences)
- Bun package manager installations and execution (2 occurrences)
- Central CI configuration module that defines the canonical version

https://claude.ai/code/session_01NE6L65VkkTTvQrSafBiruF