### PR TITLE
effects: spell the effect channel Effect, not RawEffect&lt;O, Result&lt;…&gt;&gt;

### DIFF
--- a/changelog/unreleased/1640.md
+++ b/changelog/unreleased/1640.md
@@ -1,0 +1,6 @@
+- `effects`: `Effect<O, T, E>` replaces `RawEffect<O, Result<T, E>>` wherever the
+  `Result` is the effect channel — `cas`, `cas/evo`'s runner unwrap,
+  `effects/memory`, `effects/node`'s `all`/`both`/`writeFromStream`/
+  `createServer`/`Console`, `media/type`'s `detectStream`, and MCP stdio's
+  response writer. The two spellings are the same type, so nothing changes at
+  runtime; `Effect`'s doc now states the rule that decides between them.

--- a/fjs/cas/evo/proof.f.mjs
+++ b/fjs/cas/evo/proof.f.mjs
@@ -1,9 +1,8 @@
 /**
  * @import { Cas } from '../types.ts'
- * @import { RawEffect } from '../../effects/types.ts'
+ * @import { Effect } from '../../effects/io/types.ts'
  * @import { NodeOp } from '../../effects/node/types.ts'
  * @import { State } from '../../effects/node/virtual/types.ts'
- * @import { Result } from '../../types/result/types.ts'
  * @import { Vec } from '../../types/bit_vec/types.ts'
  * @import { Ok } from '../../types/result/types.ts'
  * @import { List } from '../../effects/list/types.ts'
@@ -78,7 +77,7 @@ const fixedCas = entries => ({
  * outer one is unwrapped here, the inner domain verdict is what each proof
  * goes on to inspect.
  *
- * @type {(state: State) => <T, E>(e: RawEffect<NodeOp, Result<T, E>>) => readonly [State, T]}
+ * @type {(state: State) => <T, E>(e: Effect<NodeOp, T, E>) => readonly [State, T]}
  */
 const virtualOk = state => e => {
     const [s, r] = virtual(state)(e)

--- a/fjs/cas/module.f.mjs
+++ b/fjs/cas/module.f.mjs
@@ -5,7 +5,7 @@
  *
  * @import { Sha2, State as Sha2State } from '../crypto/sha2/types.ts'
  * @import { Vec } from '../types/bit_vec/types.ts'
- * @import { RawEffect, Operation } from '../effects/types.ts'
+ * @import { Operation } from '../effects/types.ts'
  * @import { Effect, NotImplemented } from '../effects/io/types.ts'
  * @import {
  *  IoError,
@@ -82,10 +82,10 @@ export const toPath = key => {
  *
  * @template {Operation} O
  * @param {List<O, IoResult<Vec>>} stream
- * @returns {RawEffect<O, IoResult<Vec>>}
+ * @returns {Effect<O, Vec, NotImplemented | IoError>}
  */
 export const collectRead = stream => {
-    /** @type {(acc: Vec) => (s: List<O, IoResult<Vec>>) => RawEffect<O, IoResult<Vec>>} */
+    /** @type {(acc: Vec) => (s: List<O, IoResult<Vec>>) => Effect<O, Vec, NotImplemented | IoError>} */
     const loop = acc => s =>
         step(s, node => {
             if (node === undefined) { return pure(ok(acc)) }
@@ -183,14 +183,14 @@ const gcStage = stageDir => {
  * @param {string} path
  * @param {string} stageDir
  * @param {List<O1, IoResult<Vec>>} payload
- * @returns {RawEffect<O1 | FileCasOperation, IoResult<Vec>>}
+ * @returns {Effect<O1 | FileCasOperation, Vec, NotImplemented | IoError>}
  */
 const writeImpl = (sha2, path, stageDir, payload) => {
     // Publish the finished staging file to its content-addressed shard. The three
     // filesystem steps run best-effort with their results ignored; success is decided
     // afterward by observing the target's size (see staging-lease.md "Publish ignores
     // results and checks the end state").
-    /** @type {(state: Sha2State, offset: number, curPath: string) => RawEffect<FileCasOperation, IoResult<Vec>>} */
+    /** @type {(state: Sha2State, offset: number, curPath: string) => Effect<FileCasOperation, Vec, NotImplemented | IoError>} */
     const publish = (state, offset, curPath) => {
         const hash = sha2.end(state)
         const rel = toPath(hash)
@@ -204,13 +204,13 @@ const writeImpl = (sha2, path, stageDir, payload) => {
             st => st[0] === 'ok' && st[1].size === offset ? ok(hash) : error(ioError({ message: 'publish size mismatch' })))
     }
     // Any streaming error fails closed: delete the partial file, return the error.
-    /** @type {(curPath: string, e: NotImplemented | IoError) => RawEffect<FileCasOperation, IoResult<Vec>>} */
+    /** @type {(curPath: string, e: NotImplemented | IoError) => Effect<FileCasOperation, Vec, NotImplemented | IoError>} */
     const fail = (curPath, e) =>
         mapStep(rm(curPath), () => error(e))
     const rndEffect = ioStep(gcStage(stageDir), () => random256)
     return ioStep(rndEffect, rnd => {
         const rndStr = vecToCBase32(rnd)
-        /** @type {(state: Sha2State, offset: number, curPath: string) => (stream: List<O1, IoResult<Vec>>) => RawEffect<O1 | FileCasOperation, IoResult<Vec>>} */
+        /** @type {(state: Sha2State, offset: number, curPath: string) => (stream: List<O1, IoResult<Vec>>) => Effect<O1 | FileCasOperation, Vec, NotImplemented | IoError>} */
         const loop = (state, offset, curPath) =>
             stream =>
                 step(stream, node => {
@@ -351,7 +351,7 @@ const streamFile = filePath => {
  *
  * @template {Operation} O
  * @param {Cas<O>} cas
- * @returns {(path: string) => RawEffect<O | ReadBytes, IoResult<Vec>>}
+ * @returns {(path: string) => Effect<O | ReadBytes, Vec, NotImplemented | IoError>}
  */
 export const casAddFile = cas => path =>
     // streamFile produces only ReadBytes effects. TypeScript can't prove ListEffect<ReadBytes,T>

--- a/fjs/cas/proof.f.mjs
+++ b/fjs/cas/proof.f.mjs
@@ -2,7 +2,8 @@
  * @import { Vec } from '../types/bit_vec/types.ts'
  * @import { FileCasOperation } from './types.ts'
  * @import { RawEffect } from '../effects/types.ts'
- * @import { ReadFile, WriteFile, Rm, Mkdir, IoResult } from '../effects/node/types.ts'
+ * @import { ReadFile, WriteFile, Rm, Mkdir, IoError, IoResult } from '../effects/node/types.ts'
+ * @import { Effect, NotImplemented } from '../effects/io/types.ts'
  * @import { Ok } from '../types/result/types.ts'
  * @import { List } from '../effects/list/types.ts'
  */
@@ -231,7 +232,7 @@ export const proof = {
         const hash = writeResult[1]
         assertEq(length(hash), 256n, ['expected 256-bit hash', length(hash)])
         assertEq(msb.cmp(hash)(computeSync(sha256)([content])), 0, 'write hash mismatch')
-        /** @type {(acc: readonly Vec[]) => (stream: List<FileCasOperation, IoResult<Vec>>) => RawEffect<FileCasOperation, IoResult<readonly Vec[]>>} */
+        /** @type {(acc: readonly Vec[]) => (stream: List<FileCasOperation, IoResult<Vec>>) => Effect<FileCasOperation, readonly Vec[], NotImplemented | IoError>} */
         const drain = acc =>
             stream =>
                 step(
@@ -269,7 +270,7 @@ export const proof = {
         assert(writeResult[0] === 'ok', ['expected write ok', writeResult])
         const hash = writeResult[1]
         assertEq(msb.cmp(hash)(computeSync(sha256)(chunks)), 0, 'multi-chunk write hash mismatch')
-        /** @type {(acc: readonly Vec[]) => (stream: List<FileCasOperation, IoResult<Vec>>) => RawEffect<FileCasOperation, IoResult<readonly Vec[]>>} */
+        /** @type {(acc: readonly Vec[]) => (stream: List<FileCasOperation, IoResult<Vec>>) => Effect<FileCasOperation, readonly Vec[], NotImplemented | IoError>} */
         const drain = acc =>
             stream =>
                 step(
@@ -336,7 +337,7 @@ export const proof = {
         const hash = w[1]
         assertEq(msb.cmp(hash)(computeSync(sha256)(chunks)), 0, 'oversized write hash mismatch')
         // Fold the read stream straight into a fresh SHA-2 state — never one `Vec`.
-        /** @type {(state: typeof sha256.init) => (stream: List<FileCasOperation, IoResult<Vec>>) => RawEffect<FileCasOperation, IoResult<Vec>>} */
+        /** @type {(state: typeof sha256.init) => (stream: List<FileCasOperation, IoResult<Vec>>) => Effect<FileCasOperation, Vec, NotImplemented | IoError>} */
         const rehash = state =>
             stream =>
                 step(

--- a/fjs/cas/types.ts
+++ b/fjs/cas/types.ts
@@ -5,9 +5,10 @@
  */
 
 import type { Vec } from '../types/bit_vec/types.ts'
-import type { RawEffect, Operation } from '../effects/types.ts'
+import type { Operation } from '../effects/types.ts'
 import type { List } from '../effects/list/types.ts'
-import type { IoResult, Mkdir, Now, RandomInt, ReadBytes, Readdir, Rename, Rm, CreateExclusive, WriteBytes, Access, Stat } from '../effects/node/types.ts'
+import type { Effect, NotImplemented } from '../effects/io/types.ts'
+import type { IoError, IoResult, Mkdir, Now, RandomInt, ReadBytes, Readdir, Rename, Rm, CreateExclusive, WriteBytes, Access, Stat } from '../effects/node/types.ts'
 
 /**
  * The filesystem effects the streaming CAS performs: `read` pulls shards
@@ -32,7 +33,7 @@ export type Cas<O extends Operation> = {
      * Consumes a chunk stream — each item `ok(chunk)` or `error` — hashing incrementally,
      * and returns the content address. An error item aborts the upload.
      */
-    readonly write: <O1 extends Operation>(payload: List<O1, IoResult<Vec>>) => RawEffect<O | O1, IoResult<Vec>>
+    readonly write: <O1 extends Operation>(payload: List<O1, IoResult<Vec>>) => Effect<O | O1, Vec, NotImplemented | IoError>
     /**
      * Lists all stored content hashes.
      *
@@ -43,7 +44,7 @@ export type Cas<O extends Operation> = {
      * an error, and returning it is what lets a caller say so instead of
      * reporting no content.
      */
-    readonly list: () => RawEffect<O, IoResult<readonly Vec[]>>
+    readonly list: () => Effect<O, readonly Vec[], NotImplemented | IoError>
 }
 
 export type FileCas = Cas<FileCasOperation> & {

--- a/fjs/effects/io/types.ts
+++ b/fjs/effects/io/types.ts
@@ -5,10 +5,9 @@
  *
  * The composition API — `step`, `catchStep`, `resultStep`, the two lifts, and
  * `mapStep` — is the sibling [`./module.f.mjs`](./module.f.mjs), whose
- * signatures the asserts at the bottom of this file pin. No operation, runner,
- * or consumer produces an `Effect` yet; that is stage 3 and stage 4. Why the
- * layer exists, why the `Result` sits where it does, and what is deliberately
- * absent: [`./README.md`](./README.md).
+ * signatures the asserts at the bottom of this file pin. Why the layer exists,
+ * why the `Result` sits where it does, and what is deliberately absent:
+ * [`./README.md`](./README.md).
  */
 
 import type { Assert } from '../../asserts/types.ts'
@@ -54,6 +53,22 @@ export type NotImplemented = readonly['notImplemented', string]
  * a `Program`'s exit code, an MCP tool result. A channel is not free, so
  * nothing is given one that has no failure to report.
  *
+ * **A `Result`-valued raw effect is not automatically this one.** The alias is
+ * transparent, so `RawEffect<O, Result<T, E>>` and `Effect<O, T, E>` are the
+ * same type and the choice between them says only what the `Result` *means*.
+ * It is the effect channel — spell it `Effect` — when `E` carries
+ * {@link NotImplemented}, because that error can only have come from a runner
+ * that could not dispatch. It is ordinary returned data — leave it
+ * `RawEffect` — when `E` is a domain verdict the caller asked for and that has
+ * already absorbed whatever channel produced it: `evo.revision`'s
+ * `Result<RevisionData, string>`, where a runner failure and a blob that is
+ * not a revision are the same `string` to the caller, or the transpiler's
+ * `Result<Unknown, ParseError>`, where a missing file is reported as a parse
+ * error like any other. Collapsing the second kind into the channel would
+ * report "invalid parent hash" the way it reports a runner that cannot
+ * dispatch `memWrite`; keeping the first kind out of it hides a failure the
+ * error-propagating combinators exist to carry.
+ *
  * **`E` defaults to {@link NotImplemented}**, the one error every operation can
  * answer with, so the common case is written `Effect<Sandbox, T>`. The default
  * is safe to have *now* and was not safe to have during the rename: while every
@@ -63,10 +78,9 @@ export type NotImplemented = readonly['notImplemented', string]
  *
  * `E` carries at least {@link NotImplemented}, and an operation with failures of
  * its own extends the channel — `Effect<ReadFile, Vec, NotImplemented |
- * IoError>`. That envelope belongs to the *operation's declared return type*
- * (stage 3), not to a wrapper a constructor puts around a raw operation, so
- * that a runner can eventually deliver `error(notImplemented)` through the
- * ordinary continuation.
+ * IoError>`. That envelope belongs to the *operation's declared return type*,
+ * not to a wrapper a constructor puts around a raw operation, so that a runner
+ * can deliver `error(notImplemented)` through the ordinary continuation.
  *
  * The alias is transparent, so every raw combinator already applies at this
  * instantiation. What the sibling module adds is the branch-aware vocabulary —

--- a/fjs/effects/memory/module.f.mjs
+++ b/fjs/effects/memory/module.f.mjs
@@ -16,8 +16,7 @@
  * @module
  *
  * @import { Nominal } from '../../types/nominal/types.ts'
- * @import { RawEffect } from '../types.ts'
- * @import { OpResult } from '../node/types.ts'
+ * @import { Effect } from '../io/types.ts'
  * @import { Key, MemCreate, MemRead, MemWrite, _MemKeyHash } from './types.ts'
  */
 
@@ -32,14 +31,14 @@ export const asNominal = nominalAsNominal
 
 /** Creates a new typed memory slot with `value` as its initial contents. */
 export const create =
-    /** @type {<T>(value: T) => RawEffect<MemCreate, OpResult<Key<T>>>} */
+    /** @type {<T>(value: T) => Effect<MemCreate, Key<T>>} */
     (do_('memCreate'))
 
 /** Reads the current contents of a typed memory slot. */
 export const read =
-    /** @type {<T>(key: Key<T>) => RawEffect<MemRead, OpResult<T>>} */
+    /** @type {<T>(key: Key<T>) => Effect<MemRead, T>} */
     (do_('memRead'))
 
 /** Replaces the current contents of a typed memory slot. */
-/** @type {<T>(key: Key<T>, value: T) => RawEffect<MemWrite, OpResult<void>>} */
+/** @type {<T>(key: Key<T>, value: T) => Effect<MemWrite, void>} */
 export const write = do_('memWrite')

--- a/fjs/effects/node/module.f.mjs
+++ b/fjs/effects/node/module.f.mjs
@@ -14,7 +14,7 @@
  * @import { Result } from '../../types/result/types.ts'
  * @import { Commands, CommandSet, RawEffect, Func, Operation } from '../types.ts'
  * @import { List } from '../list/types.ts'
- * @import { All, Access, Await, Console, CreateExclusive, CreateServer, Dirent, Engine, Env, Exec, ExecResult, Fetch, FileStat, Forever, Fs, Headers, Http, IncomingMessage, Import, IoError, IoErrorInfo, IoResult, Listen, MakeDirectoryOptions, Mkdir, Module, Now, NodeOp, NodeProgramOptions, OpResult, RandomInt, Read, ReadBytes, ReadConsoles, ReadFile, Readdir, ReaddirOptions, RequestListener, Rename, Rm, Sandbox, SandboxResult, Server, ServerResponse, Stat, Test, TestContext, TestFn, Write, WriteBytes, WriteConsoles, WriteFile, _UtfList, _WriteLoop, } from './types.ts'
+ * @import { All, Access, Await, Console, CreateExclusive, CreateServer, Dirent, Engine, Env, Exec, ExecResult, Fetch, FileStat, Forever, Fs, Headers, Http, IncomingMessage, Import, IoError, IoErrorInfo, IoResult, Listen, MakeDirectoryOptions, Mkdir, Module, Now, NodeOp, NodeProgramOptions, RandomInt, Read, ReadBytes, ReadConsoles, ReadFile, Readdir, ReaddirOptions, RequestListener, Rename, Rm, Sandbox, SandboxResult, Server, ServerResponse, Stat, Test, TestContext, TestFn, Write, WriteBytes, WriteConsoles, WriteFile, _UtfList, _WriteLoop, } from './types.ts'
  * @import { Effect, NotImplemented } from '../io/types.ts'
  */
 
@@ -115,7 +115,7 @@ export const nodeCommands = /** @type {Commands<NodeOp>} */ (Object.keys(nodeCom
  * This is the reason why we merge `O` with `All` in the resulted `RawEffect`.
  */
 export const all =
-    /** @type {<O extends Operation, T>(...a: readonly RawEffect<O, T>[]) => RawEffect<O | All, OpResult<readonly T[]>>} */
+    /** @type {<O extends Operation, T>(...a: readonly RawEffect<O, T>[]) => Effect<O | All, readonly T[]>} */
     (do_('all'))
 
 /**
@@ -164,7 +164,7 @@ export const allOk = (...a) =>
  * @template {Operation} O0
  * @template T0
  * @param {RawEffect<O0, T0>} a
- * @returns {<O1 extends Operation, T1>(b: RawEffect<O1, T1>) => RawEffect<O0 | O1 | All, OpResult<readonly[T0, T1]>>}
+ * @returns {<O1 extends Operation, T1>(b: RawEffect<O1, T1>) => Effect<O0 | O1 | All, readonly[T0, T1]>}
  */
 export const both = a => b =>
     /** @type {any} */ (all)(a, b)
@@ -281,7 +281,7 @@ const writeLoop = path => {
  * @template {Operation} O
  * @param {string} path
  * @param {List<O, IoResult<Vec>>} e
- * @returns {RawEffect<O | WriteBytes | CreateExclusive, IoResult<void>>}
+ * @returns {Effect<O | WriteBytes | CreateExclusive, void, NotImplemented | IoError>}
  */
 export const writeFromStream = (path, e) =>
     ioStep(
@@ -296,7 +296,7 @@ export const stat = do_('stat')
 // createServer
 
 export const createServer =
-    /** @type {<O extends Operation>(listener: RequestListener<O>) => RawEffect<O | CreateServer, OpResult<Server>>} */
+    /** @type {<O extends Operation>(listener: RequestListener<O>) => Effect<O | CreateServer, Server>} */
     (do_('createServer'))
 
 // listen

--- a/fjs/effects/node/types.ts
+++ b/fjs/effects/node/types.ts
@@ -12,7 +12,7 @@ import type { Result } from '../../types/result/types.ts'
 import type { StringMap } from '../../types/object/types.ts'
 import type { RawEffect, Operation, ToAsyncOperationMap } from '../types.ts'
 import type { List } from '../list/types.ts'
-import type { NotImplemented } from '../io/types.ts'
+import type { Effect, NotImplemented } from '../io/types.ts'
 
 /**
  * A host failure, normalized: whatever the runtime threw reduced to a
@@ -150,7 +150,7 @@ export type CreateExclusive = readonly['createExclusive', (path: string) => IoRe
 export type WriteBytes = readonly['writeBytes', (path: string, offset: number, data: Vec) => IoResult<void>]
 
 /** @internal */
-export type _WriteLoop = <O extends Operation>(offset: number, e: List<O, IoResult<Vec>>) => RawEffect<O | WriteBytes, IoResult<void>>
+export type _WriteLoop = <O extends Operation>(offset: number, e: List<O, IoResult<Vec>>) => Effect<O | WriteBytes, void, NotImplemented | IoError>
 
 // stat
 
@@ -219,7 +219,7 @@ export type WriteConsoles = 'stdout' | 'stderr'
  */
 export type Write = readonly['write', (stream: WriteConsoles, data: Vec) => OpResult<void>]
 
-export type Console = (s: string) => RawEffect<Write, OpResult<void>>
+export type Console = (s: string) => Effect<Write, void>
 
 // read
 

--- a/fjs/media/type/module.f.mjs
+++ b/fjs/media/type/module.f.mjs
@@ -37,9 +37,10 @@
  *
  * @import { Vec } from '../../types/bit_vec/types.ts'
  * @import { Nullable } from '../../types/nullable/types.ts'
- * @import { RawEffect, Operation } from '../../effects/types.ts'
+ * @import { Operation } from '../../effects/types.ts'
  * @import { List } from '../../effects/list/types.ts'
- * @import { IoResult } from '../../effects/node/types.ts'
+ * @import { IoError, IoResult } from '../../effects/node/types.ts'
+ * @import { Effect, NotImplemented } from '../../effects/io/types.ts'
  * @import { DetectMeta, DetectState, _MagicState, _Signature, _Utf8Detect } from './types.ts'
  */
 
@@ -254,10 +255,10 @@ export const detectVec = bytes => finish(push(detectInit)(bytes))
  *
  * @template {Operation} O
  * @param {List<O, IoResult<Vec>>} stream
- * @returns {RawEffect<O, IoResult<DetectMeta>>}
+ * @returns {Effect<O, DetectMeta, NotImplemented | IoError>}
  */
 export const detectStream = stream => {
-    /** @type {(s: DetectState) => (l: List<O, IoResult<Vec>>) => RawEffect<O, IoResult<DetectMeta>>} */
+    /** @type {(s: DetectState) => (l: List<O, IoResult<Vec>>) => Effect<O, DetectMeta, NotImplemented | IoError>} */
     const loop = s => l =>
         step(
             l,

--- a/fjs/protocol/mcp/stdio/module.f.mjs
+++ b/fjs/protocol/mcp/stdio/module.f.mjs
@@ -29,8 +29,8 @@
  *
  * @module
  *
- * @import { RawEffect, Operation } from '../../../effects/types.ts'
- * @import { IoError, IoResult, Read, Write } from '../../../effects/node/types.ts'
+ * @import { Operation } from '../../../effects/types.ts'
+ * @import { IoError, Read, Write } from '../../../effects/node/types.ts'
  * @import { Effect, NotImplemented } from '../../../effects/io/types.ts'
  * @import { Response } from '../../json_rpc/types.ts'
  * @import { Step } from './types.ts'
@@ -57,7 +57,7 @@ const parseErrorResponse = { jsonrpc, error: parseError, id: null }
 const internalErrorResponse = id => ({ jsonrpc, error: internalError, id })
 
 /** Encodes a response as a newline-terminated UTF-8 line and writes it to `stdout`.
- * @type {(resp: Response) => RawEffect<Write, IoResult<void>>}
+ * @type {(resp: Response) => Effect<Write, void, NotImplemented | IoError>}
  */
 const writeResponse = resp => {
     const v = tryUtf8(stringifyJson(resp) + '\n')


### PR DESCRIPTION
**Stacked on #1639** (itself stacked on #1636). Until those merge, the diff here shows Stage 5's rename and Stage 6 as well; afterwards it reduces to the one commit `effects: spell the effect channel Effect, not RawEffect<O, Result<…>>`.

`RawEffect` is still all over the tree in a spelling that predates the `Effect` alias. Because `Effect<O, T, E>` **is** `RawEffect<O, Result<T, E>>`, every change here is type-identical — nothing changes at runtime, and the whole value of the change is that the annotation now says what the `Result` means.

## Not every `Result`-valued raw effect is an `Effect`

Which is why this is 25 sites and not the 42 a grep suggests. The rule, now written into `Effect`'s doc rather than left to be re-derived on the next sweep:

It is the **effect channel** — spell it `Effect` — when `E` carries `NotImplemented`, because only a runner that could not dispatch produces that error.

It is **returned data** — leave it `RawEffect` — when `E` is a domain verdict the caller asked for, one that has *already absorbed* whatever channel produced it. Two of those:

- `evo.revision`'s `Result<RevisionData, string>`: a runner failure, a missing shard, and a blob that is not a revision are all the same `string` to the caller. `Evo.add`'s doc already says the domain verdict must not be collapsed into the channel; this is that rule applied to its sibling.
- the transpiler's `Result<Unknown, ParseError>`: a missing file is reported as a `ParseError` like any other parse failure.

Nine sites are left raw for that reason (five in `djs/transpiler`, four in `cas/evo`). Converting them would claim `string` or `ParseError` is what a runner answers when it cannot dispatch.

The remaining hits were prose describing the alias, or names that merely end in `Result` — `MatchResult`, `ToolsCallResult`, `ToolsListResult` — and one `OpResult` sitting in an operation's own return type rather than in an effect's payload.

## What was converted

`RawEffect<O, OpResult<T>>` → `Effect<O, T>` (the default channel); `RawEffect<O, IoResult<T>>` → `Effect<O, T, NotImplemented | IoError>`, the spelling `Effect`'s doc already uses as its example.

| file | n |
|---|---|
| `fjs/cas/module.f.mjs` | 7 |
| `fjs/cas/proof.f.mjs` | 3 |
| `fjs/cas/types.ts` — `Cas.write`, `Cas.list` | 2 |
| `fjs/cas/evo/proof.f.mjs` — `virtualOk` | 1 |
| `fjs/effects/node/module.f.mjs` — `all`, `both`, `writeFromStream`, `createServer` | 4 |
| `fjs/effects/node/types.ts` — `_WriteLoop`, `Console` | 2 |
| `fjs/effects/memory/module.f.mjs` | 3 |
| `fjs/media/type/module.f.mjs` — `detectStream` | 2 |
| `fjs/protocol/mcp/stdio/module.f.mjs` | 1 |

Also drops two claims in `effects/io/types.ts` that stages 3 and 4 had not happened yet.

## Validation

`npx tsc` clean, `fjs t` 2971 pass / 0 fail, `npm run cov` 100/100/100, `fjs ci` leaves the tree clean. Coverage is unmoved because no branch moved: these annotations are erased.

Changelog:
- `effects`: `Effect<O, T, E>` replaces `RawEffect<O, Result<T, E>>` wherever the
  `Result` is the effect channel — `cas`, `cas/evo`'s runner unwrap,
  `effects/memory`, `effects/node`'s `all`/`both`/`writeFromStream`/
  `createServer`/`Console`, `media/type`'s `detectStream`, and MCP stdio's
  response writer. The two spellings are the same type, so nothing changes at
  runtime; `Effect`'s doc now states the rule that decides between them.

https://claude.ai/code/session_01Hwo7tmdoraUvWmGWDUygPG