### PR TITLE
emergent_testing: migrate to IoEffect composition

### DIFF
--- a/changelog/unreleased/1629.md
+++ b/changelog/unreleased/1629.md
@@ -1,0 +1,6 @@
+- **BREAKING CHANGES:** `emergent_testing`: `Reporter`'s members and the
+  `registerModule` / `runModuleMap` / `testAll` chain are fallible `IoEffect`s.
+  A failed reporter write now ends the run with exit `1`, as does a failed
+  `register`, which used to answer `0` either way.
+- `effects/node`: new `allOk` — `all` in the `ok` channel, answering with the
+  first error instead of a list of results for the caller to collapse.

--- a/fjs/effects/node/module.f.mjs
+++ b/fjs/effects/node/module.f.mjs
@@ -11,6 +11,7 @@
  * @module
  *
  * @import { Vec } from '../../types/bit_vec/types.ts'
+ * @import { Result } from '../../types/result/types.ts'
  * @import { Effect, Func, Operation } from '../types.ts'
  * @import { List } from '../list/types.ts'
  * @import { All, Access, Await, Console, CreateExclusive, CreateServer, Dirent, Engine, Env, Exec, ExecResult, Fetch, FileStat, Forever, Fs, Headers, Http, IncomingMessage, Import, IoError, IoErrorInfo, IoResult, Listen, MakeDirectoryOptions, Mkdir, Module, Now, NodeOp, NodeProgramOptions, OpResult, RandomInt, Read, ReadBytes, ReadConsoles, ReadFile, Readdir, ReaddirOptions, RequestListener, Rename, Rm, Sandbox, SandboxResult, Server, ServerResponse, Stat, Test, TestContext, TestFn, Write, WriteBytes, WriteConsoles, WriteFile, _UtfList, _WriteLoop, } from './types.ts'
@@ -22,7 +23,7 @@ import { toCodePointList } from '../../text/utf8/module.f.mjs'
 import { codePointListToString } from '../../text/utf16/module.f.mjs'
 import { reverse } from '../../types/list/module.f.mjs'
 import { length } from '../../types/bit_vec/module.f.mjs'
-import { error as resultError } from '../../types/result/module.f.mjs'
+import { error as resultError, ok as resultOk, unwrap } from '../../types/result/module.f.mjs'
 import { do_, mapStep, pure, step } from '../module.f.mjs'
 import { mapStep as ioMapStep, pureError, pureOk, step as ioStep } from '../io/module.f.mjs'
 
@@ -84,6 +85,48 @@ export const isNotFound = ([tag, payload]) =>
 export const all =
     /** @type {<O extends Operation, T>(...a: readonly Effect<O, T>[]) => Effect<O | All, OpResult<readonly T[]>>} */
     (do_('all'))
