### PR TITLE
Bring asn.1 to 100% line/branch/function coverage: 90.91% → 100% branch

### DIFF
--- a/changelog/unreleased/1596.md
+++ b/changelog/unreleased/1596.md
@@ -1,0 +1,3 @@
+- `asn.1`: adds proof coverage for `parsedTagDecode`'s tag class ×
+  primitive/constructed combinations, bringing the module to 100%
+  line/branch/function coverage

--- a/fjs/asn.1/proof.f.mjs
+++ b/fjs/asn.1/proof.f.mjs
@@ -296,6 +296,22 @@ export const proof = {
         // Re-encoding an UnsupportedRecord returns it unchanged (it is already the TLV bytes)
         assertEq(encode(decoded), raw, 'encode should round-trip UnsupportedRecord')
     },
+    // parsedTagDecode narrows the top three bits of the tag's first byte
+    // (class + primitive/constructed) to one of exactly eight values via an
+    // 8-way `||` assert. Every other test in this file only ever exercises
+    // the universal-primitive tag (top bits 000), so each of the other seven
+    // comparisons has never had a case where it's the one that turns the
+    // assert true — one round trip per class×P/C combination covers them all.
+    tagClass: {
+        universalPrimitive: () => check(0x02n, vec8(0x42n), empty),
+        universalConstructed: () => check(0x22n, vec8(0x42n), empty),
+        applicationPrimitive: () => check(0x42n, vec8(0x42n), empty),
+        applicationConstructed: () => check(0x62n, vec8(0x42n), empty),
+        contextPrimitive: () => check(0x82n, vec8(0x42n), empty),
+        contextConstructed: () => check(0xA2n, vec8(0x42n), empty),
+        privatePrimitive: () => check(0xC2n, vec8(0x42n), empty),
+        privateConstructed: () => check(0xE2n, vec8(0x42n), empty),
+    },
     raw: [
         () => {
             const e = encodeRaw([0x00n, vec8(0x23n)])


### PR DESCRIPTION
## Summary

`fjs/asn.1/module.f.mjs` was at 90.91% branch coverage (6 uncovered branches). This brings it to 100% line/branch/function coverage:

- **`parsedTagDecode`'s 8-way `||` assert** narrows a decoded tag's class + primitive/constructed bits (top 3 bits of the first byte) to one of exactly eight values. Every existing test in this file only ever decoded a universal-primitive tag (top bits `000`), so the other seven `===` comparisons in the chain never had a case where they were the one making the assert true — they were always short-circuited past.
- Adds `tagClass`, one `check` round trip per class×primitive/constructed combination (universal/application/context/private × primitive/constructed), covering all eight.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `node --test --experimental-test-coverage --test-coverage-include='fjs/asn.1/module.f.mjs' fjs/emergent_testing/all.test.mjs` → 100.00% line/branch/func
- [x] `node ./fjs/module.mjs t` → 2856 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmWCv5YGRXToq26xPoSXjX)_