### PR TITLE
Add defensive branch coverage for endObject non-object guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ history.
 
 ## Unreleased
 
+- `fjs/djs/parser`'s `proof` covers `endObject`'s defensive non-object-top
+  guard directly, the same way it already covers `pushKey` and `endArray`'s
+  equivalent unreachable branches
+  [#1525](https://github.com/functionalscript/functionalscript/pull/1525)
 - `fjs/text/ascii` owns the hex-digit codec: `hexDigitValue`,
   `hexDigitCodePoint`, and the `a-f` / `A-F` ranges. The JSON serializer and
   both tokenizers use it instead of rederiving the offsets; the DJS tokenizer

--- a/fjs/djs/parser/module.f.mjs
+++ b/fjs/djs/parser/module.f.mjs
@@ -544,4 +544,22 @@ export const proof = {
             assertEq(result.state, 'result')
         },
     },
+    endObject: {
+        // `endObject` is only ever invoked while `state.top` is an object
+        // (the `'{'`/`'{k'`/`'{:'`/`'{v'`/`'{,'` value-states guarantee it),
+        // so its non-object guard is a defensive branch unreachable through
+        // `parseFromTokens`. Call it directly to cover that branch.
+        nonObjectTop: () => {
+            /** @type {_ParseValueState} */
+            const state = {
+                state: 'exportValue',
+                module: { refs: null, modules: null, consts: null },
+                valueState: '{,',
+                top: null,
+                stack: null,
+            }
+            const result = endObject(state)
+            assertEq(result.state, 'result')
+        },
+    },
 }


### PR DESCRIPTION
## Summary
Added a new test case to the proof object that covers a defensive, unreachable code branch in the `endObject` function. This improves test coverage for edge cases that cannot be reached through normal parsing flow.

## Key Changes
- Added `endObject.nonObjectTop` test case to the proof object
- Tests the defensive guard that handles non-object values at `state.top`
- Creates a synthetic parser state with `top: null` to trigger the unreachable branch
- Verifies the function correctly transitions to the `'result'` state

## Implementation Details
- The test acknowledges that `endObject` is only invoked when `state.top` is an object during normal parsing (guaranteed by value-states like `'{'`, `'{k'`, `'{:'`, `'{v'`, `'{,'`)
- The non-object guard exists as a defensive measure but is unreachable through `parseFromTokens`
- Direct invocation with a crafted state object allows coverage of this defensive branch

https://claude.ai/code/session_01SEkx5h5qGhKB7C6wAmsu2j