### PR TITLE
protocol/mcp: file the one-version McpConfig limit

### DIFF
--- a/fjs/protocol/mcp/todo/protocol-version-negotiation.md
+++ b/fjs/protocol/mcp/todo/protocol-version-negotiation.md
@@ -1,0 +1,101 @@
+## `McpConfig` supports one protocol version
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`McpConfig` (`../types.ts`) holds a single `protocolVersion: string`, and
+`mcpStep`'s `initialize` branch (`../module.f.mjs:310-341`) answers with it
+unconditionally:
+
+```js
+const [pr] = parse(initializeParams)(params)
+if (pr === 'error') {
+    return pureOk(_errResponse(id)(invalidParams))
+}
+/** @type {InitializeResult} */
+const result = {
+    protocolVersion,
+    capabilities,
+    serverInfo,
+}
+```
+
+`initializeParams` requires the client's `protocolVersion` to be present and a
+`string`, so it is checked as a shape and then dropped — nothing reads it.
+
+**This is conformant for a server that supports exactly one version, which is
+the only server `McpConfig` can describe.** The
+[lifecycle spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#version-negotiation)
+says:
+
+> If the server supports the requested protocol version, it **MUST** respond
+> with the same version. Otherwise, the server **MUST** respond with another
+> protocol version it supports. This **SHOULD** be the *latest* version
+> supported by the server.
+>
+> If the client does not support the version in the server's response, it
+> **SHOULD** disconnect.
+
+Echoing the one supported version satisfies both branches: it is *the same
+version* when the client asked for it, and *another version the server
+supports* when it did not. `casConfig` (`../../../mcp/module.f.mjs`) pins
+`2024-11-05` and real clients that ask for a later revision are answered with
+it and proceed, which is the counter-propose branch working as written.
+
+What is missing is the **multi-version** case. A server that supports two or
+more revisions cannot say so — it has one string — so it cannot honour the
+first MUST (respond with the *same* version when it is supported) for any
+version but the pinned one. It has to pick a single revision at configuration
+time and counter-propose it to everyone else, which costs clients that would
+have matched.
+
+Two things are deliberately **not** the problem here:
+
+- **Not a missing error path.** The negotiation rule prescribes a
+  counter-proposal, not a JSON-RPC error, and puts the decision on the client
+  (`SHOULD disconnect`). The spec's Error Handling section shows an
+  `Unsupported protocol version` (`-32602`) example, so an error is a shape the
+  ecosystem understands, but returning one where a counter-proposal is
+  prescribed narrows what the server interoperates with rather than widening
+  it. If a version-mismatch error is ever wanted it belongs behind an explicit
+  strict-mode opt-in, not as the default.
+- **Not a fix to be written against `pr`.** `parse` returns a `Result` tuple, so
+  in `const [pr] = parse(initializeParams)(params)` the binding is the **tag** —
+  the next line compares it to `'error'`. `pr.protocolVersion` is `undefined`
+  for every input, and a guard written on it is unconditionally true: a
+  "negotiation" that turns away every client, including a correct one. Any fix
+  widens the destructuring first (`const [pr, pv] = …`) and reads
+  `pv.protocolVersion`.
+
+### Proposal
+
+Only worth doing when a server here needs to support more than one revision.
+When it does:
+
+- Widen `McpConfig.protocolVersion` to accept a non-empty list of supported
+  versions, latest first, keeping the single-string form working (either as an
+  overload or by treating a string as a one-element list). The current field is
+  public API; a breaking change is acceptable if the list form reads better.
+- In the `initialize` branch, bind the validated params (`const [pr, pv] = …`),
+  and answer with `pv.protocolVersion` when it is in the supported list, the
+  first (latest) supported version otherwise.
+- Leave the state transition where it is: `uninitialized → initializing` on any
+  answered `initialize`, since a counter-proposal is a success frame and the
+  client decides whether to continue.
+
+### Tasks
+
+- [ ] Widen `McpConfig` to a supported-version list.
+- [ ] Bind the validated params and select the answer from that list.
+- [ ] Proofs: requested version supported → echoed; not supported → latest
+      supported; single-version config unchanged in behaviour.
+- [ ] Update `casConfig` only if `fjs/mcp` gains a second supported revision.
+
+### Related
+
+- [lifecycle spec, version negotiation](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#version-negotiation)
+  — the two MUSTs quoted above.
+- `../module.f.mjs:310-341` — the `initialize` branch.
+- `../../../mcp/module.f.mjs` — `casConfig`, the one in-repo `McpConfig`.

--- a/fjs/protocol/mcp/todo/protocol-version-negotiation.md
+++ b/fjs/protocol/mcp/todo/protocol-version-negotiation.md
@@ -74,10 +74,18 @@ Two things are deliberately **not** the problem here:
 Only worth doing when a server here needs to support more than one revision.
 When it does:
 
-- Widen `McpConfig.protocolVersion` to accept a non-empty list of supported
-  versions, latest first, keeping the single-string form working (either as an
-  overload or by treating a string as a one-element list). The current field is
-  public API; a breaking change is acceptable if the list form reads better.
+- **Replace** `McpConfig.protocolVersion: string` with one list-shaped field:
+  `protocolVersions: readonly[string, ...readonly string[]]`, latest first,
+  non-empty by construction. **One shape, not two.** Keeping the string form
+  alongside the list — as an overload or as an accepted alternative — would make
+  every consumer normalise a union and would leave a singular name responsible
+  for several values, which is complexity bought to avoid a rename. AGENTS.md
+  settles that trade directly: *"the API is the most important part of quality
+  — breaking changes are the right call whenever they improve the API"*.
+- **Move the in-repo producers in the same change**, not later. There is exactly
+  one — `casConfig` (`../../../mcp/module.f.mjs:71`) — plus the `McpConfig`
+  literals in `../proof.f.mjs`; each becomes a one-element list. This is a
+  rename, so it is unconditional; it does not wait for a second revision.
 - In the `initialize` branch, bind the validated params (`const [pr, pv] = …`),
   and answer with `pv.protocolVersion` when it is in the supported list, the
   first (latest) supported version otherwise.
@@ -87,11 +95,14 @@ When it does:
 
 ### Tasks
 
-- [ ] Widen `McpConfig` to a supported-version list.
+- [ ] Replace `McpConfig.protocolVersion` with the non-empty `protocolVersions`
+      list — the string form goes away rather than staying as an alternative.
+- [ ] Move `casConfig` and the `McpConfig` literals in the proofs to the
+      one-element list form, in the same PR as the type change.
 - [ ] Bind the validated params and select the answer from that list.
 - [ ] Proofs: requested version supported → echoed; not supported → latest
-      supported; single-version config unchanged in behaviour.
-- [ ] Update `casConfig` only if `fjs/mcp` gains a second supported revision.
+      supported; a one-element config answers exactly as the string field did.
+- [ ] Changelog: the field rename is a breaking change to a public type.
 
 ### Related
 


### PR DESCRIPTION
A downstream MCP server built on `mcpStep` carried a note saying `initialize`
"does not negotiate protocol version" and calling it a protocol defect to be
fixed upstream. Re-checked against `2e9ad76f` (0.46.1) with the spec text in
hand, most of that is wrong and the part that is left is a feature request.
This files the accurate version.

## What `initialize` does at 0.46.1

`fjs/protocol/mcp/module.f.mjs:310-341`. The client's `protocolVersion` is
required by `initializeParams` and then dropped; the response carries the
`McpConfig` string unconditionally. 0.46 touched this branch twice — `validate`
became `parse`, and the `write`'s outcome now decides the answer instead of
being discarded by a `() =>` continuation — and left the version handling
alone.

## Why that is conformant

The [lifecycle
spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#version-negotiation):
if the server supports the requested version it MUST answer with the same one,
**otherwise it MUST answer with another version it supports**. A server with
exactly one supported version satisfies both branches by echoing it — and one
version is all `McpConfig` can hold. `casConfig` pins `2024-11-05`, answers
clients that ask for later revisions with it, and they proceed; that is the
counter-propose branch working, not a bug being tolerated.

The real gap is narrower: a server that supports two revisions cannot say so,
so it cannot honour the *first* MUST for any version but its pinned one. P4 —
nothing here needs it yet.

## Two remedies the issue explicitly rules out

Both were in the downstream note; recording why they are wrong is half the
value of filing it.

- **A version-mismatch JSON-RPC error as the default.** The rule prescribes a
  counter-proposal and leaves the decision to the client (`SHOULD disconnect`).
  The spec's Error Handling section does show an `Unsupported protocol version`
  `-32602` example, so it is a shape the ecosystem understands — but as a
  default it narrows what the server interoperates with.
- **Comparing `pr.protocolVersion`.** `const [pr] = parse(...)` binds the
  **tag** — the next line compares it to `'error'`. `pr.protocolVersion` is
  `undefined` for every input, so a guard on it is unconditionally true: a
  negotiation that turns away every client, including a correct one. Any fix
  widens to `const [pr, pv]` first.

## Review round

One finding, accepted. The proposal kept the string form of
`McpConfig.protocolVersion` alongside the list "either as an overload or by
treating a string as a one-element list" — compatibility bought with a union
every consumer normalises and a singular name responsible for several values,
where AGENTS.md already says breaking changes are the right call when they
improve the API. The field is now replaced outright by
`protocolVersions: readonly[string, ...readonly string[]]`.

That falsified one of the tasks with it: "update `casConfig` only if `fjs/mcp`
gains a second supported revision". A rename is unconditional, so `casConfig`
(`fjs/mcp/module.f.mjs:71`) and the `McpConfig` literals in the proofs move in
the same change — there is exactly one producer. A changelog task replaces it.

## Checks

Documentation only. Re-run on the review commit: `npx tsc` clean, `npm test`
3032/3032, `npm run cov` 100% line/branch/function, `npm run prepack` clean,
`npm run ci-update` produces no diff. Every relative path and line citation in
the file re-resolved against the tree.

Changelog: none

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

