### PR TITLE
mcp: file the cas_get uri host-path disclosure

### DIFF
--- a/fjs/mcp/todo/cas-get-uri-discloses-host-path.md
+++ b/fjs/mcp/todo/cas-get-uri-discloses-host-path.md
@@ -1,0 +1,118 @@
+## `cas_get`'s `uri` is an absolute host path
+
+**Priority:** P3
+**Status:** open — a design decision, not a patch to apply
+
+### Problem
+
+Every `cas_get` result carries the blob's absolute path on the server's
+filesystem. `../cas/module.f.mjs:222` computes it unconditionally
+
+```js
+const uri = c.url(key)
+```
+
+and it is in the metadata object on both paths (`:231`, `:271`) and in the
+oversized-blob error text (`:257`). `FileCas.url` (`../../cas/module.f.mjs:303`)
+is `join(path, toPath(hash))`, `path` is `NodeProgramOptions.home` — `fjs mcp`'s
+handler is `({ home }) => exitStep(casMcpServer(home))` (`../../module.f.mjs:49`)
+and the Node runner fills it from `os.homedir()`. Verified by execution against
+`2e9ad76f`:
+
+```
+uri = /Users/<username>/.cas/g0/00/00000000000000000000000000000000000938nkrj2nwvvw
+```
+
+So the field is not a URI in the `scheme:` sense at all — it is a host path, and
+it names the account the server runs under. Every client that calls `cas_get`
+once learns the server's home directory, its username, and the store layout,
+whether or not it can reach that path.
+
+This is deliberate, which is why it wants a decision rather than a fix.
+`README.md`'s store-location section states it outright — "the `uri` field
+returned by `cas_get` contains the full absolute path to the blob file" — and
+[cas-get-mcp-resource-response.md](./cas-get-mcp-resource-response.md) chose the
+name so the tool view and the future `resources/read` view share a vocabulary.
+The intent is a *resource* URI; the current value is a placeholder standing in
+for one.
+
+Three things sharpen it:
+
+- **The README already describes the behaviour we would want, and it is not the
+  behaviour.** It says `uri` "is present only when the server was started with a
+  `toUrl` resolver … it is omitted in memory-backed contexts such as tests". No
+  such resolver exists; `url` is a required member of `FileCas` and the field is
+  unconditional, in tests too (`../cas/proof.f.mjs:119` asserts it present). A
+  reader of the docs believes this is opt-in when it is not.
+- **It sits against this module's own stated boundary.** README's design
+  invariant is that the server never opens a client-named local path — every
+  path it touches is self-derived. That invariant is about what the server
+  *accepts*; nothing yet says anything about what it *emits*, and a store path
+  handed to the client is the same information travelling the other way.
+- **It leaks past a downstream server's own hygiene.** `fjs-dev/finance` runs an
+  MCP server over this registry and has just finished removing host paths from
+  its own tool error text, with a real-process test proving neither its
+  responses nor its stored run records carry one. `cas_get`'s envelope
+  reintroduces the path underneath that work, and the test currently has to
+  parse its own field *out of* the envelope so it does not redden on the `uri` —
+  a leak handled in a test's parsing, which is the weakest place to handle one.
+
+Exposure today is latent rather than live: the only transport is stdio
+(`../../protocol/mcp/stdio/`), so the client is a local process that could read
+`os.homedir()` for itself. [remote-url.md](./remote-url.md) is the point at which
+it stops being latent, and it should be settled before that lands rather than as
+part of it.
+
+### Proposal
+
+Pick one; each is a different answer to "what is `uri` *for*".
+
+1. **Opaque, transport-independent identifier.** `uri` becomes something like
+   `cas:<cBase32-hash>` — derived from what the client already sent, so it
+   discloses nothing, and it is a well-formed URI, which the current value is
+   not. A `resources/read` handler resolves it to a local path server-side.
+   *Cost:* a client that today reads the field and opens the file directly
+   loses that shortcut and must go through the server. The tool description
+   ("To download a blob, prefer the uri field returned in the result") and the
+   oversized-blob error text both promise that shortcut and would change.
+2. **Store-relative path.** `uri` becomes `<AB>/<CD>/<rest>` — the sharded
+   suffix without the root. Keeps the shape and its usefulness to anyone who
+   knows the root; discloses only the layout, not the account.
+   *Cost:* a half-measure. It is still not a URI, and a client that does not
+   know the root cannot use it, so the shortcut is preserved only for clients
+   for whom the disclosure was harmless anyway.
+3. **Resolver-supplied, absent by default.** Make it what the README already
+   claims: the server is constructed with an optional `toUrl` resolver and omits
+   `uri` when there is none. An HTTP server supplies one that produces a real
+   URL under its own domain — exactly [remote-url.md](./remote-url.md)'s
+   "URL translation function instead of returning a URL from `FileCas`" — and a
+   local stdio server may supply an absolute-path resolver deliberately.
+   *Cost:* the largest change, and it makes `uri` optional in a shape
+   [cas-get-mcp-resource-response.md](./cas-get-mcp-resource-response.md) is
+   trying to make resource-like. It is also the only option that keeps the
+   absolute path available to the local case that wants it while removing it
+   from the default.
+
+Option 3 subsumes option 1 as its default-resolver choice, and is the one
+[remote-url.md](./remote-url.md) already points at from the other direction.
+Whatever is chosen, `README.md`'s two statements about `uri` have to end up
+agreeing with the code — today they contradict each other.
+
+### Tasks
+
+- [ ] Decide between the three (maintainer call — public protocol surface).
+- [ ] Implement, including the tool-description string and the oversized-blob
+      error text, both of which name `uri` as a download route.
+- [ ] Reconcile `README.md`'s "only when started with a `toUrl` resolver" and
+      "contains the full absolute path" with whatever ships.
+- [ ] State the emit-side boundary next to the existing design invariant, so the
+      next field to carry a server path is a decision rather than an accident.
+
+### Related
+
+- [remote-url.md](./remote-url.md) — the URL-translation function; this issue is
+  the reason to settle it before a remote transport, not with it.
+- [cas-get-mcp-resource-response.md](./cas-get-mcp-resource-response.md) — chose
+  the `uri` name and its intended relation to `resources/read`.
+- `../README.md` — the store-location section and the design invariant.
+- `../cas/module.f.mjs:222,231,257,271` — the four sites that carry the value.

--- a/fjs/mcp/todo/cas-get-uri-discloses-host-path.md
+++ b/fjs/mcp/todo/cas-get-uri-discloses-host-path.md
@@ -5,8 +5,8 @@
 
 ### Problem
 
-Every `cas_get` result carries the blob's absolute path on the server's
-filesystem. `../cas/module.f.mjs:222` computes it unconditionally
+A `cas_get` that finds a blob carries that blob's absolute path on the
+server's filesystem. `../cas/module.f.mjs:222` computes it before the read
 
 ```js
 const uri = c.url(key)
@@ -24,9 +24,20 @@ uri = /Users/<username>/.cas/g0/00/00000000000000000000000000000000000938nkrj2nw
 ```
 
 So the field is not a URI in the `scheme:` sense at all — it is a host path, and
-it names the account the server runs under. Every client that calls `cas_get`
-once learns the server's home directory, its username, and the store layout,
-whether or not it can reach that path.
+it names the account the server runs under.
+
+**Precisely which calls emit it**, since the priority rests on this: a
+successful lookup does, in both content shapes (`:231`, `:271`), and so does the
+oversized-blob refusal (`:257`). The two failure paths do **not** — an invalid
+cBase32 hash is rejected at `:219-220` before `uri` is computed, and a well-formed
+hash with no blob behind it answers `no such hash` at `:226-227`. So a client learns
+the path by naming a hash that exists, not by calling the tool at all.
+
+That narrows the wording and not the exposure: `cas_list` answers *"All stored
+content hashes (cBase32), one per line"* (`../cas/module.f.mjs:295-303`) to any
+client that can call `cas_get`, and `cas_add` returns the hash of whatever the
+client just stored. A caller who wants the path is one call away from a hash
+that produces it, and needs no prior knowledge of the store. **P2 stands.**
 
 This is deliberate, which is why it wants a decision rather than a fix.
 `README.md`'s store-location section states it outright — "the `uri` field