+
+/**
+ * Collapses a list of results into a result of the list, keeping the **first**
+ * error in list order and discarding the later ones.
+ *
+ * Keeping one is what makes this a `Result` rather than a report: the callers
+ * that need it are chains, and a chain has one error channel. A site that wants
+ * every failure wants a different return type and should not reach for this.
+ *
+ * @type {<T, E>(list: readonly Result<T, E>[]) => Result<readonly T[], E>}
+ */
+const okList = list => {
+    for (const r of list) {
+        if (r[0] === 'error') { return r }
+    }
+    return resultOk(list.map(unwrap))
+}
+
+/**
+ * {@link all} in the `ok` channel: collects the values when every effect
+ * succeeded, and answers with the first failure otherwise.
+ *
+ * `all` alone cannot serve a fallible chain. Its envelope is the runner's
+ * (`OpResult`, saying whether the *operation* could be dispatched), so handing
+ * it `IoEffect`s nests one `Result` inside another and the caller receives
+ * `readonly Result<T, E>[]`. That has to be collapsed before the chain can
+ * `step` again, and a continuation that forgets to is the value-discarding
+ * hazard this migration exists to remove — one level in, where it is harder to
+ * see.
+ *
+ * **Every effect still runs.** The short-circuit is in the *result*, not in the
+ * execution: `all` performs them concurrently and this reads the answers once
+ * they are all in, so a failure does not cancel its siblings the way it stops
+ * the sequential `forEachStep` in `../io/module.f.mjs`. The error channel
+ * unions the runner's
+ * `NotImplemented` with the effects' own `E` for the same reason every other
+ * step does — either can be what went wrong.
+ *
+ * @type {<O extends Operation, T, E>(...a: readonly IoEffect<O, T, E>[]) => IoEffect<O | All, readonly T[], NotImplemented | E>}
+ */
+export const allOk = (...a) =>
+    ioStep(all(...a), rs => pure(okList(rs)))
 
 /**
  * @template {Operation} O0

--- a/fjs/effects/todo/io-effect-consumer-migration.md
+++ b/fjs/effects/todo/io-effect-consumer-migration.md
@@ -71,9 +71,31 @@ Where a module genuinely has no answer to a failure, `unwrapStep` stays — the
 goal is a *considered* policy at every site, not zero panics. Say so in a
 comment when it stays.
 
+### What `fjs/emergent_testing` settled
+
+Its eight sites came down to one, and the three findings generalize to the
+modules still queued:
+
+- **`all` needed an `ok`-channel twin, and it is shared.** `all`'s envelope is
+  the runner's, so handing it `IoEffect`s nests one `Result` inside another and
+  the caller receives `readonly Result<T, E>[]` — the value-discarding hazard,
+  one level in. `allOk` (`fjs/effects/node/module.f.mjs`) collapses that to the
+  first error. `fjs/dev`'s two `all`s want the same combinator, so it is already
+  where that migration needs it.
+- **The panic that stayed is at a foreign boundary.** `Test` hands its callback
+  to an external framework whose contract is a raw `Effect<…, void>`, so there
+  is no channel to answer through and a throw is what that framework reports as
+  a failed test. The remaining `unwrapStep` is there, with that reason in a
+  comment; every other site now propagates.
+- **A tail is not always `exitStep`.** That one answers `0` for every success,
+  and `testAll`'s success value *is* the exit code (`1` when a test failed), so
+  it needs a sibling that keeps the computed code and reports only the channel
+  failure. `register`, whose success carries nothing, uses `exitStep` unchanged.
+  Expect the same split wherever a program already computes a code.
+
 ### Tasks
 
-- [ ] `fjs/emergent_testing` — reporter, `registerModule`, `runModuleMap`,
+- [x] `fjs/emergent_testing` — reporter, `registerModule`, `runModuleMap`,
       `defaultTest`; `Reporter<O>` member types.
 - [ ] `fjs/dev` — `loadModuleMap` and `allFiles`.
 - [ ] `fjs/cas/evo` — the cache slot and the `Evo<O>` API, plus `fjs/mcp/evo`.

--- a/fjs/effects/todo/io-effect-migration.md
+++ b/fjs/effects/todo/io-effect-migration.md
@@ -325,7 +325,7 @@ and the worklist is the `unwrapStep` call sites — every one is a consumer that
 has not yet chosen a policy beyond "panic".
 
 Migrated so far: `fjs/ci`, `fjs/ci/nix`, `fjs/nanvm/update`, `fjs/dev/update`,
-`fjs/cas` and `cas list`. Still on `unwrapStep`: `fjs/emergent_testing`,
+`fjs/cas`, `cas list` and `fjs/emergent_testing`. Still on `unwrapStep`:
 `fjs/cas/evo`, `fjs/mcp`, `fjs/protocol/mcp` (and its stdio transport),
 `fjs/dev`, and the proofs that drive them.
 
@@ -345,8 +345,9 @@ Migrated so far: `fjs/ci`, `fjs/ci/nix`, `fjs/nanvm/update`, `fjs/dev/update`,
 - [x] Add IoEffect variants of other combinators only when real consumers
       require them; do not mirror the whole raw-effect API speculatively.
       `history` / `historyStep` / `foldStep` / `forEachStep` landed with the
-      consumers that required them; `items` stays a **raw** effect in both
-      folds, since no consumer produces its list fallibly.
+      consumers that required them, and `allOk` with `fjs/emergent_testing`;
+      `items` stays a **raw** effect in both folds, since no consumer produces
+      its list fallibly.
 - [ ] Revisit `okStep`, `IoResult`, stream-fold helpers, and specialized
       recovery adapters as consumers migrate; remove redundant APIs when
       possible.

--- a/fjs/emergent_testing/module.f.mjs
+++ b/fjs/emergent_testing/module.f.mjs
@@ -11,15 +11,16 @@
  * @module
  *
  * @import { Effect, Operation } from '../effects/types.ts'
+ * @import { IoEffect, NotImplemented } from '../effects/io/types.ts'
  * @import { LoadModuleOperations, ModuleMap } from '../dev/types.ts'
  * @import { TestFn, TestEntry, TestSet, Path, Reporter, _TestState, _TestAndPath } from './types.ts'
- * @import { All, Await, Env, NodeProgram, NodeProgramOptions, Program, Sandbox, SandboxResult, Test, TestContext, Write, WriteConsoles } from '../effects/node/types.ts'
+ * @import { All, Await, Env, IoError, NodeProgram, NodeProgramOptions, Program, Sandbox, SandboxResult, Test, TestContext, Write, WriteConsoles } from '../effects/node/types.ts'
  */
 
 import { reset, fgGreen, fgRed, bold, csiWrite } from '../text/sgr/module.f.mjs'
