### PR TITLE
Remove Eff wrapper; convert all modules to raw step combinators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ history.
 
 ## Unreleased
 
+- `fjs/cas`, `fjs/cas/evo` and `fjs/emergent_testing` compose through the raw
+  `step` / `mapStep` / `historyStep` combinators instead of the fluent `Eff`
+  wrapper, which keeps its module but now has no consumers. Behavior is
+  unchanged
+  [#1534](https://github.com/functionalscript/functionalscript/pull/1534)
 - **BREAKING CHANGES:** `fjs/bnf/ll1`'s matcher runs as an explicit-stack
   machine over a cursor into the shared input, so long or deeply nested input
   no longer overflows the JS call stack and matching is no longer quadratic.

--- a/fjs/cas/evo/module.f.mjs
+++ b/fjs/cas/evo/module.f.mjs
@@ -53,8 +53,7 @@
  * @import { Hash, Subject, RevisionData, SubjectState, Cache, Evo } from './types.ts'
  */
 
-import { pure, foldStep } from '../../effects/module.f.mjs'
-import { eff } from '../../effects/eff/module.f.mjs'
+import { pure, foldStep, mapStep, step } from '../../effects/module.f.mjs'
 import { create, read, write } from '../../effects/memory/module.f.mjs'
 import { collectRead } from '../module.f.mjs'
 import { cBase32ToVec, vecToCBase32 } from '../../basen/cbase32/module.f.mjs'
@@ -185,9 +184,9 @@ export const decodeRevisionVec = value => {
  * @returns {(hash: Vec) => Effect<O, Revision | null>}
  */
 export const decodeRevisionBlob = cas => hash =>
-    eff(collectRead(cas.read(hash)))
-        .map(([tag, value]) => tag === 'error' ? null : decodeRevisionVec(value))
-        .value
+    mapStep(
+        collectRead(cas.read(hash)),
+        ([tag, value]) => tag === 'error' ? null : decodeRevisionVec(value))
 
 /**
  * Scans every hash in `cas` and builds a fresh {@link Cache} from the
@@ -202,11 +201,10 @@ export const buildCache = cas =>
         cas.list(),
         emptyCache,
         hash => cache =>
-            eff(decodeRevisionBlob(cas)(hash))
-                .step(revision =>
-                    pure(revision === null ? cache : addRevisionToCache(vecToCBase32(hash), revision)(cache))
-                )
-                .value)
+            mapStep(
+                decodeRevisionBlob(cas)(hash),
+                revision =>
+                    revision === null ? cache : addRevisionToCache(vecToCBase32(hash), revision)(cache)))
 
 /**
  * Scans `cas` once and allocates a memory slot holding the resulting {@link Cache}.
@@ -216,17 +214,13 @@ export const buildCache = cas =>
  * @returns {Effect<O | MemOp, Key<Cache>>}
  */
 export const initEvo = cas =>
-    eff(buildCache(cas))
-        .step(cache => create(cache))
-        .value
+    step(buildCache(cas), cache => create(cache))
 
 /** Reads, then rewrites, the cache at `cacheKey` with `revision` folded in at `hash`.
  * @type {(cacheKey: Key<Cache>) => (hash: Hash) => (revision: Revision) => Effect<MemOp, void>}
  */
 const foldIntoCache = cacheKey => hash => revision =>
-    eff(read(cacheKey))
-        .step(cache => write(cacheKey, addRevisionToCache(hash, revision)(cache)))
-        .value
+    step(read(cacheKey), cache => write(cacheKey, addRevisionToCache(hash, revision)(cache)))
 
 /**
  * Folds `value` — bytes already written to a `Cas` at `hash` by some other
@@ -259,11 +253,9 @@ const resolveParent = cas => parentRef => {
     if (parentHash === null) {
         return pure(error(`invalid parent hash: ${parentRef}`))
     }
-    return eff(decodeRevisionBlob(cas)(parentHash))
-        .step(parent =>
-            pure(parent === null ? error(`parent is not a revision blob: ${parentRef}`) : ok(parent))
-        )
-        .value
+    return mapStep(
+        decodeRevisionBlob(cas)(parentHash),
+        parent => parent === null ? error(`parent is not a revision blob: ${parentRef}`) : ok(parent))
 }
 
 /**
@@ -281,12 +273,11 @@ const resolveParents = cas => parents => {
         init,
         parentRef => (/** @type {Result<readonly Revision[], string>} */ acc) => {
             if (acc[0] === 'error') { return pure(acc) }
-            return eff(resolveParent(cas)(parentRef))
-                .step((/** @type {Result<Revision, string>} */ parentResult) =>
-                    /** @type {Effect<never, Result<readonly Revision[], string>>} */
-                    (pure(parentResult[0] === 'error' ? parentResult : ok([...acc[1], parentResult[1]])))
-                )
-                .value
+            return mapStep(
+                resolveParent(cas)(parentRef),
+                (/** @type {Result<Revision, string>} */ parentResult) =>
+                    /** @type {Result<readonly Revision[], string>} */
+                    (parentResult[0] === 'error' ? parentResult : ok([...acc[1], parentResult[1]])))
         })
 }
 
