### PR TITLE
Exact emitted declarations: keep every @module header, remove the last elided any

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,10 +318,12 @@ and the test entry is authored `all.test.mjs`.
 The runtime-import grouping applies to repository-owned relative imports, not to
 external or built-in modules: a FunctionalScript module may depend at runtime on
 external modules and on repository `.mjs`, and there is no relative runtime `.ts`
-import group at all. In a `module.*` file, the blank line after the leading JSDoc
-block is required even when the module has no `@import` tags; it keeps the
-`@module` header detached from the first import/declaration and preserves it
-through declaration emit.
+import group at all. The blank line after the leading JSDoc block is required
+in every file that has one — `module.*` (even with no `@import` tags),
+`types.ts`, and `proof.*` alike; it keeps the header detached from the first
+import/declaration and preserves it through declaration emit. `types.ts` is
+the most easily missed case, since its emitted `types.d.ts` is the published
+documentation for the whole type-level API.
 
 Where each kind of documentation belongs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ history.
 
 ## Unreleased
 
+- Emitted declarations keep their `@module` documentation header: 24 modules
+  lost it to declaration emit and 4 never had one; all 127 module
+  declarations now carry it
+  [#1526](https://github.com/functionalscript/functionalscript/pull/1526)
+
 - **BREAKING CHANGES:** the npm package ships no `.js` files: the empty
   `types.js` stubs and compiled test files are gone. Import types only with
   fully erased `import type`, and use `fjs/emergent_testing/all.test.mjs` as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ history.
   lost it to declaration emit and 4 never had one; all 127 module
   declarations now carry it
   [#1526](https://github.com/functionalscript/functionalscript/pull/1526)
+- `fjs/media/json/schema`'s emitted declaration is exact: an explicit `@type`
+  naming the recursive schema by `typeof` replaces the `@type {const}` cast
+  that collapsed `not` to `/*elided*/ any` and four sibling fields to `any`
+  [#1526](https://github.com/functionalscript/functionalscript/pull/1526)
 
 - **BREAKING CHANGES:** the npm package ships no `.js` files: the empty
   `types.js` stubs and compiled test files are gone. Import types only with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,15 @@ history.
 
 ## Unreleased
 
-- Emitted declarations keep their `@module` documentation header: 24 modules
-  lost it to declaration emit and 4 never had one; all 127 module
-  declarations now carry it
+- Emitted declarations keep their documentation headers: 24 modules lost
+  `@module` to declaration emit and 4 never had one; all 127 module
+  declarations now carry it, and every `types.ts` / `proof.*` prose header
+  now leads its emitted declaration
   [#1526](https://github.com/functionalscript/functionalscript/pull/1526)
 - `fjs/media/json/schema`'s emitted declaration is exact: an explicit `@type`
   naming the recursive schema by `typeof` replaces the `@type {const}` cast
-  that collapsed `not` to `/*elided*/ any` and four sibling fields to `any`
+  that collapsed `not` to `/*elided*/ any` and five sibling fields to `any`
   [#1526](https://github.com/functionalscript/functionalscript/pull/1526)
-
 - **BREAKING CHANGES:** the npm package ships no `.js` files: the empty
   `types.js` stubs and compiled test files are gone. Import types only with
   fully erased `import type`, and use `fjs/emergent_testing/all.test.mjs` as

--- a/fjs/ci/common/module.f.mjs
+++ b/fjs/ci/common/module.f.mjs
@@ -9,6 +9,7 @@
  *
  * @import { Step, Job, MetaStep, StepType } from './types.ts'
  */
+
 import { actions, images } from '../config/module.f.mjs'
 import { option, array, record, string } from '../../types/rtti/module.f.mjs'
 import { parse as rttiParse } from '../../types/rtti/parse/module.f.mjs'

--- a/fjs/ci/common/types.ts
+++ b/fjs/ci/common/types.ts
@@ -4,6 +4,7 @@
  *
  * @module
  */
+
 import type { Ts } from '../../types/rtti/ts/types.ts'
 import type { images } from '../config/module.f.mjs'
 import type { os, architecture, stepSchema, jobSchema, jobsSchema, gitHubActionSchema } from './module.f.mjs'

--- a/fjs/crypto/vdf/module.f.mjs
+++ b/fjs/crypto/vdf/module.f.mjs
@@ -16,6 +16,7 @@
  * if (y === null || !sloth.verify(steps)(x)(y)) { throw y }
  * ```
  */
+
 import { modSqrt, prime_field } from '../../types/prime_field/module.f.mjs'
 /** @import { PrimeField } from '../../types/prime_field/types.ts' */
 /** @import { Nullable } from '../../types/nullable/types.ts' */

--- a/fjs/dev/update/proof.f.mjs
+++ b/fjs/dev/update/proof.f.mjs
@@ -1,8 +1,7 @@
 /**
  * Proofs for local development configuration generation.
- *
- * @module
  */
+
 import { assert, assertEq } from '../../asserts/module.f.mjs'
 import { utf8 } from '../../text/module.f.mjs'
 import { readUtf8File } from '../../effects/node/module.f.mjs'

--- a/fjs/effects/eff/module.f.mjs
+++ b/fjs/effects/eff/module.f.mjs
@@ -5,6 +5,7 @@
  *
  * @module
  */
+
 import { history, historyStep, mapStep, pure } from '../module.f.mjs'
 /** @import { Effect, Operation } from '../types.ts' */
 /** @import { Eff } from './types.ts' */

--- a/fjs/effects/list/module.f.mjs
+++ b/fjs/effects/list/module.f.mjs
@@ -5,6 +5,7 @@
  *
  * @module
  */
+
 import { pure } from "../module.f.mjs"
 /** @import { Effect, Operation } from "../types.ts" */
 /** @import { List, Next } from "./types.ts" */

--- a/fjs/effects/mock/module.f.mjs
+++ b/fjs/effects/mock/module.f.mjs
@@ -5,6 +5,7 @@
  *
  * @module
  */
+
 import { match } from "../module.f.mjs"
 /** @import { Operation } from '../types.ts' */
 /** @import { MemOperationMap, RunInstance } from './types.ts' */

--- a/fjs/effects/module.mjs
+++ b/fjs/effects/module.mjs
@@ -1,4 +1,12 @@
-/** @import { Effect, Operation, ToAsyncOperationMap } from './types.ts' */
+/**
+ * Impure effect interpretation: runs an `Effect` step by step against an
+ * asynchronous operation map.
+ *
+ * @module
+ *
+ * @import { Effect, Operation, ToAsyncOperationMap } from './types.ts'
+ */
+
 import { match } from './module.f.mjs'
 
 /**

--- a/fjs/effects/node/module.f.mjs
+++ b/fjs/effects/node/module.f.mjs
@@ -10,6 +10,7 @@
  *
  * @module
  */
+
 import { utf8, utf8ToString } from '../../text/module.f.mjs'
 import { toCodePointList } from '../../text/utf8/module.f.mjs'
 import { codePointListToString } from '../../text/utf16/module.f.mjs'

--- a/fjs/fsc/module.f.mjs
+++ b/fjs/fsc/module.f.mjs
@@ -3,6 +3,7 @@
  *
  * @module
  */
+
 import { strictEqual } from '../types/function/operator/module.f.mjs'
 import { merge as rangeMapMerge, fromRange, get } from '../types/range_map/module.f.mjs'
 /** @import { RangeMapArray, RangeMerge } from '../types/range_map/types.ts' */

--- a/fjs/mcp/module.f.mjs
+++ b/fjs/mcp/module.f.mjs
@@ -26,6 +26,7 @@
  *
  * @module
  */
+
 import { step } from '../effects/module.f.mjs'
 /** @import { Effect } from '../effects/types.ts' */
 import { create } from '../effects/memory/module.f.mjs'

--- a/fjs/media/html/module.f.mjs
+++ b/fjs/media/html/module.f.mjs
@@ -5,6 +5,7 @@
  *
  * @module
  */
+
 /** @import { List } from '../../types/list/types.ts' */
 import { map, flatMap, flat, concat as listConcat } from '../../types/list/module.f.mjs'
 import { concat, concat as stringConcat } from '../../types/string/module.f.mjs'

--- a/fjs/media/json/schema/module.f.mjs
+++ b/fjs/media/json/schema/module.f.mjs
@@ -17,7 +17,8 @@ import { array, option, or, record, string } from '../../../types/rtti/module.f.
 import { visit } from '../../../types/rtti/common/module.f.mjs'
 import { unknown as jsonUnknown } from '../rtti/module.f.mjs'
 
-const unknownThunk = () => /** @type {const} */ (['const', unknownConst])
+/** @type {() => readonly ['const', typeof unknownConst]} */
+const unknownThunk = () => ['const', unknownConst]
 
 /**
  * rtti schema for a JSON Schema (draft 2020-12) document.

--- a/fjs/media/json/serializer/module.f.mjs
+++ b/fjs/media/json/serializer/module.f.mjs
@@ -7,6 +7,7 @@
  *
  * @module
  */
+
 /** @import { List } from '../../../types/list/types.ts' */
 import { flat, map, reduce, empty } from '../../../types/list/module.f.mjs'
 /** @import { Reduce } from '../../../types/function/operator/types.ts' */

--- a/fjs/media/nix/module.f.mjs
+++ b/fjs/media/nix/module.f.mjs
@@ -8,6 +8,7 @@
  *
  * @module
  */
+
 /** @import { List as ChunkList } from '../../types/list/types.ts' */
 import { toArray } from '../../types/list/module.f.mjs'
 import { concat } from '../../types/string/module.f.mjs'

--- a/fjs/module.f.mjs
+++ b/fjs/module.f.mjs
@@ -3,6 +3,7 @@
  *
  * @module
  */
+
 import { compile } from './djs/module.f.mjs'
 import { main as testMain } from './emergent_testing/module.f.mjs'
 import { commands as casCommands } from './cas/cli/module.f.mjs'

--- a/fjs/module.mjs
+++ b/fjs/module.mjs
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
 
+/**
+ * The `fjs` CLI executable entry point.
+ *
+ * @module
+ */
+
 import { main } from './module.f.mjs'
 import { run } from './effects/node/module.mjs'
 

--- a/fjs/path/module.f.mjs
+++ b/fjs/path/module.f.mjs
@@ -3,6 +3,7 @@
  *
  * @module
  */
+
 /** @import { Fold, Reduce, Unary } from '../types/function/operator/types.ts' */
 /** @import { List } from '../types/list/types.ts' */
 import { fold, last, take, length, concat as listConcat, toArray } from '../types/list/module.f.mjs'

--- a/fjs/types/btree/find/module.f.mjs
+++ b/fjs/types/btree/find/module.f.mjs
@@ -3,6 +3,7 @@
  *
  * @module
  */
+
 /** @import { TNode } from '../types/types.ts' */
 
 import { index3, index5 } from '../../function/compare/module.f.mjs'

--- a/fjs/types/btree/remove/module.f.mjs
+++ b/fjs/types/btree/remove/module.f.mjs
@@ -3,6 +3,7 @@
  *
  * @module
  */
+
 import { collapseRoot } from '../types/module.f.mjs'
 /** @import { Leaf1, TNode, Branch1, Branch3, Branch5, Tree } from '../types/types.ts' */
 

--- a/fjs/types/btree/set/module.f.mjs
+++ b/fjs/types/btree/set/module.f.mjs
@@ -3,6 +3,7 @@
  *
  * @module
  */
+
 import { collapseRoot } from '../types/module.f.mjs'
 /** @import { Branch1, Branch3, Branch5, Branch7, TNode, Tree } from '../types/types.ts' */
 

--- a/fjs/types/btree/types/module.f.mjs
+++ b/fjs/types/btree/types/module.f.mjs
@@ -4,6 +4,7 @@
  *
  * @module
  */
+
 /** @import { Branch1, Branch3, Branch5, TNode } from './types.ts' */
 
 /**

--- a/fjs/types/byte_set/module.f.mjs
+++ b/fjs/types/byte_set/module.f.mjs
@@ -4,6 +4,7 @@
  *
  * @module
  */
+
 import { compose } from '../function/module.f.mjs'
 /** @import { RangeMap } from '../range_map/types.ts' */
 /** @import { SortedSet } from '../sorted_set/types.ts' */

--- a/fjs/types/function/compare/module.f.mjs
+++ b/fjs/types/function/compare/module.f.mjs
@@ -3,6 +3,7 @@
  *
  * @module
  */
+
 /** @import { Index, Tuple } from '../../array/types.ts' */
 /** @import { Cmp1, Cmp2, Compare, Sign } from './types.ts' */
 

--- a/fjs/types/function/module.f.mjs
+++ b/fjs/types/function/module.f.mjs
@@ -1,4 +1,11 @@
-/** @import { Func, Fn } from './types.ts' */
+/**
+ * Function combinators: composition, identity, argument flipping, and the
+ * chainable `Fn` wrapper.
+ *
+ * @module
+ *
+ * @import { Func, Fn } from './types.ts'
+ */
 
 /**
  * A postfix compose function.

--- a/fjs/types/list/module.f.mjs
+++ b/fjs/types/list/module.f.mjs
@@ -3,6 +3,7 @@
  *
  * @module
  */
+
 import { identity, fn, compose } from '../function/module.f.mjs'
 /** @import { Nullable } from '../nullable/types.ts' */
 import {

--- a/fjs/types/nullable/module.f.mjs
+++ b/fjs/types/nullable/module.f.mjs
@@ -3,6 +3,7 @@
  *
  * @module
  */
+
 import { assert } from '../../asserts/module.f.mjs'
 import { fn } from '../function/module.f.mjs'
 /** @import { Option } from '../option/types.ts' */

--- a/fjs/types/range_set/module.f.mjs
+++ b/fjs/types/range_set/module.f.mjs
@@ -3,6 +3,7 @@
  *
  * @module
  */
+
 import { rangeMap } from '../range_map/module.f.mjs'
 
 const map = rangeMap({

--- a/fjs/types/result/module.mjs
+++ b/fjs/types/result/module.mjs
@@ -1,4 +1,12 @@
-/** @import { Result } from './types.ts' */
+/**
+ * Impure `Result` companions: capture thrown exceptions as `Result` values,
+ * since `try`/`catch` is not allowed in FunctionalScript itself.
+ *
+ * @module
+ *
+ * @import { Result } from './types.ts'
+ */
+
 import { ok, error } from './module.f.mjs'
 
 /** @type {<T>(f: () => T) => Result<T, unknown>} */

--- a/fjs/types/rtti/common/module.f.mjs
+++ b/fjs/types/rtti/common/module.f.mjs
@@ -27,6 +27,7 @@
  *
  * @module
  */
+
 /** @import { Primitive, Unknown } from '../ts/types.ts' */
 /** @import { Const, Info0, Primitive0, Struct, Tag1, Tuple, Type } from '../types.ts' */
 /** @import { Error, Result as CommonResult } from '../../result/types.ts' */

--- a/fjs/types/rtti/common/types.ts
+++ b/fjs/types/rtti/common/types.ts
@@ -3,6 +3,7 @@
  *
  * @module
  */
+
 import type { Primitive, Unknown } from '../ts/types.ts'
 import type { Primitive0, Struct, Tag1, Tuple, Type } from '../types.ts'
 import type { Result as CommonResult } from '../../result/types.ts'

--- a/fjs/types/rtti/module.f.mjs
+++ b/fjs/types/rtti/module.f.mjs
@@ -4,6 +4,7 @@
  *
  * @module
  */
+
 import { includes } from '../array/module.f.mjs'
 /** @import { Includes } from '../array/types.ts' */
 /** @import { Assert } from '../../asserts/types.ts' */

--- a/fjs/types/rtti/parse/module.f.mjs
+++ b/fjs/types/rtti/parse/module.f.mjs
@@ -28,6 +28,7 @@
  *
  * @module
  */
+
 /** @import { Info1, Struct, Tag1, Tuple, Type } from '../types.ts' */
 /** @import { Result as CommonResult } from '../../result/types.ts' */
 import { ok } from '../../result/module.f.mjs'

--- a/fjs/types/rtti/parse/types.ts
+++ b/fjs/types/rtti/parse/types.ts
@@ -3,6 +3,7 @@
  *
  * @module
  */
+
 import type { Type } from '../types.ts'
 import type { Result as CommonValidateResult, Validate } from '../common/types.ts'
 

--- a/fjs/types/rtti/ts/module.f.mjs
+++ b/fjs/types/rtti/ts/module.f.mjs
@@ -4,6 +4,7 @@
  *
  * @module
  */
+
 import { primitive, union, printer as tsPrinter } from '../../ts/module.f.mjs'
 /** @import { Const, Type } from '../types.ts' */
 

--- a/fjs/types/rtti/ts/types.ts
+++ b/fjs/types/rtti/ts/types.ts
@@ -9,6 +9,7 @@
  *
  * @module
  */
+
 import type { Equal } from '../../ts/types.ts'
 import type { Tag0, Tag1, Const, Or, String as RttiString, Struct, Tuple, Type, ConstObject } from '../types.ts'
 import type { Assert } from '../../../asserts/types.ts'

--- a/fjs/types/rtti/types.ts
+++ b/fjs/types/rtti/types.ts
@@ -38,6 +38,7 @@
  *
  * @module
  */
+
 import type { Assert } from '../../asserts/types.ts'
 import type { Equal } from '../ts/types.ts'
 import type { StringMap } from '../object/types.ts'

--- a/fjs/types/rtti/validate/module.f.mjs
+++ b/fjs/types/rtti/validate/module.f.mjs
@@ -29,6 +29,7 @@
  *
  * @module
  */
+
 /** @import { Unknown } from '../ts/types.ts' */
 /** @import { Info1, Struct, Tag1, Tuple, Type } from '../types.ts' */
 import { ok } from '../../result/module.f.mjs'

--- a/fjs/types/rtti/validate/types.ts
+++ b/fjs/types/rtti/validate/types.ts
@@ -3,4 +3,5 @@
  *
  * @module
  */
+
 export type { Path, Result, Validate, ValidationError } from '../common/types.ts'

--- a/fjs/types/sorted_set/module.f.mjs
+++ b/fjs/types/sorted_set/module.f.mjs
@@ -26,6 +26,7 @@
  * has(cmp)(2)(setA) // false
  * ```
  */
+
 /** @import { Cmp } from '../function/compare/types.ts' */
 import { toArray } from "../list/module.f.mjs"
 import { merge, intersect as listIntersect, find } from '../sorted_list/module.f.mjs'

--- a/todo/migrate-typescript-to-mjs.md
+++ b/todo/migrate-typescript-to-mjs.md
@@ -809,7 +809,7 @@ blocking, plus the prose sweep. The remaining items are listed under
       migrated, and keep an `Assert<Equal<…, Ts<typeof …>>>` beside the schema
       so the explicit annotation stays verified rather than asserted. The last
       known instance — `fjs/media/json/schema`'s `unknownThunk`, whose
-      `@type {const}` cast collapsed `not` to `/*elided*/ any` and four
+      `@type {const}` cast collapsed `not` to `/*elided*/ any` and five
       sibling fields to bare `any` — was fixed with the `typeof` annotation in
       [#1526](https://github.com/functionalscript/functionalscript/pull/1526);
       emitted declarations measure zero `elided` repo-wide after it. (Its

--- a/todo/migrate-typescript-to-mjs.md
+++ b/todo/migrate-typescript-to-mjs.md
@@ -807,7 +807,14 @@ blocking, plus the prose sweep. The remaining items are listed under
       repository stays green. Expect more of these as rtti spreads; check the
       emitted declaration for `any` / `elided` before calling such a group
       migrated, and keep an `Assert<Equal<…, Ts<typeof …>>>` beside the schema
-      so the explicit annotation stays verified rather than asserted.
+      so the explicit annotation stays verified rather than asserted. The last
+      known instance — `fjs/media/json/schema`'s `unknownThunk`, whose
+      `@type {const}` cast collapsed `not` to `/*elided*/ any` and four
+      sibling fields to bare `any` — was fixed with the `typeof` annotation in
+      [#1526](https://github.com/functionalscript/functionalscript/pull/1526);
+      emitted declarations measure zero `elided` repo-wide after it. (Its
+      Phantom `$out` intentionally differs from `Ts<typeof unknownThunk>` in
+      field optionality, so no exact `Equal` round-trip assert applies there.)
 - [ ] Decide each JSDoc typedef's visibility at the migration boundary: prefix
       implementation-only typedefs with `_` and leave publicly useful ones
       unprefixed, judged by what the module should offer its consumers rather

--- a/todo/migrate-typescript-to-mjs.md
+++ b/todo/migrate-typescript-to-mjs.md
@@ -507,8 +507,12 @@ migrated modules are in one of the two safe categories by accident, not by
 intent.
 
 `fjs/common/monoid`, `fjs/types/btree/remove`, `fjs/types/btree/set`,
-`fjs/types/list` and `fjs/types/nullable` are the five that currently lose their
-header and want the same one-line fix.
+`fjs/types/list` and `fjs/types/nullable` were the five known to lose their
+header and want the same one-line fix. That count was stale: re-measured in
+[#1526](https://github.com/functionalscript/functionalscript/pull/1526), 24
+modules lost the header this way and another 4 had no `@module` block in
+source at all. All are fixed there — every one of the 127 emitted
+`module.f.d.mts` / `module.d.mts` files now carries `@module`.
 
 #### Curried generic exports need an explicit `@returns`
 
@@ -817,9 +821,13 @@ blocking, plus the prose sweep. The remaining items are listed under
       always put one blank line after that block, group external/built-in
       runtime imports separately, and order repository-owned relative runtime
       imports as migrated `.mjs` before remaining `.ts`; fix the modules that
-      already lose their header. `fjs/common/monoid` is now fixed; four remain
-      (`fjs/types/btree/remove`, `fjs/types/btree/set`, `fjs/types/list`,
-      `fjs/types/nullable`), each emitting a declaration with no `@module`.
+      already lose their header. The header half is done: the "four remain"
+      count was stale, and
+      [#1526](https://github.com/functionalscript/functionalscript/pull/1526)
+      fixed the measured 24 emit losses plus 4 sources with no `@module`
+      block, so all 127 emitted module declarations carry the header. Still
+      open in this item: sweeping scattered `@import` comments into the
+      leading block and the import-group ordering.
 - [ ] File an upstream issue for JSDoc typedef documentation being dropped from
       declaration emit, and keep writing type documentation in the source
       meanwhile; substantial type APIs may instead live directly in `types.ts`


### PR DESCRIPTION
Two declaration-fidelity fixes from `todo/migrate-typescript-to-mjs.md`, both of the invisible-in-repository class: `npx tsc` and `npm test` stay green either way, and only a consumer reading the published `.d.mts` sees the difference.

## 1. Every emitted module declaration keeps its `@module` header

Before this change, 28 of the 127 emitted `module.f.d.mts` / `module.d.mts` files had no `@module` documentation header.

The TODO records the mechanism: declaration emit rewrites the import list, and when the header comment is attached to the first `import` statement (no blank line after the leading JSDoc block), the header is dropped with that statement. The TODO named four modules to fix — but that count was as of #1505 and stale. Measured at `main` today:

- **24 modules** had an `@module` header in source that emit dropped — the four known ones (`fjs/types/btree/remove`, `btree/set`, `list`, `nullable`) plus 20 more (`sorted_set`, `range_set`, `rtti` ×5, `byte_set`, `fjs/module.f.mjs`, `effects/node`/`mock`/`eff`/`list`, `media/json/serializer`, `media/html`, `media/nix`, `crypto/vdf`, `path`, `mcp`, `fsc`). Each gets the load-bearing blank line after its header block.
- **4 modules** had no `@module` header at all (`fjs/types/result/module.mjs`, `fjs/types/function/module.f.mjs`, `fjs/effects/module.mjs`, and the `fjs/module.mjs` CLI entry) — a §4-convention gap rather than an emit loss. Each gets a leading JSDoc block with `@module` and a one-sentence description, folding its pre-existing `@import` tags into the block per convention.

**Verified:** `grep -L '@module'` over every emitted module declaration after declaration emit — **0 missing of 127**, up from 99 of 127. The diff for this part is comments and blank lines only.

## 2. `fjs/media/json/schema` emits an exact declaration

`unknownThunk` was typed only through a `@type {const}` cast — the exact middle-row failure of the AGENTS.md §6.2 table: it type-checks, but the emitter has no name for the recursive position. The emitted declaration collapsed `not` to `/*elided*/ any` and four sibling fields (`anyOf`, `items`, `prefixItems`, `properties`, `additionalProperties`) to bare `any` — this was the last `elided` anywhere in the published type surface.

The fix is §6.2's own prescription: an explicit `@type {() => readonly ['const', typeof unknownConst]}` closes the recursion cycle by name, and the emitter prints `typeof unknownConst` instead of inlining and giving up.

No exact `Equal` round-trip assert accompanies it because the schema's Phantom `$out` (`_UnknownConst`) intentionally differs from the derived type in field optionality — the TODO's §6.2 note records this.

**Verified:** the emitted `module.f.d.mts` contains 0 `elided` and 0 bare `any` (was 1 + 5); repo-wide `elided` count across all emitted declarations is **0**.

## Battery

- `npx tsc` clean; `tsc --noEmit false --emitDeclarationOnly && tsc` (the prepack round-trip) clean.
- `npm test` **2532 / 0**.
- CHANGELOG entries added for both fixes; the migration TODO records the corrected header measurement and the schema outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkqgqTaffDpYFQEJydpqHF