### PR TITLE
Add 30 todo items documenting refactoring opportunities

### DIFF
--- a/fjs/basen/base128/todo/continuation-bit-layout.md
+++ b/fjs/basen/base128/todo/continuation-bit-layout.md
@@ -1,0 +1,51 @@
+## continuation-bit-layout. Name the continuation-bit layout once for the encode/decode pair
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`base128`'s varint layout — 7 payload bits, `0x80` continuation flag — is
+hardcoded in both halves of an exact-inverse pair, five literals with no name
+and no comment tying them together:
+
+```js
+// fjs/basen/base128/module.f.mjs:25-28 (encode)
+const item = uint & 0x7Fn
+const flag = result === empty ? 0n : 0x80n
+...
+uint >>= 7n
+
+// fjs/basen/base128/module.f.mjs:45-47 (decode)
+result = (result << 7n) | (byte & 0x7Fn)
+if (byte < 0x80n) { return [result, rest] }
+```
+
+`encode` and `decode` must agree bit-for-bit, but nothing states the layout
+they agree on. This is the same shape as the accepted
+`fjs/text/utf8/todo/error-tag-layout-constants.md` — two exact-inverse
+functions sharing an unnamed bit layout.
+
+### Proposal
+
+```js
+// One statement of the layout, at module top:
+const payloadBits = 7n
+const payloadMask = 0x7fn          // mask(payloadBits)
+const continuationFlag = 0x80n     // 1n << payloadBits
+```
+
+Express both functions through the names. Pure rename — the emitted bytes are
+unchanged.
+
+### Tasks
+
+- [ ] Add the three constants with a doc comment stating the varint layout;
+      rewrite `encode`/`decode` through them.
+- [ ] `npx tsc`, `fjs t` — base128 proofs pass unchanged.
+
+### Related
+
+- `fjs/text/utf8/todo/error-tag-layout-constants.md` — the precedent.
+- `fjs/basen/todo/basen-padding-strategy.md` — explicitly leaves `base128`
+  out of scope; no overlap.

--- a/fjs/basen/todo/proof-crockford-copy.md
+++ b/fjs/basen/todo/proof-crockford-copy.md
@@ -1,0 +1,57 @@
+## proof-crockford-copy. `basen/proof.f.mjs` copies cbase32's alphabet and normalizer
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`fjs/basen/proof.f.mjs:7-15` re-declares the Crockford Base32 codec —
+character-for-character the alphabet and fold table that
+`fjs/basen/cbase32/module.f.mjs` owns:
+
+```js
+// fjs/basen/proof.f.mjs:7-15
+const cb32 = baseN(5n, '0123456789abcdefghjkmnpqrstvwxyz', c => {
+    const lower = c.toLowerCase()
+    switch (lower) {
+        case 'i': { return '1' }
+        case 'l': { return '1' }
+        case 'o': { return '0' }
+        default: { return lower }
+    }
+})
+
+// fjs/basen/cbase32/module.f.mjs:14, :21-29 — the owner
+const m = '0123456789abcdefghjkmnpqrstvwxyz'
+const normalizeChar = c => {
+    const lower = c.toLowerCase()
+    switch (lower) {
+        case 'i': { return '1' }
+        ...
+```
+
+The Crockford i/l→1, o→0 rule now has two definitions. If `cbase32` changes,
+`basen`'s `normalizeHit`/`normalizeMiss` proofs keep silently testing the old
+one and stay green.
+
+### Proposal
+
+Either direction works; pick one:
+
+1. Export the codec parameters (`alphabet`, `normalizeChar`) from `cbase32`
+   and build `basen/proof`'s `cb32` from the imports. Note the layering: a
+   lower module's proof importing from a child package — acceptable for a
+   proof, since `cbase32` already depends on `basen` only at runtime, not the
+   reverse.
+2. If that layering is unwanted: replace the copy with a deliberately
+   synthetic normalizing alphabet (e.g. 4-bit with one fold rule) so the
+   `basen` normalization proofs test the *mechanism* without mirroring a real
+   codec's data.
+
+Option 2 is simpler and keeps `basen`'s proof self-contained; the proof only
+needs *a* normalizer, not Crockford's.
+
+### Tasks
+
+- [ ] Replace `basen/proof.f.mjs`'s `cb32` per one of the options above.
+- [ ] `fjs t` — basen and cbase32 proofs pass.

--- a/fjs/cas/evo/todo/proof-fixture.md
+++ b/fjs/cas/evo/todo/proof-fixture.md
@@ -1,0 +1,53 @@
+## proof-fixture. Share the Evo proof fixture between `cas/evo` and `mcp/evo`
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+The three-line Evo setup preamble is repeated ~50 times across two proof
+files — 44 `fileCas(sha256)(home)` occurrences in `fjs/cas/evo/proof.f.mjs`
+(e.g. `:69`, `:74`, `:81`, …) and 10 in `fjs/mcp/evo/proof.f.mjs` (e.g.
+`:57-59`, `:71-73`, …):
+
+```js
+const c = fileCas(sha256)(home)
+const [state0, cacheKey] = virtual(emptyState)(initEvo(c))
+const e = evo(c)(cacheKey)
+```
+
+`fjs/cas/evo/proof.f.mjs` additionally defines three reusable `Cas` stubs —
+`writeFailingCas` (`:35`), `readFailingCas` (`:45`), `fixedCas` (`:56`) — that
+`fjs/mcp/evo/proof.f.mjs` cannot reach, so any new Evo-over-MCP failure-path
+test would re-derive them.
+
+### Proposal
+
+Export one fixture from `fjs/cas/evo/proof.f.mjs` (the repo precedent for a
+cross-file proof helper is `assertPure`, exported from
+`fjs/effects/proof.f.mjs` exactly so another proof shares it instead of
+repeating it):
+
+```js
+/** @type {(home: string) => readonly [State, Evo, Key<Cache>]} */
+export const freshEvo = home => {
+    const c = fileCas(sha256)(home)
+    const [state0, cacheKey] = virtual(emptyState)(initEvo(c))
+    return [state0, evo(c)(cacheKey), cacheKey]
+}
+```
+
+plus exports for the three `Cas` stubs. Both proof files call `freshEvo`; the
+per-test bodies keep only what they actually vary.
+
+### Tasks
+
+- [ ] Add `freshEvo` (and export the stub `Cas` implementations) in
+      `fjs/cas/evo/proof.f.mjs`; rewrite its tests through it.
+- [ ] `fjs/mcp/evo/proof.f.mjs`: import the fixture.
+- [ ] `fjs t` — both proof suites pass unchanged.
+
+### Related
+
+- `fjs/effects/proof.f.mjs` — `assertPure`, the exported-proof-helper
+  precedent.

--- a/fjs/cas/todo/casupload-dead.md
+++ b/fjs/cas/todo/casupload-dead.md
@@ -1,0 +1,48 @@
+## casupload-dead. `casUpload` has no consumer and `casAddFile`'s doc describes a removed path
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`casUpload` (`fjs/cas/module.f.mjs:343-350`) is exported but has no caller
+outside its own proofs (`fjs/cas/proof.f.mjs:420-441`). It is the residue of
+the MCP `type: 'url'` upload flow that was deliberately removed for
+symlink-escape reasons (`fjs/mcp/README.md`, `changelog/0.32.2.md`); it still
+hard-codes the now-unreachable `~/cas_upload/` location and builds its own
+`fileCas(sha256)(home)`.
+
+The stale claim sits on the function next door
+(`fjs/cas/module.f.mjs:321-324`):
+
+```js
+/**
+ * Streams the file at `path` through `cas.write`, returning the content hash.
+ * Both the CLI `cas add` and the MCP `add` delegate to this; the MCP layer
+ * additionally deletes the source file on success.
+ */
+export const casAddFile = ...
+```
+
+Neither half of the second sentence is true anymore: the MCP `cas_add`
+handler (`fjs/mcp/cas/module.f.mjs:188-210`) accepts inline content, never
+calls `casAddFile`, and deletes nothing. The only caller is the CLI
+(`fjs/cas/cli/module.f.mjs:30`).
+
+### Proposal
+
+- Delete `casUpload` and its two proofs (`casUploadSuccess`,
+  `casUploadFailureKeepsSource`). If the upload flow ever returns it should be
+  redesigned against the current MCP architecture, not resurrected from this
+  remnant.
+- Rewrite `casAddFile`'s doc to name its single CLI consumer.
+
+### Tasks
+
+- [ ] Remove `casUpload` + proofs; fix `casAddFile`'s JSDoc.
+- [ ] `npx tsc`, `fjs t`.
+
+### Related
+
+- `fjs/cas/todo/66k-cas-cli-mcp-shared-core.md` — the current thinking on
+  what CLI/MCP actually share; this issue removes a stale third path.

--- a/fjs/cas/todo/proof-drain-collectread.md
+++ b/fjs/cas/todo/proof-drain-collectread.md
@@ -1,0 +1,50 @@
+## proof-drain-collectread. `proof.f.mjs` hand-rolls `collectRead` twice as `drain`
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`fjs/cas/proof.f.mjs` defines `drain` twice, byte-identical
+(`:213-224` and `:251-262`):
+
+```js
+const drain = acc =>
+    stream =>
+        step(
+            stream,
+            (node) => {
+                if (node === undefined) { return pure(ok(acc)) }
+                const { first, tail } = node
+                if (first[0] === 'error') { return pure(first) }
+                return drain([...acc, first[1]])(tail)
+            },
+        )
+```
+
+Both call sites then concatenate the collected chunks —
+`msb.listToVec(readResult[1])` at `:227` and `:265` — which is exactly what
+the module's own exported `collectRead` returns. `collectRead` is *already
+imported in this very file* (`:13`) and exercised directly at `:448`, `:458`,
+`:473`. So the proof bypasses the module's abstraction and re-implements the
+streaming fold it elsewhere proves, twice — the exact way a production/proof
+pair drifts apart.
+
+### Proposal
+
+Delete both `drain` definitions and assert through the export:
+
+```js
+const [, readResult] = virtual(state1)(collectRead(c.read(hash)))
+// readResult is IoResult<Vec>: drop the msb.listToVec wrapper at both sites.
+```
+
+(One behavioral nuance to keep in mind: `collectRead` enforces the
+`maxLength` vector cap — `fjs/cas/module.f.mjs:81-83` — which these proofs'
+payloads are far below; no expectation changes.)
+
+### Tasks
+
+- [ ] Replace both `drain([])(c.read(hash))` pipelines with
+      `collectRead(c.read(hash))`; drop the two `msb.listToVec` wrappers.
+- [ ] `fjs t` — cas proofs pass unchanged.

--- a/fjs/cas/todo/proof-drain-collectread.md
+++ b/fjs/cas/todo/proof-drain-collectread.md
@@ -48,3 +48,10 @@ payloads are far below; no expectation changes.)
 - [ ] Replace both `drain([])(c.read(hash))` pipelines with
       `collectRead(c.read(hash))`; drop the two `msb.listToVec` wrappers.
 - [ ] `fjs t` — cas proofs pass unchanged.
+
+### Related
+
+- `fjs/effects/todo/fold-stream-combinator.md` — extracts the three-case
+  stream fold from the four *production* consumers (`collectRead` among
+  them); these proof-side copies are not in its list and disappear
+  independently by calling `collectRead`.

--- a/fjs/crypto/sha2/todo/byte-length-fields.md
+++ b/fjs/crypto/sha2/todo/byte-length-fields.md
@@ -1,0 +1,55 @@
+## byte-length-fields. Consumers re-derive `Sha2` byte lengths from bit counts
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`Sha2` publishes only bit counts (`fjs/crypto/sha2/types.ts:58-59`:
+`hashLength`, `blockLength`), so every consumer that needs bytes re-does the
+conversion — with two different spellings:
+
+```js
+// fjs/crypto/hmac/module.f.mjs:47-48
+const { blockLength } = hashFunc
+const p = repeat(blockLength >> 3n)
+
+// fjs/crypto/sign/module.f.mjs:78
+const rep = repeat(divUp8(hf.hashLength))
+```
+
+Same three-step idiom — take a bit length off a `Sha2`, convert to bytes,
+`repeat` a `vec8` constant (`oPad`/`iPad` at `hmac:32,37`, `x01`/`x00` at
+`sign:52-53`) — written twice, once as `>> 3n` and once as `divUp8`
+(`fjs/types/bigint/module.f.mjs`). The reader has to work out per site whether
+the two roundings agree (they do: SHA-2 lengths are byte-multiples), and a
+third variant of "digest bits → scalar" arithmetic lives in
+`fjs/crypto/pow/module.f.mjs:79-80`.
+
+### Proposal
+
+Compute the byte counts once where the record is built — `sha2(...)`
+(`fjs/crypto/sha2/module.f.mjs:257`) — and publish them on the type:
+
+```ts
+// fjs/crypto/sha2/types.ts
+readonly hashLength: bigint     // bits (unchanged)
+readonly blockLength: bigint    // bits (unchanged)
+readonly hashBytes: bigint
+readonly blockBytes: bigint
+```
+
+`hmac` and `sign` then read `blockBytes`/`hashBytes` instead of converting,
+and the bits-vs-bytes decision has one owner.
+
+### Tasks
+
+- [ ] Add the byte fields to `Sha2` and `sha2(...)`; proof-cover them for all
+      four variants.
+- [ ] `hmac`: `repeat(blockBytes)`; `sign`: `repeat(hashBytes)`.
+- [ ] `npx tsc`, `fjs t`.
+
+### Related
+
+- `fjs/crypto/sign/todo/computek-digest-param.md` — adjacent `sign`/sha2
+  interface cleanup.

--- a/fjs/crypto/sign/todo/rfc6979-vector-harness.md
+++ b/fjs/crypto/sign/todo/rfc6979-vector-harness.md
@@ -1,0 +1,63 @@
+## rfc6979-vector-harness. The RFC 6979 test-vector walker is written twice in `proof.f.mjs`
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`fjs/crypto/sign/proof.f.mjs` carries the "two messages × four SHA-2 variants"
+vector harness twice — `a2` (`:127-153`) checks the deterministic `k`, `a2s`
+(`:369-410`) checks full `{k, r, s}` signatures — with identical structure:
+
+```js
+// :137-152 (a2)                                  // :385-401 (a2s)
+const check = ({ q, x, msg0, msg1 }) => {         const check = ({ q, x, msg0, msg1 }) => {
+    const a = all(q)                                  const a = all(q.nf.p)   // <-- not fromCurve
+    const check = (sha, expected, m) => { ... }       const check = (sha, { k, r, s }, m) => { ... }
+    const check4 = (m, h) => {                        const check4 = (m, h) => {
+        check(sha224, h[0], m)                            check(sha224, h[0], m)
+        check(sha256, h[1], m)                            check(sha256, h[1], m)
+        check(sha384, h[2], m)                            check(sha384, h[2], m)
+        check(sha512, h[3], m)                            check(sha512, h[3], m)
+    }                                                 }
+    check4(sample, msg0)                              check4(sample, msg0)
+    check4(test, msg1)                                check4(test, msg1)
+}                                                 }
+```
+
+Only the per-`(sha, expected, message)` assertion body differs. Adding a curve
+or hash variant means editing two nested walkers that must stay in sync.
+
+`a2s`'s `all(q.nf.p)` (`:386`) is also a third site of the `fromCurve` bypass
+that `fjs/crypto/todo/666-crypto-sign-fromcurve.md` files for
+`sign/module.f.mjs` — the proof re-derives the RFC 6979 helpers from the raw
+prime instead of the curve.
+
+### Proposal
+
+One vector driver, parameterized by the assertion:
+
+```js
+/** @type {(assert: (a: _All) => (sha: Sha2, expected: _E, m: Vec) => void)
+ *  => (v: _Vector) => void} */
+const forEachVector = assert => ({ q, x, msg0, msg1 }) => {
+    const check = assert(all(q))
+    const check4 = (m, h) => { check(sha224, h[0], m); check(sha256, h[1], m); ... }
+    check4(sample, msg0)
+    check4(test, msg1)
+}
+```
+
+`a2` and `a2s` each supply only their assertion body; `:386` becomes `all(q)`
+(or `fromCurve(q)` once 666-crypto-sign-fromcurve lands).
+
+### Tasks
+
+- [ ] Extract the shared driver; rewrite `a2` and `a2s` through it.
+- [ ] Replace `all(q.nf.p)` with the curve-based call.
+- [ ] `fjs t` — the sign proofs pass unchanged.
+
+### Related
+
+- `fjs/crypto/todo/666-crypto-sign-fromcurve.md` — the module-side bypass;
+  this issue adds the proof-side site.

--- a/fjs/djs/tokenizer/todo/tokenize-string-derive.md
+++ b/fjs/djs/tokenizer/todo/tokenize-string-derive.md
@@ -1,0 +1,65 @@
+## tokenize-string-derive. `tokenizeString` re-implements `tokenizeJs`; `toJsTokens` re-implements `toJsTokenWithMetadata`
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+Two metadata-free copies of metadata-aware pipelines live in
+`fjs/djs/tokenizer/module.f.mjs`:
+
+1. `tokenizeString` (`:464-486`) vs `tokenizeJs` (`:501-531`): the same
+   pipeline in the same order — empty-input short circuit →
+   `descentParser(jsGrammar())` → `codePointsWithMetadata` → match →
+   `getTokensFromAstRule` → the `'unterminated'`/`'numError'` structural-error
+   probe → `filter(filterFunc)` + `concat(…)([''])` →
+   `stateScan(scanFunc)(['', null, []])` → `flatMap(toJsToken*)` → append
+   `eof`. The differences are only the error representation (`return 'error'`
+   vs an error token with metadata) and the final `stringify`.
+
+2. `toJsTokens` (`:410-418`) vs `toJsTokenWithMetadata` (`:422-431`) — the
+   "a `/*` comment containing a newline also emits an `nl`" rule, twice:
+
+   ```js
+   if (token.kind === '/*') {
+       const hasNl = token.value.includes('\n') || token.value.includes('\r')
+       if (hasNl) return [token, { kind: 'nl' }]
+   }
+   ```
+
+The module already contains the needed lifting idiom one screen lower, for
+the DJS layer: `mapDjsTokenWithMetadata` (`:601-608`) derives the
+metadata-aware scanner from the plain one by mapping metadata over the
+produced tokens. The JS layer just doesn't use it.
+
+There is also a separation-of-concerns problem: `tokenizeString` is
+proof-only (`fjs/djs/tokenizer/proof.f.mjs` is its sole consumer) yet it
+lives in the production module and pulls `stringifyAsTree`/`sort` from
+`fjs/djs/serializer` into the tokenizer's import graph purely to format test
+output. `fjs/js/tokenizer/proof.f.mjs:12` already shows the right shape for
+its tokenizer: a proof-local stringifier over the production tokenizer.
+
+### Proposal
+
+- Keep `tokenizeJs` as the only pipeline. Derive the token-only view by
+  projection: `tokenizeString` becomes (proof-local)
+  `stringify(toArray(map(({ token }) => token)(tokenizeJs(cp)(''))))`, with
+  the `'error'` result recovered from the single `{ kind: 'error' }` token.
+- Derive `toJsTokenWithMetadata` from `toJsTokens` (or both from one
+  `hasNlComment` helper), mirroring `mapDjsTokenWithMetadata`.
+- Move `tokenizeString` (and the serializer imports it drags in) to
+  `proof.f.mjs`.
+
+### Tasks
+
+- [ ] Unify the `/*`-with-newline rule; delete one of the twin functions.
+- [ ] Rewrite `tokenizeString` as a projection of `tokenizeJs`; move it to
+      the proof; drop the serializer imports from the tokenizer module.
+- [ ] `npx tsc`, `fjs t` — the ~90 `tokenizeString` proof cases pass
+      unchanged.
+
+### Related
+
+- `fjs/js/todo/666-js-tokenizer-position-layer.md` — the same
+  "position/metadata as a separable layer" idea for the *other* tokenizer;
+  this issue is the djs-side counterpart at the pipeline level.

--- a/fjs/effects/memory/todo/sync-interpreter-owner.md
+++ b/fjs/effects/memory/todo/sync-interpreter-owner.md
@@ -1,0 +1,70 @@
+## sync-interpreter-owner. The synchronous memory interpreter is written three times
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+`fjs/effects/memory` exports only the `MemOp` effect *constructors*
+(`create`/`read`/`write`) and no synchronous interpreter, so every consumer
+that runs memory effects against `fjs/effects/mock`'s `run` writes its own —
+three copies today:
+
+- `fjs/effects/memory/proof.f.mjs:14-45` — `_MemoryState` typedef,
+  `initial = { next: 0, values: {} }`, and a `MemOperationMap<MemOp, _MemoryState>`
+  with the `k${state.next}` key scheme;
+- `fjs/protocol/mcp/proof.f.mjs:21-43` — the same, character-for-character
+  apart from one `assert`;
+- `fjs/effects/node/virtual/module.f.mjs:360-377` — a third structural copy
+  over `State.memoryNext`/`State.memoryValues` with `mem${state.memoryNext}`
+  ids, inlined into the virtual node interpreter.
+
+```js
+// both proof files:
+memCreate: value => state => {
+    const id = `k${state.next}`
+    const key = /** @type {Key<unknown>} */ (asNominal(id))
+    return [{ next: state.next + 1, values: { ...state.values, [id]: value } }, key]
+},
+memRead: key => state => [state, state.values[asBase(key)]],
+```
+
+The async counterpart is already shared (`fjs/effects/node/memory`); only the
+sync one is not. The key-scheme and state shape are incidental details that
+now exist in two variants for no reason.
+
+### Proposal
+
+`fjs/effects/memory` exports the sync interpreter next to the constructors:
+
+```js
+/** @typedef {{ readonly next: number,
+ *   readonly values: { readonly [k: string]: unknown } }} MemoryState */
+
+/** @type {MemoryState} */
+export const memoryInitial = { next: 0, values: {} }
+
+/** @type {MemOperationMap<MemOp, MemoryState>} */
+export const memoryOperationMap = { memCreate, memRead, memWrite }
+```
+
+Both proof files import it. `virtual` keeps its own `State` (memory is one
+facet of a larger record), but should build its three handlers by delegating
+to the shared map over a lensed `{ next, values }` view — or, minimally, its
+copy gets a comment naming the shared map as the reference. The first option
+is preferred: the `mem${…}`-vs-`k${…}` divergence disappears.
+
+### Tasks
+
+- [ ] Export `MemoryState`, `memoryInitial`, `memoryOperationMap` from
+      `fjs/effects/memory` with proof coverage.
+- [ ] Replace the copies in `fjs/effects/memory/proof.f.mjs` and
+      `fjs/protocol/mcp/proof.f.mjs`.
+- [ ] `fjs/effects/node/virtual`: delegate the `mem*` handlers to the shared
+      map (state-lens wrapper) or document why the inline copy stays.
+- [ ] `npx tsc`, `fjs t`.
+
+### Related
+
+- `fjs/effects/node/memory/module.mjs` — the async interpreter, already
+  shared; this issue gives the sync side the same owner.

--- a/fjs/effects/node/virtual/todo/node-program-options-factory.md
+++ b/fjs/effects/node/virtual/todo/node-program-options-factory.md
@@ -1,0 +1,37 @@
+## node-program-options-factory. Export the `NodeProgramOptions`-from-args factory the JSDoc already spells out
+
+**Priority:** P5
+**Status:** open
+
+### Problem
+
+Three proof files re-type the same one-liner:
+
+```js
+// fjs/cli/proof.f.mjs:11-13, fjs/cas/cli/proof.f.mjs:13-15, fjs/proof.f.mjs:11-12
+/** @type {(args: readonly string[]) => NodeProgramOptions} */
+const makeOptions = args => ({ ...defaultNodeProgramOptions, args })
+```
+
+The shape was even named in prose — `defaultNodeProgramOptions`' JSDoc
+(`fjs/effects/node/virtual/module.f.mjs:434`) shows
+`const opts: NodeProgramOptions = { ...defaultNodeProgramOptions, args }` as
+the intended usage — but never exported, so each call site re-derives it.
+
+### Proposal
+
+Export it next to the default (`fjs/effects/node/virtual/module.f.mjs:442`):
+
+```js
+/** @type {(args: readonly string[]) => NodeProgramOptions} */
+export const nodeProgramOptions = args => ({ ...defaultNodeProgramOptions, args })
+```
+
+and delete the three copies.
+
+### Tasks
+
+- [ ] Export `nodeProgramOptions` (with proof coverage); update the JSDoc
+      example to reference it.
+- [ ] Replace `makeOptions` in the three proof files.
+- [ ] `npx tsc`, `fjs t`.

--- a/fjs/js/todo/trivia-merge-rule.md
+++ b/fjs/js/todo/trivia-merge-rule.md
@@ -1,0 +1,62 @@
+## trivia-merge-rule. The ws/nl coalescing contract is implemented independently by both tokenizers
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+"A maximal run of whitespace/newline trivia collapses to a single token, and
+a run containing any newline is an `nl`" is a contract of `JsToken`'s
+`ws`/`nl` — but it is decided independently in two modules.
+
+`fjs/js/tokenizer/module.f.mjs:598-614` encodes it as two range-map states
+(`ws + ws → ws`, `ws + nl → nl` with the pending `ws` dropped, `nl + ws → nl`,
+`nl + nl → nl`).
+
+`fjs/djs/tokenizer/module.f.mjs:285-288` restates the same four-way table over
+grammar tags:
+
+```js
+if (isNlTag(input) && isNlTag(stateTag)) return [null, state]
+if (isWsTag(input) && isWsTag(stateTag)) return [null, state]
+if (isNlTag(input) && isWsTag(stateTag)) return [null, [input, null, []]]
+if (isWsTag(input) && isNlTag(stateTag)) return [null, state]
+```
+
+The DJS copy exists only to reproduce the JS tokenizer's output (the proofs
+compare the two token-for-token), so it is a re-derivation of a contract the
+other module owns, with no shared statement of it. Change the absorption rule
+in one place and the proofs are the only thing standing between the two.
+
+### Proposal
+
+State the rule once in `fjs/js/tokenizer` — it defines `JsToken` and is the
+reference implementation — as a data-level merge on trivia kinds:
+
+```js
+/** nl absorbs ws; equal kinds coalesce. */
+export const mergeTrivia = (a, b) => a === 'nl' || b === 'nl' ? 'nl' : 'ws'
+```
+
+and have both consumers express their four branches through it: the JS
+tokenizer's two trivia states pass the pending and incoming kind; the DJS
+`scanFunc` maps its tags to kinds (`isNlTag` → `'nl'`, `isWsTag` → `'ws'`)
+and keeps only the state bookkeeping.
+
+This does not merge the two tokenizers (that is
+`fjs/djs/todo/157.md`-adjacent territory); it only gives the one shared rule
+one owner.
+
+### Tasks
+
+- [ ] Export `mergeTrivia` from `fjs/js/tokenizer` with proof coverage of the
+      four combinations.
+- [ ] Rewrite the JS tokenizer's `parseWhitespaceStateOp`/`parseNewLineStateOp`
+      transitions and the DJS `scanFunc` trivia branches through it.
+- [ ] `npx tsc`, `fjs t` — both tokenizers' proofs pass unchanged.
+
+### Related
+
+- `fjs/djs/tokenizer/todo/vocabulary-single-source.md` — derives the ws/nl
+  *character lists* from the grammar inside `djs/tokenizer`; this issue is
+  the cross-module *coalescing rule*, distinct.

--- a/fjs/media/json/schema/todo/strip-undefined-set-op.md
+++ b/fjs/media/json/schema/todo/strip-undefined-set-op.md
@@ -1,0 +1,60 @@
+## strip-undefined-set-op. `stripUndefined` hand-rebuilds `UnionSet` field by field
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`fjs/media/json/schema/module.f.mjs:202-213` performs a *set operation on the
+rtti data form* — remove the `undefined` unit from a union — by enumerating
+every member of `UnionSet` to copy it:
+
+```js
+const stripUndefined = n => {
+    if (typeof n === 'string') { return n }
+    const unit = (n.unit ?? 0) & ~undefinedBit
+    return {
+        ...(unit === 0 ? {} : { unit }),
+        ...(n.number === undefined ? {} : { number: n.number }),
+        ...(n.string === undefined ? {} : { string: n.string }),
+        ...(n.bigint === undefined ? {} : { bigint: n.bigint }),
+        ...(n.array === undefined ? {} : { array: n.array }),
+        ...(n.object === undefined ? {} : { object: n.object }),
+    }
+}
+```
+
+mirroring the field list of `fjs/types/rtti/data/types.ts`. The same file
+enumerates the kinds a second time in `unionSchema` (`:242-257`) — that one
+is a genuine per-kind eliminator (each kind maps to a different schema form),
+but the two enumerations fail differently if `UnionSet` ever gains a kind:
+`unionSchema` visibly stops handling it, while `stripUndefined` silently
+**drops** it from every optional property's schema.
+
+### Proposal
+
+`fjs/types/rtti/data` owns `UnionSet` and its algebra (`cmp`, merge,
+normalization); give it the missing operation and export it:
+
+```js
+// fjs/types/rtti/data — remove unit bits from a union, dropping the key when empty
+/** @type {(bits: number) => (n: Node) => Node} */
+export const withoutUnits = bits => n => ...
+```
+
+`stripUndefined` becomes `withoutUnits(undefinedBit)` plus nothing — the
+schema module keeps only JSON-Schema decisions, and a new kind can't be
+silently dropped because the owner's implementation is written next to the
+type it must mirror.
+
+### Tasks
+
+- [ ] Add `withoutUnits` (or `subtractUnit`) to `fjs/types/rtti/data` with
+      proof coverage, including the drop-empty-`unit`-key rule.
+- [ ] Rewrite `stripUndefined` through it.
+- [ ] `npx tsc`, `fjs t` — schema proofs pass unchanged.
+
+### Related
+
+- `fjs/types/rtti/todo/kindset-eliminator.md` — the same "state the
+  `UnionSet` shape once" theme inside `rtti` itself.

--- a/fjs/media/type/todo/detect-via-push.md
+++ b/fjs/media/type/todo/detect-via-push.md
@@ -1,0 +1,56 @@
+## detect-via-push. `detect` re-drives the byte fold that `push` owns
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+The module doc says both detectors read the signature table "through the same
+eliminator (`magicStep`)" — true of the step, but the driving fold is written
+twice:
+
+```js
+// fjs/media/type/module.f.mjs:120-128
+export const detect = bytes => {
+    let magic = magicInit
+    for (const byte of iterable(u8List(msb)(bytes))) {
+        magic = magicStep(magic, byte)
+        if (magic.tag !== 'scan') { break }
+    }
+    return magicMime(magic)
+}
+
+// :198-210 — push: the same loop plus the utf8 factor, with isSettled as the break
+```
+
+`detect(bytes)` is equivalent to `magicMime(push(detectInit)(bytes).magic)`:
+`push` breaks on `isSettled`, which returns `true` the moment the magic state
+matches, and while the utf8 factor keeps running a settled magic state is a
+fixed point of `magicStep` — the final `magic` is the same either way.
+
+`detect` also has no production consumer: `fjs/mcp/cas` uses `detectStream`,
+`fjs/media` uses `detectVec`; the only callers of `detect` are in
+`fjs/media/type/proof.f.mjs`.
+
+### Proposal
+
+Make `detect` a projection of the state machine it fronts:
+
+```js
+/** @type {(bytes: Vec) => Nullable<string>} */
+export const detect = bytes => magicMime(push(detectInit)(bytes).magic)
+```
+
+— or delete it and let the signature proofs assert on `detectVec`'s
+`mime_type`. Verify the fixed-point claim about `magicStep` on settled states
+in the proofs before relying on it (add a case if it isn't pinned yet).
+
+### Tasks
+
+- [ ] Rewrite `detect` over `push` (or remove it and repoint the proofs).
+- [ ] `npx tsc`, `fjs t` — media/type proofs pass unchanged.
+
+### Related
+
+- `fjs/media/type/todo/detect-json.md` — extends what detection returns;
+  fewer copies of the fold makes that change smaller.

--- a/fjs/nanvm/todo/corpus-eliminators.md
+++ b/fjs/nanvm/todo/corpus-eliminators.md
@@ -52,3 +52,10 @@ get one owner each.
       proof-covered); import them from `proof.f.mjs` and `rust/module.f.mjs`.
 - [ ] `npx tsc`, `fjs t`; `npm run update` if the generated Rust output is
       affected (it should be byte-identical).
+
+### Related
+
+- `nanvm-lib/todo/operator-test-operation-model.md` — rewrites the corpus
+  model (semantic operations + arity) across the same three files and keeps
+  the `Swapped` disambiguation; if it lands first, `orders`/`isThrows` should
+  be extracted as part of that rewrite rather than separately.

--- a/fjs/nanvm/todo/corpus-eliminators.md
+++ b/fjs/nanvm/todo/corpus-eliminators.md
@@ -1,0 +1,54 @@
+## corpus-eliminators. The operator-corpus rules are re-implemented by both consumers
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`fjs/nanvm/module.f.mjs` declares itself the single source of truth for the
+operator test corpus ("a new case is written once and checked twice"). The
+*cases* are — but two *rules of the corpus format* are written twice, once in
+each consumer, with each copy's comment pointing at the other:
+
+Commutative-order expansion, byte-identical including the JSDoc type
+(`fjs/nanvm/proof.f.mjs:78-80` vs `fjs/nanvm/rust/module.f.mjs:119-121`):
+
+```js
+const orders = commutative => c => commutative
+    ? [[c.name, c.args], [`${c.name}Swapped`, c.args.toReversed()]]
+    : [[c.name, c.args]]
+```
+
+The `Swapped` suffix is a test-*name* convention: change it in one file and
+the JS and Rust test names for the same case silently diverge.
+
+The `throws`-marker probe (`proof.f.mjs:69-70` as `isThrows` vs inlined in
+`rust/module.f.mjs:125`):
+
+```js
+typeof expected === 'function' && expected()[0] === 'throw'
+```
+
+And the same guard again at `proof.f.mjs:36` / `rust/module.f.mjs:70`
+(`` case 'throw': { throw ['`throws` is not a value', info] } ``).
+
+### Proposal
+
+The corpus module already exports the format's *constructors* (`throws`,
+`ref`, `functionValue`); export its *eliminators* beside them:
+
+```js
+// fjs/nanvm/module.f.mjs
+export const isThrows = ...
+export const orders = ...
+```
+
+Both consumers import them; the `Swapped` naming rule and the marker encoding
+get one owner each.
+
+### Tasks
+
+- [ ] Move `orders` and `isThrows` into `fjs/nanvm/module.f.mjs` (exported,
+      proof-covered); import them from `proof.f.mjs` and `rust/module.f.mjs`.
+- [ ] `npx tsc`, `fjs t`; `npm run update` if the generated Rust output is
+      affected (it should be byte-identical).

--- a/fjs/text/code_point/todo/codepoint-type-owner.md
+++ b/fjs/text/code_point/todo/codepoint-type-owner.md
@@ -1,0 +1,69 @@
+## codepoint-type-owner. The shared `CodePoint` type has no owner
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+`fjs/text/code_point` is documented as the shared Unicode code-point contract
+for the UTF-8 and UTF-16 codecs — it owns `errorMask`, `decoder`, `eofFlush`,
+and the classification predicates — yet it ships no `types.ts`, and the *name*
+of the value it operates on lives in two codec-private type modules under two
+spellings:
+
+```ts
+// fjs/text/utf16/types.ts:22
+export type CodePoint = number
+// fjs/text/utf8/types.ts:13
+export type I32 = number   // "A singed 32-bit integer"
+```
+
+Consequences:
+
+- Six modules that have nothing to do with UTF-16 import the generic type from
+  the UTF-16 codec: `fjs/djs/tokenizer/module.f.mjs:29`,
+  `fjs/bnf/descent/types.ts:7`, `fjs/bnf/descent/proof.f.mjs`,
+  `fjs/bnf/ll1/types.ts:7`, `fjs/bnf/ll1/module.f.mjs`,
+  `fjs/media/json/serializer/module.f.mjs:17`.
+- At the seam the two spellings meet with no named relation:
+  `utf8.toCodePointList` is typed `(input: List<U8>) => List<I32>`
+  (`fjs/text/utf8/module.f.mjs:259-262`) and its output is handed to
+  `codePointListToString`, which takes `List<CodePoint>`
+  (`fjs/text/module.f.mjs:62`).
+- `code_point`'s own signatures fall back to bare `number`
+  (`fjs/text/code_point/module.f.mjs:106`, `:129`, `:153`).
+
+Also found in the same pass: `ByteOrEof` (`fjs/text/utf8/types.ts:20`) is
+named in `utf8/module.f.mjs:9`'s `@import` but referenced nowhere — dead.
+
+### Proposal
+
+Create `fjs/text/code_point/types.ts` owning:
+
+- `CodePoint` — a valid code point or an `errorMask`-tagged error value
+  (documenting that the error tag is part of the domain; this replaces
+  `utf8`'s `I32` name).
+
+Then:
+
+- retype `code_point`'s predicates and `decoder`/`eofFlush` with it;
+- `utf16/types.ts` and `utf8/types.ts` re-export or import it, dropping the
+  local `CodePoint`/`I32` aliases;
+- repoint the six external importers at `text/code_point/types.ts`;
+- delete the dead `ByteOrEof`.
+
+### Tasks
+
+- [ ] Add `fjs/text/code_point/types.ts` with `CodePoint` and JSDoc stating
+      the error-tag convention.
+- [ ] Retype `code_point`, `utf8` (replace `I32`), `utf16`; delete `ByteOrEof`.
+- [ ] Repoint the importers in `djs/tokenizer`, `bnf/descent`, `bnf/ll1`,
+      `media/json/serializer`.
+- [ ] `npx tsc`, `fjs t`.
+
+### Related
+
+- [190](../../todo/190.md) — the code-unit/code-point ↔ string *value*
+  boundary; this issue is the *type* boundary, complementary.
+- `fjs/text/utf8/todo/error-tag-layout-constants.md` — names the error-tag
+  bit layout; the new type's JSDoc should link there.

--- a/fjs/text/utf8/todo/encoder-code-point-bounds.md
+++ b/fjs/text/utf8/todo/encoder-code-point-bounds.md
@@ -1,0 +1,50 @@
+## encoder-code-point-bounds. `codePointToUtf8` re-spells `code_point`'s boundary constants
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`fjs/text/code_point/module.f.mjs:73-75` states its own contract: "Every
+predicate below is derived from these constants so the surrogate bounds and
+the maximum appear exactly once":
+
+```js
+// fjs/text/code_point/module.f.mjs:79-80
+const bmpMax = /** @type {const} */ 0xffff
+const maxCodePoint = /** @type {const} */ 0x10_ffff
+```
+
+The UTF-16 encoder honours that — `codePointToUtf16` dispatches through
+`isBmpCodePoint`/`isSupplementaryPlane`. But the UTF-8 encoder imports nothing
+from `code_point` except `errorMask` and re-spells both boundaries inline:
+
+```js
+// fjs/text/utf8/module.f.mjs:97, :104
+if (input >= 0x0800 && input <= 0xffff) { ... }
+if (input >= 0x10000 && input <= 0x10ffff) { ... }
+```
+
+So the "appears exactly once" invariant is already broken one directory up.
+
+### Proposal
+
+Export `bmpMax` and `maxCodePoint` from `code_point` (or an
+`isSupplementaryPlane`-style range predicate where one fits) and write the
+3- and 4-byte guards of `codePointToUtf8` through them. The genuinely
+UTF-8-specific thresholds (`0x7f`, `0x7ff` — encoding-length boundaries, not
+code-point-domain boundaries) stay local.
+
+### Tasks
+
+- [ ] Export the two constants from `fjs/text/code_point/module.f.mjs` with
+      proof coverage.
+- [ ] Rewrite `codePointToUtf8`'s valid-range guards through them.
+- [ ] `npx tsc`, `fjs t` — pure refactor.
+
+### Related
+
+- `fjs/text/utf8/todo/error-tag-layout-constants.md` — covers the *error*
+  branch of the same function; this issue covers the valid-range branches.
+- `fjs/text/todo/surrogate-pair-in-code-point.md` — the utf16 counterpart of
+  moving code-point-domain arithmetic into `code_point`.

--- a/fjs/types/bit_vec/todo/mapped-list-to-vec.md
+++ b/fjs/types/bit_vec/todo/mapped-list-to-vec.md
@@ -1,0 +1,61 @@
+## mapped-list-to-vec. The `try*ListToVec` + `mapUnwrap` pair is written once per element type
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`bit_vec` builds "concatenate a mapped list into one vector" twice — once for
+`Vec` elements inside the `bo` record, once for `U8` elements as top-level
+exports — with the same two-step shape and the same `mapUnwrap` lift:
+
+```js
+// fjs/types/bit_vec/module.f.mjs:297-305 (inside bo)
+const unpackedListToVec = unpackListToVec(unpackConcat)
+const tryListToVec = list => unpackedListToVec(mapUnpack(list))
+...
+listToVec: mapUnwrap(tryListToVec),
+
+// fjs/types/bit_vec/module.f.mjs:373-386
+export const tryU8ListToVec = ({ unpackConcat }) => {
+    const unpackedListToVec = unpackListToVec(unpackConcat)
+    return list => unpackedListToVec(mapU8ToUnpacked(list))
+}
+...
+export const u8ListToVec = bo =>
+    mapUnwrap(tryU8ListToVec(bo))
+```
+
+The only difference is the element-to-`Unpacked` map (`mapUnpack` at `:188` vs
+`mapU8ToUnpacked` at `:193`). The module already has exactly this combinator
+for the opposite direction — `mappedChunkList` (`:423-427`) parameterizes
+chunking by an in-map and an out-map, and `chunkList`/`unpackedChunkList`
+(`:437`, `:445`) are its two instantiations — so the abstraction exists and
+just was not applied to concatenation.
+
+### Proposal
+
+Mirror `mappedChunkList`:
+
+```js
+/** @type {<I>(g: (i: I) => Unpacked) => (bo: BitOrder) => (list: List<I>) => Nullable<Vec>} */
+const mappedListToVec = g => ({ unpackConcat }) => {
+    const f = unpackListToVec(unpackConcat)
+    return list => f(map(g)(list))
+}
+```
+
+Then `tryListToVec = mappedListToVec(unpack)(bo)` inside `bo`, and
+`tryU8ListToVec = mappedListToVec(u8ToUnpacked)`, with both unwrapping
+variants staying `mapUnwrap(...)` one-liners.
+
+### Tasks
+
+- [ ] Add `mappedListToVec`; re-derive `tryListToVec`/`listToVec` and
+      `tryU8ListToVec`/`u8ListToVec` from it.
+- [ ] `npx tsc`, `fjs t` — pure refactor, `bit_vec` proofs pass unchanged.
+
+### Related
+
+- `fjs/types/bit_vec/module.f.mjs:423-427` — `mappedChunkList`, the precedent
+  this mirrors.

--- a/fjs/types/rtti/todo/export-node-accessors.md
+++ b/fjs/types/rtti/todo/export-node-accessors.md
@@ -1,0 +1,63 @@
+## export-node-accessors. `rtti/ts` re-implements `rtti/data`'s private `Node` accessors
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`rtti/data` owns the `Node`/`UnionSet` algebra but keeps its accessors private,
+so `rtti/ts` re-implements them — once even by allocating fake `Data` tuples to
+reach a private comparison through the public `cmp`.
+
+Resolving a `Node` through the rule set:
+
+```js
+// fjs/types/rtti/data/module.f.mjs:331
+const resolve = rules => n => typeof n === 'string' ? assertNotNullish(at(n)(rules)) : n
+
+// fjs/types/rtti/ts/module.f.mjs:166-169 — the same lookup, open-coded
+const admitsUndefined = ctx => n => {
+    const u = typeof n === 'string' ? assertNotNullish(at(n)(ctx.rules)) : n
+    ...
+```
+
+Testing "is this the top set":
+
+```js
+// fjs/types/rtti/data/module.f.mjs:268
+const isTop = n => typeof n !== 'string' && cmpUnion(n, unknown) === 0
+
+// fjs/types/rtti/ts/module.f.mjs:197
+const isTop = u => cmp([{}, u])([{}, top]) === 0
+```
+
+The `ts` version is the tell: `cmpUnion` is private, so the printer wraps `u`
+and `top` in two throwaway `[{}, …]` `Data` tuples purely to reach the union
+comparison through the public `cmp`. `rtti/ts` already imports `cmp`, `toData`,
+`unitBit`, and `unknown as top` from `../data/module.f.mjs`, so this is a
+missing export, not a layering problem. The own-property-lookup subtlety that
+`resolve`'s JSDoc documents (`data/module.f.mjs:325-329`) is silently repeated
+by the copy.
+
+### Proposal
+
+Export a small `Node` accessor API from `rtti/data` — `resolve`, `isTop`
+(and `isNever`, `data/module.f.mjs:265`, for symmetry) — and delete the copies
+in `rtti/ts`:
+
+- `admitsUndefined` becomes `const u = resolve(ctx.rules)(n)`.
+- `ts`'s `isTop` disappears; call the imported one (its argument is a
+  `UnionSet`, which the data version accepts as a `Node`).
+
+### Tasks
+
+- [ ] Export `resolve`, `isTop`, `isNever` from `fjs/types/rtti/data/module.f.mjs`
+      with JSDoc; add proof coverage for the exported forms.
+- [ ] Rewrite `admitsUndefined` and `isTop` in `fjs/types/rtti/ts/module.f.mjs`
+      through the imports; drop the fake-`Data` `cmp` trick.
+- [ ] `npx tsc`, `fjs t` — rtti proofs pass unchanged.
+
+### Related
+
+- [172](./172.md) — one container skeleton for `validate`/`parse`;
+  same theme of `rtti` submodules sharing the `data` algebra instead of copying it.

--- a/fjs/types/rtti/todo/kindset-eliminator.md
+++ b/fjs/types/rtti/todo/kindset-eliminator.md
@@ -1,0 +1,108 @@
+## kindset-eliminator. Name the `KindSet` absent/whole/members trichotomy once
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`KindSet<T> | undefined` always means the same three-way contract — `undefined`
+= empty set, `true` = the whole kind, array = these members — but every
+consumer re-spells the trichotomy inline. Unary eliminations alone:
+
+```js
+// fjs/types/rtti/data/module.f.mjs:852
+const kindRefs = f => k => k === undefined || k === true ? [] : k.flatMap(f)
+
+// fjs/types/rtti/data/module.f.mjs:956-965
+const patternsValidate = (k, item, value) => {
+    if (k === undefined) { return verror('unexpected value') }
+    if (k === true) { return ok(value) }
+    ...
+
+// fjs/types/rtti/ts/module.f.mjs:130-133
+const kindToTs = (k, whole, item) =>
+    k === undefined ? [] :
+    k === true ? [whole] :
+    k.map(item)
+```
+
+and the same `undefined || true` guard is duplicated twice within each of two
+structurally identical union rewriters:
+
+```js
+// fjs/types/rtti/data/module.f.mjs:493-501
+const mapChildren = f => u => ({
+    ...u,
+    ...(u.array === undefined || u.array === true ? {} : {
+        array: sortedDedup(cmpArraySet)(u.array.map(mapArraySet(f))),
+    }),
+    ...(u.object === undefined || u.object === true ? {} : {
+        object: sortedDedup(cmpObjectSet)(u.object.map(mapObjectSet(f))),
+    }),
+})
+
+// fjs/types/rtti/data/module.f.mjs:519-527 — same skeleton, different transform
+const dropSubsumedUnion = ctx => u => ({
+    ...u,
+    ...(u.array === undefined || u.array === true ? {} : {
+        array: dropSubsumed(arraySetSubset(ctx)({}))(u.array),
+    }),
+    ...(u.object === undefined || u.object === true ? {} : {
+        object: dropSubsumed(objectSetSubset(ctx)({}))(u.object),
+    }),
+})
+```
+
+The binary combinators `cmpKind` (`data:119`), `mergeKind` (`data:233`),
+`kindSubset` (`data:344`) and the membership test `kindHas` (`data:940`) spell
+the same case analysis pairwise. Nine sites total state the "absent / whole /
+members" contract; none of them names it.
+
+### Proposal
+
+Two extractions in `rtti/data`, both exported for `rtti/ts`:
+
+1. A unary eliminator stating the trichotomy once:
+
+   ```js
+   /** @type {<T, R>(cases: {
+    *     readonly absent: () => R
+    *     readonly whole: () => R
+    *     readonly members: (list: readonly T[]) => R
+    * }) => (k: KindSet<T> | undefined) => R} */
+   const kindFold = ({ absent, whole, members }) => k =>
+       k === undefined ? absent() :
+       k === true ? whole() :
+       members(k)
+   ```
+
+   Derive `kindRefs`, `kindToTs`, `patternsValidate` (and the guard used by
+   the rewriters below) from it.
+
+2. A shared skeleton for the two union rewriters, holding the spread and both
+   guards once:
+
+   ```js
+   /** @type {(onArray: (l: readonly ArraySet[]) => readonly ArraySet[],
+    *          onObject: (l: readonly ObjectSet[]) => readonly ObjectSet[])
+    *  => (u: UnionSet) => UnionSet} */
+   const mapPatternKinds = (onArray, onObject) => u => ({ ... })
+   ```
+
+   `mapChildren` and `dropSubsumedUnion` become two instantiations.
+
+The binary sites (`cmpKind`, `mergeKind`, `kindSubset`, `kindHas`) genuinely
+need pairwise case analysis, so they stay — but their doc comments should point
+at `kindFold` as the statement of the contract.
+
+### Tasks
+
+- [ ] Add `kindFold` to `fjs/types/rtti/data/module.f.mjs`; rewrite `kindRefs`,
+      `patternsValidate`, and `ts`'s `kindToTs` through it.
+- [ ] Extract `mapPatternKinds`; re-derive `mapChildren` and `dropSubsumedUnion`.
+- [ ] `npx tsc`, `fjs t` — pure refactor, rtti proofs pass unchanged.
+
+### Related
+
+- [172](./172.md) — validate/parse container skeleton; touches
+  `patternsValidate`'s callers, coordinate if both land.

--- a/fjs/types/rtti/todo/shared-helper-reuse.md
+++ b/fjs/types/rtti/todo/shared-helper-reuse.md
@@ -1,0 +1,74 @@
+## shared-helper-reuse. `rtti` re-spells tiny helpers that shared modules own
+
+**Priority:** P5
+**Status:** open
+
+### Problem
+
+`rtti/data` and `rtti/ts` re-implement, between them, four helpers whose
+canonical owners already exist under `fjs/types`:
+
+Association-list lookup, byte-identical modulo parameter names:
+
+```js
+// fjs/types/rtti/data/module.f.mjs:614-619
+const assoc = (list, key) => {
+    for (const [k, v] of list) {
+        if (k === key) { return v }
+    }
+    return undefined
+}
+
+// fjs/types/rtti/ts/module.f.mjs:102-107
+const idOf = (ids, name) => {
+    for (const [k, v] of ids) {
+        if (k === name) { return v }
+    }
+    return undefined
+}
+```
+
+Order-preserving dedup, byte-identical:
+
+```js
+// fjs/types/rtti/data/module.f.mjs:392
+const dedup = list => list.filter((n, i) => list.indexOf(n) === i)
+// fjs/types/rtti/ts/module.f.mjs:172
+const dedup = list => list.filter((s, i) => list.indexOf(s) === i)
+```
+
+And uncurried re-spellings of `function/compare.cmp` and
+`function/operator.strictEqual`:
+
+```js
+// fjs/types/rtti/data/module.f.mjs:74, :93 — twice in one file
+const cmpString = (a, b) => a < b ? -1 : a > b ? 1 : 0
+const cmpBigint = (a, b) => a < b ? -1 : a > b ? 1 : 0
+// fjs/types/rtti/data/module.f.mjs:334
+const strictEqual = (a, b) => a === b
+
+// the owners:
+// fjs/types/function/compare/module.f.mjs:21-22
+export const cmp = a => b => a < b ? -1 : a > b ? 1 : 0
+// fjs/types/function/operator/module.f.mjs:25
+export const strictEqual = a => b => a === b
+```
+
+The only reason for the comparator copies is currying: `rtti/data` feeds
+uncurried `(a, b)` comparators to `toSorted`/`cmpList`.
+
+### Proposal
+
+- Add `dedup` and `assoc` (linear `readonly [K, V][]` lookup by `===`) to
+  `fjs/types/array/module.f.mjs` — the home of the other plain-array helpers —
+  and import them from both rtti modules.
+- Define the comparators through the owners:
+  `const cmpString = (a, b) => cmp(a)(b)`, likewise `cmpBigint` and
+  `strictEqual`. If the uncurried adaptation recurs elsewhere, add `uncurry2`
+  to `fjs/types/function/module.f.mjs` instead of repeating the lambda.
+
+### Tasks
+
+- [ ] `fjs/types/array`: add `dedup`, `assoc` with proofs.
+- [ ] `rtti/data`, `rtti/ts`: replace the four local copies with imports.
+- [ ] `npx tsc`, `fjs t`.

--- a/nanvm-lib/todo/bigint-eq-cmp-owner.md
+++ b/nanvm-lib/todo/bigint-eq-cmp-owner.md
@@ -1,0 +1,53 @@
+## bigint-eq-cmp-owner. `BigInt` equality and ordering are decided by unrelated code paths
+
+**Priority:** P5
+**Status:** open
+
+### Problem
+
+`PartialEq` and `Ord` for `BigInt<A>` are computed by two independent owners:
+
+```rust
+// src/vm/bigint/partial_eq.rs:3-7 — generic container walk (header, then items)
+impl<A: IVm> PartialEq for BigInt<A> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.items_eq(&other.0)
+    }
+}
+
+// src/vm/bigint/cmp.rs:12-23 — bigint's own sign dispatch over abs_cmp_vec
+let lhs_sign = *self.0.header();
+let rhs_sign = *rhs.0.header();
+match (lhs_sign, rhs_sign) { ... }
+```
+
+`Ord`'s contract requires `cmp(a, b) == Equal` exactly when `a == b`. The two
+agree today only because normalization forbids a negative zero (so equal
+header + equal items ⇔ compare-equal), but neither file states that
+dependency, and the two paths differ operationally: `abs_cmp_vec` panics on
+non-normalized input while `items_eq` accepts it. A future representation
+tweak that keeps one path correct can silently break the other's agreement.
+
+### Proposal
+
+Make one relation the owner. Either:
+
+1. `PartialEq::eq` delegates: `self.cmp(other) == Ordering::Equal`; or
+2. keep the cheap `items_eq` path and add a comment on both impls naming the
+   normalization invariant ("no negative zero; items normalized") that makes
+   them coincide — plus a debug assertion or proof-level test pinning
+   `(a == b) == (a.cmp(&b) == Equal)` across sign/zero cases.
+
+Option 2 preserves the O(1)-bailout equality; option 1 is the smaller rule.
+
+### Tasks
+
+- [ ] Pick a single owner (or document + test the invariant); apply.
+- [ ] `cargo test`, `cargo clippy`, `cargo fmt -- --check`.
+
+### Related
+
+- [sign-algebra](./sign-algebra.md) — rewrites `cmp.rs`'s four-arm match but
+  keeps the two relations separate; independent of this issue.
+- [bigint-normalized-check-reuse](./bigint-normalized-check-reuse.md) — the
+  normalization invariant this agreement silently depends on.

--- a/nanvm-lib/todo/bigint-sign-accessor.md
+++ b/nanvm-lib/todo/bigint-sign-accessor.md
@@ -1,0 +1,50 @@
+## bigint-sign-accessor. `*self.0.header()` is open-coded in eight bigint files
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`BigInt<A>` stores its sign as the container header but exposes no accessor,
+so every operator file reaches through the private tuple field into the
+generic container — ten sites in eight files under `src/vm/bigint/`:
+
+```rust
+// mod.rs:78      let lhs_sign = *self.0.header();
+// cmp.rs:14-15   let lhs_sign = *self.0.header();  let rhs_sign = *rhs.0.header();
+// add.rs:8       let rhs_sign = *rhs.0.header();
+// sub.rs:8       let rhs_sign = rhs.0.header().flip();
+// neg.rs:14      Self::unchecked_new(self.0.header().flip(), self.index_iter())
+// mul.rs:37      if self.0.header() == rhs.0.header() {
+// shl.rs:61      Ok(Self::unchecked_new(*self.0.header(), value))
+// shr.rs:41      Self::normalize_new(*self.0.header(), value)
+// debug.rs:13    if *self.0.header() == Sign::Negative {
+```
+
+This is also why most `bigint/*.rs` files carry a `use crate::vm::IContainer`
+import they need for nothing else. The crate already has the right shape one
+directory over: `Function<A>` exposes `name()`/`length()` instead of letting
+callers read `self.0.header().0`, and `BigInt` itself already wraps one
+container access in `is_zero()` (`mod.rs:45-47`).
+
+### Proposal
+
+```rust
+// src/vm/bigint/mod.rs, next to is_zero():
+pub(crate) fn sign(&self) -> Sign {
+    *self.0.header()
+}
+```
+
+Route the ten sites through it (`rhs.sign()`, `self.sign().flip()`, …) and
+drop the now-unneeded `IContainer` imports.
+
+### Tasks
+
+- [ ] Add `sign()`; rewrite the ten sites; prune imports.
+- [ ] `cargo test`, `cargo clippy`, `cargo fmt -- --check`.
+
+### Related
+
+- [sign-algebra](./sign-algebra.md) — gives `Sign` its algebra once the sign
+  is in hand; this issue is about how the sign is *read*.

--- a/nanvm-lib/todo/ivm-from-unpacked.md
+++ b/nanvm-lib/todo/ivm-from-unpacked.md
@@ -1,0 +1,74 @@
+## ivm-from-unpacked. Collapse `IVm`'s eight `From` bounds to `From<Unpacked<Self>>`
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+The eight-variant table is restated in two places that are both derivable from
+the `From<X> for Unpacked` impl set. `src/vm/internal/mod.rs:13-24` spells it
+as supertrait bounds:
+
+```rust
+pub trait IVm:
+    Sized
+    + Clone
+    + From<Nullish>
+    + From<bool>
+    + From<f64>
+    + From<String<Self>>
+    + From<BigInt<Self>>
+    + From<Object<Self>>
+    + From<Array<Self>>
+    + From<Function<Self>>
+```
+
+and `src/vm/impls/from.rs:5-18` as an eight-arm match:
+
+```rust
+impl<A: IVm> From<Unpacked<A>> for Any<A> {
+    fn from(value: Unpacked<A>) -> Self {
+        match value {
+            Unpacked::Nullish(n) => n.to_any(),
+            Unpacked::Boolean(b) => b.to_any(),
+            ...
+            Unpacked::Function(f) => f.to_any(),
+        }
+    }
+}
+```
+
+Adding a variant currently means touching both, plus the `From<X> for
+Unpacked` impls. The proof that this collapses is already in the crate:
+`src/naive/mod.rs:14-18` writes
+`impl<T: Into<Unpacked<Naive>>> From<T> for Naive`, i.e. `Naive` already
+satisfies `From<Unpacked<Naive>>` and derives all eight variant conversions
+from it.
+
+### Proposal
+
+No macros needed:
+
+- `IVm: Sized + Clone + From<Unpacked<Self>>` replaces the eight bounds.
+- `ToAny::to_any` (`src/vm/any/to_any.rs`) bounds on
+  `Self: Into<Unpacked<A>>` with body `Any(Unpacked::from(self).into())`.
+- `From<Unpacked<A>> for Any<A>` becomes `Any(value.into())` — the match
+  disappears.
+
+Deletes ~20 lines and removes two of the places a new variant must be
+registered.
+
+### Tasks
+
+- [ ] Rewrite the `IVm` bound, `ToAny`, and `impls/from.rs`; check no caller
+      relied on the direct `From<X> for A` bounds (they still hold via
+      `X → Unpacked<Self> → Self`, but the *trait bound* changes shape).
+- [ ] `cargo test`, `cargo clippy`, `cargo fmt -- --check`.
+
+### Related
+
+- [65Y-nanvm-conversion-macros](./65y-nanvm-conversion-macros.md) — targets
+  the `From<X> for Unpacked` / `TryFrom` copies themselves; complementary,
+  and both reduce the per-variant registration count.
+- [159](./159.md) — the wrapper-trait boilerplate; same spirit at the
+  container layer.

