### PR TITLE
dev: migrate module discovery to IoEffect composition

### DIFF
--- a/changelog/unreleased/1630.md
+++ b/changelog/unreleased/1630.md
@@ -1,0 +1,3 @@
+- **BREAKING CHANGES:** `dev`: `loadModuleMap` is a fallible `IoEffect`. A
+  directory it cannot list or a module that will not import is now an `error`
+  the caller handles, where discovery used to panic.

--- a/fjs/dev/module.f.mjs
+++ b/fjs/dev/module.f.mjs
@@ -178,6 +178,16 @@ export const proof = {
         const [, result] = virtual({ ...emptyState, root: {} })(loadModuleMap({ INIT_CWD: 'missing' }))
         assert(result[0] === 'error', result)
     },
+    loadModuleMapReportsUnimportableModule: () => {
+        // The other half of the same breaking change, and the half `readdir`
+        // does not cover: discovery lists the file, then the import of it
+        // fails. `'a.f.ts': []` is content rather than a module, so the
+        // virtual runner's `import` refuses it. Without this, a `loadFile`
+        // that turned every import failure into a success would still pass
+        // every other proof here.
+        const [, result] = virtual({ ...emptyState, root: { 'a.f.ts': [] } })(loadModuleMap({}))
+        assert(result[0] === 'error', result)
+    },
     loadModuleMapStripsInitCwdPrefix: () => {
         // With `INIT_CWD` set (the normal `npm run` case), discovery starts
         // from that subdirectory and each key is relativized against it, so

--- a/fjs/dev/module.f.mjs
+++ b/fjs/dev/module.f.mjs
@@ -3,16 +3,16 @@
  *
  * @module
  *
- * @import { Access, All, Env, Import, Readdir } from '../effects/node/types.ts'
- * @import { Effect } from '../effects/types.ts'
+ * @import { Access, All, Env, Import, IoError, Readdir } from '../effects/node/types.ts'
+ * @import { IoEffect, NotImplemented } from '../effects/io/types.ts'
  * @import { Dir } from '../effects/node/virtual/types.ts'
  * @import { Module, ModuleMap, LoadModuleOperations } from './types.ts'
  */
 
-import { all, import_, readdir } from '../effects/node/module.f.mjs'
+import { allOk, import_, readdir } from '../effects/node/module.f.mjs'
 import { cmp as strCmp } from '../types/string/module.f.mjs'
 import { unwrap } from '../types/result/module.f.mjs'
-import { pure, step } from '../effects/module.f.mjs'
+import { mapStep, pureOk, step } from '../effects/io/module.f.mjs'
 import { join, relativize, toPosix } from '../path/module.f.mjs'
 import { assert, assertEq } from '../asserts/module.f.mjs'
 import { emptyState, virtual } from '../effects/node/virtual/module.f.mjs'
@@ -49,16 +49,16 @@ export const shouldLoad = s =>
 const isSourceFile = path =>
     path.endsWith('.js') || path.endsWith('.ts') || path.endsWith('.mts') || path.endsWith('.mjs')
 
-/** @type {(s: string, predicate: (path: string) => boolean) => Effect<Readdir | All, readonly string[]>} */
+/** @type {(s: string, predicate: (path: string) => boolean) => IoEffect<Readdir | All, readonly string[], NotImplemented | IoError>} */
 const allFiles = (s, predicate) => {
-    /** @type {(p: string) => Effect<Readdir | All, readonly string[]>} */
+    /** @type {(p: string) => IoEffect<Readdir | All, readonly string[], NotImplemented | IoError>} */
     const load = p => {
-        const x0 = step(
+        const listed = step(
             readdir(p, {}),
             d => {
-                /** @type {readonly Effect<Readdir | All, readonly string[]>[]} */
+                /** @type {readonly IoEffect<Readdir | All, readonly string[], NotImplemented | IoError>[]} */
                 let result = []
-                for (const i of unwrap(d)) {
+                for (const i of d) {
                     const { name } = i
                     if (name.startsWith('.')) { continue }
                     const file = join(p, name)
@@ -68,26 +68,19 @@ const allFiles = (s, predicate) => {
                         continue
                     }
                     if (predicate(file)) {
-                        result = [...result, pure([file])]
+                        result = [...result, pureOk([file])]
                     }
                 }
-                return all(...result)
+                return allOk(...result)
             })
-        // `all`'s own result is unwrapped like every other operation's in this
-        // module: a dev tool that cannot list a directory has no fallback, so
-        // the failure is a panic here rather than a value threaded upward.
-        return step(
-            x0,
-            v => pure(unwrap(v).flat()))
+        return mapStep(listed, v => v.flat())
     }
     return load(s)
 }
 
-/** @type {(f: string) => Effect<Access | Import, readonly (readonly [string, Module])[]>} */
+/** @type {(f: string) => IoEffect<Access | Import, readonly (readonly [string, Module])[], NotImplemented | IoError>} */
 const loadFile = f =>
-    step(
-        import_(f),
-        r => pure([/** @type {const} */ ([f, unwrap(r)])]))
+    mapStep(import_(f), m => [/** @type {const} */ ([f, m])])
 
 const { fromEntries } = Object
 
@@ -105,7 +98,13 @@ const { fromEntries } = Object
  * The result is sorted by path key using `string.cmp` so the order is
  * deterministic regardless of filesystem traversal order.
  *
- * @type {(env: Env) => Effect<LoadModuleOperations, ModuleMap>}
+ * A failure — a directory that cannot be listed, a module that will not import
+ * — propagates instead of panicking, so the program that asked for the map
+ * decides what a partial view of the source tree means for it. Discovery reads
+ * the whole tree, and a map missing the file it was asked about is worse than
+ * no map at all.
+ *
+ * @type {(env: Env) => IoEffect<LoadModuleOperations, ModuleMap, NotImplemented | IoError>}
  */
 export const loadModuleMap = env => {
     const initCwd = env['INIT_CWD']
@@ -115,17 +114,17 @@ export const loadModuleMap = env => {
     //       we should consider optimizing them by ALIQ technique or something similar.
     //       For example, we should be able to write it like `allFiles(s).flatMap(loadFile)`,
     //       then an effect runner can batch all file loading operations together.
-    const x0 = step(
+    const loaded = step(
         allFiles(s, shouldLoad),
-        files => all(...files.map(loadFile)))
-    return step(
-        x0,
-        entries => pure(fromEntries(
-            unwrap(entries)
+        files => allOk(...files.map(loadFile)))
+    return mapStep(
+        loaded,
+        entries => fromEntries(
+            entries
                 .flat()
                 .map(([k, v]) => /** @type {const} */ ([relativize(prefix, k), v]))
                 .toSorted(([a], [b]) => strCmp(a)(b))
-        )))
+        ))
 }
 
 export const proof = {
@@ -149,7 +148,7 @@ export const proof = {
             'd.mjs': [],
         }
         const [, result] = virtual({ ...emptyState, root })(allFiles('.', shouldLoad))
-        assertEq(result.join(','), './a.f.ts,./b.f.mjs,./c.f.mts')
+        assertEq(unwrap(result).join(','), './a.f.ts,./b.f.mjs,./c.f.mts')
     },
     allFilesSkipsNodeModules: () => {
         // `node_modules` is skipped without descending into it, even though
@@ -160,7 +159,7 @@ export const proof = {
             'a.f.ts': [],
         }
         const [, result] = virtual({ ...emptyState, root })(allFiles('.', shouldLoad))
-        assertEq(result.join(','), './a.f.ts')
+        assertEq(unwrap(result).join(','), './a.f.ts')
     },
     loadModuleMapDefaultsToCwdWhenInitCwdUnset: () => {
         // With no `INIT_CWD` (e.g. `fjs t` invoked outside `npm run`), `env`
@@ -169,7 +168,15 @@ export const proof = {
         /** @type {Dir} */
         const root = { 'a.f.ts': () => ({}) }
         const [, result] = virtual({ ...emptyState, root })(loadModuleMap({}))
-        assertEq(Object.keys(result).join(','), './a.f.ts')
+        assertEq(Object.keys(unwrap(result)).join(','), './a.f.ts')
+    },
+    loadModuleMapReportsUnreadableRoot: () => {
+        // A directory that cannot be listed is no longer a panic. Discovery
+        // hands the failure back, and the program that asked for the map is
+        // the one that decides what a source tree it cannot read means — for
+        // `fjs t` that is a message on `stderr` and exit `1`.
+        const [, result] = virtual({ ...emptyState, root: {} })(loadModuleMap({ INIT_CWD: 'missing' }))
+        assert(result[0] === 'error', result)
     },
     loadModuleMapStripsInitCwdPrefix: () => {
         // With `INIT_CWD` set (the normal `npm run` case), discovery starts
@@ -178,6 +185,6 @@ export const proof = {
         /** @type {Dir} */
         const root = { 'sub': { 'a.f.ts': () => ({}) } }
         const [, result] = virtual({ ...emptyState, root })(loadModuleMap({ INIT_CWD: 'sub' }))
-        assertEq(Object.keys(result).join(','), './a.f.ts')
+        assertEq(Object.keys(unwrap(result)).join(','), './a.f.ts')
     },
 }

--- a/fjs/effects/todo/io-effect-consumer-migration.md
+++ b/fjs/effects/todo/io-effect-consumer-migration.md
@@ -71,10 +71,10 @@ Where a module genuinely has no answer to a failure, `unwrapStep` stays — the
 goal is a *considered* policy at every site, not zero panics. Say so in a
 comment when it stays.
 
-### What `fjs/emergent_testing` settled
+### What the migrated modules settled
 
-Its eight sites came down to one, and the three findings generalize to the
-modules still queued:
+`fjs/emergent_testing`'s eight sites came down to one, and the three findings
+generalize to the modules still queued:
 
 - **`all` needed an `ok`-channel twin, and it is shared.** `all`'s envelope is
   the runner's, so handing it `IoEffect`s nests one `Result` inside another and
@@ -93,11 +93,18 @@ modules still queued:
   failure. `register`, whose success carries nothing, uses `exitStep` unchanged.
   Expect the same split wherever a program already computes a code.
 
+`fjs/dev` then cost four `unwrap`s and no new vocabulary — `allOk` was already
+there for its two `all`s, which is what the ordering was for. It confirms the
+other half of that prediction too: `loadModuleMap` became fallible, so
+`testAll` and `register` turned their raw `step` into the Io one, and the two
+modules met at the tail exactly where this plan said they would. Discovery no
+longer panics on a tree it cannot read; `fjs t` reports it and exits `1`.
+
 ### Tasks
 
 - [x] `fjs/emergent_testing` — reporter, `registerModule`, `runModuleMap`,
       `defaultTest`; `Reporter<O>` member types.
-- [ ] `fjs/dev` — `loadModuleMap` and `allFiles`.
+- [x] `fjs/dev` — `loadModuleMap` and `allFiles`.
 - [ ] `fjs/cas/evo` — the cache slot and the `Evo<O>` API, plus `fjs/mcp/evo`.
 - [ ] `fjs/protocol/mcp` and its stdio transport.
 - [ ] `fjs/mcp`.

--- a/fjs/effects/todo/io-effect-migration.md
+++ b/fjs/effects/todo/io-effect-migration.md
@@ -325,9 +325,9 @@ and the worklist is the `unwrapStep` call sites — every one is a consumer that
 has not yet chosen a policy beyond "panic".
 
 Migrated so far: `fjs/ci`, `fjs/ci/nix`, `fjs/nanvm/update`, `fjs/dev/update`,
-`fjs/cas`, `cas list` and `fjs/emergent_testing`. Still on `unwrapStep`:
-`fjs/cas/evo`, `fjs/mcp`, `fjs/protocol/mcp` (and its stdio transport),
-`fjs/dev`, and the proofs that drive them.
+`fjs/cas`, `cas list`, `fjs/emergent_testing` and `fjs/dev`. Still on
+`unwrapStep`: `fjs/cas/evo`, `fjs/mcp`, `fjs/protocol/mcp` (and its stdio
+transport), and the proofs that drive them.
 
 - [x] Migrate consumers module by module to IoEffect composition.
 - [x] Replace `step(e, okStep(f))` and equivalent manual propagation with

--- a/fjs/emergent_testing/module.f.mjs
+++ b/fjs/emergent_testing/module.f.mjs
@@ -247,7 +247,7 @@ const exitCodeStep = e =>
  * @returns {Program<O | All | LoadModuleOperations | Write>}
  */
 export const testAll = reporter => options =>
-    exitCodeStep(rawStep(loadModuleMap(options.env), runModuleMap(reporter)))
+    exitCodeStep(step(loadModuleMap(options.env), runModuleMap(reporter)))
 
 /**
  * Registers all modules in `moduleMap` that export a `proof` property with
@@ -419,7 +419,7 @@ export const main =
 export const register = o => {
     const star = o.inlineTestContext ? ' ...' : ''
     const ctx = o.engine === 'bun' ? o.bunTestContext : o.testContext
-    const registered = rawStep(loadModuleMap(o.env), registerModuleMap(ctx, star))
+    const registered = step(loadModuleMap(o.env), registerModuleMap(ctx, star))
     // `exitStep`, not `mapStep(…, () => 0)`: registering is the whole job here,
     // so "registered nothing, exit 0" is the answer this used to give and the
     // one it must not. A success has no code of its own, which is exactly the


### PR DESCRIPTION
Stage 4 of the io-effect migration, the second of the queued consumer modules, following #1629. Four bare `unwrap`s leave `fjs/dev`: `allFiles`, `loadFile` and `loadModuleMap` propagate their failures instead of panicking, so a directory that cannot be listed or a module that will not import is the caller's decision rather than a stack trace.

Propagating is the right answer for discovery specifically, and the JSDoc says so: it reads the whole source tree, and a map silently missing the file it was asked about is worse than no map at all.

Both halves of the plan's prediction for this module held. It needed **no new vocabulary** — `allOk` landed with #1629 precisely because `fjs/dev`'s two `all` sites wanted the same combinator, which is what the ordering was for. And `loadModuleMap` becoming fallible turned `testAll` and `register`'s raw `step` into the Io one, so the two modules met at the same tail exactly where the plan said they would; that is the whole four-line `fjs/emergent_testing` diff here.

This is a semantic change to a public function, not only a typing one: callers that relied on `loadModuleMap` throwing now receive an `error` result they have to handle. `fjs/emergent_testing` is its only consumer in the repository, and it handles it — `fjs t` reports the reason on `stderr` and exits `1` where it used to unwind.

Validation: `npx tsc` clean, `fjs t` 2952 pass / 0 fail, `npm run cov` 100/100/100, `fjs ci` leaves the tree clean. Coverage stayed at 100% unaided here, since the migration adds no branches — so unlike #1629 the gate did not force a proof, and `loadModuleMapReportsUnreadableRoot` was added anyway to pin the behavior change it does make.

Rebased onto `main` after #1629 squash-merged, so this now contains only the `fjs/dev` commit.

Changelog:
- **BREAKING CHANGES:** `dev`: `loadModuleMap` is a fallible `IoEffect`. A
  directory it cannot list or a module that will not import is now an `error`
  the caller handles, where discovery used to panic.

https://claude.ai/code/session_01Hwo7tmdoraUvWmGWDUygPG