@@ -444,8 +435,9 @@ const buildRevision = input => parents => {
  * @returns {(cacheKey: Key<Cache>) => (input: RevisionData) => Effect<O | MemOp, Result<Hash, string>>}
  */
 export const addRevision = cas => cacheKey => input =>
-    eff(resolveParents(cas)(input.parents))
-        .step((/** @type {Result<readonly Revision[], string>} */ parentsResult) => {
+    step(
+        resolveParents(cas)(input.parents),
+        (/** @type {Result<readonly Revision[], string>} */ parentsResult) => {
             const revisionResult = okThen(buildRevision(input))(parentsResult)
             if (revisionResult[0] === 'error') { return pure(revisionResult) }
             const canonicalRevision = revisionResult[1]
@@ -453,19 +445,16 @@ export const addRevision = cas => cacheKey => input =>
             if (bytes === null) {
                 return pure(error('revision too large to encode'))
             }
-            return eff(cas.write(nonEmpty(ok(bytes), /** @type {List<never, Ok<Vec>>} */ (elEmpty()))))
-                .step((/** @type {IoResult<Vec>} */ writeResult) => {
+            return step(
+                cas.write(nonEmpty(ok(bytes), /** @type {List<never, Ok<Vec>>} */ (elEmpty()))),
+                (/** @type {IoResult<Vec>} */ writeResult) => {
                     if (writeResult[0] === 'error') {
                         return /** @type {Effect<MemOp, Result<Hash, string>>} */ (pure(error('failed to write revision to CAS')))
                     }
                     const hash = vecToCBase32(writeResult[1])
-                    return eff(foldIntoCache(cacheKey)(hash)(canonicalRevision))
-                        .step(() => pure(ok(hash)))
-                        .value
+                    return mapStep(foldIntoCache(cacheKey)(hash)(canonicalRevision), () => ok(hash))
                 })
-                .value
         })
-        .value
 
 /**
  * Projects a decoded `Revision` into the shared {@link RevisionData}
@@ -547,9 +536,7 @@ export const readRevision = cas => hash => {
     const hashVec = cBase32ToVec(hash)
     return hashVec === null
         ? pure(error(`invalid hash: ${hash}`))
-        : eff(collectRead(cas.read(hashVec)))
-            .map(decodeReadRevision(hash))
-            .value
+        : mapStep(collectRead(cas.read(hashVec)), decodeReadRevision(hash))
 }
 
 /**
@@ -562,17 +549,15 @@ export const readRevision = cas => hash => {
 export const evo = cas => cacheKey => ({
     list: archived => {
         const listed = subjectListed(archived)
-        return eff(read(cacheKey))
-            .step(cache => pure(definedEntries(cache.bySubject)
-                .flatMap(([subject, state]) => listed(state) ? [subject] : [])))
-            .value
+        return mapStep(
+            read(cacheKey),
+            cache => definedEntries(cache.bySubject)
+                .flatMap(([subject, state]) => listed(state) ? [subject] : []))
     },
-    head: subject => eff(read(cacheKey))
-        .step(cache => {
-            const state = at(subject)(cache.bySubject)
-            return pure(state === null ? [] : headsOf(state))
-        })
-        .value,
+    head: subject => mapStep(read(cacheKey), cache => {
+        const state = at(subject)(cache.bySubject)
+        return state === null ? [] : headsOf(state)
+    }),
     add: input => addRevision(cas)(cacheKey)(input),
     revision: readRevision(cas),
 })

--- a/fjs/cas/module.f.mjs
+++ b/fjs/cas/module.f.mjs
@@ -22,8 +22,7 @@ import { sha256 } from '../crypto/sha2/module.f.mjs'
 import { join, normalize, parse } from '../path/module.f.mjs'
 import { empty, length, maxLength, maxLengthBytes, msb, vec } from '../types/bit_vec/module.f.mjs'
 import { cBase32ToVec, vecToCBase32 } from '../basen/cbase32/module.f.mjs'
-import { foldStep, forEachStep, history, historyStep, okStep, pure, step } from '../effects/module.f.mjs'
-import { eff } from '../effects/eff/module.f.mjs'
+import { foldStep, forEachStep, history, historyStep, mapStep, okStep, pure, step } from '../effects/module.f.mjs'
 import {
     access,
     createExclusive,
@@ -74,18 +73,16 @@ export const toPath = key => {
 export const collectRead = stream => {
     /** @type {(acc: Vec) => (s: List<O, IoResult<Vec>>) => Effect<O, IoResult<Vec>>} */
     const loop = acc => s =>
-        eff(s)
-            .step((/** @type {*} */ node) => {
-                if (node === undefined) { return pure(ok(acc)) }
-                const { first, tail } = node
-                const [t, v] = first
-                if (t === 'error') { return pure(first) }
-                if (length(acc) + length(v) > maxLength) {
-                    return pure(error(`cas blob exceeds maximum vector length of ${maxLength} bits`))
-                }
-                return loop(msb.concat(acc)(v))(tail)
-            })
-            .value
+        step(s, node => {
+            if (node === undefined) { return pure(ok(acc)) }
+            const { first, tail } = node
+            const [t, v] = first
+            if (t === 'error') { return pure(first) }
+            if (length(acc) + length(v) > maxLength) {
+                return pure(error(`cas blob exceeds maximum vector length of ${maxLength} bits`))
+            }
+            return loop(msb.concat(acc)(v))(tail)
+        })
     return loop(empty)(stream)
 }
 
@@ -133,21 +130,24 @@ const deadlineOf = name => Number(name.slice(0, name.indexOf('-')))
  * @param {string} stageDir
  * @returns {Effect<O, void>}
  */
-const gcStage = stageDir =>
-    eff(now())
-        .step(() => readdir(stageDir, {}))
-        .step(([k, v], t) => {
+const gcStage = stageDir => {
+    // The `readdir` result and the `now()` timestamp are both needed by the last
+    // link, so the timestamp is carried forward in a history rather than closed
+    // over by a nested continuation.
+    const listed = historyStep(
+        history(now()),
+        () => readdir(stageDir, {}))
+    return step(
+        listed,
+        ([[k, v], t]) => {
             if (k === 'error') { return pure(undefined) }
             const expired = v.flatMap(d =>
                 d.isFile && deadlineOf(d.name) < t ? [d.name] : [])
             return forEachStep(
                 pure(expired),
-                name =>
-                    eff(rm(join(stageDir, name)))
-                        .step(() => pure(undefined))
-                        .value)
+                name => mapStep(rm(join(stageDir, name)), () => undefined))
         })
-        .value
+}
 
 // Lock-free staging upload (plan/staging-lease.md): stream each chunk straight
 // to a `_stage/<deadline>-<rand>` file via `writeBytes` while folding it into the
@@ -176,69 +176,61 @@ const writeImpl = (sha2, path, stageDir, payload) => {
         const rel = toPath(hash)
         const dst = join(path, rel)
         const dstDir = join(path, ...parse(rel).slice(0, -1))
-        return eff(mkdir(dstDir, { recursive: true }))
-            .step(() => rename(curPath, dst))
-            .step(() => rm(curPath))
-            .step(() => stat(dst))
-            .step(st => pure(st[0] === 'ok' && st[1].size === offset ? ok(hash) : error('publish size mismatch')))
-            .value
+        const created = step(mkdir(dstDir, { recursive: true }), () => rename(curPath, dst))
+        const removed = step(created, () => rm(curPath))
+        const stated = step(removed, () => stat(dst))
+        return mapStep(
+            stated,
+            st => st[0] === 'ok' && st[1].size === offset ? ok(hash) : error('publish size mismatch'))
     }
     // Any streaming error fails closed: delete the partial file, return the error.
     /** @type {(curPath: string, e: unknown) => Effect<FileCasOperation, IoResult<Vec>>} */
     const fail = (curPath, e) =>
-        eff(rm(curPath))
-            .step(() => pure(error(e)))
-            .value
-    return eff(gcStage(stageDir)).step(() =>
-        eff(random256).step(rnd => {
-            const rndStr = vecToCBase32(rnd)
-            /** @type {(state: Sha2State, offset: number, curPath: string) => (stream: List<O1, IoResult<Vec>>) => Effect<O1 | FileCasOperation, IoResult<Vec>>} */
-            const loop = (state, offset, curPath) =>
-                stream =>
-                    eff(stream)
-                        .step((node) => {
-                            if (node === undefined) {
-                                return publish(state, offset, curPath)
-                            }
-                            const { first, tail } = node
-                            if (first[0] === 'error') {
-                                return fail(curPath, first[1])
-                            }
-                            const chunk = first[1]
-                            return eff(writeBytes(curPath, offset, chunk))
-                                .step(wb => {
-                                    if (wb[0] === 'error') { return fail(curPath, wb[1]) }
-                                    const newState = sha2.append(chunk)(state)
-                                    const newOffset = offset + Number(length(chunk) / 8n)
-                                    // Renew the lease: rename to a fresh deadline (keeps `delta` constant).
-                                    // The new path is still needed after the rename, to recurse with,
-                                    // so the rename captures it rather than closing over it.
-                                    const nextPath = step(
-                                        now(),
-                                        t => pure(join(stageDir, stageName(t + leaseDelta, rndStr))))
-                                    const renamed = historyStep(
-                                        history(nextPath),
-                                        next => rename(curPath, next))
-                                    return step(
-                                        renamed,
-                                        ([[rt, v], next]) =>
-                                            rt === 'error'
-                                                ? fail(curPath, v)
-                                                : loop(newState, newOffset, next)(tail))
-                                })
-                                .value
-                        })
-                        .value
-            return eff(mkdir(stageDir, { recursive: true }))
-                .step(() => now())
-                .step(t0 => {
-                    const path0 = join(stageDir, stageName(t0 + leaseDelta, rndStr))
-                    return eff(createExclusive(path0))
-                        .step(okStep(() => loop(sha2.init, 0, path0)(payload)))
-                        .value
+        mapStep(rm(curPath), () => error(e))
+    const rndEffect = step(gcStage(stageDir), () => random256)
+    return step(rndEffect, rnd => {
+        const rndStr = vecToCBase32(rnd)
+        /** @type {(state: Sha2State, offset: number, curPath: string) => (stream: List<O1, IoResult<Vec>>) => Effect<O1 | FileCasOperation, IoResult<Vec>>} */
+        const loop = (state, offset, curPath) =>
+            stream =>
+                step(stream, node => {
+                    if (node === undefined) {
+                        return publish(state, offset, curPath)
+                    }
+                    const { first, tail } = node
+                    if (first[0] === 'error') {
+                        return fail(curPath, first[1])
+                    }
+                    const chunk = first[1]
+                    return step(writeBytes(curPath, offset, chunk), wb => {
+                        if (wb[0] === 'error') { return fail(curPath, wb[1]) }
+                        const newState = sha2.append(chunk)(state)
+                        const newOffset = offset + Number(length(chunk) / 8n)
+                        // Renew the lease: rename to a fresh deadline (keeps `delta` constant).
+                        // The new path is still needed after the rename, to recurse with,
+                        // so the rename captures it rather than closing over it.
+                        const nextPath = step(
+                            now(),
+                            t => pure(join(stageDir, stageName(t + leaseDelta, rndStr))))
+                        const renamed = historyStep(
+                            history(nextPath),
+                            next => rename(curPath, next))
+                        return step(
+                            renamed,
+                            ([[rt, v], next]) =>
+                                rt === 'error'
+                                    ? fail(curPath, v)
+                                    : loop(newState, newOffset, next)(tail))
+                    })
                 })
-                .value
-        }).value).value
+        const started = step(mkdir(stageDir, { recursive: true }), () => now())
+        return step(started, t0 => {
+            const path0 = join(stageDir, stageName(t0 + leaseDelta, rndStr))
+            return step(
+                createExclusive(path0),
+                okStep(() => loop(sha2.init, 0, path0)(payload)))
+        })
+    })
 }
 
 /**
@@ -255,8 +247,9 @@ export const fileCas = sha2 => path => {
             const p = join(path, toPath(hash))
             /** @type {(offset: number) => List<FileCasOperation, IoResult<Vec>>} */
             const loop = offset =>
-                eff(readBytes(p, offset, chunkBytes))
-                    .step(/** @type {(result: IoResult<Vec>) => List<FileCasOperation, IoResult<Vec>>} */ (result) => {
+                step(
+                    readBytes(p, offset, chunkBytes),
+                    /** @type {(result: IoResult<Vec>) => List<FileCasOperation, IoResult<Vec>>} */ (result) => {
                         const [t, v] = result
                         // A missing shard or read error is an explicit error item, never EOF.
                         if (t === 'error') {
@@ -268,7 +261,6 @@ export const fileCas = sha2 => path => {
                             ? elEmpty()
                             : nonEmpty(ok(v), loop(offset + chunkBytes))
                     })
-                    .value
             return loop(0)
         },
         write: payload => writeImpl(sha2, path, stageDir, payload),
@@ -277,20 +269,18 @@ export const fileCas = sha2 => path => {
             // empty store, mirroring how `read` maps a missing shard to an error item.
             // A `.cas` that exists but cannot be read (permissions, corruption) is a
             // genuine storage error and is surfaced, not masked as "no hashes".
-            eff(access(storePrefix))
-                .step(a => {
-                    if (a[0] === 'error') {
-                        if (isNotFound(a[1])) { return pure(/** @type {readonly Vec[]} */ ([])) }
-                        throw a[1]
-                    }
-                    return eff(readdir(storePrefix, { recursive: true }))
-                        .step(r => pure(unwrap(r).flatMap(({ name, parentPath, isFile }) =>
-                            toOption(isFile
-                                ? cBase32ToVec(normalize(parentPath).substring(normalizedStorePrefix.length).replaceAll('/', '') + name)
-                                : null))))
-                        .value
-                })
-                .value,
+            step(access(storePrefix), a => {
+                if (a[0] === 'error') {
+                    if (isNotFound(a[1])) { return pure(/** @type {readonly Vec[]} */ ([])) }
+                    throw a[1]
+                }
+                return mapStep(
+                    readdir(storePrefix, { recursive: true }),
+                    r => unwrap(r).flatMap(({ name, parentPath, isFile }) =>
+                        toOption(isFile
+                            ? cBase32ToVec(normalize(parentPath).substring(normalizedStorePrefix.length).replaceAll('/', '') + name)
+                            : null)))
+            }),
         url: hash =>
             join(path, toPath(hash))
     }
@@ -305,9 +295,7 @@ const random256 =
         pure([0, 1, 2, 3, 4, 5, 6, 7]),
         empty,
         () => (/** @type {Vec} */ acc) =>
-            eff(randomInt())
-                .step(r => pure(msb.concat(acc)(vec(32n)(BigInt(r)))))
-                .value)
+            mapStep(randomInt(), r => msb.concat(acc)(vec(32n)(BigInt(r)))))
 
 /** Streams any file at `filePath` in `<=128 KiB` chunks as a `ListEffect` of `ok` items.
  *
@@ -316,8 +304,9 @@ const random256 =
 const streamFile = filePath => {
     /** @type {(offset: number) => List<ReadBytes, IoResult<Vec>>} */
     const loop = offset =>
-        eff(readBytes(filePath, offset, chunkBytes))
-            .step(/** @type {(result: IoResult<Vec>) => List<ReadBytes, IoResult<Vec>>} */ (result) => {
+        step(
+            readBytes(filePath, offset, chunkBytes),
+            /** @type {(result: IoResult<Vec>) => List<ReadBytes, IoResult<Vec>>} */ (result) => {
                 if (result[0] === 'error') {
                     return nonEmpty(result, elEmpty())
                 }
@@ -326,7 +315,6 @@ const streamFile = filePath => {
                     ? elEmpty()
                     : nonEmpty(ok(chunk), loop(offset + chunkBytes))
             })
-            .value
     return loop(0)
 }
 
@@ -355,9 +343,8 @@ export const casAddFile = cas => path =>
 export const casUpload = home => fileName => {
     const src = join(home, 'cas_upload', fileName)
     const c = fileCas(sha256)(home)
-    return eff(casAddFile(c)(src))
-        .step(okStep(/** @type {(v: Vec) => Effect<Rm, IoResult<Vec>>} */ (v => eff(rm(src))
-            .step(() => pure(ok(v)))
-            .value)))
-        .value
+    return step(
+        casAddFile(c)(src),
+        okStep(/** @type {(v: Vec) => Effect<Rm, IoResult<Vec>>} */ (v =>
+            mapStep(rm(src), () => ok(v)))))
 }

--- a/fjs/effects/eff/README.md
+++ b/fjs/effects/eff/README.md
@@ -99,16 +99,42 @@ than of this implementation.
 
 By conversion and comparison, over multiple pull requests.
 
-Usage is currently split cleanly by file rather than mixed within one: `fjs/cas`,
-`fjs/cas/evo`, and `fjs/emergent_testing` use `Eff`; most other effect code uses
-raw `step`. That split is historical — those three simply were not converted
-when `eff` was removed elsewhere — but it is useful anyway, because they are the
-most effect-dense modules in the repository. Converting them is where the
-wrapper should pay off most, and so is where the evidence will be clearest.
+**Nothing in the repository uses `Eff` today.** The last consumers — `fjs/cas`,
+`fjs/cas/evo`, `fjs/emergent_testing`, and `fjs/protocol/mcp`'s proof — have
+been converted to raw `step` / `mapStep` / `historyStep`, so this module and its
+proof are all that remain. Those were the most effect-dense modules in the
+repository, which is why they were where the wrapper should have paid off most
+and where the evidence is clearest.
 
-What is worth recording for each conversion: how many call sites changed, what
-happened to nesting depth and indentation, whether intermediate names had to be
-invented, and whether the value history was actually used or merely carried.
+That is a pause, not a verdict. The wrapper stays available and stays cheap to
+keep, for the reason given above: nothing in the primitive layer depends on it.
+
+What the conversion recorded, in the terms this section asked for:
+
+- **Call sites.** Every `eff(e).step(f).value` had a mechanical raw
+  equivalent, so nothing had to be redesigned to lose the wrapper. A chain
+  whose last link was a pure projection collapsed to a single `mapStep`,
+  shorter than the fluent form it replaced.
+- **Nesting and indentation.** Flat chains came out *less* indented: the
+  `eff(…)` / `.value` bracketing costs a level the raw form does not pay. The
+  chains that genuinely nested — `writeImpl` in `fjs/cas` — nested identically
+  either way, because that nesting is forced by locals computed inside a
+  continuation rather than by the spelling.
+- **Intermediate names.** A handful had to be invented, and they read as
+  documentation rather than ceremony (`listed`, `reported`, `total`). The raw
+  form asks for one name per link; that is the SSA cost described above, and it
+  bites only where a link has nothing worth calling it — `publish`'s
+  `created` / `removed` / `stated` are three such names for what the fluent
+  chain wrote as three anonymous `.step`s.
+- **The history.** Mostly carried, not used. Only three chains read a prior
+  value at all — `gcStage` (`fjs/cas`), `runModuleMap`
+  (`fjs/emergent_testing`), and the state read-back in the MCP proof — and each
+  became an explicit `historyStep` that says so where it happens. The fluent
+  `.step` was paying for the history tuple on every link regardless.
+
+What conversion cannot supply is the other half of the trade: what the wrapper
+actually costs when a chain is long and hot. That needs a measurement, not
+another rewrite.
 
 ## Related open questions
 

--- a/fjs/effects/todo/allreduce-combinator.md
+++ b/fjs/effects/todo/allreduce-combinator.md
@@ -27,9 +27,8 @@ export const allReduce =
 ```
 
 Note the standalone `step`: `all(...)` returns a raw `Effect`, which is plain
-data with no methods — `.step` exists only on the `Eff` wrapper
-(`fjs/effects/eff/module.f.mjs`). An earlier draft of this issue wrote
-`all(...).step(...)`, which would not compile. If
+data with no methods, so `all(...).step(...)` — as an earlier draft of this
+issue wrote it — would not compile. If
 [map-step-combinator](./map-step-combinator.md) lands first, the body is
 `mapStep(all(...toArray(items).map(f)), rs => rs.reduce(...))`.
 

--- a/fjs/effects/todo/allvoid-combinator.md
+++ b/fjs/effects/todo/allvoid-combinator.md
@@ -19,32 +19,20 @@
 ### Problem
 
 The *fan out in parallel, then discard the results* idiom is spelled out
-verbatim three times in `fjs/emergent_testing/module.f.mjs` (lines 141-143,
-189-191, 276-278):
+verbatim three times in `fjs/emergent_testing/module.f.mjs`:
 
 ```ts
-return eff(all(...sub.map(e => registerOne(t, e))))
-    .step(() => pure(undefined))
-    .value
+return mapStep(all(...sub.map(e => registerOne(t, e))), () => undefined)
 
-return eff(all(...tests.map(e => registerOne(ctx, e))))
-    .step(() => pure(undefined))
-    .value
+return mapStep(all(...tests.map(e => registerOne(ctx, e))), () => undefined)
 
-return eff(all(...modules.map(([k, v]) => registerModule(ctx, k, v, star))))
-    .step(() => pure(undefined))
-    .value
+return mapStep(all(...modules.map(([k, v]) => registerModule(ctx, k, v, star))), () => undefined)
 ```
-
-Note the `eff(...)` / `.value` bracketing: a raw `Effect` is plain data with no
-methods, so `.step` is reachable only through the `Eff` wrapper
-(`fjs/effects/eff/module.f.mjs`). An earlier draft of this issue quoted these
-sites as `all(...).step(...)` — that form does not exist and would not compile.
 
 `fjs/effects/module.f.mjs` already ships `forEachStep` (the *sequential* void
 combinator, line 90), and [allreduce-combinator](./allreduce-combinator.md)
 covers the parallel *reduce* variant — but the parallel *void* sibling is
-missing, so every call site re-spells the whole wrap-step-unwrap dance.
+missing, so every call site re-spells the whole fan-out-then-discard dance.
 
 ### Proposal
 
@@ -73,9 +61,7 @@ If `All` is ever lowered out of the node module (it is runner
 infrastructure, not node-specific I/O — a separate design question),
 `allVoid` moves down with it alongside `all` and `both`.
 
-The three call sites become `allVoid(e => registerOne(t, e))(sub)` etc. —
-dropping the `eff(...)` / `.value` bracketing along with the step, since
-`allVoid` returns a raw `Effect` and all three sites want one.
+The three call sites become `allVoid(e => registerOne(t, e))(sub)` etc.
 If [allreduce-combinator](./allreduce-combinator.md) lands first, consider
 deriving `allVoid` from `allReduce` with a unit monoid instead of
 duplicating the `all(...map)` core — whichever reads better.
@@ -86,9 +72,8 @@ duplicating the `all(...map)` core — whichever reads better.
       `All`/`all`/`both` to `fjs/effects/all/module.f.mjs`.
 - [ ] Add `allVoid` there (next to `all`/`both`) with proof coverage — **not**
       to `fjs/effects/node/module.f.mjs`, per the note at the top of this issue.
-- [ ] Convert the three call sites in `fjs/emergent_testing/module.f.mjs`
-      (lines 141-143, 150-152, 251-253), dropping their `eff(...)` / `.value`
-      bracketing.
+- [ ] Convert the three `mapStep(all(...), () => undefined)` call sites in
+      `fjs/emergent_testing/module.f.mjs`.
 - [ ] Run `npx tsc` and `fjs t`.
 
 ### Related

--- a/fjs/effects/todo/io-effect-migration.md
+++ b/fjs/effects/todo/io-effect-migration.md
@@ -272,11 +272,12 @@ represented as a pair of effects.
 - [ ] Use `catchStep` only for intentional recovery/fallback, including
       `NotImplemented` handling.
 - [ ] Use `resultStep` where both branches genuinely matter.
-- [ ] **Decide `Eff`'s fate before the first fluent consumer migrates.**
-      `fjs/cas/module.f.mjs` composes via `eff(...).step(okStep(...))`; either
-      `Eff` (`fjs/effects/eff/module.f.mjs`) grows an Io-aware `.step`, or
-      those consumers migrate off `Eff` onto the flat IoEffect combinators.
-      Pick one; do not leave cas half-fluent.
+- [ ] No fluent consumer is left to decide about: every module now composes
+      through the flat combinators, and `Eff`
+      (`fjs/effects/eff/module.f.mjs`) is kept only as the experiment its
+      [README](../eff/README.md) describes. If it gains a consumer again
+      before this stage lands, it needs an Io-aware `.step` — otherwise
+      nothing here depends on it.
 - [ ] Update the flat-step / "do not nest steps" guidance for the new
       semantics.
 - [ ] Add IoEffect variants of other combinators only when real consumers
@@ -376,7 +377,6 @@ current runners remain total over their declared operation maps.
 - [`../../../todo/044-error-handling-pattern.md`](../../../todo/044-error-handling-pattern.md)
 - `fjs/effects/module.f.mjs` — raw `step`, `okStep`, `match` (whose
   missing-handler `assert` Stage 6 reworks).
-- `fjs/effects/eff/module.f.mjs` — the fluent wrapper whose fate Stage 4
-  decides.
+- `fjs/effects/eff/module.f.mjs` — the fluent wrapper, currently consumer-free.
 - `fjs/types/result/module.f.mjs` — `okThen`, the union-not-unify precedent
   for the signatures above.

--- a/fjs/effects/todo/map-step-combinator.md
+++ b/fjs/effects/todo/map-step-combinator.md
@@ -1,15 +1,14 @@
-## map-step-combinator. Convert the remaining `step(e, x => pure(f(x)))` sites to `mapStep` / `Eff.map`
+## map-step-combinator. Convert the remaining `step(e, x => pure(f(x)))` sites to `mapStep`
 
 **Priority:** P3
 **Status:** open
 
-> **The APIs have landed.** `mapStep` is in `fjs/effects/module.f.mjs` and
-> `Eff.map` in `fjs/effects/eff/module.f.mjs`, each with proof coverage and with
-> its first real consumers converted in the same change — `readUtf8File`,
-> `awaitIfPromise` and `errorExit` (`fjs/effects/node/module.f.mjs`),
-> `decodeRevisionBlob` (`fjs/cas/evo/module.f.mjs`), and `Eff`'s own `.step`,
-> whose history projection is now a `mapStep`. What remains is the mechanical
-> part: the other call sites, module by module.
+> **The API has landed.** `mapStep` is in `fjs/effects/module.f.mjs` with proof
+> coverage, and its first real consumers were converted in the same change —
+> `readUtf8File`, `awaitIfPromise` and `errorExit`
+> (`fjs/effects/node/module.f.mjs`) and `decodeRevisionBlob`
+> (`fjs/cas/evo/module.f.mjs`). What remains is the mechanical part: the other
+> call sites, module by module.
 
 ### Problem
 
@@ -69,12 +68,8 @@ step(a, x => step(f(x), y => pure(g(x, y))))
 
 ### Proposal
 
-Rewrite each remaining site with the combinator that already exists:
-
-```ts
-mapStep(e, f)                       // raw Effect
-eff(e).map(f).value                 // fluent Eff
-```
+Rewrite each remaining site with the combinator that already exists —
+`mapStep(e, f)`.
 
 `mapStep` does **not** widen the operation set (`Effect<O, R>`, not
 `Effect<O | Q, R>`) — a pure projection adds no commands. That is a small typing
@@ -88,17 +83,11 @@ construction rather than inside the continuation), which is invisible for the
 cheap pure values used today but is a semantic difference not worth introducing
 for brevity. The rationale is recorded in `mapStep`'s JSDoc.
 
-**Conversion hazard: callback arity.** `Eff`'s docs warn that the history is
-positional, so "every parameter a callback declares is meaningful … a defaulted
-or rest parameter after the current value is a bug, not a convenience." A
-conversion from `.step(y => pure(f(y)))` to `.map(f)` is only safe when `f` is
-genuinely unary — the explicit lambda pins arity at one, while passing `f`
-point-free exposes it to the prior values. This is `["1","2","3"].map(parseInt)`
-with a longer history tuple. When converting, either keep the lambda or confirm
-the callee takes exactly one argument; `mapOk(utf8ToString)` and `vecToCBase32`
-qualify, and anything with optional parameters does not. `mapStep` is not exposed
-to this — it applies `f` to exactly one argument — so only the fluent sites need
-the check.
+**No callback-arity hazard here.** `mapStep` applies `f` to exactly one
+argument, so passing a callee point-free cannot expose it to extra arguments the
+way `["1","2","3"].map(parseInt)` does. (`Eff.map` *is* exposed to that, because
+its history is positional — but no module uses `Eff` any more, so no site in
+this conversion needs the check.)
 
 **Scope.** `AGENTS.md` asks one improvement per PR. Take one module or one
 closely related group per PR; what must **not** happen is landing the whole
@@ -111,8 +100,6 @@ conversion as one 14-module diff.
 - [ ] `fjs/protocol/mcp` + `fjs/protocol/mcp/stdio`.
 - [ ] `fjs/cas` + `fjs/cas/evo` + `fjs/mcp/evo` + `fjs/mcp`.
 - [ ] `fjs/emergent_testing`, `fjs/dev`.
-- [ ] When converting fluent sites, check callback arity (see the hazard note
-      above) rather than mechanically dropping the lambda.
 - [ ] `npx tsc` clean; `fjs t` passes after each PR.
 
 ### Related

--- a/fjs/emergent_testing/module.f.mjs
+++ b/fjs/emergent_testing/module.f.mjs
@@ -27,9 +27,8 @@ import { all, awaitIfPromise, sandbox, test } from '../effects/node/module.f.mjs
     Write,
     WriteConsoles
 } from '../effects/node/types.ts' */
-import { history, historyStep, pure, step } from '../effects/module.f.mjs'
+import { history, historyStep, mapStep, pure, step } from '../effects/module.f.mjs'
 /** @import { Effect, Operation } from '../effects/types.ts' */
-import { eff } from '../effects/eff/module.f.mjs'
 import { loadModuleMap } from '../dev/module.f.mjs'
 /** @import { LoadModuleOperations, ModuleMap } from '../dev/types.ts' */
 import { invert } from '../types/result/module.f.mjs'
@@ -131,27 +130,21 @@ export const registerModule = (ctx, k, v, star) => {
         const base = fmtImport(k, path)
         const name = throws ? base : `${base}${star}`
         return test(ctx, name, throws, (/** @type {TestContext} */ t) =>
-            eff(awaitIfPromise(fn()))
-                .step(resolved => {
-                    if (throws) {
-                        return pure(undefined)
-                    }
-                    const sub = collectTests([...path, null], false, resolved)
-                    if (sub.length === 0) {
-                        return pure(undefined)
-                    }
-                    return eff(all(...sub.map(e => registerOne(t, e))))
-                        .step(() => pure(undefined))
-                        .value
-                })
-                .value
+            step(awaitIfPromise(fn()), resolved => {
+                if (throws) {
+                    return pure(undefined)
+                }
+                const sub = collectTests([...path, null], false, resolved)
+                if (sub.length === 0) {
+                    return pure(undefined)
+                }
+                return mapStep(all(...sub.map(e => registerOne(t, e))), () => undefined)
+            })
         )
     }
     const tests = collectTests([], false, v)
     if (tests.length === 0) { return pure(undefined) }
-    return eff(all(...tests.map(e => registerOne(ctx, e))))
-        .step(() => pure(undefined))
-        .value
+    return mapStep(all(...tests.map(e => registerOne(ctx, e))), () => undefined)
 }
 
 /** @type {(a: _TestState, b: _TestState) => _TestState} */
@@ -194,13 +187,9 @@ const runModule = ({ result, test }) => (k, v) => ts => {
     /** @type {(path: Path, throws: boolean, v: unknown) => Effect<O | All, _TestState>} */
     const walk = (path, throws, v) => {
         const effects = collectTests(path, throws, v).map(one)
-        return eff(all(...effects))
-            .step(states => pure(states.reduce(mergeState, zero)))
-            .value
+        return mapStep(all(...effects), states => states.reduce(mergeState, zero))
     }
-    return eff(walk([], false, v))
-        .step(delta => pure(mergeState(ts, delta)))
-        .value
+    return mapStep(walk([], false, v), delta => mergeState(ts, delta))
 }
 
 /** @type {(moduleMap: ModuleMap) => readonly (readonly [string, unknown])[]} */
@@ -220,11 +209,16 @@ const proofEntries = moduleMap =>
 export const runModuleMap = reporter => moduleMap => {
     const { summary } = reporter
     const modules = proofEntries(moduleMap)
-    return eff(all(...modules.map(([k, v]) => runModule(reporter)(k, v)(zero))))
-        .step(m => pure(m.reduce(mergeState, zero)))
-        .step(ts => summary(ts.pass, ts.fail, ts.time))
-        .step((_, ts) => pure(ts.fail !== 0 ? 1 : 0))
-        .value
+    const total = mapStep(
+        all(...modules.map(([k, v]) => runModule(reporter)(k, v)(zero))),
+        m => m.reduce(mergeState, zero))
+    // The totals are still needed after the summary has been printed, so they
+    // are carried forward in a history rather than closed over by a nested
+    // continuation.
+    const reported = historyStep(
+        history(total),
+        ts => summary(ts.pass, ts.fail, ts.time))
+    return mapStep(reported, ([, ts]) => ts.fail !== 0 ? 1 : 0)
 }
 
 /**
@@ -237,9 +231,7 @@ export const runModuleMap = reporter => moduleMap => {
  * @returns {Program<O | All | LoadModuleOperations>}
  */
 export const testAll = reporter => options =>
-    eff(loadModuleMap(options.env))
-        .step(runModuleMap(reporter))
-        .value
+    step(loadModuleMap(options.env), runModuleMap(reporter))
 
 /**
  * Registers all modules in `moduleMap` that export a `proof` property with
@@ -250,9 +242,7 @@ export const testAll = reporter => options =>
 const registerModuleMap = (ctx, star) => moduleMap => {
     const modules = proofEntries(moduleMap)
     if (modules.length === 0) { return pure(undefined) }
-    return eff(all(...modules.map(([k, v]) => registerModule(ctx, k, v, star))))
-        .step(() => pure(undefined))
-        .value
+    return mapStep(all(...modules.map(([k, v]) => registerModule(ctx, k, v, star))), () => undefined)
 }
 
 /** @type {(c: string) => boolean} */
@@ -341,9 +331,7 @@ export const ghEscape = s =>
  * @type {(file: string, path: Path, entry: TestEntry) => Effect<Sandbox, SandboxResult<unknown>>}
  */
 export const defaultTest = (file, path, { fn, throws }) =>
-    eff(sandbox(fn))
-        .step(r => pure(throws ? { ...r, result: invert(r.result) } : r))
-        .value
+    mapStep(sandbox(fn), r => throws ? { ...r, result: invert(r.result) } : r)
 
 /** @type {(file: string, path: Path, color: string, label: string, duration: number) => string} */
 const fmtResultLine = (file, path, color, label, duration) =>
@@ -375,14 +363,14 @@ export const defaultReporter = options => {
                 ? csiLog(fmtResultLine(file, path, fgGreen, 'ok', duration) + (throws ? ' # EXPECTED TO THROW' : ''))
                 : isGitHub
                     ? csiError(`::error file=${file},line=1,title=${ghEscape(fmtImport(file, path))}::${ghEscape(String(v))}`)
-                    : eff(csiError(fmtResultLine(file, path, fgRed, 'error', duration)))
-                        .step(() => csiError(`${fgRed}${v}${reset}`))
-                        .value,
+                    : step(
+                        csiError(fmtResultLine(file, path, fgRed, 'error', duration)),
+                        () => csiError(`${fgRed}${v}${reset}`)),
         summary: (pass, fail, time) => {
             const fgFail = fail === 0 ? fgGreen : fgRed
-            return eff(csiLog(`${bold}Number of tests: pass: ${fgGreen}${pass}${reset}${bold}, fail: ${fgFail}${fail}${reset}${bold}, total: ${pass + fail}${reset}`))
-                .step(() => csiLog(`${bold}Time: ${timeFormat(time)}${reset}`))
-                .value
+            return step(
+                csiLog(`${bold}Number of tests: pass: ${fgGreen}${pass}${reset}${bold}, fail: ${fgFail}${fail}${reset}${bold}, total: ${pass + fail}${reset}`),
+                () => csiLog(`${bold}Time: ${timeFormat(time)}${reset}`))
         },
         test: defaultTest,
     }
@@ -407,8 +395,6 @@ export const main =
 export const register = o => {
     const star = o.inlineTestContext ? ' ...' : ''
     const ctx = o.engine === 'bun' ? o.bunTestContext : o.testContext
-    return eff(loadModuleMap(o.env))
-        .step(registerModuleMap(ctx, star))
-        .step(() => pure(0))
-        .value
+    const registered = step(loadModuleMap(o.env), registerModuleMap(ctx, star))
+    return mapStep(registered, () => 0)
 }

--- a/fjs/protocol/mcp/proof.f.mjs
+++ b/fjs/protocol/mcp/proof.f.mjs
@@ -11,8 +11,7 @@
  */
 
 import { assert, assertEq } from '../../asserts/module.f.mjs'
-import { pure, step, runPure } from '../../effects/module.f.mjs'
-import { eff } from '../../effects/eff/module.f.mjs'
+import { history, historyStep, mapStep, pure, step, runPure } from '../../effects/module.f.mjs'
 import { run } from '../../effects/mock/module.f.mjs'
 import { asBase, asNominal, create, read } from '../../effects/memory/module.f.mjs'
 import {
@@ -81,40 +80,44 @@ const runMem = effect =>
 /** @type {<T>(e: Effect<Operation, T>) => Effect<MemOp, T>} */
 const asMemEffect = e => /** @type {Effect<MemOp, any>} */ (/** @type {unknown} */ (e))
 
+// Pairs the last step's response with the session state read back afterwards.
+// The response is still needed after the read, so it is carried forward in a
+// history rather than closed over by a nested continuation.
+/** @type {(key: Key<McpSessionState>) => (e: Effect<Operation, unknown>) => Effect<Operation, _StepResult>} */
+const withState = key => e => {
+    const read0 = historyStep(history(e), () => read(key))
+    return mapStep(read0, ([state, resp]) => /** @type {const} */ ([resp, state]))
+}
+
 // Run one step from uninitializedState, return [response, newState].
 /** @type {(cfg: McpConfig) => (msg: unknown) => _StepResult} */
 const step1 = cfg => msg =>
     runMem(asMemEffect(step(
         create(/** @type {McpSessionState} */ (uninitializedState)),
-        key => step(
-            mcpStep(cfg)(handlers)(key)(/** @type {Unknown} */ (msg)),
-            resp => step(
-                read(key),
-                state => pure(/** @type {const} */ ([resp, state])),
-            ),
-        ),
-    )))
+        key => withState(key)(mcpStep(cfg)(handlers)(key)(/** @type {Unknown} */ (msg))))))
 
 // Run initialize then a second step, return [response, newState] of the second.
 /** @type {(cfg: McpConfig) => (msg1: unknown) => (msg2: unknown) => _StepResult} */
 const step2 = cfg => msg1 => msg2 =>
-    runMem(asMemEffect(eff(create(/** @type {McpSessionState} */ (uninitializedState))).step(key =>
-        eff(mcpStep(cfg)(handlers)(key)(/** @type {Unknown} */ (msg1))).step(() =>
-            eff(mcpStep(cfg)(handlers)(key)(/** @type {Unknown} */ (msg2))).step(resp =>
-                step(
-                    read(key),
-                    state => pure(/** @type {const} */ ([resp, state])),
-                )
-            ).value).value).value))
+    runMem(asMemEffect(step(
+        create(/** @type {McpSessionState} */ (uninitializedState)),
+        key => {
+            const r1 = mcpStep(cfg)(handlers)(key)(/** @type {Unknown} */ (msg1))
+            const r2 = step(r1, () => mcpStep(cfg)(handlers)(key)(/** @type {Unknown} */ (msg2)))
+            return withState(key)(r2)
+        })))
 
 // Run initialize, notifications/initialized, then a third step; return [response, newState] of the third.
 /** @type {(cfg: McpConfig) => (msg1: unknown) => (msg2: unknown) => (msg3: unknown) => _StepResult} */
 const step3 = cfg => msg1 => msg2 => msg3 =>
-    runMem(asMemEffect(eff(create(/** @type {McpSessionState} */ (uninitializedState))).step(key =>
-        eff(mcpStep(cfg)(handlers)(key)(/** @type {Unknown} */ (msg1))).step(() =>
-            eff(mcpStep(cfg)(handlers)(key)(/** @type {Unknown} */ (msg2))).step(() =>
-                eff(mcpStep(cfg)(handlers)(key)(/** @type {Unknown} */ (msg3))).step(resp =>
-                    eff(read(key)).step(state => pure(/** @type {const} */ ([/** @type {unknown} */ (resp), state]))).value).value).value).value).value))
+    runMem(asMemEffect(step(
+        create(/** @type {McpSessionState} */ (uninitializedState)),
+        key => {
+            const r1 = mcpStep(cfg)(handlers)(key)(/** @type {Unknown} */ (msg1))
+            const r2 = step(r1, () => mcpStep(cfg)(handlers)(key)(/** @type {Unknown} */ (msg2)))
+            const r3 = step(r2, () => mcpStep(cfg)(handlers)(key)(/** @type {Unknown} */ (msg3)))
+            return withState(key)(r3)
+        })))
 
 // ── Test messages ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
This change completes the migration away from the `Eff` fluent wrapper by converting the last four effect-dense modules (`fjs/cas`, `fjs/cas/evo`, `fjs/emergent_testing`, and `fjs/protocol/mcp/proof`) to use raw `step`, `mapStep`, and `historyStep` combinators directly.

## Summary

The `Eff` wrapper (`fjs/effects/eff/module.f.mjs`) provided a fluent API for chaining effects via `.step()` and `.value`. This change removes all remaining uses of `Eff` from the codebase, leaving it only as a documented experiment in the effects module. All effect composition now uses the flat combinator API.

## Key Changes

- **Removed `Eff` imports** from `fjs/cas/module.f.mjs`, `fjs/cas/evo/module.f.mjs`, `fjs/emergent_testing/module.f.mjs`, and `fjs/protocol/mcp/proof.f.mjs`
- **Converted fluent chains** of the form `eff(e).step(f).value` to raw `step(e, f)` calls
- **Introduced `mapStep`** for chains ending in pure projections: `eff(e).step(x => pure(f(x))).value` → `mapStep(e, f)`
- **Added explicit `historyStep`** calls where prior effect results are needed after subsequent operations (e.g., in `gcStage`, `runModuleMap`, and MCP state read-back), replacing implicit history tuples in the fluent form
- **Flattened deeply nested continuations** in `writeImpl` (`fjs/cas`) by introducing intermediate named bindings (`created`, `removed`, `stated`) that serve as documentation
- **Updated documentation** in `fjs/effects/eff/README.md` to reflect that no production code uses `Eff` anymore, and updated related todo items to remove references to fluent conversion hazards

## Implementation Details

- The conversion is mechanical: every `eff(e).step(f).value` has a direct raw equivalent with no redesign needed
- Chains that previously used implicit history tuples now use explicit `historyStep(history(e), f)` when the prior value is needed, making the intent clear at the call site
- Indentation improved in flat chains (no `eff(…)` / `.value` bracketing overhead), though deeply nested continuations remain equally nested
- Three modules required explicit history handling: `gcStage` (carries timestamp forward), `runModuleMap` (carries totals forward), and MCP proof (carries response forward for state read-back)

https://claude.ai/code/session_01X1p7SirShiavEkwB1YkTNx