### PR TITLE
Bring dev to 100% line/branch/function coverage: 97.50% → 100% branch

### DIFF
--- a/changelog/unreleased/1597.md
+++ b/changelog/unreleased/1597.md
@@ -1,0 +1,2 @@
+- `dev`: adds proof coverage for `loadModuleMap`'s `INIT_CWD`-prefix
+  stripping, bringing the module to 100% line/branch/function coverage

--- a/fjs/dev/module.f.mjs
+++ b/fjs/dev/module.f.mjs
@@ -168,4 +168,13 @@ export const proof = {
         const [, result] = virtual({ ...emptyState, root })(loadModuleMap({}))
         assertEq(Object.keys(result).join(','), './a.f.ts')
     },
+    loadModuleMapStripsInitCwdPrefix: () => {
+        // With `INIT_CWD` set (the normal `npm run` case), discovery starts
+        // from that subdirectory and each key is relativized against it, so
+        // keys are still `./`-relative to `INIT_CWD` rather than carrying it.
+        /** @type {Dir} */
+        const root = { 'sub': { 'a.f.ts': () => ({}) } }
+        const [, result] = virtual({ ...emptyState, root })(loadModuleMap({ INIT_CWD: 'sub' }))
+        assertEq(Object.keys(result).join(','), './a.f.ts')
+    },
 }


### PR DESCRIPTION
## Summary

`fjs/dev/module.f.mjs` was at 97.50% branch coverage (1 uncovered branch). This brings it to 100% line/branch/function coverage:

- **`loadModuleMap`'s `s === '.' ? '' : s` prefix computation** only ever saw the `s === '.'` side (`INIT_CWD` unset). The normal case — `INIT_CWD` set to a real subdirectory, as it is under `npm run` — was never exercised, so the `false` side of the ternary had no test.
- Adds `loadModuleMapStripsInitCwdPrefix`, which sets `INIT_CWD` to a real subdirectory and verifies discovered keys are still relativized to `./`-prefixed paths (not left carrying the `INIT_CWD` prefix).

## Test plan

- [x] `npx tsc --noEmit`
- [x] `node --test --experimental-test-coverage --test-coverage-include='fjs/dev/module.f.mjs' fjs/emergent_testing/all.test.mjs` → 100.00% line/branch/func
- [x] `node ./fjs/module.mjs t` → 2857 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmWCv5YGRXToq26xPoSXjX)_