@@ -102,7 +113,12 @@ Pick one; each is a different answer to "what is `uri` *for*".
    know the root cannot use it, so the shortcut is preserved only for clients
    for whom the disclosure was harmless anyway.
 3. **Resolver-supplied, absent by default.** The server is constructed with an
-   optional `toUrl` resolver and omits `uri` when there is none. **This is a
+   optional `toUrl` resolver and omits `uri` when there is none. **Absent is the
+   default, and that is the whole contract** — an earlier draft of this file also
+   said option 3 "subsumes option 1 as its default-resolver choice", which is
+   the opposite default and cannot hold at the same time. Option 1's
+   `cas:<hash>` is *expressible* under option 3, as one resolver a server may
+   choose to install; it is not what option 3 does when nobody installs one. **This is a
    restoration, and it is worth knowing which kind.** `toUrl` shipped in
    [#1102](https://github.com/functionalscript/functionalscript/pull/1102) and
    `deb4f122`
@@ -123,8 +139,15 @@ Pick one; each is a different answer to "what is `uri` *for*".
    absolute path available to the local case that wants it while removing it
    from the default.
 
-Option 3 subsumes option 1 as its default-resolver choice, and is the one
-[remote-url.md](./remote-url.md) already points at from the other direction.
+The three are genuinely alternatives, not a ladder: option 1 makes `uri`
+always present and never a host path, option 3 makes it absent unless a server
+opts in. Option 3 is the one [remote-url.md](./remote-url.md) points at from the
+other direction, and it is the only one that keeps the absolute path reachable
+for a local caller that wants it — but it is also the only one that leaves
+`uri` optional, which is a cost for
+[cas-get-mcp-resource-response.md](./cas-get-mcp-resource-response.md). The
+choice is the maintainer's; this issue's job is to make it an informed one.
+
 Whatever is chosen, `README.md`'s two statements about `uri` have to end up
 agreeing with the code — today they contradict each other.
 

--- a/fjs/mcp/todo/cas-get-uri-discloses-host-path.md
+++ b/fjs/mcp/todo/cas-get-uri-discloses-host-path.md
@@ -1,6 +1,6 @@
 ## `cas_get`'s `uri` is an absolute host path
 
-**Priority:** P3
+**Priority:** P2
 **Status:** open — a design decision, not a patch to apply
 
 ### Problem
@@ -38,12 +38,24 @@ for one.
 
 Three things sharpen it:
 
-- **The README already describes the behaviour we would want, and it is not the
-  behaviour.** It says `uri` "is present only when the server was started with a
-  `toUrl` resolver … it is omitted in memory-backed contexts such as tests". No
-  such resolver exists; `url` is a required member of `FileCas` and the field is
-  unconditional, in tests too (`../cas/proof.f.mjs:119` asserts it present). A
-  reader of the docs believes this is opt-in when it is not.
+- **The README's opt-in sentence is stale documentation of a removed API, not a
+  description of behaviour anyone still intends.** It says `uri` "is present
+  only when the server was started with a `toUrl` resolver … it is omitted in
+  memory-backed contexts such as tests". That resolver was real:
+  `casMcpHandlers` took an optional `toUrl` from
+  [#1102](https://github.com/functionalscript/functionalscript/pull/1102)
+  (`../../../changelog/0.31.0.md:5-7`), and `deb4f122`
+  ([#1159](https://github.com/functionalscript/functionalscript/pull/1159))
+  removed it — *"remove toUrl"* is one of that commit's own lines — making
+  `url` a required member of `FileCas` and the field unconditional. The README
+  sentence predates the removal (it was written in
+  [#1106](https://github.com/functionalscript/functionalscript/pull/1106)) and
+  has been carried through two moves since (`#1316`, `#1401`) without being
+  re-read; the field it names became `uri` in
+  [#1248](https://github.com/functionalscript/functionalscript/pull/1248)
+  (`../../../changelog/0.37.0.md:12-15`). No changelog entry records the
+  removal, which is part of why the sentence outlived it. Today the field is
+  unconditional in tests too — `../cas/proof.f.mjs:119` asserts it present.
 - **It sits against this module's own stated boundary.** README's design
   invariant is that the server never opens a client-named local path — every
   path it touches is self-derived. That invariant is about what the server
@@ -57,11 +69,19 @@ Three things sharpen it:
   parse its own field *out of* the envelope so it does not redden on the `uri` —
   a leak handled in a test's parsing, which is the weakest place to handle one.
 
-Exposure today is latent rather than live: the only transport is stdio
-(`../../protocol/mcp/stdio/`), so the client is a local process that could read
-`os.homedir()` for itself. [remote-url.md](./remote-url.md) is the point at which
-it stops being latent, and it should be settled before that lands rather than as
-part of it.
+Exposure depends on how the server was launched, and only one launch is the
+harmless one. Over stdio the client is a local *process*, which is not the same
+as a process that could learn this for itself: `ssh host npx functionalscript
+mcp`, a container, and a wrapper that runs the server under a different UID are
+all ordinary stdio launches (`../../protocol/mcp/stdio/`) in which the client
+cannot read the server account's home directory — and `cas_get` hands it over.
+Same machine, same user is the only case where the field tells the client what
+it already knew. So the disclosure is live today under configurations this
+transport supports, not something that waits for
+[remote-url.md](./remote-url.md); what that change adds is a transport where the
+harmless case stops being available at all. **P2 rather than P3 for that
+reason** — still a design decision rather than a patch, but not one to carry
+indefinitely.
 
 ### Proposal
 
@@ -81,9 +101,19 @@ Pick one; each is a different answer to "what is `uri` *for*".
    *Cost:* a half-measure. It is still not a URI, and a client that does not
    know the root cannot use it, so the shortcut is preserved only for clients
    for whom the disclosure was harmless anyway.
-3. **Resolver-supplied, absent by default.** Make it what the README already
-   claims: the server is constructed with an optional `toUrl` resolver and omits
-   `uri` when there is none. An HTTP server supplies one that produces a real
+3. **Resolver-supplied, absent by default.** The server is constructed with an
+   optional `toUrl` resolver and omits `uri` when there is none. **This is a
+   restoration, and it is worth knowing which kind.** `toUrl` shipped in
+   [#1102](https://github.com/functionalscript/functionalscript/pull/1102) and
+   `deb4f122`
+   ([#1159](https://github.com/functionalscript/functionalscript/pull/1159))
+   removed it under the heading of simplification — but that same commit
+   created [remote-url.md](./remote-url.md), which asks for "a URL translation
+   function instead of returning a URL from `FileCas`". The resolver was
+   superseded pending a design, not judged wrong; option 3 is that design
+   reached from the security side instead of the remote-transport side. An
+   implementer should read `deb4f122` before restoring anything, so the second
+   version is chosen rather than repeated. An HTTP server supplies one that produces a real
    URL under its own domain — exactly [remote-url.md](./remote-url.md)'s
    "URL translation function instead of returning a URL from `FileCas`" — and a
    local stdio server may supply an absolute-path resolver deliberately.
@@ -104,7 +134,9 @@ agreeing with the code — today they contradict each other.
 - [ ] Implement, including the tool-description string and the oversized-blob
       error text, both of which name `uri` as a download route.
 - [ ] Reconcile `README.md`'s "only when started with a `toUrl` resolver" and
-      "contains the full absolute path" with whatever ships.
+      "contains the full absolute path" with whatever ships — the first has
+      described a removed API since `deb4f122` and is wrong today whatever is
+      decided, so it does not wait for the decision.
 - [ ] State the emit-side boundary next to the existing design invariant, so the
       next field to carry a server path is a decision rather than an accident.
 


### PR DESCRIPTION
A `cas_get` that finds a blob carries that blob's absolute path on the server's
filesystem, and that path names the account the server runs under. Verified by
execution against `2e9ad76f`:

```
uri = /Users/<username>/.cas/g0/00/00000000000000000000000000000000000938nkrj2nwvvw
```

`fjs/mcp/cas/module.f.mjs:222` computes `c.url(key)` before the read; it reaches
the metadata object on both content shapes (`:231`, `:271`) and the
oversized-blob error text (`:257`). `FileCas.url` is `join(path, toPath(hash))`,
`path` is `NodeProgramOptions.home`, and the Node runner fills that from
`os.homedir()`.

**Which calls emit it** — review round 2 corrected an overstatement here. The
two failure paths do not: an invalid cBase32 hash is rejected at `:219-220`,
before `uri` exists, and a well-formed hash with no blob answers `no such hash`
at `:226-227`. A client learns the path by naming a hash that **exists**.

That narrows the sentence, not the exposure. `cas_list` answers *"All stored
content hashes (cBase32), one per line"* (`:295-303`) to the same client, and
`cas_add` returns the hash of whatever it just stored — so a hash that produces
the path is one call away, with no prior knowledge of the store. **Filed P2.**

This is deliberate — `fjs/mcp/README.md` says so outright, and
`cas-get-mcp-resource-response.md` chose the name for the future
`resources/read` view — which is why this is filed as a decision rather than
fixed. Three things sharpen it, and they are the reason it is worth a separate
issue rather than a line in `remote-url.md`:

- **The README's opt-in sentence documents an API that was removed, and nobody
  re-read it.** It says `uri` "is present only when the server was started with
  a `toUrl` resolver … it is omitted in memory-backed contexts such as tests".
  That resolver shipped in #1102 (`changelog/0.31.0.md:5-7`) and `deb4f122`
  (#1159) removed it — *"remove toUrl"* is one of that commit's own lines —
  making `url` required on `FileCas` and the field unconditional, in the
  memory-backed proof too (`cas/proof.f.mjs:119`). The sentence predates the
  removal (#1106), rode through #1316 and #1401 unread, and the field it names
  was renamed `url` → `uri` by #1248. No changelog entry records the removal.
  So the two README statements contradict each other because one of them is a
  fossil, not because the design is undecided.
- **The module's stated boundary is one-directional.** The design invariant is
  that the server never opens a client-named local path. That is about what it
  accepts; nothing says anything about what it emits, and a store path handed to
  the client is the same information going the other way.
- **It leaks past a downstream server's own hygiene.** `fjs-dev/finance` runs an
  MCP server over this registry and has just removed host paths from its own
  tool error text, with a real-process test proving neither its responses nor
  its stored run records carry one. This envelope reintroduces the path
  underneath that work, and that test currently parses its own field *out of*
  the envelope so it does not redden on the `uri` — a leak handled in a test's
  parsing.

Exposure is **live today**, not latent, and that is the review's correction to
the first version of this PR. Stdio does not mean same-machine, same-user:
`ssh host npx functionalscript mcp`, a container, and a different-UID wrapper
are all ordinary stdio launches in which the client cannot read the server
account's home directory — and `cas_get` hands it over. Same user is the only
case where the field tells a client what it already knew. `remote-url.md` is
where even that case disappears, which is still an argument for settling this
before it lands. Filed at P2.

The issue lays out three options with their costs — an opaque `cas:<hash>`
identifier, a store-relative path, or the resolver-supplied field — and leaves
the choice open. Option 3 is a **restoration**, and the file now says which
kind: `deb4f122` removed `toUrl` and created `remote-url.md` in the same
commit, asking for "a URL translation function instead of returning a URL from
`FileCas`". The resolver was superseded pending a design rather than judged
wrong, so an implementer is pointed at `deb4f122` first — to choose the second
version rather than repeat the first.

## Checks

Documentation only. Re-run on the review commit: `npx tsc` clean, `npm test`
3032/3032, `npm run cov` 100% line/branch/function, `npm run prepack` clean,
`npm run ci-update` produces no diff. Every relative path and line citation in
the file was re-resolved against the tree rather than trusted.

Changelog: none

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


