### PR TITLE
Fail npm run cov if aggregate coverage falls under 100%

### DIFF
--- a/changelog/unreleased/1605.md
+++ b/changelog/unreleased/1605.md
@@ -1,2 +1,2 @@
-- `npm run cov` now fails the build if aggregate line, branch, or function
-  coverage falls under 100%, instead of only reporting the numbers
+- ci: `npm run cov` now fails the build if aggregate line, branch, or
+  function coverage falls under 100%, instead of only reporting the numbers

--- a/changelog/unreleased/1605.md
+++ b/changelog/unreleased/1605.md
@@ -1,0 +1,2 @@
+- `npm run cov` now fails the build if aggregate line, branch, or function
+  coverage falls under 100%, instead of only reporting the numbers

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "prepack": "tsc --noEmit false --emitDeclarationOnly && tsc",
     "test": "tsc && node ./fjs/module.mjs t",
-    "cov": "node --test --experimental-test-coverage --test-coverage-include=**/module.f.mjs",
+    "cov": "node --test --experimental-test-coverage --test-coverage-include=**/module.f.mjs --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100",
     "start": "node ./fjs/module.mjs",
     "ci-update": "node ./fjs/module.mjs ci && node ./fjs/module.mjs r ./fjs/nanvm/update/module.f.mjs",
     "dev-update": "node ./fjs/module.mjs r ./fjs/dev/update/module.f.mjs",


### PR DESCRIPTION
## Summary

- `node --test`'s coverage support includes `--test-coverage-lines`, `--test-coverage-branches`, and `--test-coverage-functions` — minimum-threshold flags that make the run exit non-zero if the aggregate percentage across included files falls below the given value.
- `cov` previously only *reported* coverage numbers; nothing in CI's node26 job actually failed the build when coverage regressed. That's how the gaps fixed in #1596, #1597, and #1600 slipped in unnoticed until a repo-wide sweep found them after the fact.
- Sets all three thresholds to 100, matching AGENTS.md's existing "new code ships at 100% coverage" policy — now enforced by CI instead of only by review/manual sweeps.

No change to `.github/workflows/ci.yml` or the CI generator (`fjs/ci/`) is needed: the generated `node26` job already runs `npm run cov` as a plain step, so the new thresholds take effect purely from `package.json`. Verified with `npm run ci-update` that nothing else drifts.

**Sequencing note (resolved):** this PR was opened before #1603 (the `js/tokenizer` coverage fix) merged, so its own CI initially failed at exactly the gate this PR adds — confirming the gate works. #1603 has since merged; after rebasing, `npm run cov` exits 0 locally with `100.00 | 100.00 | 100.00` aggregate.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run ci-update` → `git status` shows only `package.json` changed (no generated-file drift)
- [x] `node ./fjs/module.mjs t` → 2882 pass, 0 fail
- [x] `npm run cov` → exits 0, `100.00 | 100.00 | 100.00` aggregate (after rebasing onto main with #1603)

## Changelog

- ci: `npm run cov` now fails the build if aggregate line, branch, or function coverage falls under 100%, instead of only reporting the numbers

🤖 Generated with [Claude Code](https://claude.ai/code)