### PR TITLE
Migration close-out: drop the .js ignore, browser-native browser-testing plan, @import sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,6 @@ _*
 .DS_Store
 **/*.d.mts
 **/*.d.ts
-**/*.js
 
 test-results/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ history.
 
 ## Unreleased
 
+- Every module-level `@import` tag lives in its module's leading JSDoc block
+  (125 files swept), so emitted declaration headers list their type imports
+  in one place
+  [#1545](https://github.com/functionalscript/functionalscript/pull/1545)
+
 - `types/uint8array`: `toVec` attempts the conversion instead of precomputing a
   byte-count bound; behavior and error message unchanged
   [#1543](https://github.com/functionalscript/functionalscript/pull/1543)

--- a/fjs/asn.1/proof.f.mjs
+++ b/fjs/asn.1/proof.f.mjs
@@ -1,6 +1,9 @@
-/** @import { Vec } from '../types/bit_vec/types.ts' */
-import { empty, isVec, length, msb, uint, unpack, vec, vec8 } from '../types/bit_vec/module.f.mjs'
+/**
+ * @import { Vec } from '../types/bit_vec/types.ts'
+ * @import { SupportedRecord, ObjectIdentifier } from './types.ts'
+ */
 
+import { empty, isVec, length, msb, uint, unpack, vec, vec8 } from '../types/bit_vec/module.f.mjs'
 import { asBase } from '../types/nominal/module.f.mjs'
 
 import {
@@ -19,7 +22,6 @@ import {
     encodeObjectIdentifier,
     decodeObjectIdentifier,
 } from './module.f.mjs'
-/** @import { SupportedRecord, ObjectIdentifier } from './types.ts' */
 
 import { assert, assertEq } from '../asserts/module.f.mjs'
 

--- a/fjs/basen/base128/proof.f.mjs
+++ b/fjs/basen/base128/proof.f.mjs
@@ -1,4 +1,6 @@
-/** @import { Vec } from '../../types/bit_vec/types.ts' */
+/**
+ * @import { Vec } from '../../types/bit_vec/types.ts'
+ */
 
 import { empty, vec, vec8 } from '../../types/bit_vec/module.f.mjs'
 import { asBase } from '../../types/nominal/module.f.mjs'

--- a/fjs/basen/base64/proof.f.mjs
+++ b/fjs/basen/base64/proof.f.mjs
@@ -1,4 +1,6 @@
-/** @import { Vec } from '../../types/bit_vec/types.ts' */
+/**
+ * @import { Vec } from '../../types/bit_vec/types.ts'
+ */
 
 import { assertEq } from '../../asserts/module.f.mjs'
 import { empty, vec, repeat, vec8, maxLength } from '../../types/bit_vec/module.f.mjs'

--- a/fjs/basen/cbase32/proof.f.mjs
+++ b/fjs/basen/cbase32/proof.f.mjs
@@ -1,4 +1,6 @@
-/** @import { Vec } from '../../types/bit_vec/types.ts' */
+/**
+ * @import { Vec } from '../../types/bit_vec/types.ts'
+ */
 
 import { empty, vec } from '../../types/bit_vec/module.f.mjs'
 import { cBase32ToVec, cBase32ToVec5x, vec5xToCBase32, vecToCBase32 } from './module.f.mjs'

--- a/fjs/bnf/data/proof.f.mjs
+++ b/fjs/bnf/data/proof.f.mjs
@@ -9,7 +9,6 @@ import { sort } from '../../types/object/module.f.mjs'
 import { oneEncode, option, range, rangeDecode, repeat0Plus, set } from '../module.f.mjs'
 import { emptyTagMap, toData } from './module.f.mjs'
 import { assertEq } from '../../asserts/module.f.mjs'
-
 import { stringify } from '../../media/json/module.f.mjs'
 import { classic, deterministic } from '../testlib.f.mjs'
 

--- a/fjs/cas/cli/proof.f.mjs
+++ b/fjs/cas/cli/proof.f.mjs
@@ -1,4 +1,6 @@
-/** @import { NodeProgramOptions } from '../../effects/node/types.ts' */
+/**
+ * @import { NodeProgramOptions } from '../../effects/node/types.ts'
+ */
 
 import { commands } from './module.f.mjs'
 import { computeSync, sha256 } from '../../crypto/sha2/module.f.mjs'

--- a/fjs/cas/evo/proof.f.mjs
+++ b/fjs/cas/evo/proof.f.mjs
@@ -22,7 +22,6 @@ import { unwrap } from '../../types/nullable/module.f.mjs'
 import { ok, error } from '../../types/result/module.f.mjs'
 import { nonEmpty, empty as elEmpty } from '../../effects/list/module.f.mjs'
 import { tryUtf8 } from '../../text/module.f.mjs'
-
 import { dialect as revisionDialect } from '../../media/revision/module.f.mjs'
 import {
     buildCache, decodeRevisionBlob, initEvo, evo, emptyCache, syncRevision,

--- a/fjs/ci/nix/proof.f.mjs
+++ b/fjs/ci/nix/proof.f.mjs
@@ -2,9 +2,9 @@
  * Proofs for generated CI flakes.
  *
  * @module
+ *
+ * @import { NixJob } from './types.ts'
  */
-
-/** @import { NixJob } from './types.ts' */
 
 import { assert, assertEq } from '../../asserts/module.f.mjs'
 import { step } from '../../effects/module.f.mjs'

--- a/fjs/ci/proof.f.mjs
+++ b/fjs/ci/proof.f.mjs
@@ -1,5 +1,7 @@
-/** @import { MetaStep, Os, GitHubAction } from './common/types.ts' */
-/** @import { Dir, State } from '../effects/node/virtual/types.ts' */
+/**
+ * @import { MetaStep, Os, GitHubAction } from './common/types.ts'
+ * @import { Dir, State } from '../effects/node/virtual/types.ts'
+ */
 
 import { ci, main } from './module.f.mjs'
 import { functionalscript, node } from './config/module.f.mjs'
@@ -11,7 +13,6 @@ import { assert, assertEq } from '../asserts/module.f.mjs'
 import { emptyState, virtual } from '../effects/node/virtual/module.f.mjs'
 import { unwrap } from '../types/result/module.f.mjs'
 import { definedValues } from '../types/object/module.f.mjs'
-
 import { parse as jsonParse } from '../media/json/module.f.mjs'
 
 /** @type {(cmd: string) => (gha: GitHubAction) => boolean} */

--- a/fjs/cli/proof.f.mjs
+++ b/fjs/cli/proof.f.mjs
@@ -1,5 +1,7 @@
-/** @import { NodeOp, NodeProgramOptions } from '../effects/node/types.ts' */
-/** @import { Commands } from './types.ts' */
+/**
+ * @import { NodeOp, NodeProgramOptions } from '../effects/node/types.ts'
+ * @import { Commands } from './types.ts'
+ */
 
 import { pure } from '../effects/module.f.mjs'
 import { defaultNodeProgramOptions, emptyState, virtual } from '../effects/node/virtual/module.f.mjs'

--- a/fjs/common/monoid/proof.f.mjs
+++ b/fjs/common/monoid/proof.f.mjs
@@ -1,4 +1,6 @@
-/** @import { Monoid } from './types.ts' */
+/**
+ * @import { Monoid } from './types.ts'
+ */
 
 import { repeat, fold } from './module.f.mjs'
 import { assertEq } from '../../asserts/module.f.mjs'

--- a/fjs/crypto/secp/proof.f.mjs
+++ b/fjs/crypto/secp/proof.f.mjs
@@ -1,4 +1,6 @@
-/** @import { Point, Curve, Init } from './types.ts' */
+/**
+ * @import { Point, Curve, Init } from './types.ts'
+ */
 
 import { assert, assertEq, assertNotNullish } from '../../asserts/module.f.mjs'
 import { prime_field } from '../../types/prime_field/module.f.mjs'

--- a/fjs/crypto/sha2/proof.f.mjs
+++ b/fjs/crypto/sha2/proof.f.mjs
@@ -1,4 +1,6 @@
-/** @import { Sha2 } from './types.ts' */
+/**
+ * @import { Sha2 } from './types.ts'
+ */
 
 import { utf8 } from '../../text/module.f.mjs'
 import { repeat, uint, vec } from '../../types/bit_vec/module.f.mjs'

--- a/fjs/crypto/vdf/module.f.mjs
+++ b/fjs/crypto/vdf/module.f.mjs
@@ -15,13 +15,14 @@
  * const y = sloth.eval(steps)(x)
  * if (y === null || !sloth.verify(steps)(x)(y)) { throw y }
  * ```
+ *
+ * @import { PrimeField } from '../../types/prime_field/types.ts'
+ * @import { Nullable } from '../../types/nullable/types.ts'
+ * @import { Unary } from '../../types/bigint/types.ts'
+ * @import { Sloth } from './types.ts'
  */
 
 import { modSqrt, prime_field } from '../../types/prime_field/module.f.mjs'
-/** @import { PrimeField } from '../../types/prime_field/types.ts' */
-/** @import { Nullable } from '../../types/nullable/types.ts' */
-/** @import { Unary } from '../../types/bigint/types.ts' */
-/** @import { Sloth } from './types.ts' */
 
 /** Sloth VDF modulus (3072-bit safe prime, same as reference implementations). */
 export const p =

--- a/fjs/dev/module.f.mjs
+++ b/fjs/dev/module.f.mjs
@@ -2,19 +2,20 @@
  * Development utilities for indexing modules and loading FunctionalScript files.
  *
  * @module
+ *
+ * @import { Access, All, Env, Import, Readdir } from '../effects/node/types.ts'
+ * @import { Effect } from '../effects/types.ts'
+ * @import { Dir } from '../effects/node/virtual/types.ts'
+ * @import { Module, ModuleMap, LoadModuleOperations } from './types.ts'
  */
 
 import { all, import_, readdir } from '../effects/node/module.f.mjs'
-/** @import { Access, All, Env, Import, Readdir } from '../effects/node/types.ts' */
 import { cmp as strCmp } from '../types/string/module.f.mjs'
 import { unwrap } from '../types/result/module.f.mjs'
 import { pure, step } from '../effects/module.f.mjs'
-/** @import { Effect } from '../effects/types.ts' */
 import { join, relativize, toPosix } from '../path/module.f.mjs'
 import { assert, assertEq } from '../asserts/module.f.mjs'
 import { emptyState, virtual } from '../effects/node/virtual/module.f.mjs'
-/** @import { Dir } from '../effects/node/virtual/types.ts' */
-/** @import { Module, ModuleMap, LoadModuleOperations } from './types.ts' */
 
 /**
  * Returns `true` if the file should be loaded for proof discovery.

--- a/fjs/dev/update/module.f.mjs
+++ b/fjs/dev/update/module.f.mjs
@@ -2,12 +2,13 @@
  * Synchronizes local development configuration generated from canonical repository files.
  *
  * @module
+ *
+ * @import { Effect } from '../../effects/types.ts'
+ * @import { Mkdir, NodeProgram, ReadFile, WriteFile } from '../../effects/node/types.ts'
  */
 
 import { history, historyStep, mapStep, step } from '../../effects/module.f.mjs'
-/** @import { Effect } from '../../effects/types.ts' */
 import { mkdir, readUtf8File, writeUtf8File } from '../../effects/node/module.f.mjs'
-/** @import { Mkdir, NodeProgram, ReadFile, WriteFile } from '../../effects/node/types.ts' */
 import { unwrap } from '../../types/result/module.f.mjs'
 
 const source = /** @type {const} */ ('.copilot/mcp.json')

--- a/fjs/djs/parser/proof.f.mjs
+++ b/fjs/djs/parser/proof.f.mjs
@@ -1,6 +1,9 @@
+/**
+ * @import { DjsTokenWithMetadata } from '../tokenizer/types.ts'
+ */
+
 import { parseFromTokens } from './module.f.mjs'
 import { tokenize } from '../tokenizer/module.f.mjs'
-/** @import { DjsTokenWithMetadata } from '../tokenizer/types.ts' */
 import { toArray } from '../../types/list/module.f.mjs'
 import { sort } from '../../types/object/module.f.mjs'
 import { stringToList } from '../../text/utf16/module.f.mjs'

--- a/fjs/djs/proof.f.mjs
+++ b/fjs/djs/proof.f.mjs
@@ -1,4 +1,7 @@
-/** @import { Vec } from '../types/bit_vec/types.ts' */
+/**
+ * @import { Vec } from '../types/bit_vec/types.ts'
+ */
+
 import { compile } from './module.f.mjs'
 import { virtual, emptyState } from '../effects/node/virtual/module.f.mjs'
 import { utf8, utf8ToString } from '../text/module.f.mjs'

--- a/fjs/djs/tokenizer/proof.f.mjs
+++ b/fjs/djs/tokenizer/proof.f.mjs
@@ -1,4 +1,7 @@
-/** @import { Unknown } from '../types.ts' */
+/**
+ * @import { Unknown } from '../types.ts'
+ */
+
 import { descentParser } from '../../bnf/descent/module.f.mjs'
 import { stringToCodePointList, stringToList } from '../../text/utf16/module.f.mjs'
 import { toArray } from '../../types/list/module.f.mjs'

--- a/fjs/effects/eff/module.f.mjs
+++ b/fjs/effects/eff/module.f.mjs
@@ -4,11 +4,12 @@
  * See `./types.ts` for the `Eff` type-level API.
  *
  * @module
+ *
+ * @import { Effect, Operation } from '../types.ts'
+ * @import { Eff } from './types.ts'
  */
 
 import { history, historyStep, mapStep, pure } from '../module.f.mjs'
-/** @import { Effect, Operation } from '../types.ts' */
-/** @import { Eff } from './types.ts' */
 
 /**
  * Builds an `Eff` from two views of the same chain: `value`, the effect for the

--- a/fjs/effects/eff/proof.f.mjs
+++ b/fjs/effects/eff/proof.f.mjs
@@ -1,8 +1,11 @@
+/**
+ * @import { Effect, OperationMap } from '../types.ts'
+ */
+
 import { do_, match, pure } from '../module.f.mjs'
 import { assert, assertEq } from '../../asserts/module.f.mjs'
 import { assertPure } from '../proof.f.mjs'
 import { eff } from './module.f.mjs'
-/** @import { Effect, OperationMap } from '../types.ts' */
 
 /** @typedef {readonly['add', (a: number, b: number) => number]} _AddOp */
 

--- a/fjs/effects/list/module.f.mjs
+++ b/fjs/effects/list/module.f.mjs
@@ -4,11 +4,12 @@
  * See `./types.ts` for the type-level API.
  *
  * @module
+ *
+ * @import { Effect, Operation } from "../types.ts"
+ * @import { List, Next } from "./types.ts"
  */
 
 import { pure } from "../module.f.mjs"
-/** @import { Effect, Operation } from "../types.ts" */
-/** @import { List, Next } from "./types.ts" */
 
 /**
  * The empty `List`: a pure end-of-stream marker (`undefined`).

--- a/fjs/effects/memory/module.f.mjs
+++ b/fjs/effects/memory/module.f.mjs
@@ -14,13 +14,14 @@
  * type-level API.
  *
  * @module
+ *
+ * @import { Nominal } from '../../types/nominal/types.ts'
+ * @import { Effect } from '../types.ts'
+ * @import { Key, MemCreate, MemRead, MemWrite, _MemKeyHash } from './types.ts'
  */
 
 import { asBase as nominalAsBase, asNominal as nominalAsNominal } from '../../types/nominal/module.f.mjs'
-/** @import { Nominal } from '../../types/nominal/types.ts' */
 import { do_ } from '../module.f.mjs'
-/** @import { Effect } from '../types.ts' */
-/** @import { Key, MemCreate, MemRead, MemWrite, _MemKeyHash } from './types.ts' */
 
 /** @type {(n: Nominal<'MemKey', _MemKeyHash, string>) => string} */
 export const asBase = nominalAsBase

--- a/fjs/effects/memory/proof.f.mjs
+++ b/fjs/effects/memory/proof.f.mjs
@@ -1,12 +1,15 @@
+/**
+ * @import { MemOperationMap } from '../mock/types.ts'
+ * @import { Key, MemOp } from './types.ts'
+ */
+
 import { assert, assertEq } from '../../asserts/module.f.mjs'
 import { run } from '../mock/module.f.mjs'
-/** @import { MemOperationMap } from '../mock/types.ts' */
 import { pure, step } from '../module.f.mjs'
 import {
     asBase, asNominal,
     create, read, write,
 } from './module.f.mjs'
-/** @import { Key, MemOp } from './types.ts' */
 
 /**
  * @typedef {{

--- a/fjs/effects/mock/module.f.mjs
+++ b/fjs/effects/mock/module.f.mjs
@@ -4,11 +4,12 @@
  * See `./types.ts` for the `MemOperationMap`/`RunInstance` type-level API.
  *
  * @module
+ *
+ * @import { Operation } from '../types.ts'
+ * @import { MemOperationMap, RunInstance } from './types.ts'
  */
 
 import { match } from "../module.f.mjs"
-/** @import { Operation } from '../types.ts' */
-/** @import { MemOperationMap, RunInstance } from './types.ts' */
 
 /** @type {<O extends Operation, S>(o: MemOperationMap<O, S>) => RunInstance<O, S>} */
 export const run = o => state => effect => {

--- a/fjs/effects/module.f.mjs
+++ b/fjs/effects/module.f.mjs
@@ -95,16 +95,17 @@
  * See `./types.ts` for the type-level API.
  *
  * @module
+ *
+ * @import { List } from '../types/list/types.ts'
+ * @import { Option } from '../types/option/types.ts'
+ * @import { Result } from '../types/result/types.ts'
+ * @import { Fold } from '../types/function/operator/types.ts'
+ * @import { Cont, Do, Effect, F, History, MatchResult, Operation, OperationMap, Param, Pr, Pure, Return, ToAsyncOperationMap } from './types.ts'
  */
 
 import { assert } from '../asserts/module.f.mjs'
-/** @import { List } from '../types/list/types.ts' */
 import { fold } from '../types/list/module.f.mjs'
 import { at } from '../types/object/module.f.mjs'
-/** @import { Option } from '../types/option/types.ts' */
-/** @import { Result } from '../types/result/types.ts' */
-/** @import { Fold } from '../types/function/operator/types.ts' */
-/** @import { Cont, Do, Effect, F, History, MatchResult, Operation, OperationMap, Param, Pr, Pure, Return, ToAsyncOperationMap } from './types.ts' */
 
 /** @type {<T>(v: T) => Effect<never, T>} */
 export const pure = v => () => v

--- a/fjs/effects/node/memory/module.mjs
+++ b/fjs/effects/node/memory/module.mjs
@@ -2,13 +2,14 @@
  * Node.js interpreter helpers for memory effects.
  *
  * @module
+ *
+ * @import { Effect, ToAsyncOperationMap } from '../../types.ts'
+ * @import { Key, MemOp } from '../../memory/types.ts'
  */
 
 import { randomUUID } from 'node:crypto'
 import { asyncRun } from '../../module.mjs'
-/** @import { Effect, ToAsyncOperationMap } from '../../types.ts' */
 import { asBase, asNominal } from '../../memory/module.f.mjs'
-/** @import { Key, MemOp } from '../../memory/types.ts' */
 
 /** @typedef {ToAsyncOperationMap<MemOp>} MemoryOperationMap */
 

--- a/fjs/effects/node/memory/proof.mjs
+++ b/fjs/effects/node/memory/proof.mjs
@@ -2,6 +2,8 @@
  * Node.js interpreter proofs for memory effects.
  *
  * @module
+ *
+ * @import { Key, MemOp } from '../../memory/types.ts'
  */
 
 import { asyncRun } from '../../module.mjs'
@@ -9,7 +11,6 @@ import {
     asNominal,
     create, read, write,
 } from '../../memory/module.f.mjs'
-/** @import { Key, MemOp } from '../../memory/types.ts' */
 import { memoryOperationMap, run } from './module.mjs'
 import { assert, assertEq } from '../../../asserts/module.f.mjs'
 import { step } from '../../module.f.mjs'

--- a/fjs/effects/node/module.f.mjs
+++ b/fjs/effects/node/module.f.mjs
@@ -9,6 +9,11 @@
  * See `./types.ts` for the type-level API.
  *
  * @module
+ *
+ * @import { Vec } from '../../types/bit_vec/types.ts'
+ * @import { Effect, Func, Operation } from '../types.ts'
+ * @import { List } from '../list/types.ts'
+ * @import { All, Access, Await, Console, CreateExclusive, CreateServer, Dirent, Engine, Env, Exec, ExecResult, Fetch, FileStat, Forever, Fs, Headers, Http, IncomingMessage, Import, IoResult, Listen, MakeDirectoryOptions, Mkdir, Module, Now, NodeOp, NodeProgramOptions, RandomInt, Read, ReadBytes, ReadConsoles, ReadFile, Readdir, ReaddirOptions, RequestListener, Rename, Rm, Sandbox, SandboxResult, Server, ServerResponse, Stat, Test, TestContext, TestFn, Write, WriteBytes, WriteConsoles, WriteFile, _UtfList, _WriteLoop, } from './types.ts'
  */
 
 import { utf8, utf8ToString } from '../../text/module.f.mjs'
@@ -18,18 +23,6 @@ import { reverse } from '../../types/list/module.f.mjs'
 import { length } from '../../types/bit_vec/module.f.mjs'
 import { ok, error as resultError, mapOk } from '../../types/result/module.f.mjs'
 import { do_, mapStep, okStep, pure, step } from '../module.f.mjs'
-/** @import { Vec } from '../../types/bit_vec/types.ts' */
-/** @import { Effect, Func, Operation } from '../types.ts' */
-/** @import { List } from '../list/types.ts' */
-/** @import {
-    All, Access, Await, Console, CreateExclusive, CreateServer, Dirent, Engine,
-    Env, Exec, ExecResult, Fetch, FileStat, Forever, Fs, Headers, Http,
-    IncomingMessage, Import, IoResult, Listen, MakeDirectoryOptions, Mkdir,
-    Module, Now, NodeOp, NodeProgramOptions, RandomInt, Read, ReadBytes,
-    ReadConsoles, ReadFile, Readdir, ReaddirOptions, RequestListener, Rename,
-    Rm, Sandbox, SandboxResult, Server, ServerResponse, Stat, Test, TestContext,
-    TestFn, Write, WriteBytes, WriteConsoles, WriteFile, _UtfList, _WriteLoop,
-} from './types.ts' */
 
 /**
  * True if `e` is a "file or directory does not exist" (`ENOENT`) error.

--- a/fjs/effects/node/module.mjs
+++ b/fjs/effects/node/module.mjs
@@ -11,6 +11,11 @@
  * globals directly instead.
  *
  * @module
+ *
+ * @import { Effect } from '../types.ts'
+ * @import { Server as EffectServer, Headers, Module, NodeOp, RequestListener as Erl, NodeProgram, NodeProgramOptions, WriteConsoles, TestContext, TestFn, } from './types.ts'
+ * @import { Result } from '../../types/result/types.ts'
+ * @import { StringMap } from '../../types/object/types.ts'
  */
 
 import http from 'node:http'
@@ -23,30 +28,13 @@ import { once } from 'node:events'
 import * as testContext from 'node:test'
 
 import { concat, normalize, toPosix } from '../../path/module.f.mjs'
-/** @import { Effect } from '../types.ts' */
 import { asyncRun } from '../module.mjs'
 import { memoryOperationMap } from './memory/module.mjs'
 import { usesInlineTestContext } from './module.f.mjs'
-/**
- * @import {
- *   Server as EffectServer,
- *   Headers,
- *   Module,
- *   NodeOp,
- *   RequestListener as Erl,
- *   NodeProgram,
- *   NodeProgramOptions,
- *   WriteConsoles,
- *   TestContext,
- *   TestFn,
- * } from './types.ts'
- */
 import { asBase, asNominal } from '../../types/nominal/module.f.mjs'
-/** @import { Result } from '../../types/result/types.ts' */
 import { error, ok } from '../../types/result/module.f.mjs'
 import { asyncTryCatch } from '../../types/result/module.mjs'
 import { fromVec, listToVec, toVec } from '../../types/uint8array/module.f.mjs'
-/** @import { StringMap } from '../../types/object/types.ts' */
 import { maxLengthBytes } from '../../types/bit_vec/module.f.mjs'
 
 /** @typedef {{ readonly listen: (port: number) => void }} _Server */

--- a/fjs/effects/node/virtual/module.f.mjs
+++ b/fjs/effects/node/virtual/module.f.mjs
@@ -2,20 +2,21 @@
  * Virtual Node-effect operations for filesystem and process tests.
  *
  * @module
+ *
+ * @import { Vec } from '../../../types/bit_vec/types.ts'
+ * @import { MemOperationMap, RunInstance } from '../../mock/types.ts'
+ * @import { Key } from '../../memory/types.ts'
+ * @import { Dirent, FileStat, IoResult, Module, NodeOp, NodeProgramOptions, SandboxResult } from '../types.ts'
+ * @import { Dir, State, _Entity } from './types.ts'
  */
 
 import { todo } from '../../../asserts/module.f.mjs'
 import { isProperPrefix, join, parse } from '../../../path/module.f.mjs'
 import { utf8ToString } from '../../../text/module.f.mjs'
-/** @import { Vec } from '../../../types/bit_vec/types.ts' */
 import { empty, length, maxLengthBytes, msb, vec } from '../../../types/bit_vec/module.f.mjs'
 import { error, ok } from '../../../types/result/module.f.mjs'
 import { run } from '../../mock/module.f.mjs'
-/** @import { MemOperationMap, RunInstance } from '../../mock/types.ts' */
 import { asBase, asNominal } from '../../memory/module.f.mjs'
-/** @import { Key } from '../../memory/types.ts' */
-/** @import { Dirent, FileStat, IoResult, Module, NodeOp, NodeProgramOptions, SandboxResult } from '../types.ts' */
-/** @import { Dir, State, _Entity } from './types.ts' */
 
 /** @type {State} */
 export const emptyState = {

--- a/fjs/effects/node/virtual/proof.f.mjs
+++ b/fjs/effects/node/virtual/proof.f.mjs
@@ -1,8 +1,11 @@
+/**
+ * @import { Dir, JsModule } from './types.ts'
+ */
+
 import { assert, assertEq } from '../../../asserts/module.f.mjs'
 import { access, awaitIfPromise, fetch, rm, writeFile, readFile, readdir, import_, rename, readBytes, writeBytes, stat } from '../module.f.mjs'
 import { maxLengthBytes, vec, vec8 } from '../../../types/bit_vec/module.f.mjs'
 import { emptyState, virtual } from './module.f.mjs'
-/** @import { Dir, JsModule } from './types.ts' */
 
 export const proof = {
     rm: {

--- a/fjs/effects/proof.f.mjs
+++ b/fjs/effects/proof.f.mjs
@@ -1,5 +1,8 @@
+/**
+ * @import { Effect, Operation, OperationMap } from './types.ts'
+ */
+
 import { step, do_, foldStep, forEachStep, mapStep, match, okStep, history, pure, runPure, historyStep } from './module.f.mjs'
-/** @import { Effect, Operation, OperationMap } from './types.ts' */
 import { error, ok } from '../types/result/module.f.mjs'
 import { assert, assertEq } from '../asserts/module.f.mjs'
 

--- a/fjs/emergent_testing/module.f.mjs
+++ b/fjs/emergent_testing/module.f.mjs
@@ -9,31 +9,19 @@
  *   scheduling and pass/fail counting.
  *
  * @module
+ *
+ * @import { Effect, Operation } from '../effects/types.ts'
+ * @import { LoadModuleOperations, ModuleMap } from '../dev/types.ts'
+ * @import { TestFn, TestEntry, TestSet, Path, Reporter, _TestState, _TestAndPath } from './types.ts'
+ * @import { All, Await, Env, NodeProgram, NodeProgramOptions, Program, Sandbox, SandboxResult, Test, TestContext, Write, WriteConsoles } from '../effects/node/types.ts'
  */
 
 import { reset, fgGreen, fgRed, bold, csiWrite } from '../text/sgr/module.f.mjs'
 import { all, awaitIfPromise, sandbox, test } from '../effects/node/module.f.mjs'
-/** @import {
-    All,
-    Await,
-    Env,
-    NodeProgram,
-    NodeProgramOptions,
-    Program,
-    Sandbox,
-    SandboxResult,
-    Test,
-    TestContext,
-    Write,
-    WriteConsoles
-} from '../effects/node/types.ts' */
 import { history, historyStep, mapStep, pure, step } from '../effects/module.f.mjs'
-/** @import { Effect, Operation } from '../effects/types.ts' */
 import { loadModuleMap } from '../dev/module.f.mjs'
-/** @import { LoadModuleOperations, ModuleMap } from '../dev/types.ts' */
 import { invert } from '../types/result/module.f.mjs'
 import { definedEntries } from '../types/object/module.f.mjs'
-/** @import { TestFn, TestEntry, TestSet, Path, Reporter, _TestState, _TestAndPath } from './types.ts' */
 
 /** @type {(delta: number) => (ts: _TestState) => _TestState} */
 const addPass = delta => ts =>

--- a/fjs/emergent_testing/todo/browser-testing.md
+++ b/fjs/emergent_testing/todo/browser-testing.md
@@ -5,438 +5,151 @@
 
 ### Problem
 
-FunctionalScript currently has no test path that executes proof functions and their
+FunctionalScript has no test path that executes proof functions and their
 module dependencies inside browser JavaScript realms.
 
-The previous Playwright integration registered proofs in a Node worker and executed them
-through the Node effect runner, so selecting Chromium, Firefox, or WebKit did not move the
-proof code into those browsers. That integration has been removed.
+An earlier revision of this plan was built around transpiling authored `.f.ts`
+to browser-loadable `.f.js`. That premise is gone: authored source is `.f.mjs`
+— JavaScript that browsers load natively as ES modules — so no transpile,
+type-erasure, or import-rewriting step exists anywhere in this design. (After
+stage 2 of
+[`todo/migrate-typescript-to-mjs.md`](../../../todo/migrate-typescript-to-mjs.md),
+compiler-compatible modules rename to authored `.f.js`; that changes
+extensions below, nothing else.)
 
-Passing an individual function to `page.evaluate()` is not a general replacement. The
-function is reconstructed from source text and loses imported bindings, closures, module
-initialization, and the rest of its dependency graph.
-
-Browsers must load proof modules and all transitive dependencies as normal ES modules.
-They also cannot load the repository's `.ts` and `.f.ts` source directly.
+Passing an individual function to `page.evaluate()` is not a general
+replacement: the function is reconstructed from source text and loses imported
+bindings, closures, module initialization, and the rest of its dependency
+graph. Browsers must load proof modules and their transitive dependencies as
+normal ES modules.
 
 ### Goal
 
-Create one browser-native FunctionalScript test application and expose three ways to run
-it:
+One browser-native FunctionalScript test application, exposed through three
+runners:
 
 1. open its HTML page in a normal browser;
-2. run it through `fjs browser-test` without Playwright;
-3. run it through `playwright test ...` using a dynamically loaded external
-   `playwright/test` installation.
+2. `fjs browser-test`, without Playwright;
+3. `playwright test ...`, dynamically loading an external `playwright/test`
+   installation.
 
-These are three runners over one shared browser-side test system. They must use the same:
-
-- browser-ready JavaScript module graph;
-- generated HTML page;
-- in-browser emergent-test runner;
-- proof selection and recursive proof semantics;
-- serializable result format.
-
-Do not implement three independent test frameworks.
+Three runners over one shared browser-side system: the same module graph,
+generated HTML page, in-browser emergent-test runner, proof selection with
+recursive proof semantics, and serializable result format. Do not implement
+three independent test frameworks.
 
 ### Shared browser test application
-
-Generate or publish an application with a shape similar to:
 
 ```text
 browser-test output
 ├── index.html
-├── browser-test-entry.js
-├── browser-test-runner.js
-├── generated .f.js modules
-└── authored or copied .f.mjs modules
+├── browser-test-entry.mjs
+├── browser-test-runner.mjs
+└── authored or copied .f.mjs / .mjs modules
 ```
 
-`index.html` starts the browser-compatible runner. The entry module explicitly imports
-every selected module that exports `proof`. Native browser ES-module loading then resolves
-and evaluates the full transitive dependency graph.
+`index.html` starts the runner; the generated entry module explicitly imports
+every selected module that exports `proof`, and native browser ES-module
+loading evaluates the full transitive graph. The application exposes HTML and
+JavaScript only — it does not serve the repository working tree, declaration
+files, `types.ts` (type-only imports are JSDoc comments and never produce a
+request), or paths outside the application root. The browser runner must not
+import the Node effect runner, `node:test`, Node built-ins, or Playwright.
 
-The browser runner must not import:
+### Selection
 
-- the Node effect runner;
-- `node:test`;
-- Node built-ins;
-- Playwright or `playwright/test`.
+The named `proof` export is the source of truth; filenames are conventions.
 
-Playwright belongs only to the Playwright runner outside the page.
+1. Discover every authored `.f.mjs` candidate and statically select each one
+   with a named `proof` export — conventional `proof.f.mjs` files and ordinary
+   `module.f.mjs` files alike — without executing it in the preparation
+   process.
+2. Walk each selected module's complete relative runtime dependency graph and
+   accept the module only when every dependency is authored `.f.mjs` / `.mjs`
+   reachable inside the application root.
+3. Reject clearly — with an unsupported-dependency report, never a silent
+   omission or a Node fallback — when the graph reaches a `node:` import or an
+   unresolved external package.
 
-### JavaScript-only application
-
-The browser-test application must expose HTML and executable JavaScript only. It must not
-serve the repository working tree.
-
-Only `.js` and `.mjs` files may be requested as module resources. The server or static
-host must reject or omit:
-
-- `.ts`, `.f.ts`, `.tsx`, `.mts`, and `.cts` source;
-- declaration files;
-- files outside the generated application root;
-- unexpected Node, package-manager, or repository metadata files.
-
-Keep initial styling inline in `index.html`, and generate a JavaScript entry module rather
-than requiring a separate JSON manifest. The browser must never be asked to parse
-TypeScript.
-
-### Two paths to browser-ready JavaScript
-
-#### Transpile remaining FunctionalScript TypeScript
-
-For selected modules still authored as `.f.ts`:
-
-- erase TypeScript-only syntax;
-- emit browser-compatible ES modules as `.f.js`;
-- preserve the needed directory structure;
-- rewrite relative `.f.ts` imports to emitted `.f.js` paths;
-- emit no declarations into the browser-test application;
-- reject unresolved and unsupported dependencies.
-
-A dedicated `tsc` configuration is acceptable initially. A narrower type stripper or the
-FunctionalScript compiler may replace it later.
-
-#### Use authored FunctionalScript JavaScript
-
-Modules already authored as `.f.mjs` are JavaScript and do not require type erasure. Copy
-them into the application, or expose them through an explicitly constructed
-JavaScript-only output tree.
-
-Do not rewrite authored `.f.mjs` to generated `.f.js` merely for browser testing.
-
-A mixed migration graph is expected:
-
-```text
-proof.f.ts       -> generated proof.f.js
-module.f.ts      -> generated module.f.js
-migrated.f.mjs   -> authored/copied migrated.f.mjs
-```
-
-The generated entry module imports application paths, never original TypeScript paths.
-
-### Relationship to `.f.mjs` migration
-
-The repository already defines:
-
-- `.f.ts` as authored FunctionalScript-intent TypeScript;
-- `.f.mjs` as authored FunctionalScript ESM JavaScript with JSDoc types;
-- `.f.js` as generated JavaScript emitted from `.f.ts`.
-
-See the [compiler source-file and migration
-contract](../../fsc/README.md#source-files-and-incremental-repository-migration) and the
-[project roadmap](../../../todo/plan/roadmap.md#future--functionalscript-compiler-via-fjsbnf).
-
-Browser testing follows this migration rather than creating another convention:
-
-1. transpile selected `.f.ts` files today;
-2. load eligible `.f.mjs` files directly;
-3. reduce transpilation as dependency-closed groups migrate;
-4. do not block browser testing on complete repository migration;
-5. do not migrate modules merely to satisfy this task.
-
-Reuse the proof-extension policy owned by [`.f.mjs` test and coverage
-support](f-mjs-test-and-coverage.md).
-
-### Initial browser-suite selection
-
-The first implementation does not need a new Node-only marker. It uses the file-extension
-boundary already provided by FunctionalScript, while preserving the existing rule that a
-`proof` export may live in any FunctionalScript module rather than only in a file named
-`proof`.
-
-Select browser proofs deterministically as follows:
-
-1. Discover every authored FunctionalScript module candidate:
-   - any `.f.ts` file;
-   - any `.f.mjs` file.
-2. Select each candidate that has a named `proof` export. This includes conventional
-   `proof.f.ts` / `proof.f.mjs` files and ordinary files such as `module.f.ts` /
-   `module.f.mjs` that export their proofs directly.
-3. Identify the export without executing the candidate in the Node preparation process.
-   Use the TypeScript/FunctionalScript parser, emitted-module metadata, or another static
-   mechanism consistent with the existing `proofEntries` semantics.
-4. Map a selected `.f.ts` source to its generated `.f.js` path; keep a selected `.f.mjs`
-   source as authored JavaScript.
-5. Walk each selected module's complete relative runtime dependency graph.
-6. Accept the module only when every runtime dependency in that graph becomes either:
-   - generated `.f.js` from `.f.ts`; or
-   - authored/copied `.f.mjs`.
-7. Reject the selected module with a clear unsupported-dependency report when the graph
-   reaches:
-   - a `node:` import;
-   - a generic `.ts`, `.js`, or `.mjs` runtime module;
-   - an unresolved or external package import not explicitly supported by the browser
-     application.
-8. Never silently omit an accepted module or dependency, and never fall back to running
-   its proof in Node.
-
-The named-export rule is the source of truth; filenames are only conventions. A
-browser-compatible `module.f.ts` with `export const proof = ...` must be included, while a
-`proof.f.ts` with an unsupported dependency graph must be rejected clearly.
-
-This deliberately limits the first browser suite to FunctionalScript files. Extending
-browser testing later to generic `proof.ts`, `module.ts`, `.js`, or `.mjs` modules is
-optional and lower priority. That extension may introduce a naming convention or explicit
-environment metadata for Node-dependent generic modules, but it does not block the first
-working browser suite.
-
-### Proof discovery and entry generation
-
-Filesystem discovery may run outside the browser. Generate an entry module such as:
-
-```js
-import * as proof0 from './fjs/foo/proof.f.js'
-import * as proof1 from './fjs/bar/module.f.js'
-import * as proof2 from './fjs/migrated/module.f.mjs'
-import { runModuleMap } from './browser-test-runner.js'
-
-export const run = () => runModuleMap({
-    'fjs/foo/proof.f.js': proof0,
-    'fjs/bar/module.f.js': proof1,
-    'fjs/migrated/module.f.mjs': proof2,
-})
-```
-
-`runModuleMap` applies the same module-level `proof` export handling to every entry. It
-must not assume that only `proof.f.*` files contain tests.
-
-Emitted names retain the `.f` segment: `proof.f.ts` becomes `proof.f.js`, and
-`module.f.ts` becomes `module.f.js`.
-
-Each browser independently loads and evaluates the complete graph. Never serialize proof
-functions with `String(function)`.
+Extending selection to generic `.mjs` modules with Node-dependent graphs is
+optional, later, and may introduce environment metadata; it does not block the
+first working browser suite.
 
 ### In-browser runner and report
 
-Preserve existing emergent-testing conventions where practical:
+Preserve the existing emergent-testing conventions: proof exports contain
+zero-argument functions and recursively testable values, thrown exceptions
+are failures unless an expected throw is declared, asynchronous
+browser-compatible results are awaited, and failures retain module path, test
+path, message, and stack. The final report must be serializable and
+independent of the outer runner (status, browser, totals, duration, per-test
+results), exposed through a documented promise or global plus a documented
+completion event; a runner may also configure an HTTP endpoint to receive it.
 
-- each selected module contributes its named `proof` export;
-- proof exports contain zero-argument functions and recursively testable values;
-- thrown exceptions are failures unless an expected throw is declared;
-- arrays and objects use the existing recursive test semantics;
-- asynchronous browser-compatible results are awaited;
-- failures retain module path, test path, message, and stack when available.
+### The three runners and shared controller code
 
-The final result must be serializable and independent of the outer runner. A possible
-shape is:
+Common controller code owns discovery, graph acceptance, application
+preparation, loopback static serving, URL construction, report validation,
+timeout and infrastructure-error classification, and conversion of the report
+into a generic pass/fail result.
 
-```ts
-type BrowserTestReport = {
-    readonly status: 'passed' | 'failed' | 'error'
-    readonly browser: string
-    readonly total: number
-    readonly passed: number
-    readonly failed: number
-    readonly durationMs: number
-    readonly tests: readonly BrowserTestResult[]
-}
-```
-
-This TypeScript declaration documents the protocol; browser-delivered implementation
-files remain JavaScript.
-
-The page should expose completion through a stable browser API, for example both:
-
-- a documented promise or global containing the final report;
-- a documented browser event emitted when the report is ready.
-
-A runner may also configure an HTTP endpoint to receive the final report.
-
-## Runner 1: HTML page in a browser
-
-The simplest runner is the page itself.
-
-A developer opens the hosted browser-test page, presses Run or Re-run, and reads the
-results in the UI. The page should:
-
-- identify the browser and test build;
-- show loading, running, passed, failed, and infrastructure-error states;
-- display progress and totals;
-- list failed test paths, messages, and stacks;
-- distinguish module-loading failures from proof failures;
-- support automatic start through a query parameter when needed.
-
-The same browser test application should be integrated into the FunctionalScript website.
-The website integration may host a committed or generated release artifact, but it must
-use the same browser runner and report contract as local and automated execution. Avoid a
-website-only test implementation.
-
-A hosted website run does not need to post results to a local server; displaying and
-retaining the report in the page is sufficient.
-
-## Runner 2: `fjs browser-test`
-
-FunctionalScript may provide commands such as:
-
-```sh
-fjs browser-test build
-fjs browser-test serve
-fjs browser-test run --browser=firefox
-```
-
-This runner must not depend on Playwright or `playwright/test`.
-
-It may:
-
-- discover browser-compatible FunctionalScript modules with `proof` exports using the
-  initial selection algorithm;
-- prepare the JavaScript-only application;
-- start a loopback HTTP server;
-- open the URL in an installed browser or instruct the user to open it;
-- optionally launch a browser directly in headless mode;
-- receive or inspect the shared final report;
-- enforce timeout and crash handling;
-- return a nonzero exit status for failed tests or infrastructure errors.
-
-The exact browser-launch mechanism is an implementation decision, but the command must
-remain usable in an environment with no Playwright installation.
-
-## Runner 3: `playwright test ...`
-
-Playwright Test is a separate supported runner, not merely an internal implementation of
-`fjs browser-test`.
-
-A possible interface is:
-
-```sh
-playwright test --project=firefox
-```
-
-The Playwright adapter should share the proof selection, preparation, static server,
-browser page, report protocol, and result interpretation code used by
-`fjs browser-test`. It additionally uses Playwright Test for:
-
-- browser and project selection;
-- `page` and browser lifecycle fixtures;
-- Playwright reporting and process integration;
-- optional traces, screenshots, and diagnostics added later.
-
-The repository must not add `@playwright/test`, `playwright`, or `playwright-core` as a
-`devDependency` merely to provide this runner.
-
-Instead, the adapter dynamically loads `playwright/test` from the Playwright installation
-that launched the command. A conceptual adapter may use top-level asynchronous loading:
-
-```js
-const { test, expect } = await loadPlaywrightTest()
-
-test('FunctionalScript browser suite', async ({ page }) => {
-    const report = await runSharedBrowserApplication(page)
-    expect(report.status).toBe('passed')
-})
-```
-
-A plain repository-relative `import('playwright/test')` may not resolve a globally or
-Nix-installed package. The implementation must deliberately resolve the module from the
-active Playwright installation, for example through:
-
-- an explicit package root supplied by the Nix/global launcher;
-- `createRequire()` rooted at the Playwright CLI installation;
-- an adapter module installed beside Playwright that imports `playwright/test` and then
-  loads the repository's shared adapter code.
-
-Choose the simplest reliable mechanism, document it, and fail clearly when the external
-Playwright Test installation cannot be found. Do not silently fall back to Node-only
-proof execution.
-
-The dynamically loaded module and matching browsers must come from the same external or
-Nix-provided Playwright installation.
-
-### Shared controller code
-
-Separate common controller logic from runner-specific integration.
-
-Common code should own:
-
-- discovery of FunctionalScript modules with named `proof` exports;
-- dependency-graph acceptance and rejection;
-- JavaScript application preparation;
-- loopback static serving;
-- URL and run-identifier construction;
-- report validation;
-- timeout and infrastructure-error classification;
-- conversion of `BrowserTestReport` into a generic pass/fail result.
-
-`fjs browser-test` adds direct browser launching and CLI exit behavior.
-
-The Playwright adapter adds dynamic `playwright/test` loading, fixture registration, and
-Playwright reporting.
-
-The HTML runner uses only the generated page and browser-side code.
+- **HTML page**: run/re-run UI with loading, running, passed, failed, and
+  infrastructure-error states; failed test paths with messages and stacks;
+  module-loading failures distinguished from proof failures; auto-start via a
+  query parameter. The FunctionalScript website hosts the same application and
+  report contract — no website-only implementation.
+- **`fjs browser-test`** (`build` / `serve` / `run --browser=...`): no
+  Playwright dependency; starts a loopback server, opens or launches an
+  installed browser, enforces timeouts, and exits nonzero on failure.
+- **`playwright test ...`**: an adapter that reuses the shared controller and
+  dynamically resolves `playwright/test` from the external installation that
+  launched it (explicit package root, `createRequire()` at the Playwright CLI
+  root, or an adapter module installed beside Playwright), failing clearly
+  when it cannot. The repository must not add `@playwright/test`,
+  `playwright`, or `playwright-core` as dependencies.
 
 ### Validation
 
-Add end-to-end fixtures proving:
-
-- a `proof.f.ts` module is emitted and imported as `proof.f.js`;
-- a `module.f.ts` with a named `proof` export is emitted and included as `module.f.js`;
-- an authored `.f.mjs` module with a named `proof` export loads without transpilation;
-- an eligible FunctionalScript module without a `proof` export is not added as a root;
-- a mixed `.f.js`/`.f.mjs` dependency graph loads correctly;
-- a selected module whose graph reaches generic `module.ts` or `node:` is rejected clearly;
-- no TypeScript request occurs in the browser;
-- a proof reads `window`, `document`, or another browser-only global;
-- transitive FunctionalScript helper modules load through native ES-module imports;
-- the static server rejects TypeScript and paths outside its application root;
-- passing and failing reports appear correctly in the HTML UI;
-- a failed proof produces nonzero status from both automated runners;
-- syntax errors, missing modules, crashes, and timeouts are infrastructure failures;
-- Chromium, Firefox, and WebKit execute proof bodies inside their own realms;
-- the website, `fjs browser-test`, and Playwright use the same browser-side runner and
-  report shape;
-- `fjs browser-test` works with Playwright packages absent;
-- `playwright test ...` works with Playwright absent from repository dependencies;
-- the Playwright adapter resolves `playwright/test` from the external installation and
-  fails clearly when it is unavailable;
-- `npm run ci-update` remains clean when generated CI is introduced.
+End-to-end fixtures proving: an authored `.f.mjs` proof (both `proof.f.mjs`
+and a `module.f.mjs` with a named `proof` export) loads and runs in the
+browser; a module without a `proof` export is not a root; a graph reaching
+`node:` or an external package is rejected clearly; a proof reads `window` or
+`document`; the static server rejects paths outside its root; passing and
+failing reports render in the HTML UI; failures produce nonzero status from
+both automated runners; crashes and timeouts classify as infrastructure
+errors; Chromium, Firefox, and WebKit execute proof bodies in their own
+realms; `fjs browser-test` works with Playwright absent and the Playwright
+adapter resolves the external installation or fails clearly.
 
 ### Out of scope
 
-- generic `proof.ts` and `module.ts` browser coverage in the first implementation;
-- defining a Node-only marker for generic modules before generic modules are selected;
-- running Node-only effect integration tests in browsers;
-- serializing arbitrary JavaScript closures with `String(function)`;
-- duplicating Playwright Test fixtures or assertions inside the browser runner;
-- adding repository Playwright dependencies;
-- bundling or minifying before the native ES-module design works;
-- migrating all `.f.ts` files to `.f.mjs` as part of browser testing;
-- changing the existing `.f.mjs` extension contract;
-- per-test browser contexts or parallel workers in the first iteration;
-- visual regression testing;
-- Docker, OCI publication, or cache design.
+Generic Node-dependent `.mjs` coverage in the first iteration; running Node
+effect integration tests in browsers; serializing closures with
+`String(function)`; repository Playwright dependencies; bundling or minifying
+before the native ES-module design works; per-test browser contexts, parallel
+workers, or visual regression testing.
 
 ### Tasks
 
-- [ ] Discover all `.f.ts` and `.f.mjs` module candidates and statically select every
-      module with a named `proof` export, regardless of filename.
-- [ ] Map selected `.f.ts` modules to `.f.js` while preserving selected `.f.mjs` modules.
-- [ ] Accept only dependency graphs that map completely to `.f.js` and `.f.mjs` modules.
-- [ ] Report unsupported generic, Node, external, and unresolved dependencies clearly.
-- [ ] Create a JavaScript-only browser-test output root.
-- [ ] Add `.f.ts` to `.f.js` emission and rewrite relative FunctionalScript imports.
-- [ ] Copy selected authored `.f.mjs` modules without type erasure.
-- [ ] Generate a JavaScript entry module containing every accepted module with a `proof`
-      export, including `module.f.*` files.
+- [ ] Statically select every authored `.f.mjs` module with a named `proof`
+      export and accept only all-`.f.mjs`/`.mjs` dependency graphs, reporting
+      unsupported dependencies clearly.
+- [ ] Create the JavaScript-only application root with a generated entry
+      module covering every accepted module.
 - [ ] Implement the browser-compatible emergent-test runner and report API.
-- [ ] Implement the HTML UI and integrate it into the FunctionalScript website.
-- [ ] Add shared controller code for preparation, serving, report validation, and timeout
-      handling.
+- [ ] Implement the HTML UI and integrate it into the FunctionalScript
+      website.
+- [ ] Add shared controller code for preparation, serving, report validation,
+      and timeout handling.
 - [ ] Implement `fjs browser-test` without any Playwright dependency.
 - [ ] Implement a Playwright Test adapter that dynamically resolves external
-      `playwright/test`.
-- [ ] Ensure the Playwright adapter and `fjs browser-test` reuse shared controller code.
+      `playwright/test` and reuses the shared controller.
 - [ ] Run the same application in Chromium, Firefox, and WebKit.
-- [ ] Add website, no-Playwright CLI, external-Playwright, browser-realm, selection,
-      module-level-proof, failure, and timeout tests.
-- [ ] Add CI only after proof bodies demonstrably execute inside browsers.
+- [ ] Add the validation fixtures above; add CI only after proof bodies
+      demonstrably execute inside browsers.
 
 ### Related
 
-- [FunctionalScript compiler source-file and migration
-  contract](../../fsc/README.md#source-files-and-incremental-repository-migration)
-- [project compiler and incremental-migration
-  roadmap](../../../todo/plan/roadmap.md#future--functionalscript-compiler-via-fjsbnf)
 - [`.f.mjs` proof discovery and coverage](f-mjs-test-and-coverage.md)
 - [authored `.f.mjs` package support](../../ci/todo/f-mjs-package-support.md)
+- [project roadmap](../../../todo/plan/roadmap.md)

--- a/fjs/fsc/bnf.f.mjs
+++ b/fjs/fsc/bnf.f.mjs
@@ -1,5 +1,8 @@
+/**
+ * @import { Rule } from '../bnf/types.ts'
+ */
+
 import { range, remove, set, option } from '../bnf/module.f.mjs'
-/** @import { Rule } from '../bnf/types.ts' */
 import { digit, json, unicode, ws0, ws1, wsNoNewLine0 } from './json.f.mjs'
 
 /** @type {Rule} */

--- a/fjs/fsc/json.f.mjs
+++ b/fjs/fsc/json.f.mjs
@@ -1,5 +1,8 @@
+/**
+ * @import { Rule, TerminalRange } from '../bnf/types.ts'
+ */
+
 import { join0Plus, rangeEncode, range, remove, repeat0Plus, set, option } from '../bnf/module.f.mjs'
-/** @import { Rule, TerminalRange } from '../bnf/types.ts' */
 
 // space
 

--- a/fjs/fsc/module.f.mjs
+++ b/fjs/fsc/module.f.mjs
@@ -2,17 +2,18 @@
  * FunctionalScript command utilities for compile workflows.
  *
  * @module
+ *
+ * @import { RangeMapArray, RangeMerge } from '../types/range_map/types.ts'
+ * @import { List } from '../types/list/types.ts'
+ * @import { Range } from '../types/range/types.ts'
  */
 
 import { strictEqual } from '../types/function/operator/module.f.mjs'
 import { merge as rangeMapMerge, fromRange, get } from '../types/range_map/module.f.mjs'
-/** @import { RangeMapArray, RangeMerge } from '../types/range_map/types.ts' */
 import { reduce as listReduce, toArray, map } from '../types/list/module.f.mjs'
-/** @import { List } from '../types/list/types.ts' */
 import { range as asciiRange } from '../text/ascii/module.f.mjs'
 import { flip, fn } from '../types/function/module.f.mjs'
 import { one } from '../types/range/module.f.mjs'
-/** @import { Range } from '../types/range/types.ts' */
 import { assertEq } from '../asserts/module.f.mjs'
 
 const fromCharCode = String.fromCharCode

--- a/fjs/fsm/proof.f.mjs
+++ b/fjs/fsm/proof.f.mjs
@@ -1,4 +1,7 @@
-/** @import { Grammar } from './module.f.mjs' */
+/**
+ * @import { Grammar } from './module.f.mjs'
+ */
+
 import { dfa, run, toRange, toUnion } from './module.f.mjs'
 import { union } from '../types/byte_set/module.f.mjs'
 import { sort, fromEntries } from '../types/object/module.f.mjs'

--- a/fjs/js/tokenizer/module.f.mjs
+++ b/fjs/js/tokenizer/module.f.mjs
@@ -4,17 +4,19 @@
  * and numeric literals (including `BigFloat`).
  *
  * @module
+ *
+ * @import { Scan, StateScan } from '../../types/function/operator/types.ts'
+ * @import { RangeMapArray, RangeMerge } from '../../types/range_map/types.ts'
+ * @import { List } from '../../types/list/types.ts'
+ * @import { Entry } from '../../types/ordered_map/types.ts'
+ * @import { Range as NumberRange } from '../../types/range/types.ts'
+ * @import { StringToken, NumberToken, BigIntToken, ErrorToken, WhitespaceToken, NewLineToken, IdToken, CommentToken, EofToken, JsToken, TokenMetadata, JsTokenWithMetadata, _TokenizerStateWithMetadata, _TokenizerState, _ErrorMessage, _InitialState, _ParseIdState, _ParseWhitespaceState, _ParseNewLineState, _ParseStringState, _ParseEscapeCharState, _ParseOperatorState, _ParseCommentState, _ParseUnicodeCharState, _ParseNumberState, _ParseNumberBuffer, _InvalidNumberState, _EofState, _CharCodeOrEof, _ToToken, _CreateToToken, _RangeFunc, _RangeMapToToken, } from './types.ts'
  */
 
-/** @import { Scan, StateScan } from '../../types/function/operator/types.ts' */
 import { strictEqual } from '../../types/function/operator/module.f.mjs'
-/** @import { RangeMapArray, RangeMerge } from '../../types/range_map/types.ts' */
 import { merge, fromRange, get } from '../../types/range_map/module.f.mjs'
-/** @import { List } from '../../types/list/types.ts' */
 import { empty, stateScan, flat, toArray, reduce as listReduce, scan, map as listMap } from '../../types/list/module.f.mjs'
 import { at, fromEntries } from '../../types/ordered_map/module.f.mjs'
-/** @import { Entry } from '../../types/ordered_map/types.ts' */
-/** @import { Range as NumberRange } from '../../types/range/types.ts' */
 import { one } from '../../types/range/module.f.mjs'
 import {
     range,
@@ -75,41 +77,6 @@ import {
     dollarSign
 }  from '../../text/ascii/module.f.mjs'
 import { todo, assertEq } from '../../asserts/module.f.mjs'
-/** @import {
-    StringToken,
-    NumberToken,
-    BigIntToken,
-    ErrorToken,
-    WhitespaceToken,
-    NewLineToken,
-    IdToken,
-    CommentToken,
-    EofToken,
-    JsToken,
-    TokenMetadata,
-    JsTokenWithMetadata,
-    _TokenizerStateWithMetadata,
-    _TokenizerState,
-    _ErrorMessage,
-    _InitialState,
-    _ParseIdState,
-    _ParseWhitespaceState,
-    _ParseNewLineState,
-    _ParseStringState,
-    _ParseEscapeCharState,
-    _ParseOperatorState,
-    _ParseCommentState,
-    _ParseUnicodeCharState,
-    _ParseNumberState,
-    _ParseNumberBuffer,
-    _InvalidNumberState,
-    _EofState,
-    _CharCodeOrEof,
-    _ToToken,
-    _CreateToToken,
-    _RangeFunc,
-    _RangeMapToToken,
-} from './types.ts' */
 
 const { fromCharCode } = String
 

--- a/fjs/mcp/module.f.mjs
+++ b/fjs/mcp/module.f.mjs
@@ -25,26 +25,27 @@
  * store and one in-memory Evo cache scanned once at startup (`initEvo`).
  *
  * @module
+ *
+ * @import { Effect } from '../effects/types.ts'
+ * @import { MemOp } from '../effects/memory/types.ts'
+ * @import { Read, Write } from '../effects/node/types.ts'
+ * @import { McpConfig, McpHandlers } from '../protocol/mcp/types.ts'
+ * @import { FileCasOperation } from '../cas/types.ts'
+ * @import { Cache } from '../cas/evo/types.ts'
+ * @import { Key } from '../effects/memory/types.ts'
  */
 
 import { step } from '../effects/module.f.mjs'
-/** @import { Effect } from '../effects/types.ts' */
 import { create } from '../effects/memory/module.f.mjs'
-/** @import { MemOp } from '../effects/memory/types.ts' */
-/** @import { Read, Write } from '../effects/node/types.ts' */
 import { stdioTransport } from '../protocol/mcp/stdio/module.f.mjs'
 import {
     mcpStep, uninitializedState, fromRegistry,
 } from '../protocol/mcp/module.f.mjs'
-/** @import { McpConfig, McpHandlers } from '../protocol/mcp/types.ts' */
 import { fileCas } from '../cas/module.f.mjs'
-/** @import { FileCasOperation } from '../cas/types.ts' */
 import { initEvo, evo } from '../cas/evo/module.f.mjs'
-/** @import { Cache } from '../cas/evo/types.ts' */
 import { sha256 } from '../crypto/sha2/module.f.mjs'
 import { casToolRegistry } from './cas/module.f.mjs'
 import { evoToolRegistry } from './evo/module.f.mjs'
-/** @import { Key } from '../effects/memory/types.ts' */
 
 // ── Handlers ────────────────────────────────────────────────────────────────────
 

--- a/fjs/mcp/proof.f.mjs
+++ b/fjs/mcp/proof.f.mjs
@@ -1,40 +1,33 @@
-/** @import { Unknown } from '../media/json/types.ts' */
+/**
+ * @import { Unknown } from '../media/json/types.ts'
+ * @import { Effect, Operation } from '../effects/types.ts'
+ * @import { Response } from '../protocol/json_rpc/types.ts'
+ * @import { Vec } from '../types/bit_vec/types.ts'
+ * @import { FileCasOperation } from '../cas/types.ts'
+ * @import { List } from '../effects/list/types.ts'
+ * @import { McpSessionState, ToolsCallResult } from '../protocol/mcp/types.ts'
+ * @import { IoResult, Mkdir, Now, RandomInt, ReadBytes, Rename, } from '../effects/node/types.ts'
+ * @import { Dir } from '../effects/node/virtual/types.ts'
+ */
 
 import { assert, assertEq } from '../asserts/module.f.mjs'
 import { pure, step } from '../effects/module.f.mjs'
-/** @import { Effect, Operation } from '../effects/types.ts' */
 import { create } from '../effects/memory/module.f.mjs'
 import { parse as parseJson } from '../media/json/module.f.mjs'
 import { number as rttiNumber, option, string as rttiString } from '../types/rtti/module.f.mjs'
 import { parse as rttiParse } from '../types/rtti/parse/module.f.mjs'
-/** @import { Response } from '../protocol/json_rpc/types.ts' */
-/** @import { Vec } from '../types/bit_vec/types.ts' */
 import { msb, u8ListToVec, vec8, repeat, length, maxLengthBytes } from '../types/bit_vec/module.f.mjs'
 import { vecToCBase32 } from '../basen/cbase32/module.f.mjs'
 import { encode as base64Encode } from '../basen/base64/module.f.mjs'
 import { utf8 } from '../text/module.f.mjs'
 import { fileCas } from '../cas/module.f.mjs'
-/** @import { FileCasOperation } from '../cas/types.ts' */
 import { dialect as revisionDialect, mediaType as revisionMediaType } from '../media/revision/module.f.mjs'
 import { sha256 } from '../crypto/sha2/module.f.mjs'
 import { nonEmpty, empty as elEmpty } from '../effects/list/module.f.mjs'
-/** @import { List } from '../effects/list/types.ts' */
 import {
     mcpStep, uninitializedState,
 } from '../protocol/mcp/module.f.mjs'
-/** @import { McpSessionState, ToolsCallResult } from '../protocol/mcp/types.ts' */
-/**
- * @import {
- *   IoResult,
- *   Mkdir,
- *   Now,
- *   RandomInt,
- *   ReadBytes,
- *   Rename,
- * } from '../effects/node/types.ts'
- */
 import { emptyState, virtual } from '../effects/node/virtual/module.f.mjs'
-/** @import { Dir } from '../effects/node/virtual/types.ts' */
 import { casConfig, casMcpHandlers } from './module.f.mjs'
 import { ok as resultOk, unwrap } from '../types/result/module.f.mjs'
 import { stdioTransport } from '../protocol/mcp/stdio/module.f.mjs'

--- a/fjs/media/html/module.f.mjs
+++ b/fjs/media/html/module.f.mjs
@@ -4,20 +4,21 @@
  * See `./types.ts` for the `Element`/`Node` type-level API.
  *
  * @module
+ *
+ * @import { List } from '../../types/list/types.ts'
+ * @import { Entry, StringMap } from '../../types/object/types.ts'
+ * @import { Vec } from '../../types/bit_vec/types.ts'
+ * @import { Element, Node } from './types.ts'
  */
 
-/** @import { List } from '../../types/list/types.ts' */
 import { map, flatMap, flat, concat as listConcat } from '../../types/list/module.f.mjs'
 import { concat, concat as stringConcat } from '../../types/string/module.f.mjs'
 import { definedEntries } from '../../types/object/module.f.mjs'
-/** @import { Entry, StringMap } from '../../types/object/types.ts' */
 import { compose } from '../../types/function/module.f.mjs'
 import { stringToList } from '../../text/utf16/module.f.mjs'
 import { includes } from '../../types/array/module.f.mjs'
-/** @import { Vec } from '../../types/bit_vec/types.ts' */
 import { utf8 } from '../../text/module.f.mjs'
 import { quotationMark, ampersand, lessThanSign, greaterThanSign } from '../../text/ascii/module.f.mjs'
-/** @import { Element, Node } from './types.ts' */
 
 const { fromCharCode } = String
 

--- a/fjs/media/html/proof.f.mjs
+++ b/fjs/media/html/proof.f.mjs
@@ -1,5 +1,8 @@
+/**
+ * @import { Element } from './types.ts'
+ */
+
 import { htmlToString } from "./module.f.mjs"
-/** @import { Element } from './types.ts' */
 import { assertEq } from '../../asserts/module.f.mjs'
 
 export const proof = {

--- a/fjs/media/json/rtti/proof.f.mjs
+++ b/fjs/media/json/rtti/proof.f.mjs
@@ -2,14 +2,14 @@
  * Proof for the JSON rtti schemas.
  *
  * @module
+ *
+ * @import { ValidateE } from '../../../types/rtti/common/types.ts'
+ * @import { Unknown } from '../../../types/rtti/ts/types.ts'
  */
 
 import { assertEq } from '../../../asserts/module.f.mjs'
 import { validate } from '../../../types/rtti/validate/module.f.mjs'
 import { primitive, unknown, object, array } from './module.f.mjs'
-
-/** @import { ValidateE } from '../../../types/rtti/common/types.ts' */
-/** @import { Unknown } from '../../../types/rtti/ts/types.ts' */
 
 // Reduces a validation to its `ok`/`error` tag: these schemas are about what is
 // accepted, not about the payload, which validation returns unchanged. The

--- a/fjs/media/json/serializer/module.f.mjs
+++ b/fjs/media/json/serializer/module.f.mjs
@@ -6,13 +6,14 @@
  * ECMAScript `QuoteJSONString` result exactly, lone surrogates included.
  *
  * @module
+ *
+ * @import { List } from '../../../types/list/types.ts'
+ * @import { Reduce } from '../../../types/function/operator/types.ts'
+ * @import { CodePoint } from '../../../text/utf16/types.ts'
  */
 
-/** @import { List } from '../../../types/list/types.ts' */
 import { flat, map, reduce, empty } from '../../../types/list/module.f.mjs'
-/** @import { Reduce } from '../../../types/function/operator/types.ts' */
 import { concat } from '../../../types/string/module.f.mjs'
-/** @import { CodePoint } from '../../../text/utf16/types.ts' */
 import { codePointToString, stringToCodePointList } from '../../../text/utf16/module.f.mjs'
 import { errorMask } from '../../../text/code_point/module.f.mjs'
 import {

--- a/fjs/media/json/tokenizer/module.f.mjs
+++ b/fjs/media/json/tokenizer/module.f.mjs
@@ -2,15 +2,16 @@
  * Tokenizer for JSON lexical analysis.
  *
  * @module
+ *
+ * @import { StateScan } from '../../../types/function/operator/types.ts'
+ * @import { List } from '../../../types/list/types.ts'
+ * @import { JsToken } from '../../../js/tokenizer/types.ts'
+ * @import { JsonToken, _ScanState, _ScanInput } from './types.ts'
  */
 
-/** @import { StateScan } from '../../../types/function/operator/types.ts' */
-/** @import { List } from '../../../types/list/types.ts' */
 import { concat, empty, flat, stateScan } from '../../../types/list/module.f.mjs'
 import { multiply } from '../../../types/bigfloat/module.f.mjs'
 import { tokenize as jsTokenize } from '../../../js/tokenizer/module.f.mjs'
-/** @import { JsToken } from '../../../js/tokenizer/types.ts' */
-/** @import { JsonToken, _ScanState, _ScanInput } from './types.ts' */
 
 /** @type {(input: JsToken) => List<JsonToken>} */
 const mapToken = input => {

--- a/fjs/media/nix/module.f.mjs
+++ b/fjs/media/nix/module.f.mjs
@@ -7,9 +7,11 @@
  * type-level API.
  *
  * @module
+ *
+ * @import { List as ChunkList } from '../../types/list/types.ts'
+ * @import { Expression, _AttributePath, _Binding, _Reference, _AttributeSet, _NixList, _Application, _OpenSetPattern, _Lambda, _Let, _Chunks } from './types.ts'
  */
 
-/** @import { List as ChunkList } from '../../types/list/types.ts' */
 import { toArray } from '../../types/list/module.f.mjs'
 import { concat } from '../../types/string/module.f.mjs'
 import { includes } from '../../types/array/module.f.mjs'
@@ -20,7 +22,6 @@ import {
     range,
 } from '../../text/ascii/module.f.mjs'
 import { fromRange, get, merge } from '../../types/range_set/module.f.mjs'
-/** @import { Expression, _AttributePath, _Binding, _Reference, _AttributeSet, _NixList, _Application, _OpenSetPattern, _Lambda, _Let, _Chunks } from './types.ts' */
 
 const reservedWords = /** @type {const} */ ([
     'assert',

--- a/fjs/media/nix/proof.f.mjs
+++ b/fjs/media/nix/proof.f.mjs
@@ -1,7 +1,10 @@
+/**
+ * @import { Expression } from './types.ts'
+ */
+
 import { assert, assertEq } from '../../asserts/module.f.mjs'
 import { toArray } from '../../types/list/module.f.mjs'
 import { nix, nixToString } from './module.f.mjs'
-/** @import { Expression } from './types.ts' */
 
 /** @type {(nodePackage: string, shellHook: boolean) => Expression} */
 const nodeFlake = (nodePackage, shellHook) => ['set',

--- a/fjs/media/revision/proof.f.mjs
+++ b/fjs/media/revision/proof.f.mjs
@@ -1,5 +1,8 @@
-/** @import { Object as JsonObject } from '../json/types.ts' */
-/** @import { LockMap } from './types.ts' */
+/**
+ * @import { Object as JsonObject } from '../json/types.ts'
+ * @import { LockMap } from './types.ts'
+ */
+
 import { assert, assertEq } from '../../asserts/module.f.mjs'
 import { dialect, mediaType, isHash, validate, decodeText, encodeText } from './module.f.mjs'
 

--- a/fjs/media/type/module.f.mjs
+++ b/fjs/media/type/module.f.mjs
@@ -34,20 +34,21 @@
  * See `./types.ts` for the type-level API.
  *
  * @module
+ *
+ * @import { Vec } from '../../types/bit_vec/types.ts'
+ * @import { Nullable } from '../../types/nullable/types.ts'
+ * @import { Effect, Operation } from '../../effects/types.ts'
+ * @import { List } from '../../effects/list/types.ts'
+ * @import { IoResult } from '../../effects/node/types.ts'
+ * @import { DetectMeta, DetectState, _MagicState, _Signature, _Utf8Detect } from './types.ts'
  */
 
 import { msb, length, u8List } from '../../types/bit_vec/module.f.mjs'
-/** @import { Vec } from '../../types/bit_vec/types.ts' */
 import { iterable } from '../../types/list/module.f.mjs'
-/** @import { Nullable } from '../../types/nullable/types.ts' */
 import { pure, step } from '../../effects/module.f.mjs'
-/** @import { Effect, Operation } from '../../effects/types.ts' */
-/** @import { List } from '../../effects/list/types.ts' */
-/** @import { IoResult } from '../../effects/node/types.ts' */
 import { ok, error } from '../../types/result/module.f.mjs'
 import { isValidCodePoint, isTextCodePoint } from '../../text/code_point/module.f.mjs'
 import { utf8ByteToCodePointOp } from '../../text/utf8/module.f.mjs'
-/** @import { DetectMeta, DetectState, _MagicState, _Signature, _Utf8Detect } from './types.ts' */
 
 // ── Magic-byte signatures ─────────────────────────────────────────────────────────
 //

--- a/fjs/media/type/proof.f.mjs
+++ b/fjs/media/type/proof.f.mjs
@@ -1,13 +1,16 @@
+/**
+ * @import { Vec } from '../../types/bit_vec/types.ts'
+ * @import { List } from '../../effects/list/types.ts'
+ * @import { Result } from '../../types/result/types.ts'
+ * @import { DetectMeta } from './types.ts'
+ */
+
 import { assert, assertEq } from '../../asserts/module.f.mjs'
 import { msb, u8ListToVec, vec8, repeat, empty } from '../../types/bit_vec/module.f.mjs'
-/** @import { Vec } from '../../types/bit_vec/types.ts' */
 import { runPure } from '../../effects/module.f.mjs'
 import { nonEmpty, empty as emptyList } from '../../effects/list/module.f.mjs'
-/** @import { List } from '../../effects/list/types.ts' */
-/** @import { Result } from '../../types/result/types.ts' */
 import { ok } from '../../types/result/module.f.mjs'
 import { detect, detectStream, detectVec } from './module.f.mjs'
-/** @import { DetectMeta } from './types.ts' */
 
 // Builds a big-endian `Vec` from a list of byte values — mirrors how the CAS
 // store would hold the leading bytes of a stored blob.

--- a/fjs/module.f.mjs
+++ b/fjs/module.f.mjs
@@ -2,6 +2,9 @@
  * FunctionalScript compiler entry points and command handlers.
  *
  * @module
+ *
+ * @import { NodeOp, NodeProgram } from './effects/node/types.ts'
+ * @import { Commands } from './cli/types.ts'
  */
 
 import { compile } from './djs/module.f.mjs'
@@ -9,9 +12,7 @@ import { main as testMain } from './emergent_testing/module.f.mjs'
 import { commands as casCommands } from './cas/cli/module.f.mjs'
 import { main as ciMain } from './ci/module.f.mjs'
 import { import_ } from './effects/node/module.f.mjs'
-/** @import { NodeOp, NodeProgram } from './effects/node/types.ts' */
 import { dispatch } from './cli/module.f.mjs'
-/** @import { Commands } from './cli/types.ts' */
 import { casMcpServer } from './mcp/module.f.mjs'
 import { pure, step } from './effects/module.f.mjs'
 import { unwrap } from './types/result/module.f.mjs'

--- a/fjs/path/module.f.mjs
+++ b/fjs/path/module.f.mjs
@@ -2,10 +2,11 @@
  * Path parsing and normalization helpers for portable module paths.
  *
  * @module
+ *
+ * @import { Fold, Reduce, Unary } from '../types/function/operator/types.ts'
+ * @import { List } from '../types/list/types.ts'
  */
 
-/** @import { Fold, Reduce, Unary } from '../types/function/operator/types.ts' */
-/** @import { List } from '../types/list/types.ts' */
 import { fold, last, take, length, concat as listConcat, toArray } from '../types/list/module.f.mjs'
 import { join as listJoin, concat as stringConcat } from '../types/string/module.f.mjs'
 

--- a/fjs/proof.f.mjs
+++ b/fjs/proof.f.mjs
@@ -1,8 +1,11 @@
+/**
+ * @import { NodeProgram, NodeProgramOptions } from './effects/node/types.ts'
+ * @import { Dir } from './effects/node/virtual/types.ts'
+ */
+
 import { assert, assertEq } from './asserts/module.f.mjs'
 import { pure } from './effects/module.f.mjs'
-/** @import { NodeProgram, NodeProgramOptions } from './effects/node/types.ts' */
 import { defaultNodeProgramOptions, emptyState, virtual } from './effects/node/virtual/module.f.mjs'
-/** @import { Dir } from './effects/node/virtual/types.ts' */
 import { main } from './module.f.mjs'
 
 /** @type {(args: readonly string[]) => NodeProgramOptions} */

--- a/fjs/protocol/json_rpc/proof.f.mjs
+++ b/fjs/protocol/json_rpc/proof.f.mjs
@@ -1,4 +1,7 @@
-/** @import { Handlers } from './types.ts' */
+/**
+ * @import { Handlers } from './types.ts'
+ */
+
 import { assert, assertEq } from '../../asserts/module.f.mjs'
 import { ok, error } from '../../types/result/module.f.mjs'
 import { validate } from '../../types/rtti/validate/module.f.mjs'

--- a/fjs/sul/id/module.f.mjs
+++ b/fjs/sul/id/module.f.mjs
@@ -5,21 +5,22 @@
  * See `./types.ts` for the `Id` type.
  *
  * @module
+ *
+ * @import { Vec } from '../../types/bit_vec/types.ts'
+ * @import { Point2D } from '../../crypto/secp/types.ts'
+ * @import { V8 } from '../../crypto/sha2/types.ts'
+ * @import { Id } from './types.ts'
  */
 
 import { toArray } from '../../types/list/module.f.mjs'
-/** @import { Vec } from '../../types/bit_vec/types.ts' */
 import { length, msb, uint, uintChunkList, unpack, vec } from '../../types/bit_vec/module.f.mjs'
 import { assertEq } from '../../asserts/module.f.mjs'
 import { utf8 } from '../../text/module.f.mjs'
-/** @import { Point2D } from '../../crypto/secp/types.ts' */
 import { secp256r1 } from '../../crypto/secp/module.f.mjs'
-/** @import { V8 } from '../../crypto/sha2/types.ts' */
 import { base32 } from '../../crypto/sha2/module.f.mjs'
 import { literal3ToVec } from '../level/literal/module.f.mjs'
 import { log2 } from '../../types/bigint/module.f.mjs'
 import { asBase, asNominal } from '../../types/nominal/module.f.mjs'
-/** @import { Id } from './types.ts' */
 
 // 32 bytes = 256 bits.
 //

--- a/fjs/sul/level/hash/module.f.mjs
+++ b/fjs/sul/level/hash/module.f.mjs
@@ -3,14 +3,15 @@
  * See `./types.ts` for the `Add`/`EncodeState` type-level API.
  *
  * @module
+ *
+ * @import { Create } from '../../../types/patricia_trie/types.ts'
+ * @import { Id } from '../../id/types.ts'
+ * @import { Add, EncodeState } from './types.ts'
  */
 
-/** @import { Create } from '../../../types/patricia_trie/types.ts' */
 import { emptyState, patriciaTrie } from '../../../types/patricia_trie/module.f.mjs'
 import { compress } from '../../id/module.f.mjs'
-/** @import { Id } from '../../id/types.ts' */
 import { asBase } from '../../../types/nominal/module.f.mjs'
-/** @import { Add, EncodeState } from './types.ts' */
 
 /**
  * Returns a streaming encoder for hash-level symbols.

--- a/fjs/sul/level/hash/proof.f.mjs
+++ b/fjs/sul/level/hash/proof.f.mjs
@@ -1,8 +1,11 @@
+/**
+ * @import { Id } from '../../id/types.ts'
+ * @import { EncodeState } from './types.ts'
+ */
+
 import { assert, assertEq } from '../../../asserts/module.f.mjs'
 import { compress, level3Id } from '../../id/module.f.mjs'
-/** @import { Id } from '../../id/types.ts' */
 import { emptyEncodeState, encode } from './module.f.mjs'
-/** @import { EncodeState } from './types.ts' */
 
 /** @typedef {readonly (readonly [Id, Id, Id, boolean])[]} _NodeList */
 

--- a/fjs/sul/level/literal/module.f.mjs
+++ b/fjs/sul/level/literal/module.f.mjs
@@ -4,16 +4,17 @@
  * `Word`/`EncodeState`/`Level`/`PipelineState`/`LiteralToVec` type-level API.
  *
  * @module
+ *
+ * @import { Equal, StateScan } from '../../../types/function/operator/types.ts'
+ * @import { List } from '../../../types/list/types.ts'
+ * @import { EncodeState, Level, LiteralToVec, PipelineState } from './types.ts'
  */
 
 import { log2 } from '../../../types/bigint/module.f.mjs'
 import { msb, vec } from '../../../types/bit_vec/module.f.mjs'
-/** @import { Equal, StateScan } from '../../../types/function/operator/types.ts' */
 import { strictEqual } from '../../../types/function/operator/module.f.mjs'
-/** @import { List } from '../../../types/list/types.ts' */
 import { equal, map } from '../../../types/list/module.f.mjs'
 import { join } from '../../../types/string/module.f.mjs'
-/** @import { EncodeState, Level, LiteralToVec, PipelineState } from './types.ts' */
 
 /** @type {(s: bigint) => string} */
 export const symbolToString = s => s.toString(16)

--- a/fjs/sul/level/literal/proof.f.mjs
+++ b/fjs/sul/level/literal/proof.f.mjs
@@ -1,4 +1,7 @@
-/** @import { Vec } from '../../../types/bit_vec/types.ts' */
+/**
+ * @import { Vec } from '../../../types/bit_vec/types.ts'
+ */
+
 import { chunkList, msb, vec } from '../../../types/bit_vec/module.f.mjs'
 import { assert, assertEq } from '../../../asserts/module.f.mjs'
 import { map, stateScan, toArray } from '../../../types/list/module.f.mjs'

--- a/fjs/sul/module.f.mjs
+++ b/fjs/sul/module.f.mjs
@@ -4,15 +4,16 @@
  * See `./types.ts` for the `EncodeState`/`Encode` type-level API.
  *
  * @module
+ *
+ * @import { Add } from './level/hash/types.ts'
+ * @import { Id } from './id/types.ts'
+ * @import { InternalState } from '../types/patricia_trie/types.ts'
+ * @import { EncodeState, Encode } from './types.ts'
  */
 
 import { emptyPipelineState, pipelineStep } from './level/literal/module.f.mjs'
 import { encode as hashEncode } from './level/hash/module.f.mjs'
-/** @import { Add } from './level/hash/types.ts' */
 import { level3Id } from './id/module.f.mjs'
-/** @import { Id } from './id/types.ts' */
-/** @import { InternalState } from '../types/patricia_trie/types.ts' */
-/** @import { EncodeState, Encode } from './types.ts' */
 
 /** @typedef {InternalState<Id>} _HashState */
 

--- a/fjs/sul/proof.f.mjs
+++ b/fjs/sul/proof.f.mjs
@@ -1,8 +1,11 @@
+/**
+ * @import { Id } from './id/types.ts'
+ * @import { Add } from './level/hash/types.ts'
+ */
+
 import { assert, assertEq } from '../asserts/module.f.mjs'
 import { compress } from './id/module.f.mjs'
-/** @import { Id } from './id/types.ts' */
 import { encode, emptyEncodeState } from './module.f.mjs'
-/** @import { Add } from './level/hash/types.ts' */
 
 /** @typedef {readonly [Id, Id, Id, boolean]} _Merge */
 

--- a/fjs/text/code_point/module.f.mjs
+++ b/fjs/text/code_point/module.f.mjs
@@ -7,13 +7,12 @@
  * surrogate / supplementary-plane / overall validity) that both codecs share.
  *
  * @module
+ *
+ * @import { List } from '../../types/list/types.ts'
+ * @import { StateScan } from '../../types/function/operator/types.ts'
  */
 
 import { empty, flat, stateScan } from '../../types/list/module.f.mjs'
-/** @import { List } from '../../types/list/types.ts' */
-
-/** @import { StateScan } from '../../types/function/operator/types.ts' */
-
 import { contains } from '../../types/range/module.f.mjs'
 
 //

--- a/fjs/text/module.f.mjs
+++ b/fjs/text/module.f.mjs
@@ -4,16 +4,17 @@
  * strings and MSB-first UTF-8 bit vectors.
  *
  * @module
+ *
+ * @import { List } from '../types/list/types.ts'
+ * @import { Nullable } from '../types/nullable/types.ts'
+ * @import { Block, Item, Utf8 } from './types.ts'
  */
 
 import { msb, tryU8ListToVec, u8List } from '../types/bit_vec/module.f.mjs'
 import { flatMap } from '../types/list/module.f.mjs'
-/** @import { List } from '../types/list/types.ts' */
 import { fromCodePointList, toCodePointList } from './utf8/module.f.mjs'
 import { stringToCodePointList, codePointListToString } from './utf16/module.f.mjs'
 import { mapUnwrap } from '../types/nullable/module.f.mjs'
-/** @import { Nullable } from '../types/nullable/types.ts' */
-/** @import { Block, Item, Utf8 } from './types.ts' */
 
 /** @type {(indent: string) => (text: Block) => List<string>} */
 export const flat = indent => {

--- a/fjs/text/proof.f.mjs
+++ b/fjs/text/proof.f.mjs
@@ -1,5 +1,8 @@
+/**
+ * @import { Block } from './types.ts'
+ */
+
 import { assertEq, assertNotNullish } from '../asserts/module.f.mjs'
-/** @import { Block } from './types.ts' */
 import { flat, utf8, utf8ToString, tryUtf8 } from './module.f.mjs'
 import { join } from '../types/string/module.f.mjs'
 import { empty, maxLengthBytes } from '../types/bit_vec/module.f.mjs'

--- a/fjs/text/sgr/module.f.mjs
+++ b/fjs/text/sgr/module.f.mjs
@@ -5,16 +5,17 @@
  * See `./types.ts` for the type-level API.
  *
  * @module
+ *
+ * @import { Write, WriteConsoles, NodeProgramOptions } from '../../effects/node/types.ts'
+ * @import { Effect } from '../../effects/types.ts'
+ * @import { Stdout, WriteText, CsiConsole } from './types.ts'
  */
 
 // C0 control codes
 // https://en.wikipedia.org/wiki/ANSI_escape_code#C0_control_codes
 
 import { write } from '../../effects/node/module.f.mjs'
-/** @import { Write, WriteConsoles, NodeProgramOptions } from '../../effects/node/types.ts' */
-/** @import { Effect } from '../../effects/types.ts' */
 import { utf8 } from "../module.f.mjs"
-/** @import { Stdout, WriteText, CsiConsole } from './types.ts' */
 
 /** @type {string} */
 export const backspace = '\x08'

--- a/fjs/text/sgr/proof.f.mjs
+++ b/fjs/text/sgr/proof.f.mjs
@@ -1,6 +1,9 @@
+/**
+ * @import { NodeProgramOptions } from '../../effects/node/types.ts'
+ */
+
 import { fgRed, reset, createConsoleText, backspace, csiWrite } from './module.f.mjs'
 import { virtual, emptyState, defaultNodeProgramOptions } from '../../effects/node/virtual/module.f.mjs'
-/** @import { NodeProgramOptions } from '../../effects/node/types.ts' */
 import { assert, assertEq } from '../../asserts/module.f.mjs'
 
 /** @type {(isTTY: boolean) => NodeProgramOptions} */

--- a/fjs/text/utf16/module.f.mjs
+++ b/fjs/text/utf16/module.f.mjs
@@ -4,6 +4,10 @@
  * `stateScan` operations.
  *
  * @module
+ *
+ * @import { List, Result, Thunk } from '../../types/list/types.ts'
+ * @import { StateScan } from '../../types/function/operator/types.ts'
+ * @import { CodePoint, U16 } from './types.ts'
  */
 
 import {
@@ -12,13 +16,9 @@ import {
     flatMap,
     empty,
 } from '../../types/list/module.f.mjs'
-/** @import { List, Result, Thunk } from '../../types/list/types.ts' */
 
 import { concat } from '../../types/function/operator/module.f.mjs'
-/** @import { StateScan } from '../../types/function/operator/types.ts' */
-
 import { contains } from '../../types/range/module.f.mjs'
-
 import { fn } from '../../types/function/module.f.mjs'
 
 import {
@@ -37,8 +37,6 @@ import {
  *
  * @typedef {number | null} _Utf16State
  */
-
-/** @import { CodePoint, U16 } from './types.ts' */
 
 /**
  * The BMP / surrogate / supplementary-plane predicates used below live in
@@ -85,7 +83,6 @@ const codePointToUtf16 = codePoint => {
     }
     return [codePoint & 0xffff]
 }
-
 
 /**
  * Converts a UTF-16 sequence to its corresponding Unicode code points.
@@ -146,7 +143,6 @@ const isInU16Range = contains(0x0000, 0xFFFF)
  */
 const u16 = i => Number.isInteger(i) && isInU16Range(i)
 
-
 /**
  * A stateful operation that converts a UTF-16 word (U16) to a list of Unicode code points (CodePoint),
  * while maintaining the state of surrogate pair decoding.
@@ -205,7 +201,6 @@ const utf16ByteToCodePointOp = (word, state) => {
     return [[state | errorMask], word]
 }
 
-
 /**
  * Converts a pending UTF-16 decoding state — an unpaired high surrogate
  * (0xD800–0xDBFF) left from an earlier input — to an error code.
@@ -226,7 +221,6 @@ const utf16StateToError = state => state | errorMask
  * @type {(state: _Utf16State) => readonly[List<CodePoint>, _Utf16State]}
  */
 const utf16EofToCodePointOp = eofFlush(utf16StateToError)
-
 
 /**
  * Converts a list of UTF-16 code units to a list of Unicode code points (CodePoint).

--- a/fjs/text/utf16/proof.f.mjs
+++ b/fjs/text/utf16/proof.f.mjs
@@ -1,4 +1,6 @@
-/** @import { Unknown } from '../../media/json/types.ts' */
+/**
+ * @import { Unknown } from '../../media/json/types.ts'
+ */
 
 import {
     toCodePointList,

--- a/fjs/text/utf8/module.f.mjs
+++ b/fjs/text/utf8/module.f.mjs
@@ -2,11 +2,14 @@
  * UTF-8 byte-level encoding and decoding utilities for FunctionalScript streams.
  *
  * @module
+ *
+ * @import { List, Thunk } from '../../types/list/types.ts'
+ * @import { StateScan } from '../../types/function/operator/types.ts'
+ * @import { Vec } from '../../types/bit_vec/types.ts'
+ * @import { ByteOrEof, I32, U8, Utf8NonEmptyState, Utf8State, } from './types.ts'
  */
 
 import { flatMap, toArray } from '../../types/list/module.f.mjs'
-/** @import { List, Thunk } from '../../types/list/types.ts' */
-/** @import { StateScan } from '../../types/function/operator/types.ts' */
 import {
     decoder,
     eofFlush,
@@ -14,13 +17,7 @@ import {
     isValidCodePoint,
 } from '../code_point/module.f.mjs'
 import { msb, u8List, length } from '../../types/bit_vec/module.f.mjs'
-/** @import { Vec } from '../../types/bit_vec/types.ts' */
 import { codePointListToString } from '../utf16/module.f.mjs'
-/**
- * @import {
- *  ByteOrEof, I32, U8, Utf8NonEmptyState, Utf8State,
- * } from './types.ts'
- */
 
 /**
  * UTF-8 byte-format constants. Each byte kind is defined by a tag — the fixed

--- a/fjs/types/array/module.f.mjs
+++ b/fjs/types/array/module.f.mjs
@@ -2,11 +2,11 @@
  * JavaScript immutable arrays.
  *
  * @module
+ *
+ * @import { Tuple } from './types.ts'
  */
 
 import { fromUndefined, map } from '../nullable/module.f.mjs'
-
-/** @import { Tuple } from './types.ts' */
 
 /**
  * @type {(value: unknown) => value is readonly unknown[]}

--- a/fjs/types/bigfloat/module.f.mjs
+++ b/fjs/types/bigfloat/module.f.mjs
@@ -2,10 +2,11 @@
  * Big-float helpers built from bigint mantissa and exponent parts.
  *
  * @module
+ *
+ * @import { BigFloat } from './types.ts'
  */
 
 import { abs, sign } from '../bigint/module.f.mjs'
-/** @import { BigFloat } from './types.ts' */
 
 /** @typedef {readonly [BigFloat, bigint]} _BigFloatWithRemainder */
 

--- a/fjs/types/bigint/module.f.mjs
+++ b/fjs/types/bigint/module.f.mjs
@@ -15,12 +15,13 @@
  * const bitmask = mask(5n) // 31n
  * const c = combination([3n, 2n, 1n]) // 60n
  * ```
+ *
+ * @import { Sign } from '../function/compare/types.ts'
+ * @import { List } from '../list/types.ts'
+ * @import { Reduce, Unary } from './types.ts'
  */
 
 import { cmp } from '../function/compare/module.f.mjs'
-/** @import { Sign } from '../function/compare/types.ts' */
-/** @import { List } from '../list/types.ts' */
-/** @import { Reduce, Unary } from './types.ts' */
 import { fold } from '../../common/monoid/module.f.mjs'
 
 /**

--- a/fjs/types/bit_vec/module.f.mjs
+++ b/fjs/types/bit_vec/module.f.mjs
@@ -20,34 +20,22 @@
  * ```
  *
  * @module
+ *
+ * @import { Reduce as BigintReduce } from '../bigint/types.ts'
+ * @import { Fold } from '../function/operator/types.ts'
+ * @import { Accumulator, List, Thunk } from '../list/types.ts'
+ * @import { Sign } from '../function/compare/types.ts'
+ * @import { Nullable } from '../nullable/types.ts'
+ * @import { BitOrder, PopFront, Reduce, Unpacked, Vec, _NormOp, _UnpackConcat, } from './types.ts'
  */
 
 import { bitLength, divUp, mask, maxLength, xor } from '../bigint/module.f.mjs'
-/** @import { Reduce as BigintReduce } from '../bigint/types.ts' */
-
 import { flip, identity } from '../function/module.f.mjs'
-
-/** @import { Fold } from '../function/operator/types.ts' */
-
 import { map, tryFold } from '../list/module.f.mjs'
-/** @import { Accumulator, List, Thunk } from '../list/types.ts' */
-
 import { asBase, asNominal } from '../nominal/module.f.mjs'
-
 import { repeat as mRepeat } from '../../common/monoid/module.f.mjs'
-
 import { cmp, max, min } from '../function/compare/module.f.mjs'
-/** @import { Sign } from '../function/compare/types.ts' */
-
 import { mapUnwrap } from '../nullable/module.f.mjs'
-/** @import { Nullable } from '../nullable/types.ts' */
-
-/**
- * @import {
- *  BitOrder, PopFront, Reduce, Unpacked, Vec,
- *  _NormOp, _UnpackConcat,
- * } from './types.ts'
- */
 
 /**
  * Maximum length of a bit vector in bits (1_048_576 = 0x10_0000).

--- a/fjs/types/bit_vec/proof.f.mjs
+++ b/fjs/types/bit_vec/proof.f.mjs
@@ -1,10 +1,13 @@
+/**
+ * @import { Sign } from '../function/compare/types.ts'
+ * @import { Vec, BitOrder } from './types.ts'
+ * @import { List } from '../list/types.ts'
+ */
+
 import { assert, assertEq } from '../../asserts/module.f.mjs'
 import { mask } from '../bigint/module.f.mjs'
-/** @import { Sign } from '../function/compare/types.ts' */
 import { asBase, asNominal } from '../nominal/module.f.mjs'
-/** @import { Vec, BitOrder } from './types.ts' */
 import { length, empty, uint, vec, lsb, msb, repeat, vec8, maxLength, u8ListToVec, tryU8ListToVec, u8List, chunkList, fromSentinel } from './module.f.mjs'
-/** @import { List } from '../list/types.ts' */
 import { repeat as listRepeat, toArray } from '../list/module.f.mjs'
 
 /** @type {(a: bigint) => Vec} */

--- a/fjs/types/btree/find/module.f.mjs
+++ b/fjs/types/btree/find/module.f.mjs
@@ -2,15 +2,14 @@
  * Lookup operations for persistent B-tree structures.
  *
  * @module
+ *
+ * @import { TNode } from '../types/types.ts'
+ * @import { Compare } from '../../function/compare/types.ts'
+ * @import { KeyOf } from '../../array/types.ts'
+ * @import { First, Path, PathItem, Result } from './types.ts'
  */
 
-/** @import { TNode } from '../types/types.ts' */
-
 import { index3, index5 } from '../../function/compare/module.f.mjs'
-/** @import { Compare } from '../../function/compare/types.ts' */
-
-/** @import { KeyOf } from '../../array/types.ts' */
-/** @import { First, Path, PathItem, Result } from './types.ts' */
 
 /** @type {<T>(item: PathItem<T>) => TNode<T>} */
 const child = item => {

--- a/fjs/types/btree/find/proof.f.mjs
+++ b/fjs/types/btree/find/proof.f.mjs
@@ -1,11 +1,13 @@
-/** @import { Unknown } from '../../../media/json/types.ts' */
+/**
+ * @import { Unknown } from '../../../media/json/types.ts'
+ * @import { Result } from './types.ts'
+ * @import { TNode } from '../types/types.ts'
+ */
 
-/** @import { Result } from './types.ts' */
 import { find as btreeFind } from './module.f.mjs'
 import { map, toArray } from '../../list/module.f.mjs'
 import { stringify } from '../../../media/json/module.f.mjs'
 import { sort } from '../../object/module.f.mjs'
-/** @import { TNode } from '../types/types.ts' */
 import { cmp } from '../../string/module.f.mjs'
 import { set as setSet } from '../set/module.f.mjs'
 import { assertEq } from '../../../asserts/module.f.mjs'

--- a/fjs/types/btree/module.f.mjs
+++ b/fjs/types/btree/module.f.mjs
@@ -2,12 +2,13 @@
  * Core persistent B-tree construction and traversal helpers.
  *
  * @module
+ *
+ * @import { List, Thunk } from '../list/types.ts'
+ * @import { TNode, Tree } from './types/types.ts'
  */
 
 import { flat } from '../list/module.f.mjs'
-/** @import { List, Thunk } from '../list/types.ts' */
 import { map } from '../nullable/module.f.mjs'
-/** @import { TNode, Tree } from './types/types.ts' */
 
 /** @type {<T>(node: TNode<T>) => Thunk<T>} */
 const nodeValues

--- a/fjs/types/btree/proof.f.mjs
+++ b/fjs/types/btree/proof.f.mjs
@@ -1,11 +1,13 @@
-/** @import { Unknown } from '../../media/json/types.ts' */
+/**
+ * @import { Unknown } from '../../media/json/types.ts'
+ * @import { TNode } from './types/types.ts'
+ * @import { List, Result } from '../list/types.ts'
+ */
 
-/** @import { TNode } from './types/types.ts' */
 import { values } from './module.f.mjs'
 import { stringify as jsonStringify } from '../../media/json/module.f.mjs'
 import { sort } from '../object/module.f.mjs'
 import { cmp } from '../string/module.f.mjs'
-/** @import { List, Result } from '../list/types.ts' */
 import { next, toArray } from '../list/module.f.mjs'
 import { set as setSet } from './set/module.f.mjs'
 import { value, find as findFind } from './find/module.f.mjs'

--- a/fjs/types/btree/remove/module.f.mjs
+++ b/fjs/types/btree/remove/module.f.mjs
@@ -2,20 +2,16 @@
  * Removal operations for persistent B-tree structures.
  *
  * @module
+ *
+ * @import { Leaf1, TNode, Branch1, Branch3, Branch5, Tree } from '../types/types.ts'
+ * @import { Compare } from '../../function/compare/types.ts'
+ * @import { Path, PathItem } from '../find/types.ts'
+ * @import { Tuple } from '../../array/types.ts'
  */
 
 import { collapseRoot } from '../types/module.f.mjs'
-/** @import { Leaf1, TNode, Branch1, Branch3, Branch5, Tree } from '../types/types.ts' */
-
-/** @import { Compare } from '../../function/compare/types.ts' */
-
 import { find } from '../find/module.f.mjs'
-/** @import { Path, PathItem } from '../find/types.ts' */
-
 import { fold, concat, next } from '../../list/module.f.mjs'
-
-/** @import { Tuple } from '../../array/types.ts' */
-
 import { map } from '../../nullable/module.f.mjs'
 
 /**

--- a/fjs/types/btree/remove/proof.f.mjs
+++ b/fjs/types/btree/remove/proof.f.mjs
@@ -1,5 +1,8 @@
+/**
+ * @import { TNode } from '../types/types.ts'
+ */
+
 import { nodeRemove } from './module.f.mjs'
-/** @import { TNode } from '../types/types.ts' */
 import { set as setSet } from '../set/module.f.mjs'
 import { cmp } from '../../string/module.f.mjs'
 import { stringify } from '../../../media/json/module.f.mjs'

--- a/fjs/types/btree/set/module.f.mjs
+++ b/fjs/types/btree/set/module.f.mjs
@@ -2,16 +2,14 @@
  * Insertion and update operations for persistent B-tree structures.
  *
  * @module
+ *
+ * @import { Branch1, Branch3, Branch5, Branch7, TNode, Tree } from '../types/types.ts'
+ * @import { First, PathItem, Result } from '../find/types.ts'
+ * @import { Compare } from '../../function/compare/types.ts'
  */
 
 import { collapseRoot } from '../types/module.f.mjs'
-/** @import { Branch1, Branch3, Branch5, Branch7, TNode, Tree } from '../types/types.ts' */
-
 import { find } from '../find/module.f.mjs'
-/** @import { First, PathItem, Result } from '../find/types.ts' */
-
-/** @import { Compare } from '../../function/compare/types.ts' */
-
 import { fold } from '../../list/module.f.mjs'
 
 /**

--- a/fjs/types/btree/set/proof.f.mjs
+++ b/fjs/types/btree/set/proof.f.mjs
@@ -1,5 +1,8 @@
+/**
+ * @import { TNode } from '../types/types.ts'
+ */
+
 import { set as setSet } from './module.f.mjs'
-/** @import { TNode } from '../types/types.ts' */
 import { cmp } from '../../string/module.f.mjs'
 import { stringify } from '../../../media/json/module.f.mjs'
 import { sort } from '../../object/module.f.mjs'

--- a/fjs/types/btree/types/module.f.mjs
+++ b/fjs/types/btree/types/module.f.mjs
@@ -3,9 +3,9 @@
  * themselves live in `./types.ts`.
  *
  * @module
+ *
+ * @import { Branch1, Branch3, Branch5, TNode } from './types.ts'
  */
-
-/** @import { Branch1, Branch3, Branch5, TNode } from './types.ts' */
 
 /**
  * Demotes a single-child branch root to its only child.

--- a/fjs/types/byte_set/module.f.mjs
+++ b/fjs/types/byte_set/module.f.mjs
@@ -3,13 +3,14 @@
  * `ByteSet` type.
  *
  * @module
+ *
+ * @import { RangeMap } from '../range_map/types.ts'
+ * @import { SortedSet } from '../sorted_set/types.ts'
+ * @import { ByteSet } from './types.ts'
  */
 
 import { compose } from '../function/module.f.mjs'
-/** @import { RangeMap } from '../range_map/types.ts' */
-/** @import { SortedSet } from '../sorted_set/types.ts' */
 import { reverse, countdown, flat, map } from '../list/module.f.mjs'
-/** @import { ByteSet } from './types.ts' */
 
 /** @typedef {number} _Byte */
 

--- a/fjs/types/byte_set/proof.f.mjs
+++ b/fjs/types/byte_set/proof.f.mjs
@@ -1,4 +1,6 @@
-/** @import { Unknown } from '../../media/json/types.ts' */
+/**
+ * @import { Unknown } from '../../media/json/types.ts'
+ */
 
 import { has, empty, set, setRange, unset, universe, complement, toRangeMap } from './module.f.mjs'
 import { every, countdown, map, toArray } from '../list/module.f.mjs'

--- a/fjs/types/function/compare/module.f.mjs
+++ b/fjs/types/function/compare/module.f.mjs
@@ -2,10 +2,10 @@
  * Comparison function types and helpers.
  *
  * @module
+ *
+ * @import { Index, Tuple } from '../../array/types.ts'
+ * @import { Cmp1, Cmp2, Compare, Sign } from './types.ts'
  */
-
-/** @import { Index, Tuple } from '../../array/types.ts' */
-/** @import { Cmp1, Cmp2, Compare, Sign } from './types.ts' */
 
 /** @type {<T>(cmp: Compare<T>) => (value: T) => Index<3>} */
 export const index3

--- a/fjs/types/function/operator/module.f.mjs
+++ b/fjs/types/function/operator/module.f.mjs
@@ -2,9 +2,9 @@
  * Common higher-order operator type aliases.
  *
  * @module
+ *
+ * @import { Fold, Reduce, Scan, StateScan, Unary } from './types.ts'
  */
-
-/** @import { Fold, Reduce, Scan, StateScan, Unary } from './types.ts' */
 
 /** @type {(separator: string) => Reduce<string>} */
 export const join = separator => value => prior =>

--- a/fjs/types/list/module.f.mjs
+++ b/fjs/types/list/module.f.mjs
@@ -2,10 +2,13 @@
  * Immutable list data structure utilities and combinators.
  *
  * @module
+ *
+ * @import { Nullable } from '../nullable/types.ts'
+ * @import {Scan, StateScan, Fold, Reduce, Equal} from '../function/operator/types.ts'
+ * @import { Accumulator, Concat, Entry, List, NonEmpty, NotLazy, Result, Thunk } from './types.ts'
  */
 
 import { identity, fn, compose } from '../function/module.f.mjs'
-/** @import { Nullable } from '../nullable/types.ts' */
 import {
     addition,
     logicalNot,
@@ -14,8 +17,6 @@ import {
     foldToScan,
     reduceToScan,
 } from '../function/operator/module.f.mjs'
-/** @import {Scan, StateScan, Fold, Reduce, Equal} from '../function/operator/types.ts' */
-/** @import { Accumulator, Concat, Entry, List, NonEmpty, NotLazy, Result, Thunk } from './types.ts' */
 
 export const fromArrayLike =
     /**

--- a/fjs/types/list/proof.f.mjs
+++ b/fjs/types/list/proof.f.mjs
@@ -1,6 +1,8 @@
-/** @import { Unknown } from '../../media/json/types.ts' */
+/**
+ * @import { Unknown } from '../../media/json/types.ts'
+ * @import { List } from './types.ts'
+ */
 
-/** @import { List } from './types.ts' */
 import { length, concat, countdown, cycle, drop, dropWhile, entries, every, filter, find, flat, flatMap, map, next, reduce, reverse, scan, some, take, takeWhile, toArray, zip, first, filterMap, isEmpty, equal, tryFold } from './module.f.mjs'
 import { stringify } from '../../media/json/module.f.mjs'
 import { sort } from '../object/module.f.mjs'

--- a/fjs/types/nibble_set/module.f.mjs
+++ b/fjs/types/nibble_set/module.f.mjs
@@ -13,9 +13,9 @@
  * `ByteSet` is a `bigint`, which `JSON.stringify` cannot serialize.
  *
  * @module
+ *
+ * @import { Nibble, NibbleSet } from './types.ts'
  */
-
-/** @import { Nibble, NibbleSet } from './types.ts' */
 
 export const empty = 0
 

--- a/fjs/types/nominal/module.f.mjs
+++ b/fjs/types/nominal/module.f.mjs
@@ -2,10 +2,11 @@
  * Nominal typing helpers for branded TypeScript types.
  *
  * @module
+ *
+ * @import { Nominal } from './types.ts'
  */
 
 import { identity } from "../function/module.f.mjs"
-/** @import { Nominal } from './types.ts' */
 
 export const asNominal =
     /** @type {<N extends string, R extends string, B>(b: B) => Nominal<N, R, B>} */

--- a/fjs/types/nullable/module.f.mjs
+++ b/fjs/types/nullable/module.f.mjs
@@ -2,12 +2,13 @@
  * Utilities for nullable (`null`/`undefined`) value handling.
  *
  * @module
+ *
+ * @import { Option } from '../option/types.ts'
+ * @import { Nullable } from './types.ts'
  */
 
 import { assert } from '../../asserts/module.f.mjs'
 import { fn } from '../function/module.f.mjs'
-/** @import { Option } from '../option/types.ts' */
-/** @import { Nullable } from './types.ts' */
 
 /**
  * @type {<T, R>(f: (value: T) => R) => (value: Nullable<T>) => Nullable<R>}

--- a/fjs/types/number/module.f.mjs
+++ b/fjs/types/number/module.f.mjs
@@ -3,14 +3,15 @@
  * `countOnes` for 32-bit population count using SWAR.
  *
  * @module
+ *
+ * @import { List } from '../list/types.ts'
+ * @import { Reduce } from '../function/operator/types.ts'
+ * @import { Sign } from '../function/compare/types.ts'
  */
 
 import { reduce } from '../list/module.f.mjs'
-/** @import { List } from '../list/types.ts' */
 import { addition } from '../function/operator/module.f.mjs'
-/** @import { Reduce } from '../function/operator/types.ts' */
 import { cmp as uCmp, min as uMin, max as uMax } from '../function/compare/module.f.mjs'
-/** @import { Sign } from '../function/compare/types.ts' */
 import { fold } from '../../common/monoid/module.f.mjs'
 
 /** @type {(input: List<number>) => number} */

--- a/fjs/types/object/module.f.mjs
+++ b/fjs/types/object/module.f.mjs
@@ -6,16 +6,17 @@
  * `NotUnion` type-level API.
  *
  * @module
+ *
+ * @import { List } from '../list/types.ts'
+ * @import { Nullable } from '../nullable/types.ts'
+ * @import { OrderedMap } from '../ordered_map/types.ts'
+ * @import { StringMap, Entry } from './types.ts'
  */
 
 import { isArray } from '../array/module.f.mjs'
 import { iterable } from '../list/module.f.mjs'
-/** @import { List } from '../list/types.ts' */
 import { fromUndefined } from '../nullable/module.f.mjs'
-/** @import { Nullable } from '../nullable/types.ts' */
 import { entries as mapEntries, fromEntries as mapFromEntries } from '../ordered_map/module.f.mjs'
-/** @import { OrderedMap } from '../ordered_map/types.ts' */
-/** @import { StringMap, Entry } from './types.ts' */
 
 /**
  * `structurallySame` is implemented in a dependency-free leaf so `fjs/asserts`

--- a/fjs/types/object/proof.f.mjs
+++ b/fjs/types/object/proof.f.mjs
@@ -1,8 +1,11 @@
+/**
+ * @import { OptionalMap, RequiredMap, StringMap } from './types.ts'
+ * @import { Assert } from '../../asserts/types.ts'
+ * @import { Equal } from '../ts/types.ts'
+ */
+
 import { at } from './module.f.mjs'
-/** @import { OptionalMap, RequiredMap, StringMap } from './types.ts' */
 import { assertEq } from '../../asserts/module.f.mjs'
-/** @import { Assert } from '../../asserts/types.ts' */
-/** @import { Equal } from '../ts/types.ts' */
 
 /** @typedef {Assert<Equal<StringMap<bigint>, { readonly [k in string]?: bigint }>>} _StringMapIsOptional */
 

--- a/fjs/types/ordered_map/module.f.mjs
+++ b/fjs/types/ordered_map/module.f.mjs
@@ -2,18 +2,19 @@
  * Ordered map operations with deterministic key traversal.
  *
  * @module
+ *
+ * @import { Sign } from '../function/compare/types.ts'
+ * @import { List } from '../list/types.ts'
+ * @import { Reduce } from '../function/operator/types.ts'
+ * @import { Entry, OrderedMap } from './types.ts'
  */
 
 import { value, find } from '../btree/find/module.f.mjs'
 import { set } from '../btree/set/module.f.mjs'
 import { remove as btreeRemove } from '../btree/remove/module.f.mjs'
 import { values } from '../btree/module.f.mjs'
-/** @import { Sign } from '../function/compare/types.ts' */
 import { cmp } from '../string/module.f.mjs'
-/** @import { List } from '../list/types.ts' */
 import { fold } from '../list/module.f.mjs'
-/** @import { Reduce } from '../function/operator/types.ts' */
-/** @import { Entry, OrderedMap } from './types.ts' */
 
 /** @type {(a: string) => <T>(b: Entry<T>) => Sign} */
 const keyCmp = a => ([b]) => cmp(a)(b)

--- a/fjs/types/ordered_map/proof.f.mjs
+++ b/fjs/types/ordered_map/proof.f.mjs
@@ -1,5 +1,8 @@
+/**
+ * @import { OrderedMap } from './types.ts'
+ */
+
 import { at, setReplace, setReduce, empty, entries, remove, fromEntries } from './module.f.mjs'
-/** @import { OrderedMap } from './types.ts' */
 import { toArray } from '../list/module.f.mjs'
 import { assertEq } from '../../asserts/module.f.mjs'
 

--- a/fjs/types/patricia_trie/module.f.mjs
+++ b/fjs/types/patricia_trie/module.f.mjs
@@ -2,9 +2,9 @@
  * Streaming Patricia trie for building content-addressed binary trees from sorted leaf sequences.
  *
  * @module
+ *
+ * @import { Candidate, Create, PatriciaTrie } from './types.ts'
  */
-
-/** @import { Candidate, Create, PatriciaTrie } from './types.ts' */
 
 /**
  * Creates a Patricia trie whose node merging is delegated to `create`.

--- a/fjs/types/patricia_trie/proof.f.mjs
+++ b/fjs/types/patricia_trie/proof.f.mjs
@@ -1,6 +1,9 @@
+/**
+ * @import { State } from './types.ts'
+ */
+
 import { assert, assertEq } from '../../asserts/module.f.mjs'
 import { emptyState, patriciaTrie } from './module.f.mjs'
-/** @import { State } from './types.ts' */
 
 /** @typedef {readonly [bigint, bigint, bigint][]} _NodeList */
 

--- a/fjs/types/prime_field/module.f.mjs
+++ b/fjs/types/prime_field/module.f.mjs
@@ -5,12 +5,13 @@
  * `p % 4 === 3`.
  *
  * @module
+ *
+ * @import { Reduce, Unary } from '../bigint/types.ts'
+ * @import { PrimeField } from './types.ts'
  */
 
-/** @import { Reduce, Unary } from '../bigint/types.ts' */
 import { repeat } from '../../common/monoid/module.f.mjs'
 import { assertNotNullish } from '../../asserts/module.f.mjs'
-/** @import { PrimeField } from './types.ts' */
 
 /**
  * Creates a prime field with the specified prime modulus and associated operations.

--- a/fjs/types/range/module.f.mjs
+++ b/fjs/types/range/module.f.mjs
@@ -2,9 +2,9 @@
  * Range and interval utilities for numeric boundaries.
  *
  * @module
+ *
+ * @import { Range } from './types.ts'
  */
-
-/** @import { Range } from './types.ts' */
 
 /** @type {(...range: Range) => (i: number) => boolean} */
 export const contains = (b, e) => i => b <= i && i <= e

--- a/fjs/types/range_map/module.f.mjs
+++ b/fjs/types/range_map/module.f.mjs
@@ -34,21 +34,18 @@
  * //
  * if (get(16) !== 0) { throw 'error' }
  * ```
+ *
+ * @import { TailReduce, ReduceOp } from '../sorted_list/types.ts'
+ * @import { Nullable } from '../nullable/types.ts'
+ * @import { Equal } from '../function/operator/types.ts'
+ * @import { Range } from '../range/types.ts'
+ * @import { Entry, Properties, RangeMapArray, RangeMapOp, RangeMerge, } from './types.ts'
  */
 
 import { genericMerge } from '../sorted_list/module.f.mjs'
-/** @import { TailReduce, ReduceOp } from '../sorted_list/types.ts' */
 import { next } from '../list/module.f.mjs'
-/** @import { Nullable } from '../nullable/types.ts' */
 import { cmp } from '../number/module.f.mjs'
 import { bsearch } from '../function/compare/module.f.mjs'
-/** @import { Equal } from '../function/operator/types.ts' */
-/** @import { Range } from '../range/types.ts' */
-/**
- * @import {
- *  Entry, Properties, RangeMapArray, RangeMapOp, RangeMerge,
- * } from './types.ts'
- */
 
 /** @template T @typedef {Nullable<Entry<T>>} _RangeState */
 

--- a/fjs/types/range_map/proof.f.mjs
+++ b/fjs/types/range_map/proof.f.mjs
@@ -1,11 +1,13 @@
-/** @import { Unknown } from '../../media/json/types.ts' */
+/**
+ * @import { Unknown } from '../../media/json/types.ts'
+ * @import { RangeMapArray, Properties, RangeMap } from './types.ts'
+ * @import { SortedSet } from '../sorted_set/types.ts'
+ */
 
-/** @import { RangeMapArray, Properties, RangeMap } from './types.ts' */
 import { get, merge, fromRange, rangeMap } from './module.f.mjs'
 import { stringify } from '../../media/json/module.f.mjs'
 import { sort } from '../object/module.f.mjs'
 import { union } from '../sorted_set/module.f.mjs'
-/** @import { SortedSet } from '../sorted_set/types.ts' */
 import { equal, toArray } from '../list/module.f.mjs'
 import { strictEqual } from '../function/operator/module.f.mjs'
 import { cmp } from '../string/module.f.mjs'

--- a/fjs/types/range_set/proof.f.mjs
+++ b/fjs/types/range_set/proof.f.mjs
@@ -1,7 +1,10 @@
+/**
+ * @import { Range } from '../range/types.ts'
+ */
+
 import { assert } from '../../asserts/module.f.mjs'
 import { toArray } from '../list/module.f.mjs'
 import { fromRange, merge, get } from './module.f.mjs'
-/** @import { Range } from '../range/types.ts' */
 
 /** @type {(a: string) => number} */
 const c = a => a.charCodeAt(0)

--- a/fjs/types/result/module.f.mjs
+++ b/fjs/types/result/module.f.mjs
@@ -20,9 +20,9 @@
  * const half = n => n % 2 === 0 ? ok(n / 2) : error('odd')
  * if (unwrap(okThen(half)(success)) !== 21) { throw 'error' }
  * ```
+ *
+ * @import { Ok, Error, Result } from './types.ts'
  */
-
-/** @import { Ok, Error, Result } from './types.ts' */
 
 /**
  * Creates a successful result.

--- a/fjs/types/result/proof.f.mjs
+++ b/fjs/types/result/proof.f.mjs
@@ -1,5 +1,8 @@
+/**
+ * @import { Result } from './types.ts'
+ */
+
 import { error, ok, unwrap, invert, mapOk, okThen } from './module.f.mjs'
-/** @import { Result } from './types.ts' */
 import { assert, assertEq } from '../../asserts/module.f.mjs'
 
 const example = () => {

--- a/fjs/types/rtti/common/module.f.mjs
+++ b/fjs/types/rtti/common/module.f.mjs
@@ -26,16 +26,17 @@
  * `../data/module.f.mjs`) a stable shared base.
  *
  * @module
+ *
+ * @import { Primitive, Unknown } from '../ts/types.ts'
+ * @import { Const, Info0, Primitive0, Struct, Tag1, Tuple, Type } from '../types.ts'
+ * @import { Error, Result as CommonResult } from '../../result/types.ts'
+ * @import { StringMap } from '../../object/types.ts'
+ * @import { Validate, Visitor, IsContainer, Container, ResultE, ValidateE, ValidationError } from './types.ts'
  */
 
-/** @import { Primitive, Unknown } from '../ts/types.ts' */
-/** @import { Const, Info0, Primitive0, Struct, Tag1, Tuple, Type } from '../types.ts' */
-/** @import { Error, Result as CommonResult } from '../../result/types.ts' */
 import { error, ok } from '../../result/module.f.mjs'
 import { isArray as commonIsArray } from '../../array/module.f.mjs'
 import { isObject as commonIsObject } from '../../object/module.f.mjs'
-/** @import { StringMap } from '../../object/types.ts' */
-/** @import { Validate, Visitor, IsContainer, Container, ResultE, ValidateE, ValidationError } from './types.ts' */
 
 /** Builds an error result with empty path and the given message. */
 /** @type {(message: string) => Error<ValidationError>} */

--- a/fjs/types/rtti/common/proof.f.mjs
+++ b/fjs/types/rtti/common/proof.f.mjs
@@ -1,7 +1,10 @@
+/**
+ * @import { Result } from '../../result/types.ts'
+ * @import { ValidationError } from './types.ts'
+ */
+
 import { eachEntry } from './module.f.mjs'
-/** @import { Result } from '../../result/types.ts' */
 import { error, ok } from '../../result/module.f.mjs'
-/** @import { ValidationError } from './types.ts' */
 import { assert, assertEq } from '../../../asserts/module.f.mjs'
 
 /** @typedef {ReadonlyArray<readonly [string, number]>} _Entries */

--- a/fjs/types/rtti/module.f.mjs
+++ b/fjs/types/rtti/module.f.mjs
@@ -3,13 +3,14 @@
  * converting TypeScript types. See `./types.ts` for the type-level API.
  *
  * @module
+ *
+ * @import { Includes } from '../array/types.ts'
+ * @import { Assert } from '../../asserts/types.ts'
+ * @import { Equal } from '../ts/types.ts'
+ * @import { Tag0, Primitive0, _Type0, Bigint, Unknown, Tag1, _MakeType1, Array, Record, Or, Type } from './types.ts'
  */
 
 import { includes } from '../array/module.f.mjs'
-/** @import { Includes } from '../array/types.ts' */
-/** @import { Assert } from '../../asserts/types.ts' */
-/** @import { Equal } from '../ts/types.ts' */
-/** @import { Tag0, Primitive0, _Type0, Bigint, Unknown, Tag1, _MakeType1, Array, Record, Or, Type } from './types.ts' */
 
 const primitive0List = /** @type {const} */ (['bigint', 'boolean', 'number', 'string'])
 

--- a/fjs/types/rtti/parse/module.f.mjs
+++ b/fjs/types/rtti/parse/module.f.mjs
@@ -27,13 +27,17 @@
  * See `./types.ts` for the `Result`/`Parse` type-level API.
  *
  * @module
+ *
+ * @import { Info1, Struct, Tag1, Tuple, Type } from '../types.ts'
+ * @import { Result as CommonResult } from '../../result/types.ts'
+ * @import { StringMap } from '../../object/types.ts'
+ * @import { List } from '../../list/types.ts'
+ * @import { Container, IsContainer, ValidateE, ValidationError, Visitor } from '../common/types.ts'
+ * @import { Unknown } from '../ts/types.ts'
+ * @import { Parse } from './types.ts'
  */
 
-/** @import { Info1, Struct, Tag1, Tuple, Type } from '../types.ts' */
-/** @import { Result as CommonResult } from '../../result/types.ts' */
 import { ok } from '../../result/module.f.mjs'
-/** @import { StringMap } from '../../object/types.ts' */
-/** @import { List } from '../../list/types.ts' */
 import { reverse, toArray } from '../../list/module.f.mjs'
 import {
     constPrimitiveValidate,
@@ -45,9 +49,6 @@ import {
     verror,
     visit,
 } from '../common/module.f.mjs'
-/** @import { Container, IsContainer, ValidateE, ValidationError, Visitor } from '../common/types.ts' */
-/** @import { Unknown } from '../ts/types.ts' */
-/** @import { Parse } from './types.ts' */
 
 const { entries } = Object
 

--- a/fjs/types/rtti/proof.f.mjs
+++ b/fjs/types/rtti/proof.f.mjs
@@ -1,4 +1,6 @@
-/** @import { StringMap } from '../object/types.ts' */
+/**
+ * @import { StringMap } from '../object/types.ts'
+ */
 
 /** @typedef {StringMap<readonly unknown[]>} _Tests */
 

--- a/fjs/types/rtti/ts/module.f.mjs
+++ b/fjs/types/rtti/ts/module.f.mjs
@@ -3,10 +3,11 @@
  * See `./types.ts` for `Ts<T>` and the `*Ts` transformer types.
  *
  * @module
+ *
+ * @import { Const, Type } from '../types.ts'
  */
 
 import { primitive, union, printer as tsPrinter } from '../../ts/module.f.mjs'
-/** @import { Const, Type } from '../types.ts' */
 
 /**
  * Creates a printer that converts an RTTI schema `Type` to its TypeScript type expression as a string.

--- a/fjs/types/rtti/ts/proof.f.mjs
+++ b/fjs/types/rtti/ts/proof.f.mjs
@@ -1,6 +1,9 @@
+/**
+ * @import { Type } from '../types.ts'
+ */
+
 import { printer } from './module.f.mjs'
 import { boolean, number, string, bigint, unknown, array, record, or, option, never } from '../module.f.mjs'
-/** @import { Type } from '../types.ts' */
 
 const toTs = printer()
 const toTsMut = printer(true)

--- a/fjs/types/rtti/validate/module.f.mjs
+++ b/fjs/types/rtti/validate/module.f.mjs
@@ -28,12 +28,14 @@
  * See `./types.ts` for the `Path`/`Result`/`Validate`/`ValidationError` type-level API.
  *
  * @module
+ *
+ * @import { Unknown } from '../ts/types.ts'
+ * @import { Info1, Struct, Tag1, Tuple, Type } from '../types.ts'
+ * @import { StringMap } from '../../object/types.ts'
+ * @import { Container, IsContainer, Validate, ValidateE, Visitor } from '../common/types.ts'
  */
 
-/** @import { Unknown } from '../ts/types.ts' */
-/** @import { Info1, Struct, Tag1, Tuple, Type } from '../types.ts' */
 import { ok } from '../../result/module.f.mjs'
-/** @import { StringMap } from '../../object/types.ts' */
 import {
     constPrimitiveValidate,
     eachEntry,
@@ -44,7 +46,6 @@ import {
     verror,
     visit,
 } from '../common/module.f.mjs'
-/** @import { Container, IsContainer, Validate, ValidateE, Visitor } from '../common/types.ts' */
 
 export {
     constPrimitiveValidate,

--- a/fjs/types/sorted_list/module.f.mjs
+++ b/fjs/types/sorted_list/module.f.mjs
@@ -2,14 +2,15 @@
  * Sorted immutable list helpers and merge operations.
  *
  * @module
+ *
+ * @import { Cmp } from '../function/compare/types.ts'
+ * @import { List } from '../list/types.ts'
+ * @import { ReduceOp, SortedList, TailReduce, _MergeReduce } from './types.ts'
  */
 
 import { bsearch } from '../function/compare/module.f.mjs'
-/** @import { Cmp } from '../function/compare/types.ts' */
 import { next } from '../list/module.f.mjs'
-/** @import { List } from '../list/types.ts' */
 import { identity } from '../function/module.f.mjs'
-/** @import { ReduceOp, SortedList, TailReduce, _MergeReduce } from './types.ts' */
 
 /** @template T @typedef {readonly T[]} _SortedArray */
 

--- a/fjs/types/sorted_list/proof.f.mjs
+++ b/fjs/types/sorted_list/proof.f.mjs
@@ -1,4 +1,6 @@
-/** @import { Unknown } from '../../media/json/types.ts' */
+/**
+ * @import { Unknown } from '../../media/json/types.ts'
+ */
 
 import { find, merge } from './module.f.mjs'
 import { stringify } from '../../media/json/module.f.mjs'

--- a/fjs/types/sorted_set/module.f.mjs
+++ b/fjs/types/sorted_set/module.f.mjs
@@ -25,12 +25,13 @@
  * has(cmp)(3)(setA) // true
  * has(cmp)(2)(setA) // false
  * ```
+ *
+ * @import { Cmp } from '../function/compare/types.ts'
+ * @import { SortedSet } from './types.ts'
  */
 
-/** @import { Cmp } from '../function/compare/types.ts' */
 import { toArray } from "../list/module.f.mjs"
 import { merge, intersect as listIntersect, find } from '../sorted_list/module.f.mjs'
-/** @import { SortedSet } from './types.ts' */
 
 export const union =
     /**

--- a/fjs/types/sorted_set/proof.f.mjs
+++ b/fjs/types/sorted_set/proof.f.mjs
@@ -1,4 +1,6 @@
-/** @import { Unknown } from '../../media/json/types.ts' */
+/**
+ * @import { Unknown } from '../../media/json/types.ts'
+ */
 
 import { has, intersect, union } from './module.f.mjs'
 import { stringify } from '../../media/json/module.f.mjs'

--- a/fjs/types/string/module.f.mjs
+++ b/fjs/types/string/module.f.mjs
@@ -14,14 +14,15 @@
  * repeat('abc')(3) // 'abcabcabc'
  * cmp('apple')('banana') // -1
  * ```
+ *
+ * @import { List } from '../list/types.ts'
+ * @import { Sign } from '../function/compare/types.ts'
+ * @import { Reduce } from '../function/operator/types.ts'
  */
 
-/** @import { List } from '../list/types.ts' */
 import { reduce as listReduce, repeat as listRepeat } from '../list/module.f.mjs'
 import { compose } from '../function/module.f.mjs'
-/** @import { Sign } from '../function/compare/types.ts' */
 import { cmp as uCmp } from '../function/compare/module.f.mjs'
-/** @import { Reduce } from '../function/operator/types.ts' */
 import { join as joinOp } from '../function/operator/module.f.mjs'
 import { fold } from '../../common/monoid/module.f.mjs'
 

--- a/fjs/types/string_set/module.f.mjs
+++ b/fjs/types/string_set/module.f.mjs
@@ -19,6 +19,9 @@
  * mySet = remove('banana')(mySet);
  * if (contains('banana')(mySet)) { throw '4' }
  * ```
+ *
+ * @import { List } from '../list/types.ts'
+ * @import { StringSet } from './types.ts'
  */
 
 import { empty as btEmpty, values as btValues } from '../btree/module.f.mjs'
@@ -26,10 +29,8 @@ import { find, isFound } from '../btree/find/module.f.mjs'
 import { remove as btreeRemove } from '../btree/remove/module.f.mjs'
 import { set as btreeSet } from '../btree/set/module.f.mjs'
 import { cmp } from "../string/module.f.mjs"
-/** @import { List } from '../list/types.ts' */
 import { fold } from '../list/module.f.mjs'
 import { compose } from '../function/module.f.mjs'
-/** @import { StringSet } from './types.ts' */
 
 /** @type {(s: StringSet) => List<string>} */
 export const values = btValues

--- a/fjs/types/ts/module.f.mjs
+++ b/fjs/types/ts/module.f.mjs
@@ -4,9 +4,9 @@
  * primitive literals, and unions as TypeScript type expressions.
  *
  * @module
+ *
+ * @import { Printer } from './types.ts'
  */
-
-/** @import { Printer } from './types.ts' */
 
 /** @type {(open: string, close: string) => (i: readonly string[]) => string} */
 const complex = (open, close) => i =>

--- a/fjs/types/uint8array/module.f.mjs
+++ b/fjs/types/uint8array/module.f.mjs
@@ -8,15 +8,16 @@
  * (e.g. `fromVec`/`toVec` when reading or writing files).
  *
  * @module
+ *
+ * @import { Vec } from '../bit_vec/types.ts'
+ * @import { List } from '../list/types.ts'
  */
 
 import { assertNotNullish } from '../../asserts/module.f.mjs'
 import { utf8, utf8ToString } from '../../text/module.f.mjs'
 import { msb, tryU8ListToVec, u8List } from '../bit_vec/module.f.mjs'
-/** @import { Vec } from '../bit_vec/types.ts' */
 import { compose } from '../function/module.f.mjs'
 import { flat, fromArrayLike, iterable, map } from '../list/module.f.mjs'
-/** @import { List } from '../list/types.ts' */
 
 const tryU8ListToVecMsb = tryU8ListToVec(msb)
 const u8ListMsb = u8List(msb)

--- a/fjs/website/module.f.mjs
+++ b/fjs/website/module.f.mjs
@@ -2,13 +2,14 @@
  * Static website generation program for project landing content.
  *
  * @module
+ *
+ * @import { WriteFile } from '../effects/node/types.ts'
+ * @import { Effect } from '../effects/types.ts'
  */
 
 import { htmlUtf8 } from '../media/html/module.f.mjs'
 import { writeFile } from '../effects/node/module.f.mjs'
-/** @import { WriteFile } from '../effects/node/types.ts' */
 import { pure, step } from '../effects/module.f.mjs'
-/** @import { Effect } from '../effects/types.ts' */
 
 const html = htmlUtf8()(
     ['a',

--- a/todo/migrate-typescript-to-mjs.md
+++ b/todo/migrate-typescript-to-mjs.md
@@ -831,7 +831,7 @@ blocking, plus the prose sweep. The remaining items are listed under
       than by what the `.f.ts` happened to export or by what a pending refactor
       plans to delete. Types intentionally moved to `types.ts` use normal
       TypeScript source visibility instead.
-- [ ] Apply the module-header/import convention: `@module` belongs only to
+- [x] Apply the module-header/import convention: `@module` belongs only to
       `module.*` entry-point files, never to `proof.*` or other files; group
       module-level JavaScript `@import` tags into one leading JSDoc block —
       sharing it with `@module` in a `module.*` file, standing alone otherwise —
@@ -842,9 +842,13 @@ blocking, plus the prose sweep. The remaining items are listed under
       count was stale, and
       [#1526](https://github.com/functionalscript/functionalscript/pull/1526)
       fixed the measured 24 emit losses plus 4 sources with no `@module`
-      block, so all 127 emitted module declarations carry the header. Still
-      open in this item: sweeping scattered `@import` comments into the
-      leading block and the import-group ordering.
+      block, so all 127 emitted module declarations carry the header. The
+      convention half is done in
+      [#1545](https://github.com/functionalscript/functionalscript/pull/1545):
+      every scattered module-level `@import` comment (125 `.mjs` files,
+      multi-line blocks joined to one tag each) moved into its leading block,
+      the import-group ordering measured zero violations, and all 129 emitted
+      module declarations keep their header through the sweep.
 - [x] File an upstream issue for JSDoc typedef documentation being dropped from
       declaration emit, and keep writing type documentation in the source
       meanwhile; substantial type APIs may instead live directly in `types.ts`
@@ -889,8 +893,9 @@ blocking, plus the prose sweep. The remaining items are listed under
       [#1520](https://github.com/functionalscript/functionalscript/pull/1520):
       `prepack` emits declarations only, then re-checks against them without
       emitting.
-- [ ] Then remove `**/*.js` from `.gitignore` when generated implementation
-      JavaScript no longer needs the blanket ignore.
+- [x] Then remove `**/*.js` from `.gitignore` when generated implementation
+      JavaScript no longer needs the blanket ignore. Done in
+      [#1545](https://github.com/functionalscript/functionalscript/pull/1545).
 - [ ] Keep the compiler-compatibility migration explicitly **blocked by** this
       task.
 
@@ -987,15 +992,15 @@ person can re-check rather than re-derive. Counts are as of
       naive one-pass one. `prepack` is therefore
       `tsc --noEmit false --emitDeclarationOnly && tsc`: declaration
       emit, then the same round-trip check with nothing emitted.
-- [ ] **Then drop the blanket `.gitignore` rule** for generated JavaScript
+- [x] **Then drop the blanket `.gitignore` rule** for generated JavaScript
       (`.gitignore` line 131). Unblocked by
       [#1520](https://github.com/functionalscript/functionalscript/pull/1520):
-      no repository command generates `.js` any more, so the rule now guards
-      only stale artifacts in pre-existing working trees. Dropping it is a
-      policy decision, not a sequencing one — `**/*.js` deliberately stays in
-      `package.json` `files` because the extension may be used for other
-      purposes later, so a publish must keep coming from a clean checkout
-      either way.
+      no repository command generates `.js` any more, so the rule guarded
+      only stale artifacts in pre-existing working trees. Dropped in
+      [#1545](https://github.com/functionalscript/functionalscript/pull/1545);
+      `**/*.js` deliberately stays in `package.json` `files` because the
+      extension may be used for other purposes later, so a publish must keep
+      coming from a clean checkout either way.
 - [x] **Decide what happens to the `emergent_testing` scenario fixtures.**
       `fjs/emergent_testing/scenarios/*.ts`, `scenarios/all.ts` and
       `all.test.ts` were the only authored non-`types.ts` TypeScript left. Their
@@ -1040,13 +1045,16 @@ person can re-check rather than re-derive. Counts are as of
       (`fjs/bnf/todo/unicode-rules.md`, `fjs/effects/todo/node-module-layering.md`
       and ~40 others), since no such file may be authored any more.
 
-      All 21 files that still contain the old extension anywhere are listed
+      All 20 files that still contain the old extension anywhere are listed
       below, and each one is deliberate. (History of the count: `205.md` left
       the set when
       [#1520](https://github.com/functionalscript/functionalscript/pull/1520)
       deleted it, the formatter issue left when
       [#1530](https://github.com/functionalscript/functionalscript/pull/1530)
-      retitled it, and earlier revisions of this paragraph ran one short —
+      retitled it, `serializable-data.md` left when
+      [#1539](https://github.com/functionalscript/functionalscript/pull/1539)
+      implemented `fjs/types/rtti/data` and deleted it, and earlier revisions
+      of this paragraph ran one short —
       `fjs/emergent_testing/scenarios.md`, which quotes the deleted `run.sh`
       verbatim, was in the measured set but never enumerated. Review on #1530
       caught it.) Describing the migration or the
@@ -1079,20 +1087,24 @@ person can re-check rather than re-derive. Counts are as of
       and [`scenarios.md`](../fjs/emergent_testing/scenarios.md), which quotes
       the deleted scenario harness verbatim.
       Plus [`browser-testing.md`](../fjs/emergent_testing/todo/browser-testing.md),
-      its own item below. Re-measure with the same resolve-against-the-tree
+      rewritten browser-native in
+      [#1545](https://github.com/functionalscript/functionalscript/pull/1545)
+      down to one deliberate mention recording the retired transpile premise.
+      Re-measure with the same resolve-against-the-tree
       method, at the final commit, before claiming a number — prose that
       enumerates survivors can itself add mentions, which is how a stale count
       got published the first time.
-- [ ] **Redesign or retire `browser-testing.md`.**
+- [x] **Redesign or retire `browser-testing.md`.**
       [`fjs/emergent_testing/todo/browser-testing.md`](../fjs/emergent_testing/todo/browser-testing.md)
-      holds 10 of the surviving path-like mentions on 23 lines — the largest
-      single concentration — and they were left alone on
-      purpose: its whole design is a transpile step from `.f.ts` to `.f.js`
-      because browsers cannot load TypeScript. Authored source is now `.f.mjs`,
-      which a browser loads directly, so the premise is gone and a sweep would
-      have produced a plan that no longer describes anything. Decide whether the
-      transpile step survives for `types.ts`-only reasons, shrinks to a bundling
-      concern, or goes away — then rewrite the document to match.
+      held 10 of the surviving path-like mentions on 23 lines — its whole
+      design was a transpile step from `.f.ts` to `.f.js`, because browsers
+      cannot load TypeScript. Decided and done in
+      [#1545](https://github.com/functionalscript/functionalscript/pull/1545):
+      rewritten browser-native — authored `.f.mjs` loads directly, so the
+      transpile step, the generated module graph, and the mixed-graph
+      machinery are gone while the goal, the three-runner design, the report
+      protocol, and the validation list survive in condensed form (442 lines
+      to ~160, one deliberate historical `.f.ts` mention).
 - [x] **Retitle `formatter-for-f-js-and-f-ts-files.md`.** Done in
       [#1530](https://github.com/functionalscript/functionalscript/pull/1530):
       now [`fjs/todo/formatter-for-f-js-files.md`](../fjs/todo/formatter-for-f-js-files.md),


### PR DESCRIPTION
Three close-out items from `todo/migrate-typescript-to-mjs.md`, per maintainer direction. (A fourth — the broken `serializable-data.md` link — turned out to be already resolved: #1539 implemented `fjs/types/rtti/data/` and deleted that todo.)

## 1. `.gitignore` drops the blanket `**/*.js` rule

No repository command generates `.js` since #1520 (`prepack` is declaration emit plus a no-emit check), so the rule only hid stale artifacts in pre-#1520 working trees. The `**/*.d.ts` / `**/*.d.mts` ignores stay — declarations are still generated. `**/*.js` deliberately remains in `package.json` `files`, so publishes keep coming from clean checkouts as CI does.

## 2. `browser-testing.md` rewritten browser-native (maintainer's choice: rewrite, not retire)

The 442-line plan was built on transpiling `.f.ts` to browser-loadable `.f.js`. Authored source is now `.f.mjs` — JavaScript that browsers load natively — so the rewrite deletes the transpile step, the generated-`.f.js` module graph, the mixed-graph selection machinery, and the TypeScript-rejection server rules, while keeping everything still true: one shared browser test application behind three runners (HTML page, `fjs browser-test` without Playwright, external `playwright/test` adapter), static `proof`-export selection with clear rejection of `node:`/external graphs, the serializable report protocol, and the validation fixture list. 442 lines → ~160.

## 3. The `@import` sweep — the remaining half of the module-header convention item

Every scattered module-level `/** @import ... */` comment moved into its file's leading JSDoc block per §4: **125 `.mjs` files**. Multi-line `@import` blocks joined into one tag each; blank lines between same-group imports collapsed. The ordering half needed no changes — measured **zero** files with an external/built-in import after a relative one.

## Verification

- `npx tsc` and the `prepack` round-trip (`emitDeclarationOnly && tsc`) clean.
- All **129** emitted `module.f.d.mts`/`module.d.mts` carry `@module`, and every prose header repo-wide leads its emitted declaration — the #1526 properties hold through the sweep.
- `npm test` **2646 / 0**.
- Residual scattered-`@import` sweep: **0** files.

A follow-up commit on this branch checks off the corresponding items in `todo/migrate-typescript-to-mjs.md`, re-measures the `.f.ts` survivor inventory (the browser-testing rewrite removes its 10 mentions), and adds the CHANGELOG entry with this PR's number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkqgqTaffDpYFQEJydpqHF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkqgqTaffDpYFQEJydpqHF)_