### PR TITLE
Bring sul/module.f.mjs to 100% line/branch/function coverage: 93.75% → 100% branch

### DIFF
--- a/changelog/unreleased/1587.md
+++ b/changelog/unreleased/1587.md
@@ -1,0 +1,4 @@
+- `sul`: rewrites `cascade`'s `for(;;)` loop as a recursive `cascadeFrom`,
+  removing a phantom loop-exit branch V8's coverage instrumentation could
+  never mark taken, bringing the module to 100% line/branch/function
+  coverage

--- a/fjs/sul/module.f.mjs
+++ b/fjs/sul/module.f.mjs
@@ -32,21 +32,26 @@ export const encode =
 
         /** @typedef {readonly [Id | undefined, S, readonly _HashState[]]} _CascadeResult */
 
-        /** @type {(id0: Id, storage0: S, stacks0: readonly _HashState[]) => _CascadeResult} */
-        const cascade = (id0, storage0, stacks0) => {
-            let id = id0, storage = storage0, stacks = stacks0
-            for (let index = 0; ; index++) {
-                if (index >= stacks.length) {
-                    const [, [newStorage, newStack]] = step(id, [storage, []])
-                    return [id, newStorage, [...stacks, newStack]]
-                }
-                const [out, [newStorage, newStack]] = step(id, [storage, stacks[index]])
-                stacks = [...stacks.slice(0, index), newStack, ...stacks.slice(index + 1)]
-                storage = newStorage
-                if (out === undefined) return [undefined, storage, stacks]
-                id = out
+        // Recursive rather than a `for(;;)` loop: every exit is one of the two
+        // `return`s below, so a bare `for(;;)` picks up a phantom "loop falls
+        // through" branch that V8's coverage instrumentation can never mark
+        // taken — there is no third way out to take it. Recursion has no such
+        // branch to begin with.
+        /** @type {(id: Id, storage: S, stacks: readonly _HashState[], index: number) => _CascadeResult} */
+        const cascadeFrom = (id, storage, stacks, index) => {
+            if (index >= stacks.length) {
+                const [, [newStorage, newStack]] = step(id, [storage, []])
+                return [id, newStorage, [...stacks, newStack]]
             }
+            const [out, [newStorage, newStack]] = step(id, [storage, stacks[index]])
+            const newStacks = [...stacks.slice(0, index), newStack, ...stacks.slice(index + 1)]
+            return out === undefined
+                ? [undefined, newStorage, newStacks]
+                : cascadeFrom(out, newStorage, newStacks, index + 1)
         }
+
+        /** @type {(id0: Id, storage0: S, stacks0: readonly _HashState[]) => _CascadeResult} */
+        const cascade = (id0, storage0, stacks0) => cascadeFrom(id0, storage0, stacks0, 0)
 
         /** @type {(bit: bigint, state: EncodeState<S>) => readonly [Id | undefined, EncodeState<S>]} */
         const literalStep = (bit, state) => {


### PR DESCRIPTION
## Summary

`fjs/sul/module.f.mjs` was at 93.75% branch coverage (1 uncovered branch). This brings it to 100% line/branch/function coverage:

- **`cascade`'s `for (let index = 0; ; index++)` loop** carried a phantom "loop falls through" branch: V8's coverage instrumentation allocates a branch for the loop's (nonexistent) condition, but the loop only ever exits through one of its two internal `return`s — never by falling off the end — so that branch can never be marked taken by any input, no matter how the loop's logic is exercised.
- Rewrites `cascade` as a recursive `cascadeFrom`, which has no such branch to begin with — same logic, same two exit points, now expressed as two `return` statements in a plain function rather than a loop.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `node --test --experimental-test-coverage --test-coverage-include='fjs/sul/module.f.mjs' fjs/emergent_testing/all.test.mjs` → 100.00% line/branch/func
- [x] `node ./fjs/module.mjs t` → 2828 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmWCv5YGRXToq26xPoSXjX)_