### PR TITLE
tsconfig: enable the four low-cost strictness flags

### DIFF
--- a/fjs/djs/tokenizer/module.f.mjs
+++ b/fjs/djs/tokenizer/module.f.mjs
@@ -393,7 +393,12 @@ const stringDecodeScan = (cp, state) => {
                 case latinSmallLetterN: return [[lf],        { kind: 'normal' }]    // \n → line feed (LF)
                 case latinSmallLetterR: return [[cr],        { kind: 'normal' }]    // \r → carriage return (CR)
                 case latinSmallLetterT: return [[ht],        { kind: 'normal' }]    // \t → horizontal tab (HT)
-                case latinSmallLetterU: return [null, { kind: 'unicode', acc: 0, count: 0 }]  // \u → start 4 hex digits
+                // `\u` is the only case the assertion above leaves. It is a
+                // `default` rather than a `case latinSmallLetterU` because the
+                // ASCII constants are plain `number`s, so the switch can never
+                // be exhaustive to TypeScript and the clause would fall through
+                // into `unicode` below.
+                default: return [null, { kind: 'unicode', acc: 0, count: 0 }]  // \u → start 4 hex digits
             }
         }
         case 'unicode': {

--- a/fjs/types/btree/set/module.f.mjs
+++ b/fjs/types/btree/set/module.f.mjs
@@ -80,7 +80,11 @@ const nodeSet = c => g => node => {
             case 2: {
                 // insert
                 const value = g(null)
-                switch (x.length) {
+                // TODO: remove after TSGO fix the regression.
+                const xL = x.length
+                // See https://github.com/microsoft/typescript-go/issues/4613
+                assert(xL === 1 || xL === 2)
+                switch (xL) {
                     case 1: { return [[x[0], value]] }
                     case 2: { return [[x[0]], value, [x[1]]] }
                 }

--- a/todo/strict-static-analysis.md
+++ b/todo/strict-static-analysis.md
@@ -14,7 +14,7 @@ and `cargo test` in both profiles on every one of them.
 The JavaScript half runs `npx tsc` and the test suites (`fjs test`,
 `node --test`, `deno task cov`, `bun test --coverage`) — and nothing else. No
 lint, no formatting check, no unused-code check, no package-correctness check.
-`tsconfig.json` leaves eight checking flags off. There is no equivalent of
+`tsconfig.json` leaves four checking flags off. There is no equivalent of
 `-D warnings` anywhere on this side.
 
 That asymmetry is the gap to close, using well-known tools rather than
@@ -55,8 +55,8 @@ inspects the output.
 
 ### Proposal
 
-1. Enable the four zero-cost `tsc` flags
-   ([tsconfig-strict-flags.md](./tsconfig-strict-flags.md) step 1).
+1. ~~Enable the four low-cost `tsc` flags~~ — done; the remaining four are
+   tracked in [tsconfig-strict-flags.md](./tsconfig-strict-flags.md).
 2. Add `deno fmt --check` and `deno lint` to the generated workflow. Both are
    free in setup terms; expect one cleanup commit each.
 3. Add the declaration-emit check for `any` / `/*elided*/`.

--- a/todo/tsconfig-strict-flags.md
+++ b/todo/tsconfig-strict-flags.md
@@ -6,12 +6,11 @@
 ### Problem
 
 [`tsconfig.json`](../tsconfig.json) enables `strict`, `exactOptionalPropertyTypes`,
-`erasableSyntaxOnly` and `verbatimModuleSyntax`, but leaves eight further
-checking flags commented out. Nothing records whether they were rejected or
-merely never tried, so each new contributor re-asks the question.
-
-Four of them cost nothing today: the tree is already clean under them. Leaving
-them off means the property is unenforced and can silently regress.
+`erasableSyntaxOnly`, `verbatimModuleSyntax`, `noImplicitReturns`,
+`noFallthroughCasesInSwitch`, `noImplicitOverride` and `isolatedModules`, but
+leaves four further checking flags commented out. Nothing records whether they
+were rejected or merely never tried, so each new contributor re-asks the
+question.
 
 One of them — `noUncheckedIndexedAccess` — matters beyond hygiene. It makes
 every index access yield `T | undefined`, which is exactly the obligation
@@ -23,46 +22,67 @@ candidates: `fjs/effects/node/virtual/`, `fjs/bnf/descent/`,
 
 ### Measurements
 
-Error counts from `npx tsc --noEmit --<flag>` on a clean tree (TypeScript
-7.0.2), one flag at a time:
+Error counts from `npx tsc --<flag>` on a clean tree (TypeScript 7.0.2), one
+flag at a time. The four enabled flags are listed with the count they carried
+when they were turned on; the rest are current.
 
 | Flag | New errors | Notes |
 | --- | --: | --- |
-| `noImplicitReturns` | 0 | free |
-| `noFallthroughCasesInSwitch` | 0 | free |
-| `noImplicitOverride` | 0 | free |
-| `isolatedModules` | 0 | free |
+| `noImplicitReturns` | 0 | **enabled** |
+| `noImplicitOverride` | 0 | **enabled** |
+| `isolatedModules` | 0 | **enabled** |
+| `noFallthroughCasesInSwitch` | 2 | **enabled**, after two fixes — see below |
 | `noUnusedParameters` | 8 | |
-| `noPropertyAccessFromIndexSignature` | 31 | |
-| `noUncheckedIndexedAccess` | 202 | the one with design value, see above |
-| `noUnusedLocals` | 209 | 130 `TS6196` + 79 `TS6133`, see below |
+| `noPropertyAccessFromIndexSignature` | 33 | |
+| `noUncheckedIndexedAccess` | 211 | the one with design value, see above |
+| `noUnusedLocals` | 214 | 133 `TS6196` + 81 `TS6133`, see below |
+
+`noFallthroughCasesInSwitch` was measured at 0 when this issue was first
+written; the tree had drifted to 2 by the time the flag was turned on. Both
+sites were switches whose exhaustiveness TypeScript could not see, so the end of
+the enclosing `case` was reachable and control would have fallen into the next
+one:
+
+- `fjs/djs/tokenizer/module.f.mjs` — `stringDecodeScan`'s `escape` state
+  switches on a code point against the ASCII constants of `fjs/text/ascii`,
+  which are `number`, not literal types. No such switch can ever be exhaustive
+  to TypeScript, so the last clause became a `default`.
+- `fjs/types/btree/set/module.f.mjs` — `switch (x.length)` over a tuple union,
+  where TSGO does not narrow the length to a literal union
+  ([typescript-go#4613](https://github.com/microsoft/typescript-go/issues/4613)).
+  Fixed the way the same function already worked around that regression: bind
+  the length, `assert` the two possible values, switch on the binding.
+
+The two fixes are the argument for the flag: in both places a fallthrough would
+have silently continued into an unrelated state rather than failing.
 
 `noUnusedLocals` splits into two unrelated populations:
 
-- **130 `TS6196`** — type names pulled in by a JSDoc
+- **133 `TS6196`** — type names pulled in by a JSDoc
   `@import { … } from './types.ts'` list and never referenced. `@import` lists
   drift as a module changes and nothing catches it today; this is real dead
   weight and the only JSDoc-specific hygiene gap the audit found.
-- **79 `TS6133`** — unused values, e.g. the ASN.1 universal tag constants
+- **81 `TS6133`** — unused values, e.g. the ASN.1 universal tag constants
   (`eoc`, `bitString`, `null_`, `external`, …) kept as documentation of the tag
   space. Those are deliberate; enabling the flag forces a decision about them
   (export, drop, or annotate).
 
-### Proposal
+### Tasks
 
-1. Enable the four zero-cost flags now, in one commit, to lock in properties the
-   tree already has: `noImplicitReturns`, `noFallthroughCasesInSwitch`,
-   `noImplicitOverride`, `isolatedModules`.
-2. Enable `noUnusedParameters` (8 sites) and `noPropertyAccessFromIndexSignature`
-   (31 sites) as small follow-ups.
-3. Take `noUncheckedIndexedAccess` as its own task, sequenced **after** the
-   `assert` conversions in [inline-type-casts.md](./inline-type-casts.md) — the
-   two overlap, and doing the casts first shrinks the 202.
-4. For `noUnusedLocals`, fix the 130 stale `@import` entries first; that is
-   worth doing on its own even if the flag stays off. Decide the 79 unused
-   values separately.
+- [x] Enable the four low-cost flags: `noImplicitReturns`,
+      `noFallthroughCasesInSwitch`, `noImplicitOverride`, `isolatedModules`.
+- [ ] Enable `noUnusedParameters` (8 sites) and
+      `noPropertyAccessFromIndexSignature` (33 sites) as small follow-ups.
+- [ ] Take `noUncheckedIndexedAccess` as its own task, sequenced **after** the
+      `assert` conversions in [inline-type-casts.md](./inline-type-casts.md) —
+      the two overlap, and doing the casts first shrinks the 211.
+- [ ] For `noUnusedLocals`, fix the 133 stale `@import` entries first; that is
+      worth doing on its own even if the flag stays off. Decide the 81 unused
+      values separately.
 
-Each step is independently verifiable with `npx tsc` and `fjs t`.
+Each step is independently verifiable with `npx tsc` and `fjs t`. Re-measure
+before starting one: the counts above are a snapshot, and
+`noFallthroughCasesInSwitch` is the standing proof that they drift.
 
 ### Related
 

--- a/todo/tsconfig-strict-flags.md
+++ b/todo/tsconfig-strict-flags.md
@@ -1,7 +1,7 @@
 # Additional strictness flags for `tsconfig.json`
 
 **Priority:** P2
-**Status:** open
+**Status:** wip
 
 ### Problem
 
@@ -34,8 +34,8 @@ when they were turned on; the rest are current.
 | `noFallthroughCasesInSwitch` | 2 | **enabled**, after two fixes — see below |
 | `noUnusedParameters` | 8 | |
 | `noPropertyAccessFromIndexSignature` | 33 | |
-| `noUncheckedIndexedAccess` | 211 | the one with design value, see above |
-| `noUnusedLocals` | 214 | 133 `TS6196` + 81 `TS6133`, see below |
+| `noUncheckedIndexedAccess` | 212 | the one with design value, see above |
+| `noUnusedLocals` | 218 | 137 `TS6196` + 81 `TS6133`, see below |
 
 `noFallthroughCasesInSwitch` was measured at 0 when this issue was first
 written; the tree had drifted to 2 by the time the flag was turned on. Both
@@ -58,7 +58,7 @@ have silently continued into an unrelated state rather than failing.
 
 `noUnusedLocals` splits into two unrelated populations:
 
-- **133 `TS6196`** — type names pulled in by a JSDoc
+- **137 `TS6196`** — type names pulled in by a JSDoc
   `@import { … } from './types.ts'` list and never referenced. `@import` lists
   drift as a module changes and nothing catches it today; this is real dead
   weight and the only JSDoc-specific hygiene gap the audit found.
@@ -75,8 +75,8 @@ have silently continued into an unrelated state rather than failing.
       `noPropertyAccessFromIndexSignature` (33 sites) as small follow-ups.
 - [ ] Take `noUncheckedIndexedAccess` as its own task, sequenced **after** the
       `assert` conversions in [inline-type-casts.md](./inline-type-casts.md) —
-      the two overlap, and doing the casts first shrinks the 211.
-- [ ] For `noUnusedLocals`, fix the 133 stale `@import` entries first; that is
+      the two overlap, and doing the casts first shrinks the 212.
+- [ ] For `noUnusedLocals`, fix the 137 stale `@import` entries first; that is
       worth doing on its own even if the flag stays off. Decide the 81 unused
       values separately.
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -71,7 +71,7 @@
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
 
     /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    "isolatedModules": true,                             /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
@@ -91,10 +91,10 @@
     // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
     "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    "noImplicitReturns": true,                           /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    "noFallthroughCasesInSwitch": true,                  /* Enable error reporting for fallthrough cases in switch statements. */
     // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    "noImplicitOverride": true,                          /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */


### PR DESCRIPTION
Implements step 1 of [`todo/tsconfig-strict-flags.md`](https://github.com/functionalscript/functionalscript/blob/main/todo/tsconfig-strict-flags.md): turn on `noImplicitReturns`, `noImplicitOverride`, `isolatedModules` and `noFallthroughCasesInSwitch`, so properties the tree already has stop being unenforced.

The first three were clean, as the issue measured. `noFallthroughCasesInSwitch` was not: it had drifted from 0 to 2 sites since the measurement. Both are switches whose exhaustiveness TypeScript cannot see, so the end of the enclosing `case` was reachable and control would have fallen into the next one — in both places a silent continuation into an unrelated state rather than a failure. That is the argument for the flag, so they are fixed here rather than deferred:

- `djs/tokenizer` — `stringDecodeScan`'s `escape` state switches a code point against the `text/ascii` constants, which are `number` rather than literal types. No such switch can ever be exhaustive to TypeScript, so the `\u` clause becomes a `default`; the assertion above it already establishes that `\u` is the only case left.
- `types/btree/set` — `switch (x.length)` over a tuple union, where TSGO does not narrow the length to a literal union ([typescript-go#4613](https://github.com/microsoft/typescript-go/issues/4613)). Fixed the way the same function already worked around that regression at `case 3`: bind the length, `assert` its two possible values, switch on the binding.

The issue file stays — three of its four steps are still open — but its status moves to `wip` and its measurement table is refreshed against TypeScript 7.0.2 on this branch (`noUnusedParameters` 8, `noPropertyAccessFromIndexSignature` 33, `noUncheckedIndexedAccess` 212, `noUnusedLocals` 218 = 137 `TS6196` + 81 `TS6133`), records the two fallthrough fixes and their causes, and notes that counts drift and should be re-measured before the next step. `todo/strict-static-analysis.md` is updated to match.

`npx tsc`, `npm test` (2976 proofs) and `npm run cov` (100% lines/branches/functions) pass; `npm run ci-update` produces no diff.

Changelog: none