-import { all, awaitIfPromise, sandbox, test } from '../effects/node/module.f.mjs'
-import { history, historyStep, mapStep, pure, step } from '../effects/module.f.mjs'
-import { unwrapStep } from '../effects/io/module.f.mjs'
+import { allOk, awaitIfPromise, errorExit, errorMessage, exitStep, sandbox, test } from '../effects/node/module.f.mjs'
+import { pure, step as rawStep } from '../effects/module.f.mjs'
+import { history, historyStep, mapStep, pureOk, step, unwrapStep } from '../effects/io/module.f.mjs'
 import { loadModuleMap } from '../dev/module.f.mjs'
 import { invert } from '../types/result/module.f.mjs'
 import { definedEntries } from '../types/object/module.f.mjs'
@@ -105,10 +106,10 @@ export const collectTests = (path, throws, v) => {
  * This is the correct model for Node `--test`, Bun, and Deno, where tests must
  * be declared upfront and the framework drives execution.
  *
- * @type {(ctx: TestContext, k: string, v: unknown, star: string) => Effect<Test | All | Await, void>}
+ * @type {(ctx: TestContext, k: string, v: unknown, star: string) => IoEffect<Test | All | Await, void, NotImplemented>}
  */
 export const registerModule = (ctx, k, v, star) => {
-    /** @type {(ctx: TestContext, entry: _TestAndPath) => Effect<Test | All | Await, void>} */
+    /** @type {(ctx: TestContext, entry: _TestAndPath) => IoEffect<Test | All | Await, void, NotImplemented>} */
     const registerOne = (ctx, [path, { fn, throws }]) => {
         // `star` (non-empty for Bun and for Node below the 26 baseline) signals
         // that all sub-tests run inline inside this single registration, so an
@@ -118,22 +119,29 @@ export const registerModule = (ctx, k, v, star) => {
         // extra suffix is needed.
         const base = fmtImport(k, path)
         const name = throws ? base : `${base}${star}`
-        return unwrapStep(test(ctx, name, throws, (/** @type {TestContext} */ t) =>
-            step(unwrapStep(awaitIfPromise(fn())), resolved => {
+        // The registered callback panics on failure, deliberately. `Test` hands
+        // it to an external framework (node `--test`, Bun, Deno) whose contract
+        // is a raw `Effect<…, void>`: there is no channel to answer a failure
+        // through, so propagating it here would only discard it one level up.
+        // A throw is what that framework *does* understand — it reports the
+        // test as failed, which is the outcome a caller wants anyway. The `test`
+        // operation's own result is propagated normally, just below.
+        const body = (/** @type {TestContext} */ t) =>
+            unwrapStep(step(awaitIfPromise(fn()), resolved => {
                 if (throws) {
-                    return pure(undefined)
+                    return pureOk(undefined)
                 }
                 const sub = collectTests([...path, null], false, resolved)
                 if (sub.length === 0) {
-                    return pure(undefined)
+                    return pureOk(undefined)
                 }
-                return mapStep(unwrapStep(all(...sub.map(e => registerOne(t, e)))), () => undefined)
-            })
-        ))
+                return mapStep(allOk(...sub.map(e => registerOne(t, e))), () => undefined)
+            }))
+        return test(ctx, name, throws, body)
     }
     const tests = collectTests([], false, v)
-    if (tests.length === 0) { return pure(undefined) }
-    return mapStep(unwrapStep(all(...tests.map(e => registerOne(ctx, e)))), () => undefined)
+    if (tests.length === 0) { return pureOk(undefined) }
+    return mapStep(allOk(...tests.map(e => registerOne(ctx, e))), () => undefined)
 }
 
 /** @type {(a: _TestState, b: _TestState) => _TestState} */
@@ -146,10 +154,10 @@ const zero = { time: 0, pass: 0, fail: 0 }
 /**
  * @template {Operation} O
  * @param {Reporter<O>} reporter
- * @returns {(k: string, v: unknown) => (ts: _TestState) => Effect<O | All, _TestState>}
+ * @returns {(k: string, v: unknown) => (ts: _TestState) => IoEffect<O | All, _TestState, NotImplemented | IoError>}
  */
 const runModule = ({ result, test }) => (k, v) => ts => {
-    /** @type {(entry: _TestAndPath) => Effect<O | All, _TestState>} */
+    /** @type {(entry: _TestAndPath) => IoEffect<O | All, _TestState, NotImplemented | IoError>} */
     const one = ([testPath, set]) => {
         // The sandbox result is still needed after it has been reported, so the
         // reporting call is captured rather than nested inside its own step.
@@ -161,22 +169,22 @@ const runModule = ({ result, test }) => (k, v) => ts => {
             ([, sr]) => {
                 const { result: [s, r], duration } = sr
                 if (s !== 'ok') {
-                    return pure(addFail(duration)(zero))
+                    return pureOk(addFail(duration)(zero))
                 }
                 if (set.throws) {
-                    return pure(addPass(duration)(zero))
+                    return pureOk(addPass(duration)(zero))
                 }
                 // Walk return-value sub-tree; null marks the call boundary so
                 // paths render as e.g. `outer().inner`. throws resets to false.
-                return step(
+                return mapStep(
                     walk([...testPath, null], false, r),
-                    sub => pure(mergeState(addPass(duration)(zero), sub)))
+                    sub => mergeState(addPass(duration)(zero), sub))
             })
     }
-    /** @type {(path: Path, throws: boolean, v: unknown) => Effect<O | All, _TestState>} */
+    /** @type {(path: Path, throws: boolean, v: unknown) => IoEffect<O | All, _TestState, NotImplemented | IoError>} */
     const walk = (path, throws, v) => {
         const effects = collectTests(path, throws, v).map(one)
-        return mapStep(unwrapStep(all(...effects)), states => states.reduce(mergeState, zero))
+        return mapStep(allOk(...effects), states => states.reduce(mergeState, zero))
     }
     return mapStep(walk([], false, v), delta => mergeState(ts, delta))
 }
@@ -193,13 +201,13 @@ const proofEntries = moduleMap =>
  *
  * @template {Operation} O
  * @param {Reporter<O>} reporter
- * @returns {(moduleMap: ModuleMap) => Effect<O | All, number>}
+ * @returns {(moduleMap: ModuleMap) => IoEffect<O | All, number, NotImplemented | IoError>}
  */
 export const runModuleMap = reporter => moduleMap => {
     const { summary } = reporter
     const modules = proofEntries(moduleMap)
     const total = mapStep(
-        unwrapStep(all(...modules.map(([k, v]) => runModule(reporter)(k, v)(zero)))),
+        allOk(...modules.map(([k, v]) => runModule(reporter)(k, v)(zero))),
         m => m.reduce(mergeState, zero))
     // The totals are still needed after the summary has been printed, so they
     // are carried forward in a history rather than closed over by a nested
@@ -211,27 +219,46 @@ export const runModuleMap = reporter => moduleMap => {
 }
 
 /**
+ * Ends a run with the exit code it computed, reporting a channel failure on
+ * `stderr` as exit `1`.
+ *
+ * Not `exitStep`, which answers `0` for every success: this chain's success
+ * value **is** the exit code, `1` when a test failed. The two policies differ
+ * only in what an `ok` means, and conflating them would report a failing suite
+ * as a passing run.
+ *
+ * @type {<O extends Operation>(e: IoEffect<O, number, NotImplemented | IoError>) => Effect<O | Write, number>}
+ */
+const exitCodeStep = e =>
+    rawStep(e, r => r[0] === 'error' ? errorExit(errorMessage(r[1])) : pure(r[1]))
+
+/**
  * Discovers all test modules via `loadModuleMap`, then runs them through
  * `runModuleMap`. The composed effect is a `NodeProgram` entry point for the
  * `fjs t` test runner.
  *
+ * The chain leaves the Io layer here, because this is where a `Program` ends
+ * and a `Program`'s answer is an exit code rather than a `Result`. A run that
+ * could not report its own results is a failed run, so it exits `1` with the
+ * reason on `stderr` instead of unwinding as a panic.
+ *
  * @template {Operation} O
  * @param {Reporter<O>} reporter
- * @returns {Program<O | All | LoadModuleOperations>}
+ * @returns {Program<O | All | LoadModuleOperations | Write>}
  */
 export const testAll = reporter => options =>
-    step(loadModuleMap(options.env), runModuleMap(reporter))
+    exitCodeStep(rawStep(loadModuleMap(options.env), runModuleMap(reporter)))
 
 /**
  * Registers all modules in `moduleMap` that export a `proof` property with
  * `ctx`. Delegates to `registerModule` for each matching entry.
  *
- * @type {(ctx: TestContext, star: string) => (moduleMap: ModuleMap) => Effect<Test | All | Await, void>}
+ * @type {(ctx: TestContext, star: string) => (moduleMap: ModuleMap) => IoEffect<Test | All | Await, void, NotImplemented>}
  */
 const registerModuleMap = (ctx, star) => moduleMap => {
     const modules = proofEntries(moduleMap)
-    if (modules.length === 0) { return pure(undefined) }
-    return mapStep(all(...modules.map(([k, v]) => registerModule(ctx, k, v, star))), () => undefined)
+    if (modules.length === 0) { return pureOk(undefined) }
+    return mapStep(allOk(...modules.map(([k, v]) => registerModule(ctx, k, v, star))), () => undefined)
 }
 
 /** @type {(c: string) => boolean} */
@@ -317,10 +344,10 @@ export const ghEscape = s =>
  * Default `Reporter.test` implementation: sandboxes `fn` once and inverts the
  * result when `throws` is `true` (caught error → pass, clean return → fail).
  *
- * @type {(file: string, path: Path, entry: TestEntry) => Effect<Sandbox, SandboxResult<unknown>>}
+ * @type {(file: string, path: Path, entry: TestEntry) => IoEffect<Sandbox, SandboxResult<unknown>, NotImplemented>}
  */
 export const defaultTest = (file, path, { fn, throws }) =>
-    mapStep(unwrapStep(sandbox(fn)), r => throws ? { ...r, result: invert(r.result) } : r)
+    mapStep(sandbox(fn), r => throws ? { ...r, result: invert(r.result) } : r)
 
 /** @type {(file: string, path: Path, color: string, label: string, duration: number) => string} */
 const fmtResultLine = (file, path, color, label, duration) =>
@@ -338,13 +365,14 @@ const fmtResultLine = (file, path, color, label, duration) =>
 export const defaultReporter = options => {
     const write = csiWrite(options)
     // A reporter that cannot emit its own output has no fallback to choose —
-    // there is nowhere left to report the failure — so a failed write is this
-    // program's panic. One `unwrapStep` here covers every line the reporter
-    // writes.
-    /** @type {(w: WriteConsoles) => (s: string) => Effect<Write, void>} */
+    // there is nowhere left to report the failure — but it does not have to
+    // decide that here: the failure travels to the program's tail, which ends
+    // the run with the reason on `stderr` and exit `1`. That is the same
+    // outcome a panic produced, minus the stack trace.
+    /** @type {(w: WriteConsoles) => (s: string) => IoEffect<Write, void, NotImplemented>} */
     const line = w => {
         const x = write(w)
-        return s => unwrapStep(x(s + '\n'))
+        return s => x(s + '\n')
     }
     const csiLog = line('stdout')
     const csiError = line('stderr')
@@ -356,6 +384,9 @@ export const defaultReporter = options => {
                 ? csiLog(fmtResultLine(file, path, fgGreen, 'ok', duration) + (throws ? ' # EXPECTED TO THROW' : ''))
                 : isGitHub
                     ? csiError(`::error file=${file},line=1,title=${ghEscape(fmtImport(file, path))}::${ghEscape(String(v))}`)
+                    // Io `step`, so the detail line is attempted only when the
+                    // header line was written: two halves of one report, and
+                    // half of it is worse than none.
                     : step(
                         csiError(fmtResultLine(file, path, fgRed, 'error', duration)),
                         () => csiError(`${fgRed}${v}${reset}`)),
@@ -388,6 +419,10 @@ export const main =
 export const register = o => {
     const star = o.inlineTestContext ? ' ...' : ''
     const ctx = o.engine === 'bun' ? o.bunTestContext : o.testContext
-    const registered = step(loadModuleMap(o.env), registerModuleMap(ctx, star))
-    return mapStep(registered, () => 0)
+    const registered = rawStep(loadModuleMap(o.env), registerModuleMap(ctx, star))
+    // `exitStep`, not `mapStep(…, () => 0)`: registering is the whole job here,
+    // so "registered nothing, exit 0" is the answer this used to give and the
+    // one it must not. A success has no code of its own, which is exactly the
+    // shape `exitStep` is for.
+    return exitStep(registered)
 }

--- a/fjs/emergent_testing/proof.f.mjs
+++ b/fjs/emergent_testing/proof.f.mjs
@@ -1,5 +1,6 @@
 /**
  * @import { Effect } from '../effects/types.ts'
+ * @import { IoEffect, NotImplemented } from '../effects/io/types.ts'
  * @import { NodeProgramOptions, OpResult, Sandbox, Write } from '../effects/node/types.ts'
  * @import { JsModule } from '../effects/node/virtual/types.ts'
  * @import { Reporter } from './types.ts'
@@ -20,8 +21,7 @@ import { shouldLoad } from '../dev/module.f.mjs'
 import { parse as parseJson } from '../media/json/module.f.mjs'
 import { array, number as rttiNumber, or, string as rttiString } from '../types/rtti/module.f.mjs'
 import { parse as rttiParse } from '../types/rtti/parse/module.f.mjs'
-import { ok, unwrap } from '../types/result/module.f.mjs'
-import { unwrapStep } from '../effects/io/module.f.mjs'
+import { error, ok, unwrap } from '../types/result/module.f.mjs'
 
 /**
  * The mock reporter's stdout lines. A schema rather than a hand-written type:
@@ -44,8 +44,8 @@ const parseEvent = rttiParse(event)
 
 /** @typedef {Reporter<Sandbox | Write>} _TestReporter */
 
-/** @type {(e: _Event) => Effect<Write, void>} */
-const writeEvent = e => unwrapStep(log(JSON.stringify(e)))
+/** @type {(e: _Event) => IoEffect<Write, void, NotImplemented>} */
+const writeEvent = e => log(JSON.stringify(e))
 
 /** @type {(stdout: string) => readonly _Event[]} */
 const parseEvents = stdout =>
@@ -298,6 +298,40 @@ export const githubReporterOutput = () => {
         stderr,
         '::error file=./s.proof.f.ts,line=1,title=import("./s.proof.f.ts").proof["a%3Ab%2Cc%25d"]()::oops\n',
     )
+}
+
+/** @typedef {All | Import | Readdir | Sandbox | Write} _FailOps */
+
+// A reporter that cannot write neither panics nor reports success. The failed
+// `result` line short-circuits its own test, leaves `allOk` as the first error,
+// skips the summary, and reaches the program tail — which answers exit `1`.
+//
+// `write` fails for every stream here, including the one `errorExit` reports
+// the failure on, so the exit code rather than a message is what is observable:
+// a run that cannot say anything at all still says it failed.
+export const reporterWriteFailure = () => {
+    /** @type {(s: undefined) => <T>(e: Effect<_FailOps, T>) => readonly [undefined, T]} */
+    let runner
+    runner = mockRun(/** @type {Parameters<typeof mockRun<_FailOps, undefined>>[0]} */ ({
+        readdir: (_path, _o) => s => [s, ok([{ name: 'a.proof.f.ts', parentPath: '.', isFile: true }])],
+        import: _path => s => [s, ok({ proof: { x: () => { } } })],
+        all: (...effects) => s => {
+            const [st, rs] = effects.reduce(
+                ([st1, rs1], e) => {
+                    const [ns, r] = runner(st1)(e)
+                    return [ns, [...rs1, r]]
+                },
+                /** @type {readonly [undefined, readonly unknown[]]} */([s, []]),
+            )
+            return [st, ok(rs)]
+        },
+        sandbox: (/** @type {() => unknown} */ f) => (/** @type {undefined} */ s) =>
+            [s, ok({ result: ok(f()), duration: 0 })],
+        write: (_stream, _data) => s => [s, error(/** @type {const} */(['notImplemented', 'write']))],
+    }))
+    const [, exitCode] = runner(undefined)(
+        /** @type {Effect<_FailOps, number>} */(main(options('.'))))
+    assertEq(exitCode, 1)
 }
 
 /** @typedef {readonly string[]} _RegisterMockState */
@@ -578,6 +612,7 @@ export const proof = {
     defaultReporterOutputLargeDuration,
     defaultReporterFailOutput,
     githubReporterOutput,
+    reporterWriteFailure,
     registerSuffixes,
     registerThrowsWithoutThrowing,
     registerEmptyProof,

--- a/fjs/emergent_testing/types.ts
+++ b/fjs/emergent_testing/types.ts
@@ -5,7 +5,8 @@
  */
 
 import type { Effect, Operation } from '../effects/types.ts'
-import type { SandboxResult } from '../effects/node/types.ts'
+import type { IoEffect, NotImplemented } from '../effects/io/types.ts'
+import type { IoError, SandboxResult } from '../effects/node/types.ts'
 
 /** A zero-argument test function whose return value may contain sub-tests. */
 export type TestFn = () => unknown
@@ -43,11 +44,29 @@ export type Path = readonly (string | null)[]
  * leading to the current location; `null` marks a function-call boundary, e.g.
  * `['outer', null, 'inner']` means `outer` was invoked and its return value
  * contained `inner`.
+ *
+ * **Every method is fallible**, because reporting is IO and IO can fail: a
+ * write to a closed pipe, a runner that cannot dispatch `write` at all. The
+ * runner propagates what a method answers, so a reporter that cannot emit ends
+ * the run rather than being silently ignored.
+ *
+ * `result` and `summary` in particular *must* carry their `Result` in the type.
+ * They used to answer `Effect<O, void>`, and TypeScript accepts an effect of
+ * any value type where a `void` one is expected — so an implementation whose
+ * writes were fallible type-checked while its failures went nowhere. That is
+ * the hazard the Io layer exists to remove, and a `void` return position hides
+ * it exactly where a reporter's whole job is to perform IO.
+ *
+ * The channel is the standard node one (`NotImplemented | IoError`) rather than
+ * a type parameter: a reporter is free in which *operations* it performs, but
+ * it fails the way node IO fails, and pinning it here keeps the type — and the
+ * program tail that reports it — free of a parameter every caller would have to
+ * thread through unchanged.
  */
 export type Reporter<O extends Operation> = {
-    readonly result: (file: string, path: Path, r: SandboxResult<unknown>, throws: boolean) => Effect<O, void>
-    readonly summary: (pass: number, fail: number, time: number) => Effect<O, void>
-    readonly test: (file: string, path: Path, set: TestEntry) => Effect<O, SandboxResult<unknown>>
+    readonly result: (file: string, path: Path, r: SandboxResult<unknown>, throws: boolean) => IoEffect<O, void, NotImplemented | IoError>
+    readonly summary: (pass: number, fail: number, time: number) => IoEffect<O, void, NotImplemented | IoError>
+    readonly test: (file: string, path: Path, set: TestEntry) => IoEffect<O, SandboxResult<unknown>, NotImplemented | IoError>
 }
 
 /** @internal */


### PR DESCRIPTION
Stage 4 of the io-effect migration, the first of the queued consumer modules (`fjs/effects/todo/io-effect-consumer-migration.md`). Eight `unwrapStep` sites become one: the reporter's writes, `sandbox`, `awaitIfPromise` and the `all` parallelism propagate their failures instead of panicking.

`Reporter`'s members carry their `Result` in the type, which is why this module went first. `result` and `summary` returned `Effect<O, void>`, and TypeScript accepts an effect of any value type where a `void` one is expected — so a reporter whose writes were fallible type-checked while its failures went nowhere. The channel is pinned to the standard node one (`NotImplemented | IoError`) rather than made a type parameter: a reporter is free in which operations it performs, but it fails the way node IO fails, and a parameter would be threaded through every caller unchanged.

`allOk` is new, beside `all` in `fjs/effects/node/module.f.mjs`. `all`'s envelope is the runner's (`OpResult`), so handing it `IoEffect`s nests one `Result` inside another and returns `readonly Result<T, E>[]` — the value-discarding hazard, one level in where it is harder to see. `allOk` collapses that to the first error. Every effect still runs: the short-circuit is in the result, not the execution. `fjs/dev`'s two `all` sites want the same combinator, so it is already where that migration needs it.

Two defects fell out of the sweep. `registerModuleMap` discarded `all`'s result through a `() => undefined` continuation, and `register` answered exit `0` whether or not registration succeeded — it now ends with `exitStep`.

One panic stays, with the reason in a comment: `Test` hands its callback to an external framework (node `--test`, Bun, Deno) whose contract is a raw `Effect<…, void>`, so there is no channel to answer through, and a throw is what those frameworks already report as a failed test.

`testAll` needed a tail that is not `exitStep`. That one answers `0` for every success, and this chain's success value *is* the exit code (`1` when a test failed), so conflating them would report a failing suite as a passing run. The local `exitCodeStep` keeps the computed code and reports only a channel failure; `register`, whose success carries nothing, uses `exitStep` unchanged.

Validation: `npx tsc` clean, `fjs t` 2903 pass / 0 fail, `npm run cov` 100/100/100. The suite count is 2902 on the base and 2903 here — checked explicitly against the base, since this module is the test runner and a silent drop in discovered tests would otherwise read as a pass. The coverage gate first failed at 99.96% on exactly the new error branches, so `reporterWriteFailure` runs `main` against a runner whose `write` always fails and asserts exit `1`.

Changelog:
- **BREAKING CHANGES:** `emergent_testing`: `Reporter`'s members and the
  `registerModule` / `runModuleMap` / `testAll` chain are fallible `IoEffect`s.
  A failed reporter write now ends the run with exit `1`, as does a failed
  `register`, which used to answer `0` either way.
- `effects/node`: new `allOk` — `all` in the `ok` channel, answering with the
  first error instead of a list of results for the caller to collapse.

https://claude.ai/code/session_01Hwo7tmdoraUvWmGWDUygPG