--- a/nanvm-lib/todo/numeric-coercion-module.md
+++ b/nanvm-lib/todo/numeric-coercion-module.md
@@ -1,0 +1,62 @@
+## numeric-coercion-module. ToNumeric has no module and rebuilds an `Any` just to unpack it
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+Three of the four ECMAScript coercion abstract operations each own a module —
+`number_coercion.rs` (ToNumber), `string_coercion.rs` (ToString),
+`primitive_coercion.rs` (ToPrimitive). The fourth, ToNumeric, is an inline
+method body on `Any` (`src/vm/any/mod.rs:71-82`), sitting between
+`to_string`/`to_number`, which are one-line `dispatch` delegations:
+
+```rust
+pub fn to_numeric(self) -> Result<Numeric<A>, Any<A>> {
+    // https://tc39.es/ecma262/#sec-tonumeric
+    let prim_value = self.to_primitive(Some(ToPrimitivePreferredType::Number))?;
+    match prim_value {
+        Primitive::BigInt(bi) => Ok(Numeric::BigInt(bi)),
+        _ => {
+            let u: Unpacked<A> = prim_value.into();
+            let any: Any<A> = u.into();
+            Ok(Numeric::Number(any.to_number()?))
+        }
+    }
+}
+```
+
+Besides the placement, the `_` arm packs a value it has fully in hand —
+`Primitive → Unpacked → Any` (allocating through `to_any`) — purely so
+`to_number` can start by unpacking it again and re-running `to_primitive` on
+a value already known to be primitive.
+
+### Proposal
+
+A sibling `src/vm/numeric_coercion.rs` owning the operation over the type it
+actually needs:
+
+```rust
+pub fn to_numeric<A: IVm>(p: Primitive<A>) -> Result<Numeric<A>, Any<A>>
+```
+
+dispatching the non-bigint arms directly onto the number-coercion primitive
+methods (no `Any` round trip), with `Any::to_numeric` reduced to a one-liner
+like its `to_string`/`to_number` siblings:
+`Ok(match self.to_primitive(...)? { ... })` → `numeric_coercion::to_numeric`.
+
+### Tasks
+
+- [ ] Add `numeric_coercion.rs`; move the body; make the non-bigint arms call
+      `NumberCoercion`'s primitive handlers directly.
+- [ ] `cargo test`, `cargo clippy`, `cargo fmt -- --check`.
+
+### Related
+
+- [primitive-coercion-dispatch](./primitive-coercion-dispatch.md) — the
+  shared coerce-`Any`-to-T skeleton for `number_coercion.rs` /
+  `string_coercion.rs`; this issue adds the third operation to that layer's
+  scope.
+- [numeric-operator-home](./numeric-operator-home.md) — `Numeric`'s
+  *operators*; explicitly leaves the coercion layer out, which this issue
+  covers.

--- a/nanvm-lib/todo/uint-add-assign.md
+++ b/nanvm-lib/todo/uint-add-assign.md
@@ -1,0 +1,58 @@
+## uint-add-assign. `index_iter` restates `Uint`'s bounds by hand because `Uint` is missing `AddAssign`
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`src/common/uint.rs:3` owns the index-type bound:
+
+```rust
+pub trait Uint: Sized + Copy + Default + PartialEq + Sub<Output = Self> + From<u8> {}
+```
+
+`src/common/index_iter.rs` uses it at `:10`
+(`impl<I: Uint, T: SizedIndex<I>> IndexIter<I, T>`) — and then, nine lines
+later on the same struct, re-lists all the bounds by hand plus one more:
+
+```rust
+// index_iter.rs:19-22
+impl<
+    I: Copy + Default + PartialEq + AddAssign + From<u8> + Sub<Output = I>,
+    T: SizedIndex<I, Output: Clone>,
+> Iterator for IndexIter<I, T>
+```
+
+Two spellings of one bound in one file, guaranteed to drift. The extra
+`AddAssign` is the load-bearing part: because `Uint` does not carry it,
+`SizedIndex::index_iter` (`src/common/sized_index.rs:17-22`) is constrained
+only by `I: Uint` and can hand back an `IndexIter` that is not an `Iterator` —
+the crate's iteration entry point does not guarantee the thing it returns
+iterates.
+
+### Proposal
+
+Stepping by one is part of what "index type" means; put `AddAssign` in the
+owner:
+
+```rust
+pub trait Uint:
+    Sized + Copy + Default + PartialEq + AddAssign + Sub<Output = Self> + From<u8> {}
+```
+
+(and the mirroring blanket impl), then:
+
+```rust
+impl<I: Uint, T: SizedIndex<I, Output: Clone>> Iterator for IndexIter<I, T>
+```
+
+### Tasks
+
+- [ ] Add `AddAssign` to `Uint` and its blanket impl; rewrite the `Iterator`
+      impl's bounds as `I: Uint`.
+- [ ] `cargo test`, `cargo clippy`, `cargo fmt -- --check`.
+
+### Related
+
+- [sized-index-for-refs](./sized-index-for-refs.md) — adjacent `SizedIndex`
+  API work.


### PR DESCRIPTION
This commit adds 30 new todo documents across the codebase, each identifying a specific refactoring opportunity where code is duplicated, inconsistently named, or could be better organized.

## Summary

These todo items represent a systematic audit of code duplication and organizational issues across the fjs and nanvm-lib projects. Each document follows the established format with Problem, Proposal, and Tasks sections, prioritized from P3 (high) to P5 (low).

## Key Categories of Issues Identified

**Abstraction Extraction (11 items)**
- `kindset-eliminator`: Name the `KindSet` absent/whole/members trichotomy once
- `shared-helper-reuse`: Consolidate tiny helpers (`dedup`, `assoc`, comparators)
- `export-node-accessors`: Export private `Node` accessor functions from rtti/data
- `mapped-list-to-vec`: Parameterize the `try*ListToVec` + `mapUnwrap` pattern
- `strip-undefined-set-op`: Extract `withoutUnits` set operation to rtti/data owner
- `continuation-bit-layout`: Name the base128 varint layout constants once
- `byte-length-fields`: Compute SHA-2 byte lengths once, not per-consumer
- `sync-interpreter-owner`: Export shared synchronous memory interpreter
- `corpus-eliminators`: Export operator-corpus format rules as eliminators
- `proof-fixture`: Share Evo proof fixture between cas/evo and mcp/evo
- `node-program-options-factory`: Export the `NodeProgramOptions` factory

**Derivation Instead of Duplication (8 items)**
- `ivm-from-unpacked`: Collapse `IVm`'s eight `From` bounds to `From<Unpacked<Self>>`
- `tokenize-string-derive`: Derive metadata-free tokenizers from metadata-aware ones
- `rfc6979-vector-harness`: Parameterize RFC 6979 test-vector walker
- `trivia-merge-rule`: State ws/nl coalescing contract once in js/tokenizer
- `detect-via-push`: Derive `detect` from the `push` state machine
- `proof-drain-collectread`: Use exported `collectRead` instead of hand-rolled `drain`
- `bigint-eq-cmp-owner`: Unify `BigInt` equality and ordering decision paths
- `codepoint-type-owner`: Create shared `CodePoint` type owner in code_point module

**Type/Module Organization (5 items)**
- `codepoint-type-owner`: Establish code_point as the owner of the CodePoint type
- `numeric-coercion-module`: Create numeric_coercion.rs module for ToNumeric
- `bigint-sign-accessor`: Add `sign()` accessor to avoid repeated `*self.0.header()` calls
- `uint-add-assign`: Add `AddAssign` to the `Uint` trait bound
- `bigint-eq-cmp-owner`: Consolidate equality/ordering logic

**Dead Code Removal (2 items)**
- `casupload-dead`: Remove unused `casUpload` function and stale documentation
- `proof-crockford-copy`: Remove Crockford Base32 alphabet copy from basen/proof

**Documentation/Naming (4 items)**
- `encoder-code-point-bounds`: Export code-point boundary constants for UTF-8 encoder
- `sized-index-for-refs`: (referenced but not detailed in visible diff)

## Implementation Notes

- All items are marked as `open` status with clear priority levels
- Each includes concrete code examples showing the current duplication
- Proposals include specific function signatures and module locations
- Tasks are broken into actionable steps with testing requirements
- Related items cross-reference each other where applicable

These refactorings range from simple constant extraction to more involved abstraction work, but all follow the principle of "name it once" — establishing single sources of truth for shared contracts, algorithms, and data.

https://claude.ai/code/session_01EmMTBtFzoQY3NQnCsHgZ6f