### PR TITLE
djs: compile modules to EDAG before loading imports

### DIFF
--- a/fjs/djs/todo/associate-edag-with-functions.md
+++ b/fjs/djs/todo/associate-edag-with-functions.md
@@ -1,7 +1,7 @@
 ## Associate compiled functions with their EDAG
 
 **Priority:** P4
-**Status:** parked — design note
+**Status:** on-hold
 
 ### Idea
 

--- a/fjs/djs/todo/associate-edag-with-functions.md
+++ b/fjs/djs/todo/associate-edag-with-functions.md
@@ -60,6 +60,28 @@ The second direction is not expected to reconstruct an EDAG by decompiling the
 function. It retrieves the EDAG that was registered for that function. If no EDAG was
 registered, or the runtime cannot provide one, `edagGet` returns an error.
 
+### Open problem: nested functions and frames
+
+The association is less obvious for functions created dynamically from nested
+functions/closures, because the resulting function value may depend on a captured
+frame.
+
+For example:
+
+```js
+const f = a => b => a + b
+const g = f(2)
+```
+
+`g` is a new function value created by evaluating `f`, with `a` captured in its
+frame. If later code calls `edagGet(g)`, it is not yet specified what EDAG should have
+been registered for `g`, when that registration should happen, or how the captured
+frame participates in that association.
+
+This note intentionally does **not** choose a representation or solve the problem.
+Nested functions, closure creation, and frames must be considered before the
+`edagAdd` / `edagGet` contract can be treated as complete.
+
 ### Notes
 
 - Do not require every function to have an EDAG. Host/native functions may have no
@@ -76,6 +98,8 @@ registered, or the runtime cannot provide one, `edagGet` returns an error.
 ### Possible future work
 
 - [ ] Decide the canonical Effect type definitions and module location.
+- [ ] Decide how nested functions/closures and captured frames participate in
+      function-to-EDAG registration.
 - [ ] Implement `edagAdd` / `edagGet` in a runtime when function-to-EDAG lookup is
       needed.
 - [ ] Consider a NaNVM implementation that stores the EDAG alongside its internal

--- a/fjs/djs/todo/associate-edag-with-functions.md
+++ b/fjs/djs/todo/associate-edag-with-functions.md
@@ -1,0 +1,91 @@
+## Associate compiled functions with their EDAG
+
+**Priority:** P4
+**Status:** parked — design note
+
+### Idea
+
+An EDAG does not have to be interpreted directly. A compiler may instead compile an
+EDAG to a normal executable function and run that function using the host engine or a
+VM.
+
+Conceptually:
+
+```text
+EDAG
+  -> compile to Function
+  -> execute Function
+```
+
+That path is attractive because normal function execution can use the existing runtime
+and optimization machinery. However, compiling the EDAG away creates a reverse-lookup
+problem: if later code receives only the resulting `Function` and needs its EDAG, the
+association must be preserved somewhere outside the function value itself.
+
+### Effects
+
+Represent that association through Effects rather than baking EDAG metadata into the
+function representation:
+
+```ts
+['edagAdd', (e: EDAG, f: Function) => Result<void, unknown>]
+['edagGet', (f: Function) => Result<EDAG, unknown>]
+```
+
+`edagAdd` registers that `f` was compiled from `e`. `edagGet` retrieves the EDAG
+associated with a function when one is available.
+
+This keeps the compiler independent from how a particular runtime stores the
+association. The EDAG remains its own computation representation; the function can
+remain an ordinary executable value.
+
+### Runtime implementations
+
+A VM may implement these Effects directly. For example, NaNVM can register the EDAG
+when it creates/compiles a function and later answer `edagGet` from its internal
+function metadata or function table.
+
+A JavaScript-based runtime could use a separate function-to-EDAG registry instead.
+The concrete storage mechanism is runtime-specific and is deliberately not part of
+the Effect contract.
+
+The important semantic distinction is:
+
+```text
+EDAG -> Function        compilation/execution concern
+Function -> EDAG        metadata/association concern
+```
+
+The second direction is not expected to reconstruct an EDAG by decompiling the
+function. It retrieves the EDAG that was registered for that function. If no EDAG was
+registered, or the runtime cannot provide one, `edagGet` returns an error.
+
+### Notes
+
+- Do not require every function to have an EDAG. Host/native functions may have no
+  registered EDAG.
+- Do not embed the EDAG into the function merely to support lookup; the Effect exists
+  so runtimes can choose an appropriate external/internal registry.
+- The association should preserve the exact EDAG, including semantic node sharing;
+  `edagGet` is retrieval, not regeneration or normalization.
+- This mechanism can coexist with direct EDAG interpretation. A runtime may interpret
+  EDAGs, compile them to functions, or use both strategies.
+- The lifetime/identity rules of the registry are runtime-specific and can be decided
+  when an implementation needs them.
+
+### Possible future work
+
+- [ ] Decide the canonical Effect type definitions and module location.
+- [ ] Implement `edagAdd` / `edagGet` in a runtime when function-to-EDAG lookup is
+      needed.
+- [ ] Consider a NaNVM implementation that stores the EDAG alongside its internal
+      function representation.
+- [ ] Add proofs that `edagGet(f)` returns the same EDAG previously registered with
+      `edagAdd(edag, f)` and reports an error for an unregistered function.
+
+### Related
+
+- [`compile-modules-to-edag.md`](./compile-modules-to-edag.md) — compiles DJS modules
+  to EDAG before loading imported values.
+- [`../../../todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)
+  — EDAG semantics and function representation design.

--- a/fjs/djs/todo/bound-edag-interpreter-resources.md
+++ b/fjs/djs/todo/bound-edag-interpreter-resources.md
@@ -1,59 +1,66 @@
 ## Bound EDAG validation and interpreter resources
 
-**Priority:** P3
+**Priority:** P4
 **Status:** open
-**Blocked by:** [compile modules to EDAG before loading imports](./compile-modules-to-edag.md)
+**Blocked by:** [`interpret-edag.md`](./interpret-edag.md)
 
 ### Problem
 
-The initial module-to-EDAG task introduces EDAG validation and a small FunctionalScript
-interpreter, but it should not be blocked on production-grade resource accounting.
+The baseline direct EDAG interpreter is intentionally separate from module compilation.
+Once that interpreter exists, hostile or simply very large inputs can still consume
+excessive work or memory, and recursive traversal can overflow the host language call
+stack.
 
-A hostile or simply very large EDAG can consume excessive time or memory during
-validation or interpretation. Deep graphs can also overflow the host language call
-stack if traversal is recursive. These constraints are important, but they are
-orthogonal to the basic source -> EDAG -> load -> interpret pipeline and can be added
-after that pipeline works.
+These constraints should be added after the basic interpreter works. They must not
+change EDAG semantics, serialization, identity, or hash.
 
 ### Proposal
 
-Add deterministic resource limits around EDAG validation and interpretation without
-changing EDAG semantics or its canonical representation.
+Add deterministic resource limits around the complete top-level EDAG processing
+operation.
 
-Resource limits are runner/compiler inputs, **not EDAG metadata**. Therefore changing
-a limit must not change the EDAG serialization, identity, or hash.
+Resource limits are runner/compiler inputs, **not EDAG metadata**.
+
+#### Whole-operation budget
+
+Do not reset limits for each source module. A root compilation may traverse an
+arbitrarily large module graph before producing the final EDAG, so per-module budgets
+alone do not bound total work or retained structure.
+
+Use one aggregate budget for the top-level operation and thread it through recursive
+module processing, final-EDAG validation, and direct interpretation. More detailed
+sub-budgets may be added later, but they must not allow aggregate work to become
+unbounded by repeatedly resetting a per-module allowance.
 
 #### Time / work limit
 
 Use an **instruction/work-step count**, not wall-clock time, as the deterministic
-measure of computation time.
-
-The budget should cover both validation and interpretation. Validation consumes the
-budget first and passes the remainder to interpretation. Define precisely which
-traversal/evaluation actions consume one step so independent implementations can
-apply the same accounting.
+measure of computation time. Define precisely which compiler, traversal, validation,
+and evaluation actions consume one step so independent implementations can apply the
+same accounting.
 
 #### Memory / structure-growth limit
 
-Define a deterministic approximation for memory growth caused by EDAG evaluation.
-For the initial interpreter this can count newly materialized object/array structure,
-such as constructed objects, arrays, properties, and elements.
+Define a deterministic approximation for memory growth caused by module resolution and
+EDAG evaluation. For the initial interpreter this can count newly materialized
+object/array structure, explicit work-stack growth, and other retained structures
+covered by the chosen accounting rule.
 
 Shared EDAG nodes must be charged only according to the chosen materialization rule;
 reusing a memoized result must not accidentally count as constructing the same value
 again.
 
-The goal is to stop runaway structure growth before the host runs out of memory, not
-to model exact allocator byte counts.
+The goal is to stop runaway growth before the host runs out of memory, not to model
+exact allocator byte counts.
 
 #### Traversal without native-stack dependence
 
 Validation and interpretation must not rely on recursive host calls for EDAG depth.
 Use explicit work stacks/continuations and iterative traversal.
 
-Work-stack growth itself must be bounded. In particular, charge/schedule work before
-bulk-pushing arbitrarily many children so a wide or deeply nested EDAG cannot exhaust
-host memory before the deterministic budget is checked.
+Work-stack growth itself must be bounded. Charge/schedule work before bulk-pushing
+arbitrarily many children so a wide or deeply nested EDAG cannot exhaust host memory
+before the deterministic budget is checked.
 
 #### Stopped outcomes
 
@@ -63,40 +70,36 @@ host exception.
 Conceptually:
 
 ```text
-CompileOutcome<T> = completed(T) | stopped(StopReason)
+Outcome<T> = completed(T) | stopped(StopReason)
 
 StopReason =
     instruction-limit
   | structure-growth-limit
 ```
 
-Validation may also stop when the instruction budget is exhausted. If validation or
-interpretation of an imported module stops, propagate that outcome through importing
-modules without evaluating dependent parent EDAGs.
-
-The public transpile/compile API must distinguish a deterministic stopped outcome from
-source/load errors such as `ParseError`.
+Validation may also stop when the aggregate instruction budget is exhausted. The
+public API that enables these limits must distinguish a deterministic stopped outcome
+from source/load errors such as `ParseError`.
 
 ### Tasks
 
-- [ ] Define the deterministic instruction/work-step accounting model for validation
-      and interpretation.
+- [ ] Define one aggregate deterministic work budget for the complete top-level
+      compilation/execution operation; do not reset it per imported module.
+- [ ] Define the deterministic instruction/work-step accounting model for module
+      processing, validation, and interpretation.
 - [ ] Make validation iterative and independent of the host call stack.
 - [ ] Make interpreter traversal iterative and independent of the host call stack.
 - [ ] Bound explicit validator/interpreter work-stack growth; do not bulk-push
       unbounded child lists before checking the budget.
-- [ ] Share one per-module instruction budget between validation and interpretation;
-      validation passes the remaining budget to interpretation.
-- [ ] Define deterministic structure-growth accounting for constructed objects,
-      arrays, properties, and elements.
+- [ ] Define deterministic structure-growth accounting for retained compiler work and
+      constructed objects, arrays, properties, and elements.
 - [ ] Ensure memoized/shared EDAG results are accounted for consistently and are not
       charged as newly materialized structure on every reference.
-- [ ] Define `CompileOutcome` / `StopReason` (or equivalent) so resource exhaustion is
+- [ ] Define `Outcome` / `StopReason` (or equivalent) so resource exhaustion is
       distinct from parse/load errors.
-- [ ] Propagate a stopped imported module to the root without interpreting dependent
-      parent EDAGs.
-- [ ] Define documented deterministic defaults for `fjs compile` and allow explicit
-      overrides.
+- [ ] Define documented deterministic defaults and allow explicit overrides.
+- [ ] Add proofs showing a very large module graph cannot evade the aggregate limit by
+      keeping every individual module below a per-module threshold.
 - [ ] Add proofs for instruction-limit and structure-growth-limit exhaustion.
 - [ ] Add deeply nested and very wide EDAG proofs showing validation/interpretation do
       not throw `RangeError` or exhaust the native stack; they complete or stop
@@ -106,7 +109,9 @@ source/load errors such as `ParseError`.
 
 ### Related
 
-- [`compile-modules-to-edag.md`](./compile-modules-to-edag.md) — introduces the basic
-  validator/interpreter pipeline this task hardens.
+- [`interpret-edag.md`](./interpret-edag.md) — provides the baseline direct EDAG
+  interpreter this TODO hardens.
+- [`compile-modules-to-edag.md`](./compile-modules-to-edag.md) — resolves the source
+  module graph to the final EDAG before execution.
 - [`../../../todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)
   — EDAG semantics and node sharing.

--- a/fjs/djs/todo/bound-edag-interpreter-resources.md
+++ b/fjs/djs/todo/bound-edag-interpreter-resources.md
@@ -1,0 +1,112 @@
+## Bound EDAG validation and interpreter resources
+
+**Priority:** P3
+**Status:** open
+**Blocked by:** [compile modules to EDAG before loading imports](./compile-modules-to-edag.md)
+
+### Problem
+
+The initial module-to-EDAG task introduces EDAG validation and a small FunctionalScript
+interpreter, but it should not be blocked on production-grade resource accounting.
+
+A hostile or simply very large EDAG can consume excessive time or memory during
+validation or interpretation. Deep graphs can also overflow the host language call
+stack if traversal is recursive. These constraints are important, but they are
+orthogonal to the basic source -> EDAG -> load -> interpret pipeline and can be added
+after that pipeline works.
+
+### Proposal
+
+Add deterministic resource limits around EDAG validation and interpretation without
+changing EDAG semantics or its canonical representation.
+
+Resource limits are runner/compiler inputs, **not EDAG metadata**. Therefore changing
+a limit must not change the EDAG serialization, identity, or hash.
+
+#### Time / work limit
+
+Use an **instruction/work-step count**, not wall-clock time, as the deterministic
+measure of computation time.
+
+The budget should cover both validation and interpretation. Validation consumes the
+budget first and passes the remainder to interpretation. Define precisely which
+traversal/evaluation actions consume one step so independent implementations can
+apply the same accounting.
+
+#### Memory / structure-growth limit
+
+Define a deterministic approximation for memory growth caused by EDAG evaluation.
+For the initial interpreter this can count newly materialized object/array structure,
+such as constructed objects, arrays, properties, and elements.
+
+Shared EDAG nodes must be charged only according to the chosen materialization rule;
+reusing a memoized result must not accidentally count as constructing the same value
+again.
+
+The goal is to stop runaway structure growth before the host runs out of memory, not
+to model exact allocator byte counts.
+
+#### Traversal without native-stack dependence
+
+Validation and interpretation must not rely on recursive host calls for EDAG depth.
+Use explicit work stacks/continuations and iterative traversal.
+
+Work-stack growth itself must be bounded. In particular, charge/schedule work before
+bulk-pushing arbitrarily many children so a wide or deeply nested EDAG cannot exhaust
+host memory before the deterministic budget is checked.
+
+#### Stopped outcomes
+
+Resource exhaustion is not a parse error and should not be represented as a thrown
+host exception.
+
+Conceptually:
+
+```text
+CompileOutcome<T> = completed(T) | stopped(StopReason)
+
+StopReason =
+    instruction-limit
+  | structure-growth-limit
+```
+
+Validation may also stop when the instruction budget is exhausted. If validation or
+interpretation of an imported module stops, propagate that outcome through importing
+modules without evaluating dependent parent EDAGs.
+
+The public transpile/compile API must distinguish a deterministic stopped outcome from
+source/load errors such as `ParseError`.
+
+### Tasks
+
+- [ ] Define the deterministic instruction/work-step accounting model for validation
+      and interpretation.
+- [ ] Make validation iterative and independent of the host call stack.
+- [ ] Make interpreter traversal iterative and independent of the host call stack.
+- [ ] Bound explicit validator/interpreter work-stack growth; do not bulk-push
+      unbounded child lists before checking the budget.
+- [ ] Share one per-module instruction budget between validation and interpretation;
+      validation passes the remaining budget to interpretation.
+- [ ] Define deterministic structure-growth accounting for constructed objects,
+      arrays, properties, and elements.
+- [ ] Ensure memoized/shared EDAG results are accounted for consistently and are not
+      charged as newly materialized structure on every reference.
+- [ ] Define `CompileOutcome` / `StopReason` (or equivalent) so resource exhaustion is
+      distinct from parse/load errors.
+- [ ] Propagate a stopped imported module to the root without interpreting dependent
+      parent EDAGs.
+- [ ] Define documented deterministic defaults for `fjs compile` and allow explicit
+      overrides.
+- [ ] Add proofs for instruction-limit and structure-growth-limit exhaustion.
+- [ ] Add deeply nested and very wide EDAG proofs showing validation/interpretation do
+      not throw `RangeError` or exhaust the native stack; they complete or stop
+      through a deterministic limit.
+- [ ] Verify resource limits do not participate in EDAG serialization or hashing.
+- [ ] `npx tsc`, `fjs test`.
+
+### Related
+
+- [`compile-modules-to-edag.md`](./compile-modules-to-edag.md) — introduces the basic
+  validator/interpreter pipeline this task hardens.
+- [`../../../todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)
+  — EDAG semantics and node sharing.

--- a/fjs/djs/todo/cache-compiled-modules.md
+++ b/fjs/djs/todo/cache-compiled-modules.md
@@ -7,23 +7,23 @@
 
 ### Goal
 
-Persist the temporary unresolved `Module` representation so incremental compilation can
+Persist the temporary `Unresolved` representation so incremental compilation can
 reuse a module without parsing it again when the source file has not changed.
 
-This cache is an optimization around the temporary module representation. It does not
-change `Module`, EDAG, or the final compilation result: after module resolution, the
-compiler still produces one final EDAG.
+This cache is an optimization around the temporary unresolved representation. It does
+not change `Unresolved`, EDAG, or the final compilation result: after module
+resolution, the compiler still produces one final EDAG.
 
-The temporary module type remains:
+The temporary type remains:
 
 ```ts
-type Module = {
+type Unresolved = {
     readonly imports: readonly string[]
     readonly edag: EDAG
 }
 ```
 
-Source identity belongs to the cache key, not to `Module`.
+Source identity belongs to the cache key, not to `Unresolved`.
 
 ### Cache layout
 
@@ -33,15 +33,15 @@ Hash the original source-file bytes with SHA-256 and encode the digest in CBase3
 hash = CBase32(SHA256(source bytes))
 ```
 
-Store the compiled unresolved module at:
+Store the compiled unresolved value at:
 
 ```text
 .fjs/unresolved/{hash}.f.js
 ```
 
 The filename is therefore content-addressed by the original source file itself. The
-cached `.f.js` value contains only the normal temporary `Module { imports, edag }`.
-There is no `hash` or `path` field inside `Module`.
+cached `.f.js` value contains only the normal temporary `Unresolved { imports, edag }`.
+There is no `hash` or `path` field inside `Unresolved`.
 
 The cache files are build artifacts and must not be source-controlled.
 
@@ -56,40 +56,42 @@ source bytes
   -> .fjs/unresolved/{hash}.f.js
 ```
 
-If that cache file exists, parse and validate the cached `Module`. Reuse `imports` and
-`edag` without parsing the source module only when the cache artifact itself is valid.
+If that cache file exists, parse and validate the cached `Unresolved`. Reuse `imports`
+and `edag` without parsing the source module only when the cache artifact itself is
+valid.
 
 Any cache read, parse, schema-validation, or EDAG-validation failure is an ordinary
 **cache miss**. The compiler must fall back to parsing/compiling the original source;
 a corrupt, truncated, manually modified, or stale cache artifact must not make the
 build fail merely because the cache exists.
 
-If the cache file does not exist or is invalid, parse/compile the source to a `Module`
-and save a replacement cache entry.
+If the cache file does not exist or is invalid, parse/compile the source to an
+`Unresolved` and save a replacement cache entry.
 
 Conceptually:
 
 ```text
 source bytes
   -> hash
-  -> cached Module?
+  -> cached Unresolved?
        |
-       +-- valid ----------> reuse Module
+       +-- valid ----------> reuse Unresolved
        |
-       +-- missing/invalid -> parse -> Module -> cache
+       +-- missing/invalid -> parse -> Unresolved -> cache
 ```
 
 A changed source file naturally produces a different hash and therefore a different
-cache path. No source hash needs to be duplicated inside the cached `Module`.
+cache path. No source hash needs to be duplicated inside the cached `Unresolved`.
 
 ### Source maps
 
-The unresolved-module cache must not make warm builds lose source information.
+The unresolved cache must not make warm builds lose source information.
 
 The source-map design is intentionally separate and source metadata must not be
-embedded into `Module.edag`. Until a compatible per-module source-map cache/sidecar is
-defined, **bypass the unresolved-module cache when source maps are requested** and
-parse the source normally so the same source ranges are available as in a cold build.
+embedded into `Unresolved.edag`. Until a compatible per-unresolved source-map
+cache/sidecar is defined, **bypass the unresolved cache when source maps are
+requested** and parse the source normally so the same source ranges are available as
+in a cold build.
 
 A future source-map cache may remove that restriction, but a cache hit must then
 restore the same mapping information as parsing the source.
@@ -97,14 +99,14 @@ restore the same mapping information as parsing the source.
 ### Cache invalidation beyond source contents
 
 The source hash identifies the source bytes, but compiler or EDAG-format changes may
-still make an old cached `Module` unusable even when the source bytes are unchanged.
-Define cache-version invalidation separately from `Module`; do not add cache metadata
-to the temporary module structure merely for persistence.
+still make an old cached `Unresolved` unusable even when the source bytes are unchanged.
+Define cache-version invalidation separately from `Unresolved`; do not add cache
+metadata to the temporary structure merely for persistence.
 
 ### Possible second-level cache
 
-This first cache stores the **unresolved** temporary `Module` produced directly from
-one source file.
+This first cache stores the **unresolved** temporary `Unresolved` produced directly
+from one source file.
 
 Later, we may add a second level of caching for **resolved modules**, after imported
 modules have themselves been resolved. Such a cache could avoid repeating module
@@ -116,17 +118,18 @@ second-level cache yet.
 ### Tasks
 
 - [ ] Define the exact SHA-256 -> CBase32 encoding used for source cache keys.
-- [ ] Store temporary modules as `.fjs/unresolved/{hash}.f.js`, where `hash` is
-      computed from the original source-file bytes.
-- [ ] Serialize and load the unchanged `Module { imports, edag }` representation.
-- [ ] Validate cached `Module` schema and EDAG before reuse.
+- [ ] Store temporary unresolved values as `.fjs/unresolved/{hash}.f.js`, where `hash`
+      is computed from the original source-file bytes.
+- [ ] Serialize and load the unchanged `Unresolved { imports, edag }` representation.
+- [ ] Validate cached `Unresolved` schema and EDAG before reuse.
 - [ ] Treat every cache read/parse/validation failure as a cache miss and recompile
       from source rather than failing the build.
-- [ ] Reuse a valid cached `Module` without parsing the source file.
+- [ ] Reuse a valid cached `Unresolved` without parsing the source file.
 - [ ] Parse/compile and create or replace the cache entry when it is missing/invalid.
 - [ ] Bypass this cache when source maps are requested until a compatible cached
       source-map artifact is defined.
-- [ ] Define compiler/EDAG-version cache invalidation outside the `Module` structure.
+- [ ] Define compiler/EDAG-version cache invalidation outside the `Unresolved`
+      structure.
 - [ ] Ignore `.fjs/` cache artifacts in source control.
 - [ ] Add proofs/tests for valid cache hits, malformed/truncated cache entries,
       cache miss after source changes, source-map-enabled builds, and
@@ -137,7 +140,7 @@ second-level cache yet.
 ### Related
 
 - [`compile-modules-to-edag.md`](./compile-modules-to-edag.md) — defines the unchanged
-  temporary `Module { imports, edag }` and resolves temporary modules into one final
-  EDAG.
+  temporary `Unresolved { imports, edag }` and resolves unresolved values into one
+  final EDAG.
 - [`investigate-edag-source-maps.md`](./investigate-edag-source-maps.md) — investigates
   source-map artifacts that must remain separate from EDAG.

--- a/fjs/djs/todo/cache-compiled-modules.md
+++ b/fjs/djs/todo/cache-compiled-modules.md
@@ -23,7 +23,8 @@ type Unresolved = {
 }
 ```
 
-Source identity belongs to the cache key, not to `Unresolved`.
+Source identity and compiler/cache identity belong to the cache machinery, not to
+`Unresolved`.
 
 ### Cache layout
 
@@ -39,11 +40,38 @@ Store the compiled unresolved value at:
 .fjs/unresolved/{hash}.f.js
 ```
 
-The filename is therefore content-addressed by the original source file itself. The
-cached `.f.js` value contains only the normal temporary `Unresolved { imports, edag }`.
-There is no `hash` or `path` field inside `Unresolved`.
+The `.f.js` filename remains content-addressed by the original source file itself. The
+cached value contains only the normal temporary `Unresolved { imports, edag }`; there
+is no `hash`, source `path`, or compiler-version field inside `Unresolved`.
 
 The cache files are build artifacts and must not be source-controlled.
+
+### Compiler/cache identity
+
+Source bytes alone are not sufficient to decide whether a cached compilation result is
+reusable: a compiler semantic change or EDAG-format change can make an old artifact
+stale even when the source hash is unchanged.
+
+Define an explicit `cacheVersion` owned by the compiler. Bump it whenever a change can
+alter source-to-`Unresolved` output or the accepted/serialized EDAG/cache format.
+
+Keep the `.fjs/unresolved/{hash}.f.js` path unchanged and store a companion version
+marker for each reusable entry, for example:
+
+```text
+.fjs/unresolved/{hash}.version
+```
+
+The marker contains the `cacheVersion` that produced the corresponding `.f.js` entry.
+A lookup is a hit only when **both** files exist, the version marker exactly matches the
+current compiler's `cacheVersion`, and the cached `Unresolved` parses and validates.
+A missing or mismatched marker is a cache miss.
+
+Write the `.f.js` artifact successfully before publishing/updating its version marker.
+That ordering prevents a new version marker from blessing an older artifact when an
+artifact write fails. The exact atomic-write/rename mechanism can follow the normal
+cache implementation, but correctness must never depend on trusting an entry whose
+matching version marker was not written for it.
 
 ### Incremental lookup
 
@@ -54,30 +82,36 @@ source bytes
   -> SHA-256
   -> CBase32
   -> .fjs/unresolved/{hash}.f.js
+     + .fjs/unresolved/{hash}.version
 ```
 
-If that cache file exists, parse and validate the cached `Unresolved`. Reuse `imports`
-and `edag` without parsing the source module only when the cache artifact itself is
-valid.
+If the version marker matches the current `cacheVersion`, parse and validate the cached
+`Unresolved`. Reuse `imports` and `edag` without parsing the source module only when
+that cache artifact itself is valid.
 
-Any cache read, parse, schema-validation, or EDAG-validation failure is an ordinary
-**cache miss**. The compiler must fall back to parsing/compiling the original source;
-a corrupt, truncated, manually modified, or stale cache artifact must not make the
-build fail merely because the cache exists.
+Any cache read, version-check, parse, schema-validation, or EDAG-validation failure is
+an ordinary **cache miss**. The compiler must fall back to parsing/compiling the
+original source; a corrupt, truncated, manually modified, stale, or compiler-incompatible
+cache artifact must not make the build fail merely because the cache exists.
 
-If the cache file does not exist or is invalid, parse/compile the source to an
-`Unresolved` and save a replacement cache entry.
+If the cache entry is missing or invalid, parse/compile the source to an `Unresolved`
+and attempt to save a replacement cache entry.
+
+Cache writes are **best-effort**. Failure to create the cache directory, write or rename
+the `.f.js` artifact, or write/publish the version marker must not turn a successful
+source compilation into a compilation failure. Return the freshly compiled
+`Unresolved`; the failed cache update merely means a later compilation may miss again.
 
 Conceptually:
 
 ```text
 source bytes
   -> hash
-  -> cached Unresolved?
+  -> matching-version valid cached Unresolved?
        |
-       +-- valid ----------> reuse Unresolved
+       +-- yes -----------> reuse Unresolved
        |
-       +-- missing/invalid -> parse -> Unresolved -> cache
+       +-- no ------------> parse -> Unresolved -> best-effort cache
 ```
 
 A changed source file naturally produces a different hash and therefore a different
@@ -96,13 +130,6 @@ in a cold build.
 A future source-map cache may remove that restriction, but a cache hit must then
 restore the same mapping information as parsing the source.
 
-### Cache invalidation beyond source contents
-
-The source hash identifies the source bytes, but compiler or EDAG-format changes may
-still make an old cached `Unresolved` unusable even when the source bytes are unchanged.
-Define cache-version invalidation separately from `Unresolved`; do not add cache
-metadata to the temporary structure merely for persistence.
-
 ### Possible second-level cache
 
 This first cache stores the **unresolved** temporary `Unresolved` produced directly
@@ -120,20 +147,30 @@ second-level cache yet.
 - [ ] Define the exact SHA-256 -> CBase32 encoding used for source cache keys.
 - [ ] Store temporary unresolved values as `.fjs/unresolved/{hash}.f.js`, where `hash`
       is computed from the original source-file bytes.
+- [ ] Define the compiler-owned `cacheVersion` and exactly which semantic/EDAG/cache
+      changes require it to be bumped.
+- [ ] Store a matching `.fjs/unresolved/{hash}.version` companion marker and require
+      it to match the current `cacheVersion` before an artifact can be reused.
+- [ ] Publish/update the version marker only after the corresponding `.f.js` artifact
+      write succeeds, so a failed write cannot validate an older artifact.
 - [ ] Serialize and load the unchanged `Unresolved { imports, edag }` representation.
 - [ ] Validate cached `Unresolved` schema and EDAG before reuse.
-- [ ] Treat every cache read/parse/validation failure as a cache miss and recompile
-      from source rather than failing the build.
-- [ ] Reuse a valid cached `Unresolved` without parsing the source file.
-- [ ] Parse/compile and create or replace the cache entry when it is missing/invalid.
+- [ ] Treat every cache read/version/parse/validation failure as a cache miss and
+      recompile from source rather than failing the build.
+- [ ] Reuse a valid, matching-version cached `Unresolved` without parsing the source
+      file.
+- [ ] Parse/compile when the entry is missing/invalid and attempt to create or replace
+      the cache entry.
+- [ ] Make every cache-directory/artifact/version-marker write failure non-fatal; return
+      the freshly compiled `Unresolved` even when persistence fails.
 - [ ] Bypass this cache when source maps are requested until a compatible cached
       source-map artifact is defined.
-- [ ] Define compiler/EDAG-version cache invalidation outside the `Unresolved`
-      structure.
 - [ ] Ignore `.fjs/` cache artifacts in source control.
 - [ ] Add proofs/tests for valid cache hits, malformed/truncated cache entries,
-      cache miss after source changes, source-map-enabled builds, and
-      compiler/EDAG-version invalidation.
+      cache miss after source changes, missing/mismatched compiler versions, a compiler
+      version bump with unchanged source bytes, read-only/unwritable cache locations,
+      source-map-enabled builds, and failed cache writes that still return the freshly
+      compiled result.
 - [ ] Keep the possible resolved-module second-level cache as future work until its
       identity and representation are designed.
 

--- a/fjs/djs/todo/cache-compiled-modules.md
+++ b/fjs/djs/todo/cache-compiled-modules.md
@@ -11,112 +11,107 @@ Persist the temporary compiled `Module` representation so incremental compilatio
 reuse a module without parsing it again when the source file has not changed.
 
 This cache is an optimization around the temporary module representation. It does not
-change EDAG and does not change the final compilation result: after module resolution,
-the compiler still produces one final EDAG.
+change `Module`, EDAG, or the final compilation result: after module resolution, the
+compiler still produces one final EDAG.
 
-### Module metadata
-
-The temporary module representation contains enough source identity information to
-validate a cached entry:
+The temporary module type remains:
 
 ```ts
 type Module = {
-    readonly hash: string
-    readonly path: string
     readonly imports: readonly string[]
     readonly edag: EDAG
 }
 ```
 
-- `hash` is the CBase32-encoded hash of the original source file contents.
-- `path` is the source module path relative to the `.fjs/` / current-working-directory
-  context used by the compiler. It may contain parent components for modules outside
-  that tree, for example `../../third_party/something.f.js`.
-- `imports` remains a source-ordered array of module paths, not a map.
-- `edag` is the parameterized EDAG produced from that source module before imports are
-  resolved.
-
-`hash` and `path` are compiler/cache metadata. They are not fields of EDAG.
+Source identity belongs to the cache key, not to `Module`.
 
 ### Cache layout
 
-Store cached modules under:
+Hash the original source-file bytes with SHA-256 and encode the digest in CBase32:
 
 ```text
-.fjs/modules/{pathHash}.f.js
+hash = CBase32(SHA256(source bytes))
 ```
 
-`pathHash` is a hash of the relative `Module.path`, encoded using the cache's canonical
-CBase32 hash representation. The source path itself is not used as the cache filename,
-so paths containing `/`, `..`, or platform-specific filesystem characters do not
-create a nested or invalid cache layout.
+Store the compiled temporary module at:
 
-The cached value still stores `Module.path`; the filename hash is only an index into
-the cache, not a replacement for the source-path identity stored in the `Module`.
+```text
+.fjs/modules/{hash}.f.js
+```
+
+The filename is therefore content-addressed by the original source file itself. The
+cached `.f.js` value contains only the normal temporary `Module { imports, edag }`.
+There is no `hash` or `path` field inside `Module`.
 
 The cache files are build artifacts and must not be source-controlled.
 
 ### Incremental lookup
 
-For a source module at relative path `path`:
+For a source module:
 
 ```text
-path
-  -> pathHash
-  -> .fjs/modules/{pathHash}.f.js
+source bytes
+  -> SHA-256
+  -> CBase32
+  -> .fjs/modules/{hash}.f.js
 ```
 
-If the cache file exists:
-
-1. load the cached `Module`;
-2. verify that its stored `path` is the requested relative source path;
-3. hash the current source file contents and encode the hash in CBase32;
-4. compare that value with `Module.hash`;
-5. if they are equal, reuse `Module.imports` and `Module.edag` without parsing the
-   source module again;
-6. otherwise parse/compile the source again and replace the cached `Module`.
+If that cache file exists, load its `Module` and reuse `imports` and `edag` without
+parsing the source module again. If it does not exist, parse/compile the source to a
+`Module` and save that module at the content-addressed cache path.
 
 Conceptually:
 
 ```text
-source path
-  -> cache path from hash(source path)
+source bytes
+  -> hash
   -> cached Module?
        |
-       +-- cached.hash == hash(source bytes) --> reuse Module
+       +-- yes --> reuse Module
        |
-       +-- otherwise -------------------------> parse -> Module -> cache
+       +-- no  --> parse -> Module -> cache
 ```
 
-This makes source parsing incremental independently for each module. Import contents
-do not participate in validating the cached source-to-`Module` result; imported
-modules have their own cache entries and are resolved separately.
+A changed source file naturally produces a different hash and therefore a different
+cache path. No source hash needs to be duplicated inside the cached `Module`.
 
 ### Cache invalidation beyond source contents
 
-A matching source hash proves only that the source bytes are unchanged. The persistent
-cache must also be invalidated when the compiler or EDAG format changes in a way that
-can change the generated `Module.edag`. Define that invalidation mechanism separately
-from the four-field `Module` structure; do not add unrelated cache-version fields to
-`Module` merely for persistence.
+The source hash identifies the source bytes, but compiler or EDAG-format changes may
+still make an old cached `Module` unusable even when the source bytes are unchanged.
+Define cache-version invalidation separately from `Module`; do not add cache metadata
+to the temporary module structure merely for persistence.
+
+### Possible second-level cache
+
+This first cache stores the **unresolved** temporary `Module` produced directly from
+one source file.
+
+Later, we may add a second level of caching for **resolved modules**, after imported
+modules have themselves been resolved. Such a cache could avoid repeating module
+resolution/linking when the complete dependency inputs are unchanged.
+
+This note intentionally does not define the identity/key or representation of that
+second-level cache yet.
 
 ### Tasks
 
-- [ ] Define the canonical normalization of `Module.path` before hashing or storing it.
-- [ ] Define the source-file hash algorithm and its CBase32 encoding.
-- [ ] Define the path-hash algorithm/encoding used for
-      `.fjs/modules/{pathHash}.f.js`.
-- [ ] Serialize and load the temporary `Module` as a `.f.js` cache artifact.
-- [ ] On lookup, verify both the stored `Module.path` and source-content `Module.hash`.
-- [ ] Reuse a valid cached `Module` without parsing the source file.
-- [ ] Recompile and replace the cache entry when the source-content hash changes.
-- [ ] Define compiler/EDAG-version cache invalidation without extending the canonical
-      four-field `Module` structure for that purpose.
+- [ ] Define the exact SHA-256 -> CBase32 encoding used for source cache keys.
+- [ ] Store temporary modules as `.fjs/modules/{hash}.f.js`, where `hash` is computed
+      from the original source-file bytes.
+- [ ] Serialize and load the unchanged `Module { imports, edag }` representation.
+- [ ] Reuse a cached `Module` without parsing when the content-addressed cache entry
+      exists.
+- [ ] Parse/compile and create the cache entry when it does not exist.
+- [ ] Define compiler/EDAG-version cache invalidation outside the `Module` structure.
 - [ ] Ignore `.fjs/` cache artifacts in source control.
-- [ ] Add proofs/tests for cache hit, source-content cache miss, path mismatch, modules
-      outside the working tree using `..`, and compiler/EDAG-version invalidation.
+- [ ] Add proofs/tests for cache hit, cache miss after source changes, and
+      compiler/EDAG-version invalidation.
+- [ ] Keep the possible resolved-module second-level cache as future work until its
+      identity and representation are designed.
 
 ### Related
 
-- [`compile-modules-to-edag.md`](./compile-modules-to-edag.md) — defines the temporary
-  `Module` and resolves all temporary modules into one final EDAG.
+- [`compile-modules-to-edag.md`](./compile-modules-to-edag.md) — defines the unchanged
+  temporary `Module { imports, edag }` and resolves temporary modules into one final
+  EDAG.

--- a/fjs/djs/todo/cache-compiled-modules.md
+++ b/fjs/djs/todo/cache-compiled-modules.md
@@ -40,9 +40,22 @@ Store the compiled unresolved value at:
 .fjs/unresolved/{hash}.f.js
 ```
 
-The `.f.js` filename remains content-addressed by the original source file itself. The
-cached value contains only the normal temporary `Unresolved { imports, edag }`; there
-is no `hash`, source `path`, or compiler-version field inside `Unresolved`.
+The filename remains content-addressed by the original source file itself.
+
+The cache file must also carry a small **cache header/envelope outside the exported
+`Unresolved` value** containing the compiler-owned `cacheVersion`. The exact spelling
+can be chosen when implemented (for example a cache-only DJS header/comment), but it
+must not add fields to `Unresolved` or EDAG.
+
+Conceptually the one cache file contains:
+
+```text
+cacheVersion
+export default Unresolved { imports, edag }
+```
+
+The cached default value is still exactly `Unresolved { imports, edag }`; `hash`, source
+`path`, and `cacheVersion` are not fields of that type.
 
 The cache files are build artifacts and must not be source-controlled.
 
@@ -55,23 +68,15 @@ stale even when the source hash is unchanged.
 Define an explicit `cacheVersion` owned by the compiler. Bump it whenever a change can
 alter source-to-`Unresolved` output or the accepted/serialized EDAG/cache format.
 
-Keep the `.fjs/unresolved/{hash}.f.js` path unchanged and store a companion version
-marker for each reusable entry, for example:
+A lookup is a hit only when the cache file's header/envelope exactly matches the current
+compiler's `cacheVersion` **and** the exported `Unresolved` parses and validates. A
+missing or mismatched cache header is a cache miss.
 
-```text
-.fjs/unresolved/{hash}.version
-```
-
-The marker contains the `cacheVersion` that produced the corresponding `.f.js` entry.
-A lookup is a hit only when **both** files exist, the version marker exactly matches the
-current compiler's `cacheVersion`, and the cached `Unresolved` parses and validates.
-A missing or mismatched marker is a cache miss.
-
-Write the `.f.js` artifact successfully before publishing/updating its version marker.
-That ordering prevents a new version marker from blessing an older artifact when an
-artifact write fails. The exact atomic-write/rename mechanism can follow the normal
-cache implementation, but correctness must never depend on trusting an entry whose
-matching version marker was not written for it.
+Keeping version metadata and the artifact in one file is load-bearing: two compiler
+versions compiling the same source concurrently must never be able to cross-publish an
+artifact from one version with metadata from the other. Publish each cache entry as one
+atomic file replacement (write a temporary complete entry, then atomically rename it
+into `.fjs/unresolved/{hash}.f.js`).
 
 ### Incremental lookup
 
@@ -82,10 +87,10 @@ source bytes
   -> SHA-256
   -> CBase32
   -> .fjs/unresolved/{hash}.f.js
-     + .fjs/unresolved/{hash}.version
+       { cacheVersion + exported Unresolved }
 ```
 
-If the version marker matches the current `cacheVersion`, parse and validate the cached
+If the cache version matches the current compiler, parse and validate the cached
 `Unresolved`. Reuse `imports` and `edag` without parsing the source module only when
 that cache artifact itself is valid.
 
@@ -97,10 +102,10 @@ cache artifact must not make the build fail merely because the cache exists.
 If the cache entry is missing or invalid, parse/compile the source to an `Unresolved`
 and attempt to save a replacement cache entry.
 
-Cache writes are **best-effort**. Failure to create the cache directory, write or rename
-the `.f.js` artifact, or write/publish the version marker must not turn a successful
-source compilation into a compilation failure. Return the freshly compiled
-`Unresolved`; the failed cache update merely means a later compilation may miss again.
+Cache writes are **best-effort**. Failure to create the cache directory, write the
+temporary file, or atomically replace the cache entry must not turn a successful source
+compilation into a compilation failure. Return the freshly compiled `Unresolved`; the
+failed cache update merely means a later compilation may miss again.
 
 Conceptually:
 
@@ -111,7 +116,7 @@ source bytes
        |
        +-- yes -----------> reuse Unresolved
        |
-       +-- no ------------> parse -> Unresolved -> best-effort cache
+       +-- no ------------> parse -> Unresolved -> best-effort atomic cache write
 ```
 
 A changed source file naturally produces a different hash and therefore a different
@@ -149,11 +154,11 @@ second-level cache yet.
       is computed from the original source-file bytes.
 - [ ] Define the compiler-owned `cacheVersion` and exactly which semantic/EDAG/cache
       changes require it to be bumped.
-- [ ] Store a matching `.fjs/unresolved/{hash}.version` companion marker and require
-      it to match the current `cacheVersion` before an artifact can be reused.
-- [ ] Publish/update the version marker only after the corresponding `.f.js` artifact
-      write succeeds, so a failed write cannot validate an older artifact.
-- [ ] Serialize and load the unchanged `Unresolved { imports, edag }` representation.
+- [ ] Define a cache-only header/envelope in the same `.f.js` file that records
+      `cacheVersion` without changing the exported `Unresolved { imports, edag }`.
+- [ ] Publish each complete cache entry with a single atomic file replacement so
+      compiler-version metadata and its artifact cannot be mixed by concurrent writers.
+- [ ] Serialize and load the unchanged exported `Unresolved { imports, edag }` value.
 - [ ] Validate cached `Unresolved` schema and EDAG before reuse.
 - [ ] Treat every cache read/version/parse/validation failure as a cache miss and
       recompile from source rather than failing the build.
@@ -161,16 +166,16 @@ second-level cache yet.
       file.
 - [ ] Parse/compile when the entry is missing/invalid and attempt to create or replace
       the cache entry.
-- [ ] Make every cache-directory/artifact/version-marker write failure non-fatal; return
+- [ ] Make every cache-directory/temp-write/atomic-replace failure non-fatal; return
       the freshly compiled `Unresolved` even when persistence fails.
 - [ ] Bypass this cache when source maps are requested until a compatible cached
       source-map artifact is defined.
 - [ ] Ignore `.fjs/` cache artifacts in source control.
 - [ ] Add proofs/tests for valid cache hits, malformed/truncated cache entries,
       cache miss after source changes, missing/mismatched compiler versions, a compiler
-      version bump with unchanged source bytes, read-only/unwritable cache locations,
-      source-map-enabled builds, and failed cache writes that still return the freshly
-      compiled result.
+      version bump with unchanged source bytes, concurrent writers with different
+      compiler versions, read-only/unwritable cache locations, source-map-enabled
+      builds, and failed cache writes that still return the freshly compiled result.
 - [ ] Keep the possible resolved-module second-level cache as future work until its
       identity and representation are designed.
 

--- a/fjs/djs/todo/cache-compiled-modules.md
+++ b/fjs/djs/todo/cache-compiled-modules.md
@@ -1,4 +1,4 @@
-## Cache compiled modules for incremental compilation
+## Cache unresolved modules for incremental compilation
 
 **Priority:** P3
 **Status:** open
@@ -7,7 +7,7 @@
 
 ### Goal
 
-Persist the temporary compiled `Module` representation so incremental compilation can
+Persist the temporary unresolved `Module` representation so incremental compilation can
 reuse a module without parsing it again when the source file has not changed.
 
 This cache is an optimization around the temporary module representation. It does not
@@ -33,10 +33,10 @@ Hash the original source-file bytes with SHA-256 and encode the digest in CBase3
 hash = CBase32(SHA256(source bytes))
 ```
 
-Store the compiled temporary module at:
+Store the compiled unresolved module at:
 
 ```text
-.fjs/modules/{hash}.f.js
+.fjs/unresolved/{hash}.f.js
 ```
 
 The filename is therefore content-addressed by the original source file itself. The
@@ -53,7 +53,7 @@ For a source module:
 source bytes
   -> SHA-256
   -> CBase32
-  -> .fjs/modules/{hash}.f.js
+  -> .fjs/unresolved/{hash}.f.js
 ```
 
 If that cache file exists, parse and validate the cached `Module`. Reuse `imports` and
@@ -84,12 +84,12 @@ cache path. No source hash needs to be duplicated inside the cached `Module`.
 
 ### Source maps
 
-The module cache must not make warm builds lose source information.
+The unresolved-module cache must not make warm builds lose source information.
 
 The source-map design is intentionally separate and source metadata must not be
 embedded into `Module.edag`. Until a compatible per-module source-map cache/sidecar is
-defined, **bypass the module cache when source maps are requested** and parse the
-source normally so the same source ranges are available as in a cold build.
+defined, **bypass the unresolved-module cache when source maps are requested** and
+parse the source normally so the same source ranges are available as in a cold build.
 
 A future source-map cache may remove that restriction, but a cache hit must then
 restore the same mapping information as parsing the source.
@@ -116,8 +116,8 @@ second-level cache yet.
 ### Tasks
 
 - [ ] Define the exact SHA-256 -> CBase32 encoding used for source cache keys.
-- [ ] Store temporary modules as `.fjs/modules/{hash}.f.js`, where `hash` is computed
-      from the original source-file bytes.
+- [ ] Store temporary modules as `.fjs/unresolved/{hash}.f.js`, where `hash` is
+      computed from the original source-file bytes.
 - [ ] Serialize and load the unchanged `Module { imports, edag }` representation.
 - [ ] Validate cached `Module` schema and EDAG before reuse.
 - [ ] Treat every cache read/parse/validation failure as a cache miss and recompile

--- a/fjs/djs/todo/cache-compiled-modules.md
+++ b/fjs/djs/todo/cache-compiled-modules.md
@@ -56,9 +56,16 @@ source bytes
   -> .fjs/modules/{hash}.f.js
 ```
 
-If that cache file exists, load its `Module` and reuse `imports` and `edag` without
-parsing the source module again. If it does not exist, parse/compile the source to a
-`Module` and save that module at the content-addressed cache path.
+If that cache file exists, parse and validate the cached `Module`. Reuse `imports` and
+`edag` without parsing the source module only when the cache artifact itself is valid.
+
+Any cache read, parse, schema-validation, or EDAG-validation failure is an ordinary
+**cache miss**. The compiler must fall back to parsing/compiling the original source;
+a corrupt, truncated, manually modified, or stale cache artifact must not make the
+build fail merely because the cache exists.
+
+If the cache file does not exist or is invalid, parse/compile the source to a `Module`
+and save a replacement cache entry.
 
 Conceptually:
 
@@ -67,13 +74,25 @@ source bytes
   -> hash
   -> cached Module?
        |
-       +-- yes --> reuse Module
+       +-- valid ----------> reuse Module
        |
-       +-- no  --> parse -> Module -> cache
+       +-- missing/invalid -> parse -> Module -> cache
 ```
 
 A changed source file naturally produces a different hash and therefore a different
 cache path. No source hash needs to be duplicated inside the cached `Module`.
+
+### Source maps
+
+The module cache must not make warm builds lose source information.
+
+The source-map design is intentionally separate and source metadata must not be
+embedded into `Module.edag`. Until a compatible per-module source-map cache/sidecar is
+defined, **bypass the module cache when source maps are requested** and parse the
+source normally so the same source ranges are available as in a cold build.
+
+A future source-map cache may remove that restriction, but a cache hit must then
+restore the same mapping information as parsing the source.
 
 ### Cache invalidation beyond source contents
 
@@ -100,12 +119,17 @@ second-level cache yet.
 - [ ] Store temporary modules as `.fjs/modules/{hash}.f.js`, where `hash` is computed
       from the original source-file bytes.
 - [ ] Serialize and load the unchanged `Module { imports, edag }` representation.
-- [ ] Reuse a cached `Module` without parsing when the content-addressed cache entry
-      exists.
-- [ ] Parse/compile and create the cache entry when it does not exist.
+- [ ] Validate cached `Module` schema and EDAG before reuse.
+- [ ] Treat every cache read/parse/validation failure as a cache miss and recompile
+      from source rather than failing the build.
+- [ ] Reuse a valid cached `Module` without parsing the source file.
+- [ ] Parse/compile and create or replace the cache entry when it is missing/invalid.
+- [ ] Bypass this cache when source maps are requested until a compatible cached
+      source-map artifact is defined.
 - [ ] Define compiler/EDAG-version cache invalidation outside the `Module` structure.
 - [ ] Ignore `.fjs/` cache artifacts in source control.
-- [ ] Add proofs/tests for cache hit, cache miss after source changes, and
+- [ ] Add proofs/tests for valid cache hits, malformed/truncated cache entries,
+      cache miss after source changes, source-map-enabled builds, and
       compiler/EDAG-version invalidation.
 - [ ] Keep the possible resolved-module second-level cache as future work until its
       identity and representation are designed.
@@ -115,3 +139,5 @@ second-level cache yet.
 - [`compile-modules-to-edag.md`](./compile-modules-to-edag.md) — defines the unchanged
   temporary `Module { imports, edag }` and resolves temporary modules into one final
   EDAG.
+- [`investigate-edag-source-maps.md`](./investigate-edag-source-maps.md) — investigates
+  source-map artifacts that must remain separate from EDAG.

--- a/fjs/djs/todo/cache-compiled-modules.md
+++ b/fjs/djs/todo/cache-compiled-modules.md
@@ -1,0 +1,122 @@
+## Cache compiled modules for incremental compilation
+
+**Priority:** P3
+**Status:** open
+
+**Blocked by:** [`compile-modules-to-edag.md`](./compile-modules-to-edag.md)
+
+### Goal
+
+Persist the temporary compiled `Module` representation so incremental compilation can
+reuse a module without parsing it again when the source file has not changed.
+
+This cache is an optimization around the temporary module representation. It does not
+change EDAG and does not change the final compilation result: after module resolution,
+the compiler still produces one final EDAG.
+
+### Module metadata
+
+The temporary module representation contains enough source identity information to
+validate a cached entry:
+
+```ts
+type Module = {
+    readonly hash: string
+    readonly path: string
+    readonly imports: readonly string[]
+    readonly edag: EDAG
+}
+```
+
+- `hash` is the CBase32-encoded hash of the original source file contents.
+- `path` is the source module path relative to the `.fjs/` / current-working-directory
+  context used by the compiler. It may contain parent components for modules outside
+  that tree, for example `../../third_party/something.f.js`.
+- `imports` remains a source-ordered array of module paths, not a map.
+- `edag` is the parameterized EDAG produced from that source module before imports are
+  resolved.
+
+`hash` and `path` are compiler/cache metadata. They are not fields of EDAG.
+
+### Cache layout
+
+Store cached modules under:
+
+```text
+.fjs/modules/{pathHash}.f.js
+```
+
+`pathHash` is a hash of the relative `Module.path`, encoded using the cache's canonical
+CBase32 hash representation. The source path itself is not used as the cache filename,
+so paths containing `/`, `..`, or platform-specific filesystem characters do not
+create a nested or invalid cache layout.
+
+The cached value still stores `Module.path`; the filename hash is only an index into
+the cache, not a replacement for the source-path identity stored in the `Module`.
+
+The cache files are build artifacts and must not be source-controlled.
+
+### Incremental lookup
+
+For a source module at relative path `path`:
+
+```text
+path
+  -> pathHash
+  -> .fjs/modules/{pathHash}.f.js
+```
+
+If the cache file exists:
+
+1. load the cached `Module`;
+2. verify that its stored `path` is the requested relative source path;
+3. hash the current source file contents and encode the hash in CBase32;
+4. compare that value with `Module.hash`;
+5. if they are equal, reuse `Module.imports` and `Module.edag` without parsing the
+   source module again;
+6. otherwise parse/compile the source again and replace the cached `Module`.
+
+Conceptually:
+
+```text
+source path
+  -> cache path from hash(source path)
+  -> cached Module?
+       |
+       +-- cached.hash == hash(source bytes) --> reuse Module
+       |
+       +-- otherwise -------------------------> parse -> Module -> cache
+```
+
+This makes source parsing incremental independently for each module. Import contents
+do not participate in validating the cached source-to-`Module` result; imported
+modules have their own cache entries and are resolved separately.
+
+### Cache invalidation beyond source contents
+
+A matching source hash proves only that the source bytes are unchanged. The persistent
+cache must also be invalidated when the compiler or EDAG format changes in a way that
+can change the generated `Module.edag`. Define that invalidation mechanism separately
+from the four-field `Module` structure; do not add unrelated cache-version fields to
+`Module` merely for persistence.
+
+### Tasks
+
+- [ ] Define the canonical normalization of `Module.path` before hashing or storing it.
+- [ ] Define the source-file hash algorithm and its CBase32 encoding.
+- [ ] Define the path-hash algorithm/encoding used for
+      `.fjs/modules/{pathHash}.f.js`.
+- [ ] Serialize and load the temporary `Module` as a `.f.js` cache artifact.
+- [ ] On lookup, verify both the stored `Module.path` and source-content `Module.hash`.
+- [ ] Reuse a valid cached `Module` without parsing the source file.
+- [ ] Recompile and replace the cache entry when the source-content hash changes.
+- [ ] Define compiler/EDAG-version cache invalidation without extending the canonical
+      four-field `Module` structure for that purpose.
+- [ ] Ignore `.fjs/` cache artifacts in source control.
+- [ ] Add proofs/tests for cache hit, source-content cache miss, path mismatch, modules
+      outside the working tree using `..`, and compiler/EDAG-version invalidation.
+
+### Related
+
+- [`compile-modules-to-edag.md`](./compile-modules-to-edag.md) — defines the temporary
+  `Module` and resolves all temporary modules into one final EDAG.

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -179,6 +179,15 @@ parameter positions in the importing module EDAG. The import array order therefo
 remains significant: position `i` in `imports` corresponds to import parameter `i` in
 the EDAG.
 
+**Import binding is scope-aware.** At module scope, `['args']` is the import-parameter
+array described above. A nested `['=>', frame, body]` introduces a new function scope,
+where `['args']` means that function invocation's arguments instead. Module linking must
+therefore never descend into a nested function `body` while substituting module import
+parameters. The `frame` operand belongs to the enclosing scope and may be traversed
+there; Stage 2 restricts it to the empty `['[]']` form anyway. Import reachability checks
+must use the same scope boundary so function-local `['args']` nodes cannot be mistaken
+for module import parameters.
+
 One link operation must memoize resolved modules by the resolver's canonical module
 path. If the same module is reached more than once, including through a diamond import,
 reuse the same resolved EDAG rather than resolving/splicing a fresh copy. EDAG node
@@ -295,8 +304,9 @@ objects different graph identities. Sharing of the descriptor's `key` and `value
 nodes remains normal semantic EDAG sharing.
 
 Do **not** add unrelated EDAG operations in these stages: arithmetic/logical operators,
-comma, loops, `throw`, object spread, frame access/captures, or other later operations
-remain outside this task unless they become necessary for the staged parser work above.
+comma, loops, `throw`, object spread, frame access/captures, `own`, or other later
+operations remain outside this task unless they become necessary for the staged parser
+work above.
 
 ### Number parsing and serialization
 
@@ -333,6 +343,33 @@ The exact tests must distinguish the edge cases semantically:
 This parser/serializer support is required independently of module-to-EDAG conversion,
 because `.f.js` is the general representation used to persist EDAG and unresolved
 artifacts.
+
+### Existing compile API boundary
+
+This task adds an **EDAG-producing compilation path**; it does not change the public
+success result of the existing value-producing DJS transpiler/CLI yet. Until an EDAG
+execution path is integrated, existing `transpile` callers and `fjs compile` continue
+to evaluate the module and serialize its exported value exactly as they do today.
+
+In particular, the final EDAG artifact described below is a distinct compiler artifact,
+not a replacement for the current `fjs compile <input> <output>` result during this
+stage. Land the EDAG-producing path alongside the current value-producing path rather
+than routing existing callers to an EDAG value that they would accidentally stringify
+as the module result.
+
+After the baseline interpreter exists, [`interpret-edag.md`](./interpret-edag.md) owns
+the migration of the existing value-producing path to:
+
+```text
+source modules
+  -> final EDAG
+  -> interpret EDAG
+  -> exported value
+  -> existing output serialization
+```
+
+That migration changes the internal execution path, not the public value/output
+contract.
 
 ### Final EDAG serialization
 
@@ -395,13 +432,17 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
 - [ ] Replace `['aref', i]` with `['.', ['args'], i]` and replace `cref` sequencing
       with shared EDAG node identity.
 - [ ] Resolve imported `Unresolved` values recursively and bind each resolved result
-      to the corresponding import parameter position.
+      to the corresponding **module-scope** import parameter position; when Stage 2
+      functions exist, do not descend into nested `=>` bodies while substituting imports.
+- [ ] Apply the same function-scope boundary to module-import reachability checks so
+      nested function-local `['args']` nodes are never interpreted as import parameters.
 - [ ] Memoize resolved modules during one link operation by canonical module path so
       repeated/diamond imports reuse the same resolved EDAG node identities.
 - [ ] Remove the temporary `Unresolved` layer after resolution so the root compilation
       result is a plain EDAG with no unresolved module paths or temporary metadata.
-- [ ] Split the current transpiler flow into source-to-`Unresolved` compilation and
-      recursive module resolution/linking.
+- [ ] Add a distinct EDAG-producing compiler path/API alongside the current
+      value-producing transpiler; do not redirect existing `transpile` / `fjs compile`
+      callers until EDAG execution is available.
 
 #### Stage 2
 
@@ -422,6 +463,10 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
 - [ ] Add proofs for non-capturing nested functions and ordinary/method calls in the
       supported Stage 2 subset, including accepted static/numeric `.()` properties and
       rejection of prohibited/runtime-computed string properties.
+- [ ] Add a scope-aware linking proof such as
+      `import y from './y.f.js'; export default [y, (x) => x]`: resolving `y` must not
+      rewrite the nested function body's `['args']`, and calling that function still
+      returns its invocation argument.
 - [ ] Add a validation proof that reusing one operation node both outside and inside a
       nested function body is rejected.
 
@@ -434,8 +479,10 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
       policy as a side effect of this task.
 - [ ] Coordinate any shared parser/serializer extraction with [`157.md`](./157.md)
       instead of adding another duplicate JSON/DJS walker or numeric-policy layer.
-- [ ] Serialize the final EDAG to `.f.js`; allow JSON output only when it preserves
-      the EDAG completely.
+- [ ] Serialize the final EDAG to `.f.js` through the EDAG-producing artifact path;
+      allow JSON output only when it preserves the EDAG completely.
+- [ ] Preserve the existing value-producing `transpile` / `fjs compile` success output
+      until `interpret-edag.md` integrates EDAG execution behind that API.
 - [ ] Preserve current missing-file, parse-error, and circular-dependency behavior.
 - [ ] Add Stage 1 proofs that permitted `a.b`, `a['x']`, and numeric `a[0]` forms
       produce property-access EDAGs, while prohibited names and runtime-computed string
@@ -462,7 +509,8 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
 ### Related
 
 - [`../transpiler/module.f.mjs`](../transpiler/module.f.mjs) — currently loads imports
-  recursively before calling `run(module[1])(args)`.
+  recursively before calling `run(module[1])(args)`; keep its value-producing public
+  contract until EDAG interpretation is integrated.
 - [`../parser/module.f.mjs`](../parser/module.f.mjs) — DJS parser that must support the
   chosen special-number `.f.js` spellings.
 - [`../serializer/module.f.mjs`](../serializer/module.f.mjs) — DJS serializer where
@@ -480,7 +528,8 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
 - [`cache-compiled-modules.md`](./cache-compiled-modules.md) — lower-priority
   persistence/incremental-compilation task for `.fjs/unresolved/{hash}.f.js`.
 - [`interpret-edag.md`](./interpret-edag.md) — separate baseline direct-interpreter
-  execution strategy for the final EDAG.
+  execution strategy for the final EDAG and later integration behind the existing
+  value-producing transpile/compile API.
 - [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md) —
   lower-priority resource/time/memory hardening for EDAG processing.
 - [`associate-edag-with-functions.md`](./associate-edag-with-functions.md) —

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -155,6 +155,16 @@ computation, reject that module as unsupported for this stage rather than changi
 behavior. This restriction can be removed when the EDAG has an operation that can
 anchor such non-resulting computations.
 
+The same restriction applies across a **module boundary**. The current transpiler loads
+and evaluates every imported module before running the importing module body, even when
+the imported binding is never referenced. Without anchoring, replacing an unused import
+parameter with nothing would discard the imported module root and could suppress its
+failure. Therefore Stage 1 rejects a source module when an import parameter is not
+reachable from the module EDAG root. This is deliberately a reachability rule, not an
+effect analysis: Stage 1 does not inspect whether the dependency happens to throw.
+Once EDAG can anchor non-resulting computations, unused imported roots can be preserved
+instead of rejected.
+
 Persisting unresolved values under `.fjs/unresolved/` and using them for incremental
 compilation is deliberately a separate task; see
 [`cache-compiled-modules.md`](./cache-compiled-modules.md).
@@ -379,6 +389,9 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
 - [ ] Do not silently drop required body evaluation. Until an anchoring/sequencing
       operation is available, reject a Stage 1 source module if conversion would omit
       an unreachable potentially throwing body computation.
+- [ ] Until anchoring exists, reject a Stage 1 source module when any import parameter
+      is unreachable from its EDAG root; do not silently discard eager imported-module
+      evaluation just because the binding is unused.
 - [ ] Replace `['aref', i]` with `['.', ['args'], i]` and replace `cref` sequencing
       with shared EDAG node identity.
 - [ ] Resolve imported `Unresolved` values recursively and bind each resolved result
@@ -436,6 +449,9 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
 - [ ] Add a Stage 1 proof that `const check = null.x; export default 1` is not silently
       compiled to the successful constant `1`; until anchoring exists it is rejected
       as unsupported rather than changing current evaluation behavior.
+- [ ] Add a Stage 1 proof that an unused import is not silently discarded: for example,
+      `import bad from './bad.f.js'; export default 1` is rejected as unsupported until
+      imported module roots can be anchored, so a failure in `bad.f.js` cannot disappear.
 - [ ] Add a diamond-import proof showing repeated resolution of one canonical module
       reuses the same resolved EDAG and preserves shared exported object/array identity.
 - [ ] Add DJS number round-trip proofs for `-0`, `NaN`, `Infinity`, and `-Infinity`,

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -47,10 +47,23 @@ a.b
 a[b]
 ```
 
-Both forms compile to the EDAG `.` operation. This stage is required before EDAG can
-replace the current AST as the representation of an **unresolved module**, because
-imported values are parameters and module EDAGs need to access those parameters, for
-example:
+Both forms lower to the EDAG `.` operation only when the property operand satisfies the
+canonical EDAG property-access restriction. The full EDAG rule permits:
+
+- a permitted **string constant** (not a prohibited prototype-chain name such as
+  `constructor` or `__proto__`);
+- a **number constant**;
+- later, a unary `+` or `Number` node that is guaranteed to yield a number or throw.
+
+Stage 1 does not introduce unary `+` or `Number`, so its parser/compiler accepts only
+the permitted string-constant and number-constant cases. A runtime-computed string,
+a prohibited string literal, or any other unsupported property expression is rejected
+rather than compiled to `.`. For example, `a.x`, `a['x']`, and `a[0]` can lower to `.`,
+while `a['constructor']` and `a[x]` (when `x` is a runtime string value) do not.
+
+This stage is required before EDAG can replace the current AST as the representation of
+an **unresolved module**, because imported values are parameters and module EDAGs need
+to access those parameters, for example:
 
 ```js
 ['.', ['args'], 0]
@@ -214,7 +227,8 @@ The staged work builds on the basic structural forms already being defined for E
   the current DJS parser produces;
 - array constructors: `['[]', ...node]`;
 - the argument array: `['args']`;
-- Stage 1 property access: `['.', object, property]`;
+- Stage 1 property access: `['.', object, property]`, with the restricted property
+  operands described above;
 - Stage 2 non-capturing functions: `['=>', ['[]'], body]`;
 - Stage 2 calls: `['()', object, args]` and
   `['.()', object, property, args]`;
@@ -303,9 +317,13 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
 
 #### Stage 1
 
-- [ ] Introduce `['.', object, property]` into EDAG and its validation/type schema.
-- [ ] Introduce parser support for `a.b` and `a[b]`, compiling both to the EDAG `.`
-      operation.
+- [ ] Introduce `['.', object, property]` into EDAG and its validation/type schema,
+      enforcing the canonical property-operand restriction: permitted string constants,
+      number constants, and only later the approved unary numeric-conversion forms when
+      those operations exist.
+- [ ] Introduce parser support for `a.b` and `a[b]`, compiling only permitted Stage 1
+      static-string/number property cases to `.`, and reject runtime-computed strings,
+      prohibited property names, and other unsupported property expressions.
 - [ ] Define the temporary `Unresolved` type as `{ imports, edag }`; keep it outside
       the EDAG schema.
 - [ ] Keep `Unresolved.imports` as a source-ordered array of module paths, not a map,
@@ -363,14 +381,15 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
 - [ ] Serialize the final EDAG to `.f.js`; allow JSON output only when it preserves
       the EDAG completely.
 - [ ] Preserve current missing-file, parse-error, and circular-dependency behavior.
-- [ ] Add Stage 1 proofs that `a.b` and `a[b]` produce property-access EDAGs,
-      source-to-`Unresolved` compilation does not read imports, import paths and
-      parameter positions preserve source order, object-entry order **including
-      integer-like keys and duplicate keys** survives parsing/EDAG conversion,
-      non-string object-entry keys are rejected by initial validation, aliased entry
-      descriptor containers are rejected while shared key/value nodes remain valid,
-      and resolving a multi-module program produces one final EDAG with no unresolved
-      module metadata.
+- [ ] Add Stage 1 proofs that permitted `a.b`, `a['x']`, and numeric `a[0]` forms
+      produce property-access EDAGs, while prohibited names and runtime-computed string
+      properties are rejected; source-to-`Unresolved` compilation does not read imports,
+      import paths and parameter positions preserve source order, object-entry order
+      **including integer-like keys and duplicate keys** survives parsing/EDAG
+      conversion, non-string object-entry keys are rejected by initial validation,
+      aliased entry descriptor containers are rejected while shared key/value nodes
+      remain valid, and resolving a multi-module program produces one final EDAG with
+      no unresolved module metadata.
 - [ ] Add a Stage 1 proof that `const check = null.x; export default 1` is not silently
       compiled to the successful constant `1`; until anchoring exists it is rejected
       as unsupported rather than changing current evaluation behavior.

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -64,11 +64,13 @@ version in its identity; dependency values are not part of the source-to-EDAG ca
 key.
 
 The compiler may also materialize these intermediate EDAGs as **DJS files** in a
-temporary build directory, analogous to `./target/`, for example
-`./target/edag/`. This makes the independently compiled module representation easy
-to inspect, debug, and reuse during the rest of the compilation. The files contain
-the EDAG serialization, not loaded dependency values or the final compiled module.
-They are build artifacts and must not be source-controlled.
+FunctionalScript-owned temporary build directory such as `./.fjs/edag/`. This keeps
+FunctionalScript artifacts separate from Cargo's `./target/`, while leaving room for
+other FunctionalScript build artifacts under `./.fjs/` later. The independently
+compiled module representation is then easy to inspect, debug, and reuse during the
+rest of the compilation. The files contain the EDAG serialization, not loaded
+dependency values or the final compiled module. They are build artifacts and must
+not be source-controlled.
 
 #### 2. Load imports and execute the EDAG
 
@@ -125,8 +127,8 @@ are represented by their constructors.
       construct the argument array deterministically.
 - [ ] Split the current transpiler flow into source-to-EDAG compilation and recursive
       loading/evaluation.
-- [ ] Allow compiled module EDAGs to be emitted as DJS files under a temporary build
-      directory such as `./target/edag/`; keep the directory out of source control.
+- [ ] Allow compiled module EDAGs to be emitted as DJS files under `./.fjs/edag/`
+      and ignore the FunctionalScript build directory in source control.
 - [ ] Execute each module EDAG only after all of its imported values have been loaded;
       the root module's result is the final compiled value.
 - [ ] Preserve current missing-file, parse-error, and circular-dependency behavior.

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -98,32 +98,49 @@ array constructor node is referenced from several places, it must be evaluated o
 and the same resulting object/array reused. A memo table keyed by EDAG node identity
 is sufficient for the initial interpreter.
 
-The interpreter **never throws**. Validation rejects malformed EDAGs before
-interpretation; interpretation of a validated EDAG returns an explicit outcome.
-Normally that outcome contains the computed value, but the interpreter may stop
-when a deterministic resource limit is reached.
+Validation and interpretation are both **non-throwing**. Validation rejects malformed
+EDAGs before interpretation, but validation itself may stop when its deterministic
+traversal budget is exhausted. Interpretation of a successfully validated EDAG
+returns either the computed value or a stopped outcome when a deterministic resource
+limit is reached.
 
 Initially support two limits:
 
-- **instruction limit** — count interpreter instructions/EDAG evaluation steps rather
-  than wall-clock time. This is the interpreter's measure of how long a computation
-  takes and is deterministic across machines;
-- **structure-growth limit** — stop if interpretation materializes too much object or
-  array structure. Define a simple deterministic accounting rule for constructed
-  nodes/properties/elements so computations that grow data without bound cannot
-  exhaust host memory.
+- **instruction limit** — a shared per-module budget consumed by both EDAG validation
+  and interpretation. Count validator/interpreter traversal and evaluation steps
+  rather than wall-clock time, so the limit is deterministic across machines;
+- **structure-growth limit** — consumed only by interpretation; stop if evaluation
+  materializes too much object or array structure. Define a simple deterministic
+  accounting rule for constructed nodes/properties/elements so computations that
+  grow data without bound cannot exhaust host memory.
 
 The validator and interpreter must not depend on the host language call stack for
 EDAG traversal. A valid EDAG can be arbitrarily deep, so recursive traversal could
-throw a host `RangeError` before an interpreter limit is reached. Use an explicit
-work stack/continuation structure and iterative traversal instead. Advancing that
-work must count toward the deterministic instruction/traversal budget, so hostile
-operand depth stops cleanly rather than overflowing the native stack.
+throw a host `RangeError` before a limit is reached. Use an explicit work
+stack/continuation structure and iterative traversal instead.
 
-The limits are interpreter inputs/options, not fields in the EDAG, so they do not
-change the EDAG's canonical representation or identity. Reaching either limit is a
-normal stopped result with a reason, not an exception. This mechanism can later
-bound evaluation of general EDAG functions as the operation set grows.
+Validation receives the module's instruction budget first. Every traversal
+transition — including descending into/scheduling another child — consumes budget
+**before** growing the explicit work stack. Do not bulk-push an unbounded operand
+list. Therefore both traversal work and validator work-stack growth are bounded by
+the deterministic instruction limit. Validation returns one of:
+
+```text
+invalid(validationError)
+valid(remainingInstructionBudget)
+stopped(instruction-limit)
+```
+
+Only `valid` proceeds to interpretation, which receives the remaining instruction
+budget rather than resetting it. Thus validation cannot perform unbounded work before
+the interpreter's resource accounting begins.
+
+The limits are compiler inputs/options, not fields in the EDAG, so they do not change
+the EDAG's canonical representation or identity. Each module receives a fresh budget
+initialized from the requested/default limits; within that module, validation and
+interpretation share the instruction budget. Reaching either limit is a normal
+stopped result with a reason, not an exception. This mechanism can later bound
+evaluation of general EDAG functions as the operation set grows.
 
 Conceptually:
 
@@ -136,7 +153,15 @@ imports
   -> recursively load values
   -> args
 
-interpret(edag, args, limits)
+validate(edag, limits.instruction)
+  -> invalid(error)
+   | stopped(instruction-limit)
+   | valid(remainingInstructionBudget)
+
+interpret(edag, args, {
+    instruction: remainingInstructionBudget,
+    structureGrowth: limits.structureGrowth,
+})
   -> completed(value) | stopped(reason)
 ```
 
@@ -152,16 +177,17 @@ StopReason = instruction-limit | structure-growth-limit
 ```
 
 Parse/load errors therefore remain errors in `Result`, while deterministic resource
-exhaustion is an explicit non-throwing compilation outcome. Thread the interpreter
-limits through the loader/transpiler API. `fjs compile` supplies documented,
-deterministic default limits; callers may override them explicitly. Choosing and
-documenting the concrete default values is part of this task rather than an implicit
-host-dependent decision.
+exhaustion is an explicit non-throwing compilation outcome. A validation failure for
+an EDAG produced by this compiler indicates an internal compiler defect; it must not
+be reported as a source `ParseError`. Thread the compile limits through the
+loader/transpiler API. `fjs compile` supplies documented, deterministic default
+limits; callers may override them explicitly. Choosing and documenting the concrete
+default values is part of this task rather than an implicit host-dependent decision.
 
-If interpretation of an imported module returns `stopped`, propagate that outcome
-unchanged through every importing module and do not interpret dependent parent EDAGs.
-A root `stopped` outcome makes `fjs compile` terminate cleanly as an unsuccessful
-compilation without throwing or reporting a parse error.
+If validation or interpretation of an imported module returns `stopped`, propagate
+that outcome unchanged through every importing module and do not interpret dependent
+parent EDAGs. A root `stopped` outcome makes `fjs compile` terminate cleanly as an
+unsuccessful compilation without throwing or reporting a parse error.
 
 For the root module, a completed result is the complete compiled module/program
 value. Circular dependency detection remains a loading concern, as it is today.
@@ -203,6 +229,12 @@ object and array values are represented by their constructors.
       arbitrary computed key nodes until their coercion/failure semantics are defined.
 - [ ] Make EDAG validation iterative so hostile nesting cannot overflow the host
       language call stack.
+- [ ] Make validation consume the same per-module instruction budget as
+      interpretation; return `stopped(instruction-limit)` if validation exhausts it
+      and pass the remaining budget to interpretation after successful validation.
+- [ ] Count validator child scheduling/work-stack growth against the instruction
+      budget before allocating/pushing more work; do not bulk-push unbounded operand
+      lists.
 - [ ] Change the DJS parser/AST object representation to retain an ordered entry list
       until EDAG conversion; do not collapse duplicate keys or reorder integer-like
       keys through a plain JavaScript object/`OrderedMap` representation.
@@ -218,15 +250,15 @@ object and array values are represented by their constructors.
       outcome for every validated EDAG.
 - [ ] Define `CompileOutcome`/`StopReason` (or equivalent) and update the
       transpiler/compiler result type so `stopped` is distinct from `ParseError`.
-- [ ] Thread interpreter limits through loading/transpilation, define documented
+- [ ] Thread compile limits through loading/transpilation, define documented
       deterministic defaults for `fjs compile`, and allow explicit overrides.
-- [ ] Propagate an imported module's `stopped` outcome unchanged to the root without
-      interpreting dependent parent EDAGs.
+- [ ] Propagate an imported module's validation/interpreter `stopped` outcome
+      unchanged to the root without interpreting dependent parent EDAGs.
 - [ ] Implement interpreter traversal iteratively with an explicit work stack rather
       than recursive host calls; count traversal/work-stack progress against the
       deterministic instruction budget.
-- [ ] Add a deterministic instruction budget, incremented by interpreter evaluation
-      steps rather than measured with wall-clock time.
+- [ ] Add a deterministic instruction budget, shared by validation and interpretation
+      of each module and decremented by deterministic traversal/evaluation steps.
 - [ ] Add a deterministic structure-growth budget for materialized object/array
       structure; reaching it returns a stopped result rather than exhausting memory.
 - [ ] Memoize interpreter results by EDAG node identity so shared object/array nodes
@@ -247,11 +279,11 @@ object and array values are represented by their constructors.
       and a multi-module program produces the same final value as the current
       transpiler.
 - [ ] Add proofs that instruction-limit and structure-growth-limit exhaustion stop
-      deterministically and never throw, including propagation from an imported
-      module through the root compiler result.
-- [ ] Add a deeply nested validated EDAG proof that validation and interpretation do
-      not throw `RangeError`; it either completes or stops through a deterministic
-      budget.
+      deterministically and never throw, including validation exhaustion and
+      propagation from an imported module through the root compiler result.
+- [ ] Add a deeply nested valid EDAG proof that validation and interpretation do not
+      throw `RangeError`; with enough budget it completes, otherwise validation or
+      interpretation stops through the deterministic instruction limit.
 - [ ] `npx tsc`, `fjs test`.
 
 ### Related

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -123,8 +123,15 @@ The final EDAG can then be serialized as a FunctionalScript JavaScript artifact:
 ```
 
 or as JSON when the particular EDAG is representable without losing information.
-For example, JSON must not be used when it would lose semantic graph sharing or values
-that JSON cannot represent. DJS/`.f.js` remains the general representation.
+Serialization must preserve every observable primitive value exactly, including
+**negative zero**. In particular, serializing `-0` as `0` is not acceptable because
+`Object.is(-0, 0)` is false. The EDAG/DJS serializer must therefore emit a form that
+round-trips `-0`, and JSON output is allowed only when the JSON serializer also
+preserves that value and all other EDAG information.
+
+JSON must not be used when it would lose semantic graph sharing or values that the
+chosen JSON representation cannot preserve. DJS/`.f.js` remains the general
+representation.
 
 Executing the final EDAG is a separate concern. This task establishes the
 source-to-temporary-`Module` and module-resolution-to-final-EDAG pipeline. Direct EDAG
@@ -188,6 +195,8 @@ object and array values are represented by their constructors.
       recursive module resolution/linking.
 - [ ] Serialize the final EDAG to `.f.js`; allow JSON output only when it preserves
       the EDAG completely.
+- [ ] Preserve `-0` explicitly in EDAG/DJS serialization and in JSON output whenever
+      JSON output is selected.
 - [ ] Preserve current missing-file, parse-error, and circular-dependency behavior.
 - [ ] Add proofs that source-to-`Module` compilation does not read imports, import
       paths and parameter positions preserve source order, object-entry order
@@ -196,8 +205,8 @@ object and array values are represented by their constructors.
       and resolving a multi-module program produces one final EDAG with no unresolved
       module metadata.
 - [ ] Add serialization proofs covering `.f.js` and JSON-when-representable output,
-      including a case where JSON must not be used because it would lose EDAG
-      information.
+      including `Object.is(roundTrip(-0), -0)` and a case where JSON must not be used
+      because it would lose EDAG information.
 - [ ] `npx tsc`, `fjs test`.
 
 ### Related
@@ -209,6 +218,8 @@ object and array values are represented by their constructors.
 - [`../ast/module.f.mjs`](../ast/module.f.mjs) — current sequential AST evaluator.
 - [`cache-compiled-modules.md`](./cache-compiled-modules.md) — lower-priority
   persistence/incremental-compilation task for `.fjs/modules/{hash}.f.js`.
+- [`interpret-edag.md`](./interpret-edag.md) — separate baseline direct-interpreter
+  execution strategy for the final EDAG.
 - [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md) —
   lower-priority resource/time/memory hardening for EDAG processing.
 - [`associate-edag-with-functions.md`](./associate-edag-with-functions.md) —

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -56,14 +56,14 @@ example:
 ['.', ['args'], 0]
 ```
 
-#### Temporary unresolved `Module`
+#### Temporary `Unresolved`
 
 Compile each FunctionalScript source module **without loading its imports**.
 
 Use the temporary representation:
 
 ```ts
-type Module = {
+type Unresolved = {
     readonly imports: readonly string[]
     readonly edag: EDAG
 }
@@ -73,9 +73,9 @@ type Module = {
 parameter positions in `edag`. `edag` is the parameterized computation for the module,
 with `export default` as its root/result.
 
-`Module` is a compiler/loading structure only. It is **not part of EDAG**, and imported
-module paths must not be embedded into EDAG merely to make an unresolved module
-self-contained.
+`Unresolved` is a compiler/loading structure only. It is **not part of EDAG**, and
+imported module paths must not be embedded into EDAG merely to make an unresolved
+module self-contained.
 
 For example:
 
@@ -99,7 +99,7 @@ const edag = ['{}',
 ]
 ```
 
-with temporary module metadata:
+with temporary unresolved metadata:
 
 ```js
 {
@@ -111,14 +111,14 @@ with temporary module metadata:
 `x` is one shared EDAG node, so both object properties reference the same constructed
 array. DJS `const` is serialization-level sharing, not an EDAG operation.
 
-Persisting unresolved modules under `.fjs/unresolved/` and using them for incremental
+Persisting unresolved values under `.fjs/unresolved/` and using them for incremental
 compilation is deliberately a separate task; see
 [`cache-compiled-modules.md`](./cache-compiled-modules.md).
 
 #### Resolve unresolved modules to one EDAG
 
-Recursively resolve the paths in `Module.imports`. Each imported source is compiled to
-its own temporary `Module`, then its imports are resolved in the same way.
+Recursively resolve the paths in `Unresolved.imports`. Each imported source is compiled
+to its own temporary `Unresolved`, then its imports are resolved in the same way.
 
 Resolution binds the resolved imported module results to the corresponding import
 parameter positions in the importing module EDAG. The import array order therefore
@@ -132,18 +132,18 @@ identity is semantic, so duplicating a shared dependency can change reference id
 for exported arrays/objects. This in-memory link memo is required independently of the
 optional `.fjs/unresolved/` source cache.
 
-After all module dependencies are resolved, the temporary module wrappers disappear.
-The **final compilation result is an EDAG, not a `Module`**:
+After all module dependencies are resolved, the temporary unresolved wrappers
+disappear. The **final compilation result is an EDAG, not an `Unresolved`**:
 
 ```text
 source module
-  -> Module { imports, edag }
-  -> recursively resolve imported Modules
+  -> Unresolved { imports, edag }
+  -> recursively resolve imported Unresolved values
   -> EDAG
 ```
 
 The resulting EDAG contains the complete compiled program and no unresolved module
-paths or temporary module metadata.
+paths or temporary unresolved metadata.
 
 ### Stage 2: functions and calls
 
@@ -236,27 +236,27 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
 - [ ] Introduce `['.', object, property]` into EDAG and its validation/type schema.
 - [ ] Introduce parser support for `a.b` and `a[b]`, compiling both to the EDAG `.`
       operation.
-- [ ] Define the temporary `Module` type as `{ imports, edag }`; keep it outside the
-      EDAG schema.
-- [ ] Keep `Module.imports` as a source-ordered array of module paths, not a map, and
-      make import parameter positions correspond to its indices.
+- [ ] Define the temporary `Unresolved` type as `{ imports, edag }`; keep it outside
+      the EDAG schema.
+- [ ] Keep `Unresolved.imports` as a source-ordered array of module paths, not a map,
+      and make import parameter positions correspond to its indices.
 - [ ] Restrict initial `[':', key, value]` object-constructor validation to
       string-constant keys; defer arbitrary computed constructor keys until their
       coercion/failure semantics are defined.
 - [ ] Change the DJS parser/AST object representation to retain an ordered entry list
       until EDAG conversion; do not collapse duplicate keys or reorder integer-like
       keys through a plain JavaScript object/`OrderedMap` representation.
-- [ ] Convert a parsed source module to `Module { imports, edag }` without reading or
-      resolving any imported module.
+- [ ] Convert a parsed source module to `Unresolved { imports, edag }` without reading
+      or resolving any imported module.
 - [ ] Replace `['aref', i]` with `['.', ['args'], i]` and replace `cref` sequencing
       with shared EDAG node identity.
-- [ ] Resolve imported `Module`s recursively and bind each resolved result to the
-      corresponding import parameter position.
+- [ ] Resolve imported `Unresolved` values recursively and bind each resolved result
+      to the corresponding import parameter position.
 - [ ] Memoize resolved modules during one link operation by canonical module path so
       repeated/diamond imports reuse the same resolved EDAG node identities.
-- [ ] Remove the temporary `Module` layer after resolution so the root compilation
-      result is a plain EDAG with no unresolved module paths or module metadata.
-- [ ] Split the current transpiler flow into source-to-`Module` compilation and
+- [ ] Remove the temporary `Unresolved` layer after resolution so the root compilation
+      result is a plain EDAG with no unresolved module paths or temporary metadata.
+- [ ] Split the current transpiler flow into source-to-`Unresolved` compilation and
       recursive module resolution/linking.
 
 #### Stage 2
@@ -277,10 +277,10 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
       JSON output is selected.
 - [ ] Preserve current missing-file, parse-error, and circular-dependency behavior.
 - [ ] Add Stage 1 proofs that `a.b` and `a[b]` produce property-access EDAGs,
-      source-to-`Module` compilation does not read imports, import paths and parameter
-      positions preserve source order, object-entry order survives parsing/EDAG
-      conversion, and resolving a multi-module program produces one final EDAG with no
-      unresolved module metadata.
+      source-to-`Unresolved` compilation does not read imports, import paths and
+      parameter positions preserve source order, object-entry order survives
+      parsing/EDAG conversion, and resolving a multi-module program produces one final
+      EDAG with no unresolved module metadata.
 - [ ] Add a diamond-import proof showing repeated resolution of one canonical module
       reuses the same resolved EDAG and preserves shared exported object/array identity.
 - [ ] Add serialization proofs covering `.f.js` and JSON-when-representable output,

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -63,6 +63,13 @@ of imported-module contents. A persistent cache must include the compiler/EDAG
 version in its identity; dependency values are not part of the source-to-EDAG cache
 key.
 
+The compiler may also materialize these intermediate EDAGs as **DJS files** in a
+temporary build directory, analogous to `./target/`, for example
+`./target/edag/`. This makes the independently compiled module representation easy
+to inspect, debug, and reuse during the rest of the compilation. The files contain
+the EDAG serialization, not loaded dependency values or the final compiled module.
+They are build artifacts and must not be source-controlled.
+
 #### 2. Load imports and execute the EDAG
 
 The loader recursively resolves and loads the module's import specifiers. After all
@@ -118,6 +125,8 @@ are represented by their constructors.
       construct the argument array deterministically.
 - [ ] Split the current transpiler flow into source-to-EDAG compilation and recursive
       loading/evaluation.
+- [ ] Allow compiled module EDAGs to be emitted as DJS files under a temporary build
+      directory such as `./target/edag/`; keep the directory out of source control.
 - [ ] Execute each module EDAG only after all of its imported values have been loaded;
       the root module's result is the final compiled value.
 - [ ] Preserve current missing-file, parse-error, and circular-dependency behavior.

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -88,6 +88,26 @@ array constructor node is referenced from several places, it must be evaluated o
 and the same resulting object/array reused. A memo table keyed by EDAG node identity
 is sufficient for the initial interpreter.
 
+The interpreter **never throws**. Validation rejects malformed EDAGs before
+interpretation; interpretation of a validated EDAG returns an explicit outcome.
+Normally that outcome contains the computed value, but the interpreter may stop
+when a deterministic resource limit is reached.
+
+Initially support two limits:
+
+- **instruction limit** — count interpreter instructions/EDAG evaluation steps rather
+  than wall-clock time. This is the interpreter's measure of how long a computation
+  takes and is deterministic across machines;
+- **structure-growth limit** — stop if interpretation materializes too much object or
+  array structure. Define a simple deterministic accounting rule for constructed
+  nodes/properties/elements so computations that grow data without bound cannot
+  exhaust host memory.
+
+The limits are interpreter inputs/options, not fields in the EDAG, so they do not
+change the EDAG's canonical representation or identity. Reaching either limit is a
+normal stopped result with a reason, not an exception. This mechanism can later
+bound evaluation of general EDAG functions as the operation set grows.
+
 Conceptually:
 
 ```text
@@ -99,12 +119,13 @@ imports
   -> recursively load values
   -> args
 
-interpret(edag, args)
-  -> compiled module value
+interpret(edag, args, limits)
+  -> completed(value) | stopped(reason)
 ```
 
-For the root module, the result is the complete compiled module/program value.
-Circular dependency detection remains a loading concern, as it is today.
+For the root module, a completed result is the complete compiled module/program
+value. A stopped result makes compilation stop cleanly without throwing. Circular
+dependency detection remains a loading concern, as it is today.
 
 ### Initial EDAG subset
 
@@ -137,6 +158,12 @@ are represented by their constructors.
       construct the argument array deterministically.
 - [ ] Implement a small EDAG interpreter in FunctionalScript for the initial EDAG
       subset; do not execute generated EDAGs as JavaScript.
+- [ ] Make the interpreter non-throwing: return an explicit completed or stopped
+      outcome for every validated EDAG.
+- [ ] Add a deterministic instruction budget, incremented by interpreter evaluation
+      steps rather than measured with wall-clock time.
+- [ ] Add a deterministic structure-growth budget for materialized object/array
+      structure; reaching it returns a stopped result rather than exhausting memory.
 - [ ] Memoize interpreter results by EDAG node identity so shared object/array nodes
       evaluate once and preserve reference identity in the compiled value.
 - [ ] Split the current transpiler flow into source-to-EDAG compilation and recursive
@@ -144,13 +171,15 @@ are represented by their constructors.
 - [ ] Allow compiled module EDAGs to be emitted as DJS files under `./.fjs/edag/`
       and ignore the FunctionalScript build directory in source control.
 - [ ] Interpret each module EDAG only after all of its imported values have been
-      loaded; the root module's result is the final compiled value.
+      loaded; the root module's completed result is the final compiled value.
 - [ ] Preserve current missing-file, parse-error, and circular-dependency behavior.
 - [ ] Make the source-to-EDAG result cacheable; add an initial cache if useful, with
       compiler/EDAG versioning for persistent entries.
 - [ ] Add proofs that compilation does not read imports, the interpreter preserves
       shared `const` identity, imports are passed in source order, and a multi-module
       program produces the same final value as the current transpiler.
+- [ ] Add proofs that instruction-limit and structure-growth-limit exhaustion stop
+      deterministically and never throw.
 - [ ] `npx tsc`, `fjs test`.
 
 ### Related

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -140,9 +140,31 @@ interpret(edag, args, limits)
   -> completed(value) | stopped(reason)
 ```
 
+The stopped outcome must also be represented by the transpiler/compiler API; it must
+not be disguised as a `ParseError`. Extend the current
+`Result<Unknown, ParseError>` shape conceptually to:
+
+```text
+Result<CompileOutcome<Unknown>, ParseError>
+
+CompileOutcome<T> = completed(T) | stopped(StopReason)
+StopReason = instruction-limit | structure-growth-limit
+```
+
+Parse/load errors therefore remain errors in `Result`, while deterministic resource
+exhaustion is an explicit non-throwing compilation outcome. Thread the interpreter
+limits through the loader/transpiler API. `fjs compile` supplies documented,
+deterministic default limits; callers may override them explicitly. Choosing and
+documenting the concrete default values is part of this task rather than an implicit
+host-dependent decision.
+
+If interpretation of an imported module returns `stopped`, propagate that outcome
+unchanged through every importing module and do not interpret dependent parent EDAGs.
+A root `stopped` outcome makes `fjs compile` terminate cleanly as an unsuccessful
+compilation without throwing or reporting a parse error.
+
 For the root module, a completed result is the complete compiled module/program
-value. A stopped result makes compilation stop cleanly without throwing. Circular
-dependency detection remains a loading concern, as it is today.
+value. Circular dependency detection remains a loading concern, as it is today.
 
 ### Initial EDAG subset
 
@@ -151,7 +173,8 @@ Implement only the EDAG forms required by the DJS loader today:
 - primitive constants directly: `null`, `undefined`, boolean, number, string,
   `bigint`;
 - object constructors: `['{}', ...entry]`, where the initial entry form is
-  `[':', key, value]` and the current DJS parser supplies string keys;
+  `[':', key, value]` and **`key` is a string constant** in this task, matching what
+  the current DJS parser produces;
 - array constructors: `['[]', ...node]`;
 - the argument array: `['args']`;
 - import-parameter access: `['.', ['args'], index]`;
@@ -159,20 +182,25 @@ Implement only the EDAG forms required by the DJS loader today:
   needed.
 
 The object constructor is an ordered operation rather than a plain EDAG object. This
-preserves source property order and leaves room for computed keys and future entry
-forms such as object spread, for example `['...', object]`. Plain objects have no
-EDAG meaning in this initial subset and remain reserved for a future use.
+preserves source property order and leaves room for future computed keys and entry
+forms such as object spread, for example `['...', object]`. Computed key nodes are
+**not** part of this initial interpreter: allowing arbitrary key expressions would
+introduce JavaScript `ToPropertyKey` failure cases and therefore needs an explicit
+semantic-failure outcome/semantics before validation can admit them. Plain objects
+have no EDAG meaning in this initial subset and remain reserved for a future use.
 
 Do **not** add the rest of EDAG yet: arbitrary property access, calls, method calls,
-operators, comma, closures/functions, `throw`, or other later operations are outside
-this task. Do not add plain object or array constant nodes; object and array values
-are represented by their constructors.
+operators, comma, closures/functions, `throw`, computed object keys, or other later
+operations are outside this task. Do not add plain object or array constant nodes;
+object and array values are represented by their constructors.
 
 ### Tasks
 
 - [ ] Define the minimal DJS EDAG types/validation for the forms above, consistent
       with [`todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)
       and extensible to the full EDAG specification later.
+- [ ] Restrict initial `[':', key, value]` validation to string-constant keys; defer
+      arbitrary computed key nodes until their coercion/failure semantics are defined.
 - [ ] Make EDAG validation iterative so hostile nesting cannot overflow the host
       language call stack.
 - [ ] Change the DJS parser/AST object representation to retain an ordered entry list
@@ -188,6 +216,12 @@ are represented by their constructors.
       subset; do not execute generated EDAGs as JavaScript.
 - [ ] Make the interpreter non-throwing: return an explicit completed or stopped
       outcome for every validated EDAG.
+- [ ] Define `CompileOutcome`/`StopReason` (or equivalent) and update the
+      transpiler/compiler result type so `stopped` is distinct from `ParseError`.
+- [ ] Thread interpreter limits through loading/transpilation, define documented
+      deterministic defaults for `fjs compile`, and allow explicit overrides.
+- [ ] Propagate an imported module's `stopped` outcome unchanged to the root without
+      interpreting dependent parent EDAGs.
 - [ ] Implement interpreter traversal iteratively with an explicit work stack rather
       than recursive host calls; count traversal/work-stack progress against the
       deterministic instruction budget.
@@ -209,10 +243,12 @@ are represented by their constructors.
 - [ ] Add proofs that compilation does not read imports, the interpreter preserves
       shared `const` identity, imports are passed in source order, object-entry order
       (including integer-like keys and duplicate keys) survives parsing/EDAG
-      conversion, and a multi-module program produces the same final value as the
-      current transpiler.
+      conversion, non-string object-entry keys are rejected by initial validation,
+      and a multi-module program produces the same final value as the current
+      transpiler.
 - [ ] Add proofs that instruction-limit and structure-growth-limit exhaustion stop
-      deterministically and never throw.
+      deterministically and never throw, including propagation from an imported
+      module through the root compiler result.
 - [ ] Add a deeply nested validated EDAG proof that validation and interpretation do
       not throw `RangeError`; it either completes or stops through a deterministic
       budget.

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -103,6 +103,13 @@ parameter positions in the importing module EDAG. The import array order therefo
 remains significant: position `i` in `imports` corresponds to import parameter `i` in
 the EDAG.
 
+One link operation must memoize resolved modules by the resolver's canonical module
+path. If the same module is reached more than once, including through a diamond import,
+reuse the same resolved EDAG rather than resolving/splicing a fresh copy. EDAG node
+identity is semantic, so duplicating a shared dependency can change reference identity
+for exported arrays/objects. This in-memory link memo is required independently of the
+optional `.fjs/modules/` source cache.
+
 After all module dependencies are resolved, the temporary module wrappers disappear.
 The **final compilation result is an EDAG, not a `Module`**:
 
@@ -189,6 +196,8 @@ object and array values are represented by their constructors.
       sequencing with shared EDAG node identity.
 - [ ] Resolve imported `Module`s recursively and bind each resolved result to the
       corresponding import parameter position.
+- [ ] Memoize resolved modules during one link operation by canonical module path so
+      repeated/diamond imports reuse the same resolved EDAG node identities.
 - [ ] Remove the temporary `Module` layer after resolution so the root compilation
       result is a plain EDAG with no unresolved module paths or module metadata.
 - [ ] Split the current transpiler flow into source-to-`Module` compilation and
@@ -204,6 +213,8 @@ object and array values are represented by their constructors.
       conversion, non-string object-entry keys are rejected by initial validation,
       and resolving a multi-module program produces one final EDAG with no unresolved
       module metadata.
+- [ ] Add a diamond-import proof showing repeated resolution of one canonical module
+      reuses the same resolved EDAG and preserves shared exported object/array identity.
 - [ ] Add serialization proofs covering `.f.js` and JSON-when-representable output,
       including `Object.is(roundTrip(-0), -0)` and a case where JSON must not be used
       because it would lose EDAG information.

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -12,13 +12,13 @@ The current DJS transpiler couples two separate operations:
    with `run(module[1])(args)`.
 
 This means the source-to-computation representation is not available independently
-of dependency loading. A source module cannot be compiled once and cached before its
-imports are resolved, even though its computation depends only on its source and
-treats imported values as parameters.
+of dependency loading. A source module should be compilable before its imports are
+resolved, with imported values represented as parameters of its EDAG.
 
-EDAG alone is not enough to represent an unresolved parsed module: the loader also
-needs the module paths imported by that source file. Keep that information in a small
-temporary wrapper rather than adding module metadata to EDAG itself.
+EDAG alone is not enough to represent an unresolved parsed module: module resolution
+also needs source identity and the module paths imported by that source file. Keep
+that information in a small temporary wrapper rather than adding module metadata to
+EDAG itself.
 
 The current parser/AST also cannot preserve the ordered object-entry representation
 required by EDAG. Object parsing accumulates properties in an `OrderedMap` with
@@ -35,22 +35,30 @@ Split module compilation and module resolution.
 
 Compile each FunctionalScript source module **without loading its imports**.
 
-Use a temporary representation such as:
+Use the temporary representation:
 
 ```ts
 type Module = {
+    readonly hash: string
+    readonly path: string
     readonly imports: readonly string[]
     readonly edag: EDAG
 }
 ```
 
-`imports` is an **array of module paths, not a map**. The array preserves the import
-parameter positions from the source module. The module EDAG refers to imported values
-by those positions, and `export default` is the root/result of the module EDAG.
+The fields have different roles:
 
-`Module` is a compiler/loading structure only. It is **not part of EDAG**, and the
-module paths must not be embedded into the EDAG merely to make an unresolved module
-self-contained.
+- `hash` is the CBase32-encoded hash of the original source file contents;
+- `path` is the source module path relative to the `.fjs/` / current-working-directory
+  context used by the compiler;
+- `imports` is an **array of module paths, not a map**. Its order defines the import
+  parameter positions in `edag`;
+- `edag` is the parameterized computation for the module, with `export default` as
+  its root/result.
+
+`Module` is a compiler/loading structure only. It is **not part of EDAG**. In
+particular, `hash`, `path`, and imported module paths must not be embedded into EDAG
+merely to make an unresolved module self-contained.
 
 For example:
 
@@ -74,10 +82,12 @@ const edag = ['{}',
 ]
 ```
 
-with the temporary module metadata:
+with temporary module metadata such as:
 
 ```js
 {
+    hash: '<CBase32 source hash>',
+    path: 'src/example.f.js',
     imports: ['./a.f.js'],
     edag,
 }
@@ -87,27 +97,16 @@ with the temporary module metadata:
 array. DJS `const` is serialization-level sharing, not an EDAG operation.
 
 The general `['=>', ...]` function operation is not required merely to represent the
-module boundary. The temporary `Module` supplies the import list; its EDAG is the
-parameterized computation associated with those imports.
+module boundary. The temporary `Module` supplies the source/import metadata; its EDAG
+is the parameterized computation associated with those imports.
 
-Because this phase does not read dependencies, the `Module` result is cacheable
-independently of imported-module contents. A persistent cache must include the
-compiler/EDAG version in its identity; dependency contents are not part of the
-source-to-`Module` cache key.
-
-The compiler may materialize these temporary module artifacts under:
-
-```text
-./.fjs/modules/
-```
-
-They are intermediate compiler artifacts and must not be source-controlled. The
-concrete serialization can use DJS when graph sharing or other non-JSON values require
-it.
+Persisting these temporary modules under `.fjs/modules/` and using them for
+incremental compilation is deliberately a separate task; see
+[`cache-compiled-modules.md`](./cache-compiled-modules.md).
 
 #### 2. Resolve modules to one EDAG
 
-Recursively resolve the paths in `Module.imports`. Each imported module is compiled to
+Recursively resolve the paths in `Module.imports`. Each imported source is compiled to
 its own temporary `Module`, then its imports are resolved in the same way.
 
 Resolution binds the resolved imported module results to the corresponding import
@@ -120,13 +119,13 @@ The **final compilation result is an EDAG, not a `Module`**:
 
 ```text
 source module
-  -> Module { imports, edag }
+  -> Module { hash, path, imports, edag }
   -> recursively resolve imported Modules
   -> EDAG
 ```
 
 The resulting EDAG contains the complete compiled program and no unresolved module
-paths.
+paths or temporary module metadata.
 
 The final EDAG can then be serialized as a FunctionalScript JavaScript artifact:
 
@@ -176,9 +175,12 @@ object and array values are represented by their constructors.
 
 ### Tasks
 
-- [ ] Define the temporary `Module` type with exactly the unresolved import-path array
-      and parameterized EDAG needed by module resolution; keep it outside the EDAG
-      schema.
+- [ ] Define the temporary `Module` type as
+      `{ hash, path, imports, edag }`; keep all four fields outside the EDAG schema.
+- [ ] Compute `Module.hash` from the original source-file contents and encode it in
+      CBase32.
+- [ ] Define `Module.path` relative to the compiler's `.fjs/` / current-working-
+      directory context so source identity is stable during module resolution.
 - [ ] Keep `Module.imports` as a source-ordered array of module paths, not a map, and
       make import parameter positions correspond to its indices.
 - [ ] Define the minimal DJS EDAG types/validation for the forms above, consistent
@@ -189,30 +191,26 @@ object and array values are represented by their constructors.
 - [ ] Change the DJS parser/AST object representation to retain an ordered entry list
       until EDAG conversion; do not collapse duplicate keys or reorder integer-like
       keys through a plain JavaScript object/`OrderedMap` representation.
-- [ ] Convert a parsed source module to `Module { imports, edag }` without reading or
-      resolving any imported module.
+- [ ] Convert a parsed source module to `Module { hash, path, imports, edag }` without
+      reading or resolving any imported module.
 - [ ] Replace `['aref', i]` with EDAG import-parameter access and replace `cref`
       sequencing with shared EDAG node identity.
 - [ ] Resolve imported `Module`s recursively and bind each resolved result to the
       corresponding import parameter position.
 - [ ] Remove the temporary `Module` layer after resolution so the root compilation
-      result is a plain EDAG with no unresolved module paths.
+      result is a plain EDAG with no unresolved module paths or module metadata.
 - [ ] Split the current transpiler flow into source-to-`Module` compilation and
       recursive module resolution/linking.
-- [ ] Allow temporary compiled `Module` artifacts to be emitted under
-      `./.fjs/modules/` and ignore the FunctionalScript build directory in source
-      control.
 - [ ] Serialize the final EDAG to `.f.js`; allow JSON output only when it preserves
       the EDAG completely.
 - [ ] Preserve current missing-file, parse-error, and circular-dependency behavior.
-- [ ] Make the source-to-`Module` result cacheable; add an initial cache if useful,
-      with compiler/EDAG versioning for persistent entries.
 - [ ] Add proofs that source-to-`Module` compilation does not read imports, import
-      paths and parameter positions preserve source order, object-entry order
-      (including integer-like keys and duplicate keys) survives parsing/EDAG
-      conversion, non-string object-entry keys are rejected by initial validation,
-      and resolving a multi-module program produces one final EDAG with no unresolved
-      module paths.
+      paths and parameter positions preserve source order, `hash` matches the source
+      contents, `path` identifies the source relative to the compilation context,
+      object-entry order (including integer-like keys and duplicate keys) survives
+      parsing/EDAG conversion, non-string object-entry keys are rejected by initial
+      validation, and resolving a multi-module program produces one final EDAG with
+      no unresolved module metadata.
 - [ ] Add serialization proofs covering `.f.js` and JSON-when-representable output,
       including a case where JSON must not be used because it would lose EDAG
       information.
@@ -225,6 +223,8 @@ object and array values are represented by their constructors.
 - [`../ast/types.ts`](../ast/types.ts) — current `AstModule`/`AstBody`, `aref`, `cref`,
   and plain-object representation to replace.
 - [`../ast/module.f.mjs`](../ast/module.f.mjs) — current sequential AST evaluator.
+- [`cache-compiled-modules.md`](./cache-compiled-modules.md) — lower-priority
+  persistence/incremental-compilation task for `.fjs/modules/{pathHash}.f.js`.
 - [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md) —
   lower-priority resource/time/memory hardening for EDAG processing.
 - [`associate-edag-with-functions.md`](./associate-edag-with-functions.md) —

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -28,9 +28,35 @@ they are converted to `['{}', ...entry]`.
 
 ### Proposal
 
-Split module compilation and module resolution.
+Split module compilation and module resolution, and introduce the missing EDAG/parser
+operations in two stages.
 
-#### 1. Compile source to a temporary `Module`
+### Stage 1: property access and unresolved modules
+
+The first missing EDAG operation is property access:
+
+```js
+['.', object, property]
+```
+
+Introduce `.` into EDAG first. Then introduce the corresponding source syntax into the
+DJS parser:
+
+```js
+a.b
+a[b]
+```
+
+Both forms compile to the EDAG `.` operation. This stage is required before EDAG can
+replace the current AST as the representation of an **unresolved module**, because
+imported values are parameters and module EDAGs need to access those parameters, for
+example:
+
+```js
+['.', ['args'], 0]
+```
+
+#### Temporary unresolved `Module`
 
 Compile each FunctionalScript source module **without loading its imports**.
 
@@ -85,15 +111,11 @@ with temporary module metadata:
 `x` is one shared EDAG node, so both object properties reference the same constructed
 array. DJS `const` is serialization-level sharing, not an EDAG operation.
 
-The general `['=>', ...]` function operation is not required merely to represent the
-module boundary. The temporary `Module` supplies the import list; its EDAG is the
-parameterized computation associated with those imports.
-
-Persisting temporary modules under `.fjs/modules/` and using them for incremental
+Persisting unresolved modules under `.fjs/unresolved/` and using them for incremental
 compilation is deliberately a separate task; see
 [`cache-compiled-modules.md`](./cache-compiled-modules.md).
 
-#### 2. Resolve modules to one EDAG
+#### Resolve unresolved modules to one EDAG
 
 Recursively resolve the paths in `Module.imports`. Each imported source is compiled to
 its own temporary `Module`, then its imports are resolved in the same way.
@@ -108,7 +130,7 @@ path. If the same module is reached more than once, including through a diamond 
 reuse the same resolved EDAG rather than resolving/splicing a fresh copy. EDAG node
 identity is semantic, so duplicating a shared dependency can change reference identity
 for exported arrays/objects. This in-memory link memo is required independently of the
-optional `.fjs/modules/` source cache.
+optional `.fjs/unresolved/` source cache.
 
 After all module dependencies are resolved, the temporary module wrappers disappear.
 The **final compilation result is an EDAG, not a `Module`**:
@@ -123,7 +145,67 @@ source module
 The resulting EDAG contains the complete compiled program and no unresolved module
 paths or temporary module metadata.
 
-The final EDAG can then be serialized as a FunctionalScript JavaScript artifact:
+### Stage 2: functions and calls
+
+After unresolved modules can be represented as EDAG, add functions and calls.
+
+Introduce the function operation into EDAG:
+
+```js
+['=>', frame, body]
+```
+
+Then introduce the initial arrow-function form into the parser:
+
+```js
+(...a) => exp
+```
+
+Also introduce call operations into EDAG:
+
+```js
+['()', object, args]
+['.()', object, property, args]
+```
+
+This stage is intentionally after Stage 1: property access is the minimum operation
+needed for unresolved-module parameter access, while function creation and calls extend
+the set of source modules that can be represented after that basic module pipeline is
+in place.
+
+### EDAG forms used by these stages
+
+The staged work builds on the basic structural forms already being defined for EDAG:
+
+- primitive constants directly: `null`, `undefined`, boolean, number, string,
+  `bigint`;
+- object constructors: `['{}', ...entry]`, where the initial entry form is
+  `[':', key, value]` and **`key` is a string constant** in this task, matching what
+  the current DJS parser produces;
+- array constructors: `['[]', ...node]`;
+- the argument array: `['args']`;
+- Stage 1 property access: `['.', object, property]`;
+- Stage 2 functions: `['=>', frame, body]`;
+- Stage 2 calls: `['()', object, args]` and
+  `['.()', object, property, args]`;
+- semantic sharing by node identity, serialized with DJS `const` references when
+  needed.
+
+The object constructor is an ordered operation rather than a plain EDAG object. This
+preserves source property order and leaves room for future computed keys and entry
+forms such as object spread, for example `['...', object]`. Computed object-constructor
+key nodes are **not** part of this initial work: allowing arbitrary key expressions
+would introduce JavaScript `ToPropertyKey` failure cases and therefore needs explicit
+semantics before validation can admit them. Plain objects have no EDAG meaning here
+and remain reserved for a future use.
+
+Do **not** add unrelated EDAG operations in these stages: arithmetic/logical operators,
+comma, loops, `throw`, object spread, or other later operations remain outside this
+task unless they become necessary for the staged parser work above.
+
+### Final EDAG serialization
+
+The final EDAG can be serialized as a FunctionalScript JavaScript artifact:
 
 ```text
 <name>.f.js
@@ -140,60 +222,34 @@ JSON must not be used when it would lose semantic graph sharing or values that t
 chosen JSON representation cannot preserve. DJS/`.f.js` remains the general
 representation.
 
-Executing the final EDAG is a separate concern. This task establishes the
-source-to-temporary-`Module` and module-resolution-to-final-EDAG pipeline. Direct EDAG
-interpretation, compilation of EDAG to executable functions, and execution policy can
-be layered on top of the resulting EDAG.
+Executing the final EDAG is a separate concern. Direct EDAG interpretation,
+compilation of EDAG to executable functions, and execution policy can be layered on
+top of the resulting EDAG.
 
 Resource/time/memory hardening of EDAG processing is intentionally separate from this
 task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md).
 
-### Initial EDAG subset
-
-Implement only the EDAG forms required by the current DJS compiler path:
-
-- primitive constants directly: `null`, `undefined`, boolean, number, string,
-  `bigint`;
-- object constructors: `['{}', ...entry]`, where the initial entry form is
-  `[':', key, value]` and **`key` is a string constant** in this task, matching what
-  the current DJS parser produces;
-- array constructors: `['[]', ...node]`;
-- the argument array: `['args']`;
-- import-parameter access: `['.', ['args'], index]`;
-- semantic sharing by node identity, serialized with DJS `const` references when
-  needed.
-
-The object constructor is an ordered operation rather than a plain EDAG object. This
-preserves source property order and leaves room for future computed keys and entry
-forms such as object spread, for example `['...', object]`. Computed key nodes are
-**not** part of this initial subset: allowing arbitrary key expressions would
-introduce JavaScript `ToPropertyKey` failure cases and therefore needs explicit
-semantics before validation can admit them. Plain objects have no EDAG meaning in
-this initial subset and remain reserved for a future use.
-
-Do **not** add the rest of EDAG yet: arbitrary property access, calls, method calls,
-operators, comma, closures/functions, `throw`, computed object keys, or other later
-operations are outside this task. Do not add plain object or array constant nodes;
-object and array values are represented by their constructors.
-
 ### Tasks
 
+#### Stage 1
+
+- [ ] Introduce `['.', object, property]` into EDAG and its validation/type schema.
+- [ ] Introduce parser support for `a.b` and `a[b]`, compiling both to the EDAG `.`
+      operation.
 - [ ] Define the temporary `Module` type as `{ imports, edag }`; keep it outside the
       EDAG schema.
 - [ ] Keep `Module.imports` as a source-ordered array of module paths, not a map, and
       make import parameter positions correspond to its indices.
-- [ ] Define the minimal DJS EDAG types/validation for the forms above, consistent
-      with [`todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)
-      and extensible to the full EDAG specification later.
-- [ ] Restrict initial `[':', key, value]` validation to string-constant keys; defer
-      arbitrary computed key nodes until their coercion/failure semantics are defined.
+- [ ] Restrict initial `[':', key, value]` object-constructor validation to
+      string-constant keys; defer arbitrary computed constructor keys until their
+      coercion/failure semantics are defined.
 - [ ] Change the DJS parser/AST object representation to retain an ordered entry list
       until EDAG conversion; do not collapse duplicate keys or reorder integer-like
       keys through a plain JavaScript object/`OrderedMap` representation.
 - [ ] Convert a parsed source module to `Module { imports, edag }` without reading or
       resolving any imported module.
-- [ ] Replace `['aref', i]` with EDAG import-parameter access and replace `cref`
-      sequencing with shared EDAG node identity.
+- [ ] Replace `['aref', i]` with `['.', ['args'], i]` and replace `cref` sequencing
+      with shared EDAG node identity.
 - [ ] Resolve imported `Module`s recursively and bind each resolved result to the
       corresponding import parameter position.
 - [ ] Memoize resolved modules during one link operation by canonical module path so
@@ -202,17 +258,29 @@ object and array values are represented by their constructors.
       result is a plain EDAG with no unresolved module paths or module metadata.
 - [ ] Split the current transpiler flow into source-to-`Module` compilation and
       recursive module resolution/linking.
+
+#### Stage 2
+
+- [ ] Introduce `['=>', frame, body]` into EDAG and its validation/type schema.
+- [ ] Introduce parser support for the initial `(...a) => exp` function form.
+- [ ] Introduce `['()', object, args]` into EDAG.
+- [ ] Introduce `['.()', object, property, args]` into EDAG.
+- [ ] Convert the corresponding parser call expressions to the new EDAG call forms.
+- [ ] Add proofs for nested functions and ordinary/method calls in the supported
+      Stage 2 subset.
+
+#### Shared/final
+
 - [ ] Serialize the final EDAG to `.f.js`; allow JSON output only when it preserves
       the EDAG completely.
 - [ ] Preserve `-0` explicitly in EDAG/DJS serialization and in JSON output whenever
       JSON output is selected.
 - [ ] Preserve current missing-file, parse-error, and circular-dependency behavior.
-- [ ] Add proofs that source-to-`Module` compilation does not read imports, import
-      paths and parameter positions preserve source order, object-entry order
-      (including integer-like keys and duplicate keys) survives parsing/EDAG
-      conversion, non-string object-entry keys are rejected by initial validation,
-      and resolving a multi-module program produces one final EDAG with no unresolved
-      module metadata.
+- [ ] Add Stage 1 proofs that `a.b` and `a[b]` produce property-access EDAGs,
+      source-to-`Module` compilation does not read imports, import paths and parameter
+      positions preserve source order, object-entry order survives parsing/EDAG
+      conversion, and resolving a multi-module program produces one final EDAG with no
+      unresolved module metadata.
 - [ ] Add a diamond-import proof showing repeated resolution of one canonical module
       reuses the same resolved EDAG and preserves shared exported object/array identity.
 - [ ] Add serialization proofs covering `.f.js` and JSON-when-representable output,
@@ -228,7 +296,7 @@ object and array values are represented by their constructors.
   and plain-object representation to replace.
 - [`../ast/module.f.mjs`](../ast/module.f.mjs) — current sequential AST evaluator.
 - [`cache-compiled-modules.md`](./cache-compiled-modules.md) — lower-priority
-  persistence/incremental-compilation task for `.fjs/modules/{hash}.f.js`.
+  persistence/incremental-compilation task for `.fjs/unresolved/{hash}.f.js`.
 - [`interpret-edag.md`](./interpret-edag.md) — separate baseline direct-interpreter
   execution strategy for the final EDAG.
 - [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md) —
@@ -239,4 +307,4 @@ object and array values are represented by their constructors.
 - [`todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md) — EDAG
   semantics and structural operations.
 - [`todo/edag-spec.md`](../../../todo/edag-spec.md) — future complete canonical EDAG
-  schema; this task intentionally implements only the compiler-required subset first.
+  schema.

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -98,29 +98,13 @@ array constructor node is referenced from several places, it must be evaluated o
 and the same resulting object/array reused. A memo table keyed by EDAG node identity
 is sufficient for the initial interpreter.
 
-Validate the EDAG shape before interpretation. Resource hardening — deterministic
-work/time limits, memory/structure-growth limits, native-stack-independent traversal,
-and stopped-outcome propagation — is intentionally deferred to
-[`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md). Those
-concerns should not block the first working compile/load/interpret pipeline.
+Resource/time/memory hardening of validation and interpretation is intentionally
+separate from this task; see
+[`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md).
+This task only establishes the basic compile/load/interpret pipeline.
 
-Conceptually:
-
-```text
-source
-  -> compile without imports
-  -> { imports, edag }
-
-imports
-  -> recursively load values
-  -> args
-
-interpret(edag, args)
-  -> value
-```
-
-For the root module, the result is the complete compiled module/program value.
-Circular dependency detection remains a loading concern, as it is today.
+For the root module, the interpreted result is the complete compiled module/program
+value. Circular dependency detection remains a loading concern, as it is today.
 
 ### Initial EDAG subset
 
@@ -140,8 +124,9 @@ Implement only the EDAG forms required by the DJS loader today:
 The object constructor is an ordered operation rather than a plain EDAG object. This
 preserves source property order and leaves room for future computed keys and entry
 forms such as object spread, for example `['...', object]`. Computed key nodes are
-**not** part of this initial interpreter; their coercion/failure semantics can be
-specified when that extension is introduced. Plain objects have no EDAG meaning in
+**not** part of this initial interpreter: allowing arbitrary key expressions would
+introduce JavaScript `ToPropertyKey` failure cases and therefore needs explicit
+semantics before validation can admit them. Plain objects have no EDAG meaning in
 this initial subset and remain reserved for a future use.
 
 Do **not** add the rest of EDAG yet: arbitrary property access, calls, method calls,
@@ -188,13 +173,16 @@ object and array values are represented by their constructors.
 
 ### Related
 
-- [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md) —
-  lower-priority hardening for deterministic time/work and memory limits.
 - [`../transpiler/module.f.mjs`](../transpiler/module.f.mjs) — currently loads imports
   recursively before calling `run(module[1])(args)`.
 - [`../ast/types.ts`](../ast/types.ts) — current `AstModule`/`AstBody`, `aref`, `cref`,
   and plain-object representation to replace.
 - [`../ast/module.f.mjs`](../ast/module.f.mjs) — current sequential AST evaluator.
+- [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md) —
+  lower-priority resource/time/memory hardening for EDAG validation and execution.
+- [`associate-edag-with-functions.md`](./associate-edag-with-functions.md) —
+  low-priority note on compiling an EDAG to an executable function while retaining
+  the EDAG through `edagAdd` / `edagGet` Effects.
 - [`todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md) — EDAG
   semantics and structural operations.
 - [`todo/edag-spec.md`](../../../todo/edag-spec.md) — future complete canonical EDAG

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -12,14 +12,13 @@ The current DJS transpiler couples two separate operations:
    with `run(module[1])(args)`.
 
 This means the source-to-computation representation is not available independently
-of dependency loading. A module cannot be compiled once and cached before its
+of dependency loading. A source module cannot be compiled once and cached before its
 imports are resolved, even though its computation depends only on its source and
 treats imported values as parameters.
 
-The existing AST already approximates this model: `AstModule` stores import
-specifiers separately, `['aref', i]` denotes the `i`-th imported value, and the
-last `AstBody` entry is the result. Replace this temporary sequential AST execution
-model with the EDAG model directly.
+EDAG alone is not enough to represent an unresolved parsed module: the loader also
+needs the module paths imported by that source file. Keep that information in a small
+temporary wrapper rather than adding module metadata to EDAG itself.
 
 The current parser/AST also cannot preserve the ordered object-entry representation
 required by EDAG. Object parsing accumulates properties in an `OrderedMap` with
@@ -30,15 +29,28 @@ they are converted to `['{}', ...entry]`.
 
 ### Proposal
 
-Split module compilation/loading into two phases.
+Split module compilation and module resolution.
 
-#### 1. Compile source to a parameterized EDAG
+#### 1. Compile source to a temporary `Module`
 
-Compile each FunctionalScript module **without loading its imports**.
+Compile each FunctionalScript source module **without loading its imports**.
 
-The compiled-module representation keeps the import specifiers in source order and
-an EDAG root for the module body. Imported values are parameters of that EDAG, and
-`export default` is the root/result of the computation.
+Use a temporary representation such as:
+
+```ts
+type Module = {
+    readonly imports: readonly string[]
+    readonly edag: EDAG
+}
+```
+
+`imports` is an **array of module paths, not a map**. The array preserves the import
+parameter positions from the source module. The module EDAG refers to imported values
+by those positions, and `export default` is the root/result of the module EDAG.
+
+`Module` is a compiler/loading structure only. It is **not part of EDAG**, and the
+module paths must not be embedded into the EDAG merely to make an unresolved module
+self-contained.
 
 For example:
 
@@ -49,66 +61,94 @@ const x = [a, 1]
 export default { x: x, y: x }
 ```
 
-can compile conceptually to the EDAG serialized as DJS:
+can compile conceptually to:
 
 ```js
 const args = ['args']
 const a = ['.', args, 0]
 const x = ['[]', a, 1]
-export default ['{}',
+
+const edag = ['{}',
     [':', 'x', x],
     [':', 'y', x],
 ]
 ```
 
-`x` is one shared EDAG node, so both object properties receive the same array.
-`const` is serialization-level sharing, not an EDAG operation.
+with the temporary module metadata:
 
-The general `['=>', ...]` function operation is not required for this stage. The
-loader treats the compiled EDAG as an implicit module function whose argument array
-contains the imported module values.
+```js
+{
+    imports: ['./a.f.js'],
+    edag,
+}
+```
 
-Because this phase does not read dependencies, its result is cacheable independently
-of imported-module contents. A persistent cache must include the compiler/EDAG
-version in its identity; dependency values are not part of the source-to-EDAG cache
-key.
+`x` is one shared EDAG node, so both object properties reference the same constructed
+array. DJS `const` is serialization-level sharing, not an EDAG operation.
 
-The compiler may also materialize these intermediate EDAGs as **DJS files** in a
-FunctionalScript-owned temporary build directory such as `./.fjs/edag/`. This keeps
-FunctionalScript artifacts separate from Cargo's `./target/`, while leaving room for
-other FunctionalScript build artifacts under `./.fjs/` later. The independently
-compiled module representation is then easy to inspect, debug, and reuse during the
-rest of the compilation. The files contain the EDAG serialization, not loaded
-dependency values or the final compiled module. They are build artifacts and must
-not be source-controlled.
+The general `['=>', ...]` function operation is not required merely to represent the
+module boundary. The temporary `Module` supplies the import list; its EDAG is the
+parameterized computation associated with those imports.
 
-#### 2. Load imports and interpret the EDAG
+Because this phase does not read dependencies, the `Module` result is cacheable
+independently of imported-module contents. A persistent cache must include the
+compiler/EDAG version in its identity; dependency contents are not part of the
+source-to-`Module` cache key.
 
-The loader recursively resolves and loads the module's import specifiers. After all
-required imported values are available, evaluate the module EDAG with those values as
-its arguments, in import-source order.
+The compiler may materialize these temporary module artifacts under:
 
-For this first task, evaluation is performed by a **small EDAG interpreter written in
-FunctionalScript**. Do not turn the EDAG back into JavaScript and execute it through
-the host JavaScript engine. The interpreter only needs to support the initial EDAG
-subset listed below and can grow together with the EDAG format later.
+```text
+./.fjs/modules/
+```
 
-The interpreter must preserve EDAG node identity. In particular, if one object or
-array constructor node is referenced from several places, it must be evaluated once
-and the same resulting object/array reused. A memo table keyed by EDAG node identity
-is sufficient for the initial interpreter.
+They are intermediate compiler artifacts and must not be source-controlled. The
+concrete serialization can use DJS when graph sharing or other non-JSON values require
+it.
 
-Resource/time/memory hardening of validation and interpretation is intentionally
-separate from this task; see
-[`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md).
-This task only establishes the basic compile/load/interpret pipeline.
+#### 2. Resolve modules to one EDAG
 
-For the root module, the interpreted result is the complete compiled module/program
-value. Circular dependency detection remains a loading concern, as it is today.
+Recursively resolve the paths in `Module.imports`. Each imported module is compiled to
+its own temporary `Module`, then its imports are resolved in the same way.
+
+Resolution binds the resolved imported module results to the corresponding import
+parameter positions in the importing module EDAG. The import array order therefore
+remains significant: position `i` in `imports` corresponds to import parameter `i` in
+the EDAG.
+
+After all module dependencies are resolved, the temporary module wrappers disappear.
+The **final compilation result is an EDAG, not a `Module`**:
+
+```text
+source module
+  -> Module { imports, edag }
+  -> recursively resolve imported Modules
+  -> EDAG
+```
+
+The resulting EDAG contains the complete compiled program and no unresolved module
+paths.
+
+The final EDAG can then be serialized as a FunctionalScript JavaScript artifact:
+
+```text
+<name>.f.js
+```
+
+or as JSON when the particular EDAG is representable without losing information.
+For example, JSON must not be used when it would lose semantic graph sharing or values
+that JSON cannot represent. DJS/`.f.js` remains the general representation.
+
+Executing the final EDAG is a separate concern. This task establishes the
+source-to-temporary-`Module` and module-resolution-to-final-EDAG pipeline. Direct EDAG
+interpretation, compilation of EDAG to executable functions, and execution policy can
+be layered on top of the resulting EDAG.
+
+Resource/time/memory hardening of EDAG processing is intentionally separate from this
+task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md).
 
 ### Initial EDAG subset
 
-Implement only the EDAG forms required by the DJS loader today:
+Implement only the EDAG forms required by the current DJS compiler path:
 
 - primitive constants directly: `null`, `undefined`, boolean, number, string,
   `bigint`;
@@ -124,7 +164,7 @@ Implement only the EDAG forms required by the DJS loader today:
 The object constructor is an ordered operation rather than a plain EDAG object. This
 preserves source property order and leaves room for future computed keys and entry
 forms such as object spread, for example `['...', object]`. Computed key nodes are
-**not** part of this initial interpreter: allowing arbitrary key expressions would
+**not** part of this initial subset: allowing arbitrary key expressions would
 introduce JavaScript `ToPropertyKey` failure cases and therefore needs explicit
 semantics before validation can admit them. Plain objects have no EDAG meaning in
 this initial subset and remain reserved for a future use.
@@ -136,6 +176,11 @@ object and array values are represented by their constructors.
 
 ### Tasks
 
+- [ ] Define the temporary `Module` type with exactly the unresolved import-path array
+      and parameterized EDAG needed by module resolution; keep it outside the EDAG
+      schema.
+- [ ] Keep `Module.imports` as a source-ordered array of module paths, not a map, and
+      make import parameter positions correspond to its indices.
 - [ ] Define the minimal DJS EDAG types/validation for the forms above, consistent
       with [`todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)
       and extensible to the full EDAG specification later.
@@ -144,31 +189,33 @@ object and array values are represented by their constructors.
 - [ ] Change the DJS parser/AST object representation to retain an ordered entry list
       until EDAG conversion; do not collapse duplicate keys or reorder integer-like
       keys through a plain JavaScript object/`OrderedMap` representation.
-- [ ] Convert parsed module bodies to an EDAG root without reading or resolving any
-      imported module.
+- [ ] Convert a parsed source module to `Module { imports, edag }` without reading or
+      resolving any imported module.
 - [ ] Replace `['aref', i]` with EDAG import-parameter access and replace `cref`
       sequencing with shared EDAG node identity.
-- [ ] Keep import specifiers alongside the EDAG in source order so the loader can
-      construct the argument array deterministically.
-- [ ] Implement a small EDAG interpreter in FunctionalScript for the initial EDAG
-      subset; do not execute generated EDAGs as JavaScript.
-- [ ] Memoize interpreter results by EDAG node identity so shared object/array nodes
-      evaluate once and preserve reference identity in the compiled value.
-- [ ] Split the current transpiler flow into source-to-EDAG compilation and recursive
-      loading/interpretation.
-- [ ] Allow compiled module EDAGs to be emitted as DJS files under `./.fjs/edag/`
-      and ignore the FunctionalScript build directory in source control.
-- [ ] Interpret each module EDAG only after all of its imported values have been
-      loaded; the root module's result is the final compiled value.
+- [ ] Resolve imported `Module`s recursively and bind each resolved result to the
+      corresponding import parameter position.
+- [ ] Remove the temporary `Module` layer after resolution so the root compilation
+      result is a plain EDAG with no unresolved module paths.
+- [ ] Split the current transpiler flow into source-to-`Module` compilation and
+      recursive module resolution/linking.
+- [ ] Allow temporary compiled `Module` artifacts to be emitted under
+      `./.fjs/modules/` and ignore the FunctionalScript build directory in source
+      control.
+- [ ] Serialize the final EDAG to `.f.js`; allow JSON output only when it preserves
+      the EDAG completely.
 - [ ] Preserve current missing-file, parse-error, and circular-dependency behavior.
-- [ ] Make the source-to-EDAG result cacheable; add an initial cache if useful, with
-      compiler/EDAG versioning for persistent entries.
-- [ ] Add proofs that compilation does not read imports, the interpreter preserves
-      shared `const` identity, imports are passed in source order, object-entry order
+- [ ] Make the source-to-`Module` result cacheable; add an initial cache if useful,
+      with compiler/EDAG versioning for persistent entries.
+- [ ] Add proofs that source-to-`Module` compilation does not read imports, import
+      paths and parameter positions preserve source order, object-entry order
       (including integer-like keys and duplicate keys) survives parsing/EDAG
       conversion, non-string object-entry keys are rejected by initial validation,
-      and a multi-module program produces the same final value as the current
-      transpiler.
+      and resolving a multi-module program produces one final EDAG with no unresolved
+      module paths.
+- [ ] Add serialization proofs covering `.f.js` and JSON-when-representable output,
+      including a case where JSON must not be used because it would lose EDAG
+      information.
 - [ ] `npx tsc`, `fjs test`.
 
 ### Related
@@ -179,11 +226,11 @@ object and array values are represented by their constructors.
   and plain-object representation to replace.
 - [`../ast/module.f.mjs`](../ast/module.f.mjs) — current sequential AST evaluator.
 - [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md) —
-  lower-priority resource/time/memory hardening for EDAG validation and execution.
+  lower-priority resource/time/memory hardening for EDAG processing.
 - [`associate-edag-with-functions.md`](./associate-edag-with-functions.md) —
   low-priority note on compiling an EDAG to an executable function while retaining
   the EDAG through `edagAdd` / `edagGet` Effects.
 - [`todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md) — EDAG
   semantics and structural operations.
 - [`todo/edag-spec.md`](../../../todo/edag-spec.md) — future complete canonical EDAG
-  schema; this task intentionally implements only the loader-required subset first.
+  schema; this task intentionally implements only the compiler-required subset first.

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -21,6 +21,13 @@ specifiers separately, `['aref', i]` denotes the `i`-th imported value, and the
 last `AstBody` entry is the result. Replace this temporary sequential AST execution
 model with the EDAG model directly.
 
+The current parser/AST also cannot preserve the ordered object-entry representation
+required by EDAG. Object parsing accumulates properties in an `OrderedMap` with
+`setReplace` and eventually produces a plain `AstObject`; duplicate keys are therefore
+collapsed and integer-like keys can lose their written order before EDAG conversion.
+This task must preserve object entries as an ordered sequence in the parser/AST until
+they are converted to `['{}', ...entry]`.
+
 ### Proposal
 
 Split module compilation/loading into two phases.
@@ -39,7 +46,7 @@ For example:
 import a from './a.f.js'
 
 const x = [a, 1]
-export default { x, y: x }
+export default { x: x, y: x }
 ```
 
 can compile conceptually to the EDAG serialized as DJS:
@@ -168,6 +175,9 @@ are represented by their constructors.
       and extensible to the full EDAG specification later.
 - [ ] Make EDAG validation iterative so hostile nesting cannot overflow the host
       language call stack.
+- [ ] Change the DJS parser/AST object representation to retain an ordered entry list
+      until EDAG conversion; do not collapse duplicate keys or reorder integer-like
+      keys through a plain JavaScript object/`OrderedMap` representation.
 - [ ] Convert parsed module bodies to an EDAG root without reading or resolving any
       imported module.
 - [ ] Replace `['aref', i]` with EDAG import-parameter access and replace `cref`
@@ -197,8 +207,10 @@ are represented by their constructors.
 - [ ] Make the source-to-EDAG result cacheable; add an initial cache if useful, with
       compiler/EDAG versioning for persistent entries.
 - [ ] Add proofs that compilation does not read imports, the interpreter preserves
-      shared `const` identity, imports are passed in source order, and a multi-module
-      program produces the same final value as the current transpiler.
+      shared `const` identity, imports are passed in source order, object-entry order
+      (including integer-like keys and duplicate keys) survives parsing/EDAG
+      conversion, and a multi-module program produces the same final value as the
+      current transpiler.
 - [ ] Add proofs that instruction-limit and structure-growth-limit exhaustion stop
       deterministically and never throw.
 - [ ] Add a deeply nested validated EDAG proof that validation and interpretation do
@@ -210,8 +222,8 @@ are represented by their constructors.
 
 - [`../transpiler/module.f.mjs`](../transpiler/module.f.mjs) — currently loads imports
   recursively before calling `run(module[1])(args)`.
-- [`../ast/types.ts`](../ast/types.ts) — current `AstModule`/`AstBody`, `aref`, and
-  `cref` representation to replace.
+- [`../ast/types.ts`](../ast/types.ts) — current `AstModule`/`AstBody`, `aref`, `cref`,
+  and plain-object representation to replace.
 - [`../ast/module.f.mjs`](../ast/module.f.mjs) — current sequential AST evaluator.
 - [`todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md) — EDAG
   semantics and structural operations.

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -16,9 +16,8 @@ of dependency loading. A source module should be compilable before its imports a
 resolved, with imported values represented as parameters of its EDAG.
 
 EDAG alone is not enough to represent an unresolved parsed module: module resolution
-also needs source identity and the module paths imported by that source file. Keep
-that information in a small temporary wrapper rather than adding module metadata to
-EDAG itself.
+also needs the module paths imported by that source file. Keep that information in a
+small temporary wrapper rather than adding module metadata to EDAG itself.
 
 The current parser/AST also cannot preserve the ordered object-entry representation
 required by EDAG. Object parsing accumulates properties in an `OrderedMap` with
@@ -39,26 +38,18 @@ Use the temporary representation:
 
 ```ts
 type Module = {
-    readonly hash: string
-    readonly path: string
     readonly imports: readonly string[]
     readonly edag: EDAG
 }
 ```
 
-The fields have different roles:
+`imports` is an **array of module paths, not a map**. Its order defines the import
+parameter positions in `edag`. `edag` is the parameterized computation for the module,
+with `export default` as its root/result.
 
-- `hash` is the CBase32-encoded hash of the original source file contents;
-- `path` is the source module path relative to the `.fjs/` / current-working-directory
-  context used by the compiler;
-- `imports` is an **array of module paths, not a map**. Its order defines the import
-  parameter positions in `edag`;
-- `edag` is the parameterized computation for the module, with `export default` as
-  its root/result.
-
-`Module` is a compiler/loading structure only. It is **not part of EDAG**. In
-particular, `hash`, `path`, and imported module paths must not be embedded into EDAG
-merely to make an unresolved module self-contained.
+`Module` is a compiler/loading structure only. It is **not part of EDAG**, and imported
+module paths must not be embedded into EDAG merely to make an unresolved module
+self-contained.
 
 For example:
 
@@ -82,12 +73,10 @@ const edag = ['{}',
 ]
 ```
 
-with temporary module metadata such as:
+with temporary module metadata:
 
 ```js
 {
-    hash: '<CBase32 source hash>',
-    path: 'src/example.f.js',
     imports: ['./a.f.js'],
     edag,
 }
@@ -97,11 +86,11 @@ with temporary module metadata such as:
 array. DJS `const` is serialization-level sharing, not an EDAG operation.
 
 The general `['=>', ...]` function operation is not required merely to represent the
-module boundary. The temporary `Module` supplies the source/import metadata; its EDAG
-is the parameterized computation associated with those imports.
+module boundary. The temporary `Module` supplies the import list; its EDAG is the
+parameterized computation associated with those imports.
 
-Persisting these temporary modules under `.fjs/modules/` and using them for
-incremental compilation is deliberately a separate task; see
+Persisting temporary modules under `.fjs/modules/` and using them for incremental
+compilation is deliberately a separate task; see
 [`cache-compiled-modules.md`](./cache-compiled-modules.md).
 
 #### 2. Resolve modules to one EDAG
@@ -119,7 +108,7 @@ The **final compilation result is an EDAG, not a `Module`**:
 
 ```text
 source module
-  -> Module { hash, path, imports, edag }
+  -> Module { imports, edag }
   -> recursively resolve imported Modules
   -> EDAG
 ```
@@ -175,12 +164,8 @@ object and array values are represented by their constructors.
 
 ### Tasks
 
-- [ ] Define the temporary `Module` type as
-      `{ hash, path, imports, edag }`; keep all four fields outside the EDAG schema.
-- [ ] Compute `Module.hash` from the original source-file contents and encode it in
-      CBase32.
-- [ ] Define `Module.path` relative to the compiler's `.fjs/` / current-working-
-      directory context so source identity is stable during module resolution.
+- [ ] Define the temporary `Module` type as `{ imports, edag }`; keep it outside the
+      EDAG schema.
 - [ ] Keep `Module.imports` as a source-ordered array of module paths, not a map, and
       make import parameter positions correspond to its indices.
 - [ ] Define the minimal DJS EDAG types/validation for the forms above, consistent
@@ -191,8 +176,8 @@ object and array values are represented by their constructors.
 - [ ] Change the DJS parser/AST object representation to retain an ordered entry list
       until EDAG conversion; do not collapse duplicate keys or reorder integer-like
       keys through a plain JavaScript object/`OrderedMap` representation.
-- [ ] Convert a parsed source module to `Module { hash, path, imports, edag }` without
-      reading or resolving any imported module.
+- [ ] Convert a parsed source module to `Module { imports, edag }` without reading or
+      resolving any imported module.
 - [ ] Replace `['aref', i]` with EDAG import-parameter access and replace `cref`
       sequencing with shared EDAG node identity.
 - [ ] Resolve imported `Module`s recursively and bind each resolved result to the
@@ -205,12 +190,11 @@ object and array values are represented by their constructors.
       the EDAG completely.
 - [ ] Preserve current missing-file, parse-error, and circular-dependency behavior.
 - [ ] Add proofs that source-to-`Module` compilation does not read imports, import
-      paths and parameter positions preserve source order, `hash` matches the source
-      contents, `path` identifies the source relative to the compilation context,
-      object-entry order (including integer-like keys and duplicate keys) survives
-      parsing/EDAG conversion, non-string object-entry keys are rejected by initial
-      validation, and resolving a multi-module program produces one final EDAG with
-      no unresolved module metadata.
+      paths and parameter positions preserve source order, object-entry order
+      (including integer-like keys and duplicate keys) survives parsing/EDAG
+      conversion, non-string object-entry keys are rejected by initial validation,
+      and resolving a multi-module program produces one final EDAG with no unresolved
+      module metadata.
 - [ ] Add serialization proofs covering `.f.js` and JSON-when-representable output,
       including a case where JSON must not be used because it would lose EDAG
       information.
@@ -224,7 +208,7 @@ object and array values are represented by their constructors.
   and plain-object representation to replace.
 - [`../ast/module.f.mjs`](../ast/module.f.mjs) — current sequential AST evaluator.
 - [`cache-compiled-modules.md`](./cache-compiled-modules.md) — lower-priority
-  persistence/incremental-compilation task for `.fjs/modules/{pathHash}.f.js`.
+  persistence/incremental-compilation task for `.fjs/modules/{hash}.f.js`.
 - [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md) —
   lower-priority resource/time/memory hardening for EDAG processing.
 - [`associate-edag-with-functions.md`](./associate-edag-with-functions.md) —

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -103,6 +103,13 @@ Initially support two limits:
   nodes/properties/elements so computations that grow data without bound cannot
   exhaust host memory.
 
+The validator and interpreter must not depend on the host language call stack for
+EDAG traversal. A valid EDAG can be arbitrarily deep, so recursive traversal could
+throw a host `RangeError` before an interpreter limit is reached. Use an explicit
+work stack/continuation structure and iterative traversal instead. Advancing that
+work must count toward the deterministic instruction/traversal budget, so hostile
+operand depth stops cleanly rather than overflowing the native stack.
+
 The limits are interpreter inputs/options, not fields in the EDAG, so they do not
 change the EDAG's canonical representation or identity. Reaching either limit is a
 normal stopped result with a reason, not an exception. This mechanism can later
@@ -150,6 +157,8 @@ are represented by their constructors.
 - [ ] Define the minimal DJS EDAG types/validation for the forms above, consistent
       with [`todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)
       and extensible to the full EDAG specification later.
+- [ ] Make EDAG validation iterative so hostile nesting cannot overflow the host
+      language call stack.
 - [ ] Convert parsed module bodies to an EDAG root without reading or resolving any
       imported module.
 - [ ] Replace `['aref', i]` with EDAG import-parameter access and replace `cref`
@@ -160,6 +169,9 @@ are represented by their constructors.
       subset; do not execute generated EDAGs as JavaScript.
 - [ ] Make the interpreter non-throwing: return an explicit completed or stopped
       outcome for every validated EDAG.
+- [ ] Implement interpreter traversal iteratively with an explicit work stack rather
+      than recursive host calls; count traversal/work-stack progress against the
+      deterministic instruction budget.
 - [ ] Add a deterministic instruction budget, incremented by interpreter evaluation
       steps rather than measured with wall-clock time.
 - [ ] Add a deterministic structure-growth budget for materialized object/array
@@ -180,6 +192,9 @@ are represented by their constructors.
       program produces the same final value as the current transpiler.
 - [ ] Add proofs that instruction-limit and structure-growth-limit exhaustion stop
       deterministically and never throw.
+- [ ] Add a deeply nested validated EDAG proof that validation and interpretation do
+      not throw `RangeError`; it either completes or stops through a deterministic
+      budget.
 - [ ] `npx tsc`, `fjs test`.
 
 ### Related

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -98,49 +98,11 @@ array constructor node is referenced from several places, it must be evaluated o
 and the same resulting object/array reused. A memo table keyed by EDAG node identity
 is sufficient for the initial interpreter.
 
-Validation and interpretation are both **non-throwing**. Validation rejects malformed
-EDAGs before interpretation, but validation itself may stop when its deterministic
-traversal budget is exhausted. Interpretation of a successfully validated EDAG
-returns either the computed value or a stopped outcome when a deterministic resource
-limit is reached.
-
-Initially support two limits:
-
-- **instruction limit** — a shared per-module budget consumed by both EDAG validation
-  and interpretation. Count validator/interpreter traversal and evaluation steps
-  rather than wall-clock time, so the limit is deterministic across machines;
-- **structure-growth limit** — consumed only by interpretation; stop if evaluation
-  materializes too much object or array structure. Define a simple deterministic
-  accounting rule for constructed nodes/properties/elements so computations that
-  grow data without bound cannot exhaust host memory.
-
-The validator and interpreter must not depend on the host language call stack for
-EDAG traversal. A valid EDAG can be arbitrarily deep, so recursive traversal could
-throw a host `RangeError` before a limit is reached. Use an explicit work
-stack/continuation structure and iterative traversal instead.
-
-Validation receives the module's instruction budget first. Every traversal
-transition — including descending into/scheduling another child — consumes budget
-**before** growing the explicit work stack. Do not bulk-push an unbounded operand
-list. Therefore both traversal work and validator work-stack growth are bounded by
-the deterministic instruction limit. Validation returns one of:
-
-```text
-invalid(validationError)
-valid(remainingInstructionBudget)
-stopped(instruction-limit)
-```
-
-Only `valid` proceeds to interpretation, which receives the remaining instruction
-budget rather than resetting it. Thus validation cannot perform unbounded work before
-the interpreter's resource accounting begins.
-
-The limits are compiler inputs/options, not fields in the EDAG, so they do not change
-the EDAG's canonical representation or identity. Each module receives a fresh budget
-initialized from the requested/default limits; within that module, validation and
-interpretation share the instruction budget. Reaching either limit is a normal
-stopped result with a reason, not an exception. This mechanism can later bound
-evaluation of general EDAG functions as the operation set grows.
+Validate the EDAG shape before interpretation. Resource hardening — deterministic
+work/time limits, memory/structure-growth limits, native-stack-independent traversal,
+and stopped-outcome propagation — is intentionally deferred to
+[`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md). Those
+concerns should not block the first working compile/load/interpret pipeline.
 
 Conceptually:
 
@@ -153,44 +115,12 @@ imports
   -> recursively load values
   -> args
 
-validate(edag, limits.instruction)
-  -> invalid(error)
-   | stopped(instruction-limit)
-   | valid(remainingInstructionBudget)
-
-interpret(edag, args, {
-    instruction: remainingInstructionBudget,
-    structureGrowth: limits.structureGrowth,
-})
-  -> completed(value) | stopped(reason)
+interpret(edag, args)
+  -> value
 ```
 
-The stopped outcome must also be represented by the transpiler/compiler API; it must
-not be disguised as a `ParseError`. Extend the current
-`Result<Unknown, ParseError>` shape conceptually to:
-
-```text
-Result<CompileOutcome<Unknown>, ParseError>
-
-CompileOutcome<T> = completed(T) | stopped(StopReason)
-StopReason = instruction-limit | structure-growth-limit
-```
-
-Parse/load errors therefore remain errors in `Result`, while deterministic resource
-exhaustion is an explicit non-throwing compilation outcome. A validation failure for
-an EDAG produced by this compiler indicates an internal compiler defect; it must not
-be reported as a source `ParseError`. Thread the compile limits through the
-loader/transpiler API. `fjs compile` supplies documented, deterministic default
-limits; callers may override them explicitly. Choosing and documenting the concrete
-default values is part of this task rather than an implicit host-dependent decision.
-
-If validation or interpretation of an imported module returns `stopped`, propagate
-that outcome unchanged through every importing module and do not interpret dependent
-parent EDAGs. A root `stopped` outcome makes `fjs compile` terminate cleanly as an
-unsuccessful compilation without throwing or reporting a parse error.
-
-For the root module, a completed result is the complete compiled module/program
-value. Circular dependency detection remains a loading concern, as it is today.
+For the root module, the result is the complete compiled module/program value.
+Circular dependency detection remains a loading concern, as it is today.
 
 ### Initial EDAG subset
 
@@ -210,10 +140,9 @@ Implement only the EDAG forms required by the DJS loader today:
 The object constructor is an ordered operation rather than a plain EDAG object. This
 preserves source property order and leaves room for future computed keys and entry
 forms such as object spread, for example `['...', object]`. Computed key nodes are
-**not** part of this initial interpreter: allowing arbitrary key expressions would
-introduce JavaScript `ToPropertyKey` failure cases and therefore needs an explicit
-semantic-failure outcome/semantics before validation can admit them. Plain objects
-have no EDAG meaning in this initial subset and remain reserved for a future use.
+**not** part of this initial interpreter; their coercion/failure semantics can be
+specified when that extension is introduced. Plain objects have no EDAG meaning in
+this initial subset and remain reserved for a future use.
 
 Do **not** add the rest of EDAG yet: arbitrary property access, calls, method calls,
 operators, comma, closures/functions, `throw`, computed object keys, or other later
@@ -227,14 +156,6 @@ object and array values are represented by their constructors.
       and extensible to the full EDAG specification later.
 - [ ] Restrict initial `[':', key, value]` validation to string-constant keys; defer
       arbitrary computed key nodes until their coercion/failure semantics are defined.
-- [ ] Make EDAG validation iterative so hostile nesting cannot overflow the host
-      language call stack.
-- [ ] Make validation consume the same per-module instruction budget as
-      interpretation; return `stopped(instruction-limit)` if validation exhausts it
-      and pass the remaining budget to interpretation after successful validation.
-- [ ] Count validator child scheduling/work-stack growth against the instruction
-      budget before allocating/pushing more work; do not bulk-push unbounded operand
-      lists.
 - [ ] Change the DJS parser/AST object representation to retain an ordered entry list
       until EDAG conversion; do not collapse duplicate keys or reorder integer-like
       keys through a plain JavaScript object/`OrderedMap` representation.
@@ -246,21 +167,6 @@ object and array values are represented by their constructors.
       construct the argument array deterministically.
 - [ ] Implement a small EDAG interpreter in FunctionalScript for the initial EDAG
       subset; do not execute generated EDAGs as JavaScript.
-- [ ] Make the interpreter non-throwing: return an explicit completed or stopped
-      outcome for every validated EDAG.
-- [ ] Define `CompileOutcome`/`StopReason` (or equivalent) and update the
-      transpiler/compiler result type so `stopped` is distinct from `ParseError`.
-- [ ] Thread compile limits through loading/transpilation, define documented
-      deterministic defaults for `fjs compile`, and allow explicit overrides.
-- [ ] Propagate an imported module's validation/interpreter `stopped` outcome
-      unchanged to the root without interpreting dependent parent EDAGs.
-- [ ] Implement interpreter traversal iteratively with an explicit work stack rather
-      than recursive host calls; count traversal/work-stack progress against the
-      deterministic instruction budget.
-- [ ] Add a deterministic instruction budget, shared by validation and interpretation
-      of each module and decremented by deterministic traversal/evaluation steps.
-- [ ] Add a deterministic structure-growth budget for materialized object/array
-      structure; reaching it returns a stopped result rather than exhausting memory.
 - [ ] Memoize interpreter results by EDAG node identity so shared object/array nodes
       evaluate once and preserve reference identity in the compiled value.
 - [ ] Split the current transpiler flow into source-to-EDAG compilation and recursive
@@ -268,7 +174,7 @@ object and array values are represented by their constructors.
 - [ ] Allow compiled module EDAGs to be emitted as DJS files under `./.fjs/edag/`
       and ignore the FunctionalScript build directory in source control.
 - [ ] Interpret each module EDAG only after all of its imported values have been
-      loaded; the root module's completed result is the final compiled value.
+      loaded; the root module's result is the final compiled value.
 - [ ] Preserve current missing-file, parse-error, and circular-dependency behavior.
 - [ ] Make the source-to-EDAG result cacheable; add an initial cache if useful, with
       compiler/EDAG versioning for persistent entries.
@@ -278,16 +184,12 @@ object and array values are represented by their constructors.
       conversion, non-string object-entry keys are rejected by initial validation,
       and a multi-module program produces the same final value as the current
       transpiler.
-- [ ] Add proofs that instruction-limit and structure-growth-limit exhaustion stop
-      deterministically and never throw, including validation exhaustion and
-      propagation from an imported module through the root compiler result.
-- [ ] Add a deeply nested valid EDAG proof that validation and interpretation do not
-      throw `RangeError`; with enough budget it completes, otherwise validation or
-      interpretation stops through the deterministic instruction limit.
 - [ ] `npx tsc`, `fjs test`.
 
 ### Related
 
+- [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md) —
+  lower-priority hardening for deterministic time/work and memory limits.
 - [`../transpiler/module.f.mjs`](../transpiler/module.f.mjs) — currently loads imports
   recursively before calling `run(module[1])(args)`.
 - [`../ast/types.ts`](../ast/types.ts) — current `AstModule`/`AstBody`, `aref`, `cref`,

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -161,7 +161,7 @@ source module
 The resulting EDAG contains the complete compiled program and no unresolved module
 paths or temporary unresolved metadata.
 
-### Stage 2: functions and calls
+### Stage 2: functions and calls, without frames
 
 After unresolved modules can be represented as EDAG, add functions and calls.
 
@@ -171,22 +171,25 @@ Introduce the function operation into EDAG:
 ['=>', frame, body]
 ```
 
-A nested function body is a closed EDAG. Captured values are supplied by the `frame`
-operand, and the body accesses its invocation frame through:
+**Stage 2 does not implement frames/captures.** The `frame` operand is present in the
+operation shape so later frame support does not require changing `=>`, but Stage 2
+accepts only an empty frame and does not introduce `['frame']` access. Source functions
+that capture values from an enclosing function/module scope are outside this stage.
+For the initial canonical form, a function is therefore represented with an empty frame,
+for example:
 
 ```js
-['frame']
-['.', ['frame'], index]
+['=>', ['[]'], body]
 ```
 
-This keeps outer-scope EDAG nodes from being shared illegally across a function
-boundary while still allowing closures such as `a => () => a` to be represented.
-
-Then introduce the initial arrow-function form into the parser:
+Then introduce the initial non-capturing arrow-function form into the parser:
 
 ```js
 (...a) => exp
 ```
+
+The parser/compiler must reject a Stage 2 function whose body requires a captured outer
+value rather than silently sharing an outer EDAG node into the nested body.
 
 Also introduce call operations into EDAG:
 
@@ -198,7 +201,7 @@ Also introduce call operations into EDAG:
 This stage is intentionally after Stage 1: property access is the minimum operation
 needed for unresolved-module parameter access, while function creation and calls extend
 the set of source modules that can be represented after that basic module pipeline is
-in place.
+in place. Frame/capture support is a later extension.
 
 ### EDAG forms used by these stages
 
@@ -212,13 +215,18 @@ The staged work builds on the basic structural forms already being defined for E
 - array constructors: `['[]', ...node]`;
 - the argument array: `['args']`;
 - Stage 1 property access: `['.', object, property]`;
-- Stage 2 frame access: `['frame']` and property access such as
-  `['.', ['frame'], index]`;
-- Stage 2 functions: `['=>', frame, body]`;
+- Stage 2 non-capturing functions: `['=>', ['[]'], body]`;
 - Stage 2 calls: `['()', object, args]` and
   `['.()', object, property, args]`;
 - semantic sharing by node identity, serialized with DJS `const` references when
   needed.
+
+A function body is its own EDAG scope. Validation must reject an operation-node identity
+that is shared across a function boundary (for example, the same constructor node used
+both outside a function and as a node in its body). Otherwise per-invocation evaluation
+could give one semantic node multiple runtime values. Normal sharing remains valid
+inside one function body. Stage 2's compiler should naturally produce disjoint body
+graphs; validation must enforce the same rule for arbitrary public EDAG input.
 
 The object constructor is an ordered operation rather than a plain EDAG object. This
 preserves source property order and leaves room for future computed keys and entry
@@ -236,8 +244,36 @@ objects different graph identities. Sharing of the descriptor's `key` and `value
 nodes remains normal semantic EDAG sharing.
 
 Do **not** add unrelated EDAG operations in these stages: arithmetic/logical operators,
-comma, loops, `throw`, object spread, or other later operations remain outside this
-task unless they become necessary for the staged parser work above.
+comma, loops, `throw`, object spread, frame access/captures, or other later operations
+remain outside this task unless they become necessary for the staged parser work above.
+
+### Number parsing and serialization
+
+DJS must round-trip every admitted JavaScript `number` value needed by EDAG. In
+particular, the parser and serializer must explicitly support:
+
+```text
+Infinity
+-Infinity
+NaN
+-0
+```
+
+Do not rely on ordinary `JSON.stringify(number)` for the general DJS representation:
+it serializes non-finite values as `null` and loses the sign of `-0`. Define accepted
+DJS spellings for these four cases, make the parser map those spellings back to the
+exact numeric values, and make the serializer emit matching spellings.
+
+The exact tests must distinguish the edge cases semantically:
+
+- `Object.is(roundTrip(-0), -0)`;
+- `Number.isNaN(roundTrip(NaN))`;
+- `roundTrip(Infinity) === Infinity`;
+- `roundTrip(-Infinity) === -Infinity`.
+
+This parser/serializer support is required independently of module-to-EDAG conversion,
+because `.f.js` is the general representation used to persist EDAG and unresolved
+artifacts.
 
 ### Final EDAG serialization
 
@@ -248,14 +284,9 @@ The final EDAG can be serialized as a FunctionalScript JavaScript artifact:
 ```
 
 or as JSON when the particular EDAG is representable without losing information.
-Serialization must preserve every observable primitive value exactly. For `number`,
-this explicitly includes `-0`, `NaN`, `Infinity`, and `-Infinity`; ordinary
-`JSON.stringify` spellings such as `0` for `-0` or `null` for non-finite numbers are
-not acceptable for the general DJS representation.
-
-The EDAG/DJS serializer must emit forms that round-trip those values. JSON output is
-allowed only when the chosen JSON representation preserves the value and all other
-EDAG information; otherwise JSON output must be rejected for that EDAG.
+The DJS parser/serializer round-trip above is the general path. JSON output is allowed
+only when the chosen JSON representation preserves every value and all EDAG information;
+otherwise JSON output must be rejected for that EDAG.
 
 JSON must not be used when it would lose semantic graph sharing or values that the
 chosen JSON representation cannot preserve. DJS/`.f.js` remains the general
@@ -306,24 +337,31 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
 
 #### Stage 2
 
-- [ ] Introduce `['=>', frame, body]` into EDAG and its validation/type schema.
-- [ ] Introduce `['frame']` as the nested body's invocation-frame leaf and lower
-      captured-variable reads to indexed access such as `['.', ['frame'], i]`.
-- [ ] Introduce parser support for the initial `(...a) => exp` function form,
-      including construction of the capture frame for nested functions.
+- [ ] Introduce `['=>', frame, body]` into EDAG and its validation/type schema, with
+      Stage 2 restricted to the canonical empty frame `['[]']`.
+- [ ] Do **not** introduce `['frame']` or captured-variable access in Stage 2.
+- [ ] Introduce parser support for the initial non-capturing `(...a) => exp` function
+      form; reject functions that require captures.
+- [ ] Validate that a nested function body is a disjoint EDAG scope: operation nodes
+      must not be shared across a function boundary, while sharing within the body is
+      preserved.
 - [ ] Introduce `['()', object, args]` into EDAG.
 - [ ] Introduce `['.()', object, property, args]` into EDAG.
 - [ ] Convert the corresponding parser call expressions to the new EDAG call forms.
-- [ ] Add proofs for nested functions with captures, including `a => () => a`, and
-      ordinary/method calls in the supported Stage 2 subset.
+- [ ] Add proofs for non-capturing nested functions and ordinary/method calls in the
+      supported Stage 2 subset.
+- [ ] Add a validation proof that reusing one operation node both outside and inside a
+      nested function body is rejected.
 
 #### Shared/final
 
+- [ ] Add explicit DJS parser support for the chosen spellings of `Infinity`,
+      `-Infinity`, `NaN`, and `-0`.
+- [ ] Update the DJS number serializer to emit spellings that the parser round-trips to
+      exactly `Infinity`, `-Infinity`, `NaN`, and `-0`; do not delegate these cases to
+      ordinary `JSON.stringify` behavior.
 - [ ] Serialize the final EDAG to `.f.js`; allow JSON output only when it preserves
       the EDAG completely.
-- [ ] Preserve `-0`, `NaN`, `Infinity`, and `-Infinity` explicitly in EDAG/DJS
-      serialization; select JSON output only when its representation round-trips them
-      and every other EDAG value exactly.
 - [ ] Preserve current missing-file, parse-error, and circular-dependency behavior.
 - [ ] Add Stage 1 proofs that `a.b` and `a[b]` produce property-access EDAGs,
       source-to-`Unresolved` compilation does not read imports, import paths and
@@ -338,15 +376,20 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
       as unsupported rather than changing current evaluation behavior.
 - [ ] Add a diamond-import proof showing repeated resolution of one canonical module
       reuses the same resolved EDAG and preserves shared exported object/array identity.
-- [ ] Add serialization proofs covering `.f.js` and JSON-when-representable output,
-      including exact round trips for `-0`, `NaN`, `Infinity`, and `-Infinity`, plus a
-      case where JSON must not be used because it would lose EDAG information.
+- [ ] Add DJS number round-trip proofs for `-0`, `NaN`, `Infinity`, and `-Infinity`,
+      plus JSON-when-representable proofs showing JSON is not selected when its chosen
+      representation would lose an EDAG value or graph information.
 - [ ] `npx tsc`, `fjs test`.
 
 ### Related
 
 - [`../transpiler/module.f.mjs`](../transpiler/module.f.mjs) — currently loads imports
   recursively before calling `run(module[1])(args)`.
+- [`../parser/module.f.mjs`](../parser/module.f.mjs) — current number parsing uses
+  `parseFloat` for number tokens and must participate in the special-number round trip.
+- [`../../media/json/serializer/module.f.mjs`](../../media/json/serializer/module.f.mjs)
+  — current `numberSerialize` delegates to `JSON.stringify` and therefore needs explicit
+  handling for the special-number cases used by DJS.
 - [`../ast/types.ts`](../ast/types.ts) — current `AstModule`/`AstBody`, `aref`, `cref`,
   and plain-object representation to replace.
 - [`../ast/module.f.mjs`](../ast/module.f.mjs) — current sequential AST evaluator.

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -1,0 +1,141 @@
+## Compile modules to EDAG before loading imports
+
+**Priority:** P2
+**Status:** open
+
+### Problem
+
+The current DJS transpiler couples two separate operations:
+
+1. parse a module into `AstModule`;
+2. recursively load every imported module and only then evaluate the module body
+   with `run(module[1])(args)`.
+
+This means the source-to-computation representation is not available independently
+of dependency loading. A module cannot be compiled once and cached before its
+imports are resolved, even though its computation depends only on its source and
+treats imported values as parameters.
+
+The existing AST already approximates this model: `AstModule` stores import
+specifiers separately, `['aref', i]` denotes the `i`-th imported value, and the
+last `AstBody` entry is the result. Replace this temporary sequential AST execution
+model with the EDAG model directly.
+
+### Proposal
+
+Split module compilation/loading into two phases.
+
+#### 1. Compile source to a parameterized EDAG
+
+Compile each FunctionalScript module **without loading its imports**.
+
+The compiled-module representation keeps the import specifiers in source order and
+an EDAG root for the module body. Imported values are parameters of that EDAG, and
+`export default` is the root/result of the computation.
+
+For example:
+
+```js
+import a from './a.f.js'
+
+const x = [a, 1]
+export default { x, y: x }
+```
+
+can compile conceptually to the EDAG serialized as DJS:
+
+```js
+const args = ['args']
+const a = ['.', args, 0]
+const x = ['[]', a, 1]
+export default { x, y: x }
+```
+
+`x` is one shared EDAG node, so both object properties receive the same array.
+`const` is serialization-level sharing, not an EDAG operation.
+
+The general `['=>', ...]` function operation is not required for this stage. The
+loader treats the compiled EDAG as an implicit module function whose argument array
+contains the imported module values.
+
+Because this phase does not read dependencies, its result is cacheable independently
+of imported-module contents. A persistent cache must include the compiler/EDAG
+version in its identity; dependency values are not part of the source-to-EDAG cache
+key.
+
+#### 2. Load imports and execute the EDAG
+
+The loader recursively resolves and loads the module's import specifiers. After all
+required imported values are available, execute the module EDAG with those values as
+its arguments, in import-source order.
+
+Conceptually:
+
+```text
+source
+  -> compile without imports
+  -> { imports, edag }
+
+imports
+  -> recursively load values
+  -> args
+
+execute(edag, args)
+  -> compiled module value
+```
+
+For the root module, the result is the complete compiled module/program value.
+Circular dependency detection remains a loading concern, as it is today.
+
+### Initial EDAG subset
+
+Implement only the EDAG forms required by the DJS loader today:
+
+- primitive constants directly: `null`, `undefined`, boolean, number, string,
+  `bigint`;
+- object constructors: `{ key: node, ... }`;
+- array constructors: `['[]', ...node]`;
+- the argument array: `['args']`;
+- import-parameter access: `['.', ['args'], index]`;
+- semantic sharing by node identity, serialized with DJS `const` references when
+  needed.
+
+Do **not** add the rest of EDAG yet: arbitrary property access, calls, method calls,
+operators, comma, closures/functions, `throw`, or other later operations are outside
+this task. Do not add plain object or array constant nodes; object and array literals
+are represented by their constructors.
+
+### Tasks
+
+- [ ] Define the minimal DJS EDAG types/validation for the forms above, consistent
+      with [`todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)
+      and extensible to the full EDAG specification later.
+- [ ] Convert parsed module bodies to an EDAG root without reading or resolving any
+      imported module.
+- [ ] Replace `['aref', i]` with EDAG import-parameter access and replace `cref`
+      sequencing with shared EDAG node identity.
+- [ ] Keep import specifiers alongside the EDAG in source order so the loader can
+      construct the argument array deterministically.
+- [ ] Split the current transpiler flow into source-to-EDAG compilation and recursive
+      loading/evaluation.
+- [ ] Execute each module EDAG only after all of its imported values have been loaded;
+      the root module's result is the final compiled value.
+- [ ] Preserve current missing-file, parse-error, and circular-dependency behavior.
+- [ ] Make the source-to-EDAG result cacheable; add an initial cache if useful, with
+      compiler/EDAG versioning for persistent entries.
+- [ ] Add proofs that compilation does not read imports, shared `const` values retain
+      identity, imports are passed in source order, and a multi-module program
+      produces the same final value as the current transpiler.
+- [ ] `npx tsc`, `fjs test`.
+
+### Related
+
+- [`../transpiler/module.f.mjs`](../transpiler/module.f.mjs) — currently loads imports
+  recursively before calling `run(module[1])(args)`.
+- [`../ast/types.ts`](../ast/types.ts) — current `AstModule`/`AstBody`, `aref`, and
+  `cref` representation to replace.
+- [`../ast/module.f.mjs`](../ast/module.f.mjs) — current sequential AST evaluator.
+- [`todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md) — EDAG
+  semantics and structural operations.
+- [`todo/edag-spec.md`](../../../todo/edag-spec.md) — future complete canonical EDAG
+  schema; this task intentionally implements only the loader-required subset first.

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -31,6 +31,19 @@ they are converted to `['{}', ...entry]`.
 Split module compilation and module resolution, and introduce the missing EDAG/parser
 operations in two stages.
 
+This TODO coordinates the **DJS parser/module rollout**; it does not replace the
+existing semantic and VM-design TODOs. The canonical EDAG vocabulary and validation
+rules are developed in
+[`edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md), property and
+method-access safety is owned by
+[`2330-property-accessor.md`](../../../spec/todo/2330-property-accessor.md), source
+function support and later captures are tracked by
+[`3110-function.md`](../../../spec/todo/3110-function.md) and
+[`3111-function-frame.md`](../../../spec/todo/3111-function-frame.md), and VM-internal
+call lowering belongs to
+[`9100-call-like-instructions.md`](../../../spec/todo/9100-call-like-instructions.md).
+This task should reuse and cross-reference those decisions rather than duplicate them.
+
 ### Stage 1: property access and unresolved modules
 
 The first missing EDAG operation is property access:
@@ -48,7 +61,9 @@ a[b]
 ```
 
 Both forms lower to the EDAG `.` operation only when the property operand satisfies the
-canonical EDAG property-access restriction. The full EDAG rule permits:
+canonical EDAG property-access restriction from
+[`2330-property-accessor.md`](../../../spec/todo/2330-property-accessor.md). The full
+EDAG rule permits:
 
 - a permitted **string constant** (not a prohibited prototype-chain name such as
   `constructor` or `__proto__`);
@@ -202,7 +217,9 @@ Then introduce the initial non-capturing arrow-function form into the parser:
 ```
 
 The parser/compiler must reject a Stage 2 function whose body requires a captured outer
-value rather than silently sharing an outer EDAG node into the nested body.
+value rather than silently sharing an outer EDAG node into the nested body. Full frame
+semantics remain owned by
+[`3111-function-frame.md`](../../../spec/todo/3111-function-frame.md).
 
 Also introduce call operations into EDAG:
 
@@ -210,6 +227,15 @@ Also introduce call operations into EDAG:
 ['()', object, args]
 ['.()', object, property, args]
 ```
+
+The property operand of `.()` follows **the same canonical safety restriction as `.`**.
+In this stage that means a permitted string constant or number constant; prohibited
+names, runtime-computed strings, and other unsupported property expressions are
+rejected. This is the EDAG form of the method-call distinction and safety rules already
+described by
+[`2330-property-accessor.md`](../../../spec/todo/2330-property-accessor.md). The
+VM-specific lowering of these call forms is separate work in
+[`9100-call-like-instructions.md`](../../../spec/todo/9100-call-like-instructions.md).
 
 This stage is intentionally after Stage 1: property access is the minimum operation
 needed for unresolved-module parameter access, while function creation and calls extend
@@ -231,7 +257,8 @@ The staged work builds on the basic structural forms already being defined for E
   operands described above;
 - Stage 2 non-capturing functions: `['=>', ['[]'], body]`;
 - Stage 2 calls: `['()', object, args]` and
-  `['.()', object, property, args]`;
+  `['.()', object, property, args]`, with `.()` using the same property restriction as
+  `.`;
 - semantic sharing by node identity, serialized with DJS `const` references when
   needed.
 
@@ -263,8 +290,8 @@ remain outside this task unless they become necessary for the staged parser work
 
 ### Number parsing and serialization
 
-DJS must round-trip every admitted JavaScript `number` value needed by EDAG. In
-particular, the parser and serializer must explicitly support:
+DJS `.f.js` must round-trip every admitted JavaScript `number` value needed by EDAG. In
+particular, the DJS parser and serializer must explicitly support:
 
 ```text
 Infinity
@@ -273,10 +300,18 @@ NaN
 -0
 ```
 
-Do not rely on ordinary `JSON.stringify(number)` for the general DJS representation:
-it serializes non-finite values as `null` and loses the sign of `-0`. Define accepted
-DJS spellings for these four cases, make the parser map those spellings back to the
-exact numeric values, and make the serializer emit matching spellings.
+This is a **DJS-specific representation requirement**, not a decision about standard
+JSON. The standard FunctionalScript JSON codec already has its own P3 policy TODO,
+[`number-edge-cases.md`](../../media/json/todo/number-edge-cases.md), covering these
+same runtime values under the stricter requirement that output remain JSON. Do not
+resolve that TODO implicitly by changing shared JSON behavior for DJS.
+
+The current DJS serializer reuses JSON serialization primitives, so ordinary
+`JSON.stringify(number)` cannot be the DJS fallback for these values: it serializes
+non-finite values as `null` and loses the sign of `-0`. Add DJS-specific handling so
+the chosen `.f.js` spellings parse back to the exact values. If common parser/serializer
+machinery is extracted, coordinate with [`157.md`](./157.md), which already owns the
+JSON/DJS structural deduplication; codec policy remains separate.
 
 The exact tests must distinguish the edge cases semantically:
 
@@ -300,7 +335,9 @@ The final EDAG can be serialized as a FunctionalScript JavaScript artifact:
 or as JSON when the particular EDAG is representable without losing information.
 The DJS parser/serializer round-trip above is the general path. JSON output is allowed
 only when the chosen JSON representation preserves every value and all EDAG information;
-otherwise JSON output must be rejected for that EDAG.
+otherwise JSON output must be rejected for that EDAG. The standard JSON codec's own
+number policy remains defined by
+[`number-edge-cases.md`](../../media/json/todo/number-edge-cases.md).
 
 JSON must not be used when it would lose semantic graph sharing or values that the
 chosen JSON representation cannot preserve. DJS/`.f.js` remains the general
@@ -364,20 +401,26 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
       must not be shared across a function boundary, while sharing within the body is
       preserved.
 - [ ] Introduce `['()', object, args]` into EDAG.
-- [ ] Introduce `['.()', object, property, args]` into EDAG.
-- [ ] Convert the corresponding parser call expressions to the new EDAG call forms.
+- [ ] Introduce `['.()', object, property, args]` into EDAG with the same
+      property-operand validation as `.`.
+- [ ] Convert the corresponding parser call expressions to the new EDAG call forms;
+      reject prohibited or runtime-computed string properties for `.()` rather than
+      bypassing the property-access safety rule.
 - [ ] Add proofs for non-capturing nested functions and ordinary/method calls in the
-      supported Stage 2 subset.
+      supported Stage 2 subset, including accepted static/numeric `.()` properties and
+      rejection of prohibited/runtime-computed string properties.
 - [ ] Add a validation proof that reusing one operation node both outside and inside a
       nested function body is rejected.
 
 #### Shared/final
 
-- [ ] Add explicit DJS parser support for the chosen spellings of `Infinity`,
-      `-Infinity`, `NaN`, and `-0`.
-- [ ] Update the DJS number serializer to emit spellings that the parser round-trips to
-      exactly `Infinity`, `-Infinity`, `NaN`, and `-0`; do not delegate these cases to
-      ordinary `JSON.stringify` behavior.
+- [ ] Add explicit **DJS** parser support for the chosen `.f.js` spellings of
+      `Infinity`, `-Infinity`, `NaN`, and `-0`.
+- [ ] Add DJS-specific number serialization that the DJS parser round-trips to exactly
+      `Infinity`, `-Infinity`, `NaN`, and `-0`; do not change the standard JSON codec's
+      policy as a side effect of this task.
+- [ ] Coordinate any shared parser/serializer extraction with [`157.md`](./157.md)
+      instead of adding another duplicate JSON/DJS walker or numeric-policy layer.
 - [ ] Serialize the final EDAG to `.f.js`; allow JSON output only when it preserves
       the EDAG completely.
 - [ ] Preserve current missing-file, parse-error, and circular-dependency behavior.
@@ -404,11 +447,17 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
 
 - [`../transpiler/module.f.mjs`](../transpiler/module.f.mjs) — currently loads imports
   recursively before calling `run(module[1])(args)`.
-- [`../parser/module.f.mjs`](../parser/module.f.mjs) — current number parsing uses
-  `parseFloat` for number tokens and must participate in the special-number round trip.
+- [`../parser/module.f.mjs`](../parser/module.f.mjs) — DJS parser that must support the
+  chosen special-number `.f.js` spellings.
+- [`../serializer/module.f.mjs`](../serializer/module.f.mjs) — DJS serializer where
+  special-number handling belongs.
 - [`../../media/json/serializer/module.f.mjs`](../../media/json/serializer/module.f.mjs)
-  — current `numberSerialize` delegates to `JSON.stringify` and therefore needs explicit
-  handling for the special-number cases used by DJS.
+  — shared JSON serialization primitives currently reused by DJS; DJS-specific number
+  syntax must not silently change standard JSON behavior.
+- [`../../media/json/todo/number-edge-cases.md`](../../media/json/todo/number-edge-cases.md)
+  — existing owner of the standard FunctionalScript JSON policy for `-0`, `NaN`, and
+  infinities.
+- [`157.md`](./157.md) — existing JSON/DJS parser/serializer deduplication task.
 - [`../ast/types.ts`](../ast/types.ts) — current `AstModule`/`AstBody`, `aref`, `cref`,
   and plain-object representation to replace.
 - [`../ast/module.f.mjs`](../ast/module.f.mjs) — current sequential AST evaluator.
@@ -425,3 +474,11 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
   semantics and structural operations.
 - [`todo/edag-spec.md`](../../../todo/edag-spec.md) — future complete canonical EDAG
   schema.
+- [`spec/todo/2330-property-accessor.md`](../../../spec/todo/2330-property-accessor.md)
+  — property/method-access safety rules reused by `.` and `.()`.
+- [`spec/todo/3110-function.md`](../../../spec/todo/3110-function.md) — source-level
+  function support.
+- [`spec/todo/3111-function-frame.md`](../../../spec/todo/3111-function-frame.md) —
+  later captured-frame design; Stage 2 here remains non-capturing.
+- [`spec/todo/9100-call-like-instructions.md`](../../../spec/todo/9100-call-like-instructions.md)
+  — VM-internal call lowering, separate from stable EDAG call syntax.

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -72,11 +72,21 @@ rest of the compilation. The files contain the EDAG serialization, not loaded
 dependency values or the final compiled module. They are build artifacts and must
 not be source-controlled.
 
-#### 2. Load imports and execute the EDAG
+#### 2. Load imports and interpret the EDAG
 
 The loader recursively resolves and loads the module's import specifiers. After all
-required imported values are available, execute the module EDAG with those values as
+required imported values are available, evaluate the module EDAG with those values as
 its arguments, in import-source order.
+
+For this first task, evaluation is performed by a **small EDAG interpreter written in
+FunctionalScript**. Do not turn the EDAG back into JavaScript and execute it through
+the host JavaScript engine. The interpreter only needs to support the initial EDAG
+subset listed below and can grow together with the EDAG format later.
+
+The interpreter must preserve EDAG node identity. In particular, if one object or
+array constructor node is referenced from several places, it must be evaluated once
+and the same resulting object/array reused. A memo table keyed by EDAG node identity
+is sufficient for the initial interpreter.
 
 Conceptually:
 
@@ -89,7 +99,7 @@ imports
   -> recursively load values
   -> args
 
-execute(edag, args)
+interpret(edag, args)
   -> compiled module value
 ```
 
@@ -125,18 +135,22 @@ are represented by their constructors.
       sequencing with shared EDAG node identity.
 - [ ] Keep import specifiers alongside the EDAG in source order so the loader can
       construct the argument array deterministically.
+- [ ] Implement a small EDAG interpreter in FunctionalScript for the initial EDAG
+      subset; do not execute generated EDAGs as JavaScript.
+- [ ] Memoize interpreter results by EDAG node identity so shared object/array nodes
+      evaluate once and preserve reference identity in the compiled value.
 - [ ] Split the current transpiler flow into source-to-EDAG compilation and recursive
-      loading/evaluation.
+      loading/interpretation.
 - [ ] Allow compiled module EDAGs to be emitted as DJS files under `./.fjs/edag/`
       and ignore the FunctionalScript build directory in source control.
-- [ ] Execute each module EDAG only after all of its imported values have been loaded;
-      the root module's result is the final compiled value.
+- [ ] Interpret each module EDAG only after all of its imported values have been
+      loaded; the root module's result is the final compiled value.
 - [ ] Preserve current missing-file, parse-error, and circular-dependency behavior.
 - [ ] Make the source-to-EDAG result cacheable; add an initial cache if useful, with
       compiler/EDAG versioning for persistent entries.
-- [ ] Add proofs that compilation does not read imports, shared `const` values retain
-      identity, imports are passed in source order, and a multi-module program
-      produces the same final value as the current transpiler.
+- [ ] Add proofs that compilation does not read imports, the interpreter preserves
+      shared `const` identity, imports are passed in source order, and a multi-module
+      program produces the same final value as the current transpiler.
 - [ ] `npx tsc`, `fjs test`.
 
 ### Related

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -111,6 +111,22 @@ with temporary unresolved metadata:
 `x` is one shared EDAG node, so both object properties reference the same constructed
 array. DJS `const` is serialization-level sharing, not an EDAG operation.
 
+Stage 1 must also preserve the current module body's failure behavior. The current
+`run` evaluates every body entry, including a `const` whose value is not reachable from
+`export default`. For example:
+
+```js
+const check = null.x
+export default 1
+```
+
+must not silently become the successful EDAG constant `1`. Stage 1 intentionally does
+not introduce the later `','` anchoring/sequencing operation, so if source-to-
+`Unresolved` conversion would discard an otherwise-required potentially throwing body
+computation, reject that module as unsupported for this stage rather than changing its
+behavior. This restriction can be removed when the EDAG has an operation that can
+anchor such non-resulting computations.
+
 Persisting unresolved values under `.fjs/unresolved/` and using them for incremental
 compilation is deliberately a separate task; see
 [`cache-compiled-modules.md`](./cache-compiled-modules.md).
@@ -155,6 +171,17 @@ Introduce the function operation into EDAG:
 ['=>', frame, body]
 ```
 
+A nested function body is a closed EDAG. Captured values are supplied by the `frame`
+operand, and the body accesses its invocation frame through:
+
+```js
+['frame']
+['.', ['frame'], index]
+```
+
+This keeps outer-scope EDAG nodes from being shared illegally across a function
+boundary while still allowing closures such as `a => () => a` to be represented.
+
 Then introduce the initial arrow-function form into the parser:
 
 ```js
@@ -185,6 +212,8 @@ The staged work builds on the basic structural forms already being defined for E
 - array constructors: `['[]', ...node]`;
 - the argument array: `['args']`;
 - Stage 1 property access: `['.', object, property]`;
+- Stage 2 frame access: `['frame']` and property access such as
+  `['.', ['frame'], index]`;
 - Stage 2 functions: `['=>', frame, body]`;
 - Stage 2 calls: `['()', object, args]` and
   `['.()', object, property, args]`;
@@ -199,6 +228,13 @@ would introduce JavaScript `ToPropertyKey` failure cases and therefore needs exp
 semantics before validation can admit them. Plain objects have no EDAG meaning here
 and remain reserved for a future use.
 
+Object-entry descriptors such as `[':', key, value]` are structural operands of the
+object constructor, not independently evaluated EDAG nodes. Validation must therefore
+reject reusing the same descriptor-array identity in multiple entry positions; otherwise
+DJS could preserve descriptor sharing that has no semantic meaning and give equivalent
+objects different graph identities. Sharing of the descriptor's `key` and `value` EDAG
+nodes remains normal semantic EDAG sharing.
+
 Do **not** add unrelated EDAG operations in these stages: arithmetic/logical operators,
 comma, loops, `throw`, object spread, or other later operations remain outside this
 task unless they become necessary for the staged parser work above.
@@ -212,11 +248,14 @@ The final EDAG can be serialized as a FunctionalScript JavaScript artifact:
 ```
 
 or as JSON when the particular EDAG is representable without losing information.
-Serialization must preserve every observable primitive value exactly, including
-**negative zero**. In particular, serializing `-0` as `0` is not acceptable because
-`Object.is(-0, 0)` is false. The EDAG/DJS serializer must therefore emit a form that
-round-trips `-0`, and JSON output is allowed only when the JSON serializer also
-preserves that value and all other EDAG information.
+Serialization must preserve every observable primitive value exactly. For `number`,
+this explicitly includes `-0`, `NaN`, `Infinity`, and `-Infinity`; ordinary
+`JSON.stringify` spellings such as `0` for `-0` or `null` for non-finite numbers are
+not acceptable for the general DJS representation.
+
+The EDAG/DJS serializer must emit forms that round-trip those values. JSON output is
+allowed only when the chosen JSON representation preserves the value and all other
+EDAG information; otherwise JSON output must be rejected for that EDAG.
 
 JSON must not be used when it would lose semantic graph sharing or values that the
 chosen JSON representation cannot preserve. DJS/`.f.js` remains the general
@@ -243,11 +282,17 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
 - [ ] Restrict initial `[':', key, value]` object-constructor validation to
       string-constant keys; defer arbitrary computed constructor keys until their
       coercion/failure semantics are defined.
+- [ ] Treat object-entry descriptor arrays as structural/non-shareable containers;
+      reject descriptor identity reuse while retaining normal sharing of their key and
+      value EDAG nodes.
 - [ ] Change the DJS parser/AST object representation to retain an ordered entry list
       until EDAG conversion; do not collapse duplicate keys or reorder integer-like
       keys through a plain JavaScript object/`OrderedMap` representation.
 - [ ] Convert a parsed source module to `Unresolved { imports, edag }` without reading
       or resolving any imported module.
+- [ ] Do not silently drop required body evaluation. Until an anchoring/sequencing
+      operation is available, reject a Stage 1 source module if conversion would omit
+      an unreachable potentially throwing body computation.
 - [ ] Replace `['aref', i]` with `['.', ['args'], i]` and replace `cref` sequencing
       with shared EDAG node identity.
 - [ ] Resolve imported `Unresolved` values recursively and bind each resolved result
@@ -262,30 +307,40 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
 #### Stage 2
 
 - [ ] Introduce `['=>', frame, body]` into EDAG and its validation/type schema.
-- [ ] Introduce parser support for the initial `(...a) => exp` function form.
+- [ ] Introduce `['frame']` as the nested body's invocation-frame leaf and lower
+      captured-variable reads to indexed access such as `['.', ['frame'], i]`.
+- [ ] Introduce parser support for the initial `(...a) => exp` function form,
+      including construction of the capture frame for nested functions.
 - [ ] Introduce `['()', object, args]` into EDAG.
 - [ ] Introduce `['.()', object, property, args]` into EDAG.
 - [ ] Convert the corresponding parser call expressions to the new EDAG call forms.
-- [ ] Add proofs for nested functions and ordinary/method calls in the supported
-      Stage 2 subset.
+- [ ] Add proofs for nested functions with captures, including `a => () => a`, and
+      ordinary/method calls in the supported Stage 2 subset.
 
 #### Shared/final
 
 - [ ] Serialize the final EDAG to `.f.js`; allow JSON output only when it preserves
       the EDAG completely.
-- [ ] Preserve `-0` explicitly in EDAG/DJS serialization and in JSON output whenever
-      JSON output is selected.
+- [ ] Preserve `-0`, `NaN`, `Infinity`, and `-Infinity` explicitly in EDAG/DJS
+      serialization; select JSON output only when its representation round-trips them
+      and every other EDAG value exactly.
 - [ ] Preserve current missing-file, parse-error, and circular-dependency behavior.
 - [ ] Add Stage 1 proofs that `a.b` and `a[b]` produce property-access EDAGs,
       source-to-`Unresolved` compilation does not read imports, import paths and
-      parameter positions preserve source order, object-entry order survives
-      parsing/EDAG conversion, and resolving a multi-module program produces one final
-      EDAG with no unresolved module metadata.
+      parameter positions preserve source order, object-entry order **including
+      integer-like keys and duplicate keys** survives parsing/EDAG conversion,
+      non-string object-entry keys are rejected by initial validation, aliased entry
+      descriptor containers are rejected while shared key/value nodes remain valid,
+      and resolving a multi-module program produces one final EDAG with no unresolved
+      module metadata.
+- [ ] Add a Stage 1 proof that `const check = null.x; export default 1` is not silently
+      compiled to the successful constant `1`; until anchoring exists it is rejected
+      as unsupported rather than changing current evaluation behavior.
 - [ ] Add a diamond-import proof showing repeated resolution of one canonical module
       reuses the same resolved EDAG and preserves shared exported object/array identity.
 - [ ] Add serialization proofs covering `.f.js` and JSON-when-representable output,
-      including `Object.is(roundTrip(-0), -0)` and a case where JSON must not be used
-      because it would lose EDAG information.
+      including exact round trips for `-0`, `NaN`, `Infinity`, and `-Infinity`, plus a
+      case where JSON must not be used because it would lose EDAG information.
 - [ ] `npx tsc`, `fjs test`.
 
 ### Related

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -48,7 +48,10 @@ can compile conceptually to the EDAG serialized as DJS:
 const args = ['args']
 const a = ['.', args, 0]
 const x = ['[]', a, 1]
-export default { x, y: x }
+export default ['{}',
+    [':', 'x', x],
+    [':', 'y', x],
+]
 ```
 
 `x` is one shared EDAG node, so both object properties receive the same array.
@@ -140,16 +143,22 @@ Implement only the EDAG forms required by the DJS loader today:
 
 - primitive constants directly: `null`, `undefined`, boolean, number, string,
   `bigint`;
-- object constructors: `{ key: node, ... }`;
+- object constructors: `['{}', ...entry]`, where the initial entry form is
+  `[':', key, value]` and the current DJS parser supplies string keys;
 - array constructors: `['[]', ...node]`;
 - the argument array: `['args']`;
 - import-parameter access: `['.', ['args'], index]`;
 - semantic sharing by node identity, serialized with DJS `const` references when
   needed.
 
+The object constructor is an ordered operation rather than a plain EDAG object. This
+preserves source property order and leaves room for computed keys and future entry
+forms such as object spread, for example `['...', object]`. Plain objects have no
+EDAG meaning in this initial subset and remain reserved for a future use.
+
 Do **not** add the rest of EDAG yet: arbitrary property access, calls, method calls,
 operators, comma, closures/functions, `throw`, or other later operations are outside
-this task. Do not add plain object or array constant nodes; object and array literals
+this task. Do not add plain object or array constant nodes; object and array values
 are represented by their constructors.
 
 ### Tasks

--- a/fjs/djs/todo/interpret-edag.md
+++ b/fjs/djs/todo/interpret-edag.md
@@ -1,0 +1,64 @@
+## Interpret a compiled EDAG directly
+
+**Priority:** P3
+**Status:** open
+
+**Blocked by:** [`compile-modules-to-edag.md`](./compile-modules-to-edag.md)
+
+### Goal
+
+Provide a baseline FunctionalScript interpreter for a final compiled EDAG.
+
+Module compilation and module resolution produce one final EDAG. Executing that EDAG
+is a separate concern. One execution strategy is to interpret it directly; another is
+to compile it to an executable function.
+
+This TODO establishes only the basic direct-interpreter path. Deterministic time,
+memory, and hostile-depth hardening are separate work in
+[`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md).
+
+### Proposal
+
+Implement a small FunctionalScript EDAG interpreter for the EDAG forms supported by
+the compiler.
+
+Conceptually:
+
+```text
+source modules
+  -> resolve to final EDAG
+  -> validate EDAG
+  -> interpret EDAG
+  -> value
+```
+
+The interpreter must preserve EDAG node identity. If the same object/array constructor
+node is referenced more than once, evaluate it once and reuse the same resulting
+value. A memo table keyed by EDAG node identity is sufficient for the initial
+implementation.
+
+This TODO does not define resource budgets, deterministic stopped outcomes, iterative
+host-stack hardening, or production limits. Those concerns belong to the resource
+hardening TODO after the baseline interpreter exists.
+
+### Tasks
+
+- [ ] Implement a FunctionalScript interpreter for the compiler-supported EDAG subset.
+- [ ] Validate the final EDAG before interpretation.
+- [ ] Memoize results by EDAG node identity so shared constructors preserve reference
+      identity.
+- [ ] Return the interpreted value for a valid final EDAG.
+- [ ] Add proofs that primitive, array, object, import-resolved, and shared-node EDAGs
+      evaluate to the expected values.
+- [ ] Add a diamond/shared-node proof showing one shared EDAG node produces one shared
+      runtime value.
+- [ ] `npx tsc`, `fjs test`.
+
+### Related
+
+- [`compile-modules-to-edag.md`](./compile-modules-to-edag.md) — produces the final
+  EDAG this interpreter executes.
+- [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md) —
+  adds deterministic resource and host-stack hardening after this baseline exists.
+- [`associate-edag-with-functions.md`](./associate-edag-with-functions.md) — records
+  the alternative strategy of compiling EDAG to an executable function.

--- a/fjs/djs/todo/interpret-edag.md
+++ b/fjs/djs/todo/interpret-edag.md
@@ -62,6 +62,26 @@ operation-node identities shared across function boundaries; otherwise a single
 semantic node could produce different runtime values in different invocation contexts.
 Sharing within one body remains valid and is memoized per invocation.
 
+### Existing value-producing API integration
+
+The preceding P2 compiler work deliberately adds the EDAG-producing path **alongside**
+the current value-producing DJS transpiler/CLI. Once this interpreter is available,
+migrate the existing value-producing path to use EDAG internally:
+
+```text
+source modules
+  -> final EDAG
+  -> validate EDAG
+  -> interpret EDAG
+  -> exported value
+  -> existing output serialization
+```
+
+This integration must preserve the public contract. `transpile` still returns the
+module's evaluated exported value on success, and `fjs compile <input> <output>` still
+serializes that value rather than serializing the EDAG as if it were the module result.
+The separately serializable final EDAG remains a compiler artifact/API from the P2 task.
+
 This TODO does not define resource budgets, deterministic stopped outcomes, iterative
 host-stack hardening, or production limits. Those concerns belong to the resource
 hardening TODO after the baseline interpreter exists.
@@ -83,6 +103,8 @@ hardening TODO after the baseline interpreter exists.
 - [ ] Reject EDAGs that share an operation node across a function boundary; keep body
       graphs disjoint while allowing sharing inside one body.
 - [ ] Return the interpreted value for a valid final EDAG.
+- [ ] Integrate final-EDAG interpretation behind the existing value-producing DJS
+      `transpile` / `fjs compile` path without changing its success result/output.
 - [ ] Add proofs that primitive, array, object, property-access, import-resolved, and
       shared-node EDAGs evaluate to the expected values.
 - [ ] Add Stage 2 proofs for non-capturing functions, ordinary calls, and method calls.
@@ -96,12 +118,16 @@ hardening TODO after the baseline interpreter exists.
 - [ ] Add an integration proof that a multi-module program compiled/resolved to one
       final EDAG and then interpreted produces the same final value as the current DJS
       transpiler.
+- [ ] Add a CLI/API compatibility proof that the existing value-producing `transpile`
+      result and `fjs compile` output remain unchanged after switching their internals
+      to final-EDAG interpretation.
 - [ ] `npx tsc`, `fjs test`.
 
 ### Related
 
 - [`compile-modules-to-edag.md`](./compile-modules-to-edag.md) — produces the final
-  EDAG this interpreter executes.
+  EDAG this interpreter executes while keeping the old value-producing callers in
+  place until this integration lands.
 - [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md) —
   adds deterministic resource and host-stack hardening after this baseline exists.
 - [`associate-edag-with-functions.md`](./associate-edag-with-functions.md) — records

--- a/fjs/djs/todo/interpret-edag.md
+++ b/fjs/djs/todo/interpret-edag.md
@@ -20,7 +20,7 @@ memory, and hostile-depth hardening are separate work in
 ### Proposal
 
 Implement a small FunctionalScript EDAG interpreter for the EDAG forms supported by
-the compiler.
+the staged compiler work.
 
 Conceptually:
 
@@ -43,6 +43,9 @@ node is referenced more than once, evaluate it once and reuse the same resulting
 value. A memo table keyed by EDAG node identity is sufficient for the initial
 implementation.
 
+As the compiler lands the staged operators, the direct interpreter should support the
+same EDAG forms: Stage 1 adds `.` property access; Stage 2 adds `=>`, `()`, and `.()`.
+
 This TODO does not define resource budgets, deterministic stopped outcomes, iterative
 host-stack hardening, or production limits. Those concerns belong to the resource
 hardening TODO after the baseline interpreter exists.
@@ -53,11 +56,15 @@ hardening TODO after the baseline interpreter exists.
 - [ ] Validate the final EDAG before interpretation.
 - [ ] Interpret EDAG operations directly; do not generate JavaScript from EDAG and run
       it through the host JavaScript engine.
+- [ ] Support Stage 1 `['.', object, property]` property access.
+- [ ] Support Stage 2 `['=>', frame, body]`, `['()', object, args]`, and
+      `['.()', object, property, args]` when those operators land.
 - [ ] Memoize results by EDAG node identity so shared constructors preserve reference
       identity.
 - [ ] Return the interpreted value for a valid final EDAG.
-- [ ] Add proofs that primitive, array, object, import-resolved, and shared-node EDAGs
-      evaluate to the expected values.
+- [ ] Add proofs that primitive, array, object, property-access, import-resolved, and
+      shared-node EDAGs evaluate to the expected values.
+- [ ] Add Stage 2 proofs for functions, ordinary calls, and method calls.
 - [ ] Add a diamond/shared-node proof showing one shared EDAG node produces one shared
       runtime value.
 - [ ] Add an integration proof that a multi-module program compiled/resolved to one

--- a/fjs/djs/todo/interpret-edag.md
+++ b/fjs/djs/todo/interpret-edag.md
@@ -32,6 +32,12 @@ source modules
   -> value
 ```
 
+Interpret the EDAG directly. Do **not** serialize or translate the EDAG back to
+JavaScript and execute that generated JavaScript through the host engine; that would
+make this an indirect code-generation path rather than an EDAG interpreter. Compiling
+EDAG to an executable function is a separate strategy and can be developed
+independently.
+
 The interpreter must preserve EDAG node identity. If the same object/array constructor
 node is referenced more than once, evaluate it once and reuse the same resulting
 value. A memo table keyed by EDAG node identity is sufficient for the initial
@@ -45,6 +51,8 @@ hardening TODO after the baseline interpreter exists.
 
 - [ ] Implement a FunctionalScript interpreter for the compiler-supported EDAG subset.
 - [ ] Validate the final EDAG before interpretation.
+- [ ] Interpret EDAG operations directly; do not generate JavaScript from EDAG and run
+      it through the host JavaScript engine.
 - [ ] Memoize results by EDAG node identity so shared constructors preserve reference
       identity.
 - [ ] Return the interpreted value for a valid final EDAG.
@@ -52,6 +60,9 @@ hardening TODO after the baseline interpreter exists.
       evaluate to the expected values.
 - [ ] Add a diamond/shared-node proof showing one shared EDAG node produces one shared
       runtime value.
+- [ ] Add an integration proof that a multi-module program compiled/resolved to one
+      final EDAG and then interpreted produces the same final value as the current DJS
+      transpiler.
 - [ ] `npx tsc`, `fjs test`.
 
 ### Related

--- a/fjs/djs/todo/interpret-edag.md
+++ b/fjs/djs/todo/interpret-edag.md
@@ -38,13 +38,25 @@ make this an indirect code-generation path rather than an EDAG interpreter. Comp
 EDAG to an executable function is a separate strategy and can be developed
 independently.
 
-The interpreter must preserve EDAG node identity. If the same object/array constructor
-node is referenced more than once, evaluate it once and reuse the same resulting
-value. A memo table keyed by EDAG node identity is sufficient for the initial
-implementation.
+The interpreter must preserve EDAG node identity. Within one evaluation context, if
+the same object/array constructor node is referenced more than once, evaluate it once
+and reuse the same resulting value.
+
+Function bodies require a narrower memoization scope. Each function invocation has its
+own arguments/frame and therefore its own memo table for body nodes. Do **not** reuse a
+memoized body result from one invocation in another merely because the EDAG node
+identity is the same. For example, two calls to `x => [x]` with `1` and `2` must not
+reuse the first call's `[1]`. Sharing of a body node remains memoized within each
+individual invocation.
 
 As the compiler lands the staged operators, the direct interpreter should support the
-same EDAG forms: Stage 1 adds `.` property access; Stage 2 adds `=>`, `()`, and `.()`.
+same EDAG forms: Stage 1 adds `.` property access; Stage 2 adds `frame`, `=>`, `()`, and
+`.()`.
+
+For Stage 2, evaluating `['=>', frame, body]` establishes the captured frame for the
+new function. When that function is invoked, `['frame']` evaluates to that invocation's
+captured frame, and indexed property access such as `['.', ['frame'], i]` reads a
+captured value. The nested body's memoization context belongs to that invocation.
 
 This TODO does not define resource budgets, deterministic stopped outcomes, iterative
 host-stack hardening, or production limits. Those concerns belong to the resource
@@ -57,16 +69,22 @@ hardening TODO after the baseline interpreter exists.
 - [ ] Interpret EDAG operations directly; do not generate JavaScript from EDAG and run
       it through the host JavaScript engine.
 - [ ] Support Stage 1 `['.', object, property]` property access.
-- [ ] Support Stage 2 `['=>', frame, body]`, `['()', object, args]`, and
+- [ ] Support Stage 2 `['frame']`, `['=>', frame, body]`, `['()', object, args]`, and
       `['.()', object, property, args]` when those operators land.
-- [ ] Memoize results by EDAG node identity so shared constructors preserve reference
-      identity.
+- [ ] Memoize results by EDAG node identity within one evaluation context so shared
+      constructors preserve reference identity.
+- [ ] Start a fresh body-node memoization context for every function invocation; do
+      not reuse memoized body results across different argument/frame contexts.
 - [ ] Return the interpreted value for a valid final EDAG.
 - [ ] Add proofs that primitive, array, object, property-access, import-resolved, and
       shared-node EDAGs evaluate to the expected values.
-- [ ] Add Stage 2 proofs for functions, ordinary calls, and method calls.
+- [ ] Add Stage 2 proofs for functions, captured-frame access, ordinary calls, and
+      method calls.
+- [ ] Add an invocation-scope proof such as calling `x => [x]` with `1` and `2`:
+      results contain the corresponding argument and do not reuse the constructed
+      array across calls, while repeated references inside one call still share.
 - [ ] Add a diamond/shared-node proof showing one shared EDAG node produces one shared
-      runtime value.
+      runtime value within the relevant evaluation context.
 - [ ] Add an integration proof that a multi-module program compiled/resolved to one
       final EDAG and then interpreted produces the same final value as the current DJS
       transpiler.

--- a/fjs/djs/todo/interpret-edag.md
+++ b/fjs/djs/todo/interpret-edag.md
@@ -43,20 +43,24 @@ the same object/array constructor node is referenced more than once, evaluate it
 and reuse the same resulting value.
 
 Function bodies require a narrower memoization scope. Each function invocation has its
-own arguments/frame and therefore its own memo table for body nodes. Do **not** reuse a
+own arguments and therefore its own memo table for body nodes. Do **not** reuse a
 memoized body result from one invocation in another merely because the EDAG node
 identity is the same. For example, two calls to `x => [x]` with `1` and `2` must not
 reuse the first call's `[1]`. Sharing of a body node remains memoized within each
 individual invocation.
 
 As the compiler lands the staged operators, the direct interpreter should support the
-same EDAG forms: Stage 1 adds `.` property access; Stage 2 adds `frame`, `=>`, `()`, and
-`.()`.
+same EDAG forms: Stage 1 adds `.` property access; Stage 2 adds non-capturing `=>`, `()`,
+and `.()`.
 
-For Stage 2, evaluating `['=>', frame, body]` establishes the captured frame for the
-new function. When that function is invoked, `['frame']` evaluates to that invocation's
-captured frame, and indexed property access such as `['.', ['frame'], i]` reads a
-captured value. The nested body's memoization context belongs to that invocation.
+Stage 2 deliberately has **no frame support**. `['=>', frame, body]` is accepted only
+with the canonical empty frame `['[]']`; `['frame']` is not part of the Stage 2
+interpreter subset. Captured closures are deferred to later work.
+
+A function body is a separate EDAG scope. Validation before interpretation must reject
+operation-node identities shared across function boundaries; otherwise a single
+semantic node could produce different runtime values in different invocation contexts.
+Sharing within one body remains valid and is memoized per invocation.
 
 This TODO does not define resource budgets, deterministic stopped outcomes, iterative
 host-stack hardening, or production limits. Those concerns belong to the resource
@@ -69,20 +73,24 @@ hardening TODO after the baseline interpreter exists.
 - [ ] Interpret EDAG operations directly; do not generate JavaScript from EDAG and run
       it through the host JavaScript engine.
 - [ ] Support Stage 1 `['.', object, property]` property access.
-- [ ] Support Stage 2 `['frame']`, `['=>', frame, body]`, `['()', object, args]`, and
+- [ ] Support Stage 2 `['=>', ['[]'], body]`, `['()', object, args]`, and
       `['.()', object, property, args]` when those operators land.
+- [ ] Do **not** implement `['frame']` or non-empty closure frames in Stage 2.
 - [ ] Memoize results by EDAG node identity within one evaluation context so shared
       constructors preserve reference identity.
 - [ ] Start a fresh body-node memoization context for every function invocation; do
-      not reuse memoized body results across different argument/frame contexts.
+      not reuse memoized body results across different argument contexts.
+- [ ] Reject EDAGs that share an operation node across a function boundary; keep body
+      graphs disjoint while allowing sharing inside one body.
 - [ ] Return the interpreted value for a valid final EDAG.
 - [ ] Add proofs that primitive, array, object, property-access, import-resolved, and
       shared-node EDAGs evaluate to the expected values.
-- [ ] Add Stage 2 proofs for functions, captured-frame access, ordinary calls, and
-      method calls.
+- [ ] Add Stage 2 proofs for non-capturing functions, ordinary calls, and method calls.
 - [ ] Add an invocation-scope proof such as calling `x => [x]` with `1` and `2`:
       results contain the corresponding argument and do not reuse the constructed
       array across calls, while repeated references inside one call still share.
+- [ ] Add a validation proof that an operation node reused both outside and inside a
+      function body is rejected.
 - [ ] Add a diamond/shared-node proof showing one shared EDAG node produces one shared
       runtime value within the relevant evaluation context.
 - [ ] Add an integration proof that a multi-module program compiled/resolved to one
@@ -97,4 +105,5 @@ hardening TODO after the baseline interpreter exists.
 - [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resources.md) —
   adds deterministic resource and host-stack hardening after this baseline exists.
 - [`associate-edag-with-functions.md`](./associate-edag-with-functions.md) — records
-  the alternative strategy of compiling EDAG to an executable function.
+  the alternative strategy of compiling EDAG to an executable function and its later
+  open questions around nested functions/frames.

--- a/fjs/djs/todo/investigate-edag-source-maps.md
+++ b/fjs/djs/todo/investigate-edag-source-maps.md
@@ -56,15 +56,16 @@ Questions to answer:
    map itself must not participate in EDAG identity/hash.
 
 5. **Where should source-map artifacts live?**
-   Coordinate with the final EDAG output, not the temporary module cache. A final
-   `<name>.f.js` could use an adjacent `<name>.f.js.map`, or source maps could live in
-   a separate FunctionalScript-owned directory such as `./.fjs/source-map/`.
+   Coordinate with the final EDAG output, not the temporary unresolved-module cache.
+   A final `<name>.f.js` could use an adjacent `<name>.f.js.map`, or source maps could
+   live in a separate FunctionalScript-owned directory such as
+   `./.fjs/source-map/`.
 
-   The existing `./.fjs/modules/{hash}.f.js` path is a cache of temporary
+   The existing `./.fjs/unresolved/{hash}.f.js` path is a cache of temporary
    `Module { imports, edag }` values, not a directory of final EDAG artifacts, so it
    should not be treated as the final source-map location.
 
-6. **How should source maps interact with the module cache?**
+6. **How should source maps interact with the unresolved-module cache?**
    The source-to-`Module` cache can skip parsing and therefore does not automatically
    reconstruct source ranges. Until a compatible cached per-module source-map artifact
    is designed, compilation that requests source maps should bypass that cache and
@@ -96,7 +97,7 @@ Questions to answer:
 - [ ] Decide whether source-map sidecars are adjacent to final `.f.js` output or live
       under a separate FunctionalScript build directory.
 - [ ] Investigate a compatible per-module source-map cache; until then, require source-
-      map-enabled builds to bypass the `.fjs/modules/{hash}.f.js` cache.
+      map-enabled builds to bypass the `.fjs/unresolved/{hash}.f.js` cache.
 - [ ] Add a small example showing source modules -> final EDAG DJS -> separate source
       map -> recovered original location for an EDAG node.
 - [ ] Add a warm-vs-cold build proof showing source mappings are equivalent once cache
@@ -109,8 +110,8 @@ Questions to answer:
 - [`compile-modules-to-edag.md`](./compile-modules-to-edag.md) — resolves source
   modules into one final EDAG and serializes it to `.f.js` or JSON when representable.
 - [`cache-compiled-modules.md`](./cache-compiled-modules.md) — caches temporary
-  `Module { imports, edag }` values and currently bypasses that cache when source maps
-  are requested.
+  `Module { imports, edag }` values under `.fjs/unresolved/` and currently bypasses
+  that cache when source maps are requested.
 - [`../../../todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)
   — EDAG sharing and node-identity semantics.
 - [`../../../todo/edag-spec.md`](../../../todo/edag-spec.md) — future canonical EDAG

--- a/fjs/djs/todo/investigate-edag-source-maps.md
+++ b/fjs/djs/todo/investigate-edag-source-maps.md
@@ -1,0 +1,100 @@
+## Investigate EDAG source maps
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+When a FunctionalScript module is compiled to EDAG, debugging and diagnostics need
+to relate EDAG nodes back to the original source locations.
+
+The source metadata must **not** be embedded into the EDAG itself. EDAG is the
+canonical computation representation: adding file names, line/column ranges, node
+IDs, or other debug metadata would change its serialized form and therefore its
+identity/hash even though the computation is unchanged.
+
+The source map therefore has to be a separate artifact associated with the EDAG.
+The difficult part is identifying EDAG nodes from that sidecar metadata without
+changing the EDAG representation.
+
+EDAG sharing makes this more subtle than mapping an ordinary syntax tree:
+
+- two references to the same EDAG node are semantically shared;
+- two structurally equal but independently constructed nodes are semantically
+  distinct;
+- one shared node may be reachable through several graph paths;
+- a source location may describe either the expression that created a node or a
+  particular source reference to an already shared value.
+
+A source-map scheme must preserve these distinctions.
+
+### Investigation
+
+Investigate a separate source-map representation for compiled EDAGs.
+
+Questions to answer:
+
+1. **How should a sidecar source map identify an EDAG node?**
+   Possible approaches include a deterministic node ordinal derived while
+   serializing the DAG, a location in the canonical DJS serialization, or another
+   identifier derivable from the EDAG without storing metadata inside it.
+
+2. **Can the standard JavaScript Source Map format be reused?**
+   Since compiled EDAGs may be emitted as DJS files, a normal source map could map
+   positions in that generated DJS text back to the source module. Determine whether
+   mapping each uniquely serialized/shared EDAG node by its generated DJS position
+   is sufficient, or whether graph-specific metadata is required.
+
+3. **How should sharing and references be represented?**
+   A DJS serialization can emit a shared EDAG node once as a `const` and refer to it
+   elsewhere. Determine whether the source map should map only the defining node,
+   each reference occurrence, or both.
+
+4. **How stable does the mapping need to be?**
+   Determine whether source metadata is valid only for one exact serialized EDAG
+   artifact or whether it should survive deterministic reserialization. The source
+   map itself must not participate in EDAG identity/hash.
+
+5. **Where should source-map artifacts live?**
+   Coordinate with the module-to-EDAG compilation task: if EDAGs are emitted under
+   `./.fjs/edag/`, consider adjacent sidecars such as `*.map` or a separate
+   `./.fjs/source-map/` directory. These are temporary compiler artifacts and are
+   not source-controlled.
+
+6. **What metadata is required initially?**
+   Start with the minimum needed for diagnostics: source file and source range
+   (line/column or byte/UTF-16 offsets). Names, scopes, comments, and richer debugger
+   information can be deferred.
+
+### Constraints
+
+- Do not add source locations, generated node IDs, or debugging fields to EDAG nodes.
+- Do not make source metadata part of EDAG serialization or content identity.
+- Preserve semantic sharing: structurally equal but distinct nodes must not collapse
+  to one source-map entry merely because their contents are equal.
+- The design should work with EDAG serialized as DJS and should remain extensible as
+  the EDAG operation set grows.
+
+### Tasks
+
+- [ ] Prototype mapping a compiled module EDAG to a separate source-map artifact.
+- [ ] Evaluate standard Source Map v3 against the DJS serialization approach.
+- [ ] Define how shared EDAG nodes and reference occurrences map to source ranges.
+- [ ] Determine a stable external node-addressing scheme that requires no metadata in
+      EDAG nodes.
+- [ ] Decide the sidecar file format, naming, and placement under the FunctionalScript
+      temporary build directory.
+- [ ] Add a small example showing source module -> EDAG DJS -> separate source map ->
+      recovered original location for an EDAG node.
+- [ ] Record the chosen design in the relevant compiler/EDAG documentation before
+      implementing full debugger/source-map support.
+
+### Related
+
+- [`compile-modules-to-edag.md`](./compile-modules-to-edag.md) — compiles modules to
+  cacheable EDAGs before loading imports and may emit those EDAGs as DJS build
+  artifacts.
+- [`../../../todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)
+  — EDAG sharing and node-identity semantics.
+- [`../../../todo/edag-spec.md`](../../../todo/edag-spec.md) — future canonical EDAG
+  schema; source metadata must stay outside that canonical value.

--- a/fjs/djs/todo/investigate-edag-source-maps.md
+++ b/fjs/djs/todo/investigate-edag-source-maps.md
@@ -32,30 +32,66 @@ A source-map scheme must preserve these distinctions.
 
 Investigate a separate source-map representation for compiled EDAGs.
 
+#### Candidate: EDAG array paths
+
+Because EDAG operations are represented as arrays, traversal can naturally maintain a
+path from the EDAG root using array indexes. For example:
+
+```js
+[1, 3, 5]
+```
+
+means: take element `1` of the root array, then element `3`, then element `5`.
+Conceptually this is similar to a JSON path specialized to the EDAG representation.
+
+A source map could use such paths as indexes into source metadata. An interpreter,
+validator, serializer, or other EDAG traversal already knows which child it is visiting,
+so it can carry the current path in parallel with traversal without adding metadata to
+the EDAG itself.
+
+This raises an important sharing question rather than resolving it: in a DAG, one
+shared node may be reachable through multiple paths. A path therefore naturally
+identifies a traversal occurrence/reference from the root, not necessarily a unique
+node identity. The source-map design must decide how paths for shared definitions and
+shared references relate to each other.
+
+EDAG transformations also need source-map composition. If compilation/linking combines
+several EDAGs or constructs a new EDAG from existing EDAGs, the corresponding source
+map may need to be constructed/transformed **in parallel** so its paths describe the
+new EDAG. Do not assume a source map for an input EDAG remains valid after the EDAG is
+embedded, reordered, or otherwise transformed.
+
 Questions to answer:
 
-1. **How should a sidecar source map identify an EDAG node?**
-   Possible approaches include a deterministic node ordinal derived while
-   serializing the DAG, a location in the canonical DJS serialization, or another
-   identifier derivable from the EDAG without storing metadata inside it.
+1. **Can EDAG array paths be the primary source-map index?**
+   Investigate paths such as `[1, 3, 5]` as the simplest external addressing scheme.
+   Determine whether they are sufficient for diagnostics, execution/traversal, DJS
+   serialization, and shared-node references.
 
-2. **Can the standard JavaScript Source Map format be reused?**
+2. **How should sharing and multiple paths be represented?**
+   The same EDAG node can be reachable through more than one path. Determine whether
+   mappings are attached to occurrences/paths, whether one path is treated specially
+   as the defining occurrence, or whether additional graph-specific information is
+   required.
+
+3. **How should source maps be transformed when EDAGs are combined?**
+   Module resolution and later EDAG transformations can create a new EDAG from one or
+   more existing EDAGs. Determine how the new EDAG and its new source map are produced
+   together so every retained/moved/new node occurrence receives the appropriate new
+   path and source provenance.
+
+4. **Can the standard JavaScript Source Map format be reused?**
    Since final EDAGs may be serialized as `.f.js`, a normal source map could map
    positions in that generated DJS text back to the source modules. Determine whether
-   mapping each uniquely serialized/shared EDAG node by its generated DJS position
-   is sufficient, or whether graph-specific metadata is required.
+   EDAG-path mappings can be converted to Source Map v3 during serialization, or
+   whether graph-specific metadata is required in addition to a standard source map.
 
-3. **How should sharing and references be represented?**
-   A DJS serialization can emit a shared EDAG node once as a `const` and refer to it
-   elsewhere. Determine whether the source map should map only the defining node,
-   each reference occurrence, or both.
+5. **How stable does the mapping need to be?**
+   Determine whether source metadata is valid only for one exact EDAG structure or
+   serialized artifact, or whether some mapping can survive deterministic
+   reserialization. The source map itself must not participate in EDAG identity/hash.
 
-4. **How stable does the mapping need to be?**
-   Determine whether source metadata is valid only for one exact serialized EDAG
-   artifact or whether it should survive deterministic reserialization. The source
-   map itself must not participate in EDAG identity/hash.
-
-5. **Where should source-map artifacts live?**
+6. **Where should source-map artifacts live?**
    Coordinate with the final EDAG output, not the temporary unresolved cache. A final
    `<name>.f.js` could use an adjacent `<name>.f.js.map`, or source maps could live in
    a separate FunctionalScript-owned directory such as
@@ -65,14 +101,14 @@ Questions to answer:
    `Unresolved { imports, edag }` values, not a directory of final EDAG artifacts, so
    it should not be treated as the final source-map location.
 
-6. **How should source maps interact with the unresolved cache?**
+7. **How should source maps interact with the unresolved cache?**
    The source-to-`Unresolved` cache can skip parsing and therefore does not
    automatically reconstruct source ranges. Until a compatible cached source-map
    artifact is designed, compilation that requests source maps should bypass that
    cache and parse the source normally. Investigate whether an `Unresolved` mapping
    sidecar can later make warm and cold builds produce equivalent source mappings.
 
-7. **What metadata is required initially?**
+8. **What metadata is required initially?**
    Start with the minimum needed for diagnostics: source file and source range
    (line/column or byte/UTF-16 offsets). Names, scopes, comments, and richer debugger
    information can be deferred.
@@ -83,23 +119,30 @@ Questions to answer:
 - Do not make source metadata part of EDAG serialization or content identity.
 - Preserve semantic sharing: structurally equal but distinct nodes must not collapse
   to one source-map entry merely because their contents are equal.
+- Treat an EDAG path as an external structural/traversal address; do not assume it is
+  an intrinsic identity for a shared DAG node.
+- When an operation constructs or combines EDAGs, keep source-map transformation in
+  step with the EDAG transformation rather than reusing stale paths.
 - Warm builds must not silently lose source-map information compared with cold builds.
 - The design should work with EDAG serialized as DJS and should remain extensible as
   the EDAG operation set grows.
 
 ### Tasks
 
-- [ ] Prototype mapping a compiled final EDAG to a separate source-map artifact.
-- [ ] Evaluate standard Source Map v3 against the final `.f.js` DJS serialization.
-- [ ] Define how shared EDAG nodes and reference occurrences map to source ranges.
-- [ ] Determine a stable external node-addressing scheme that requires no metadata in
-      EDAG nodes.
+- [ ] Prototype an EDAG source map indexed by array paths such as `[1, 3, 5]`.
+- [ ] Carry the current EDAG path during a simple traversal and recover source metadata
+      for the visited occurrence.
+- [ ] Define how shared EDAG nodes and multiple reference paths map to source ranges.
+- [ ] Prototype combining/transforming EDAGs while constructing the corresponding new
+      source map in parallel.
+- [ ] Evaluate standard Source Map v3 against EDAG-path mappings and the final `.f.js`
+      DJS serialization.
 - [ ] Decide whether source-map sidecars are adjacent to final `.f.js` output or live
       under a separate FunctionalScript build directory.
 - [ ] Investigate a compatible source-map cache for `Unresolved`; until then, require
       source-map-enabled builds to bypass the `.fjs/unresolved/{hash}.f.js` cache.
-- [ ] Add a small example showing source modules -> final EDAG DJS -> separate source
-      map -> recovered original location for an EDAG node.
+- [ ] Add a small example showing source modules -> EDAG + path-indexed source map ->
+      transformed/combined EDAG + transformed source map -> final EDAG DJS.
 - [ ] Add a warm-vs-cold build proof showing source mappings are equivalent once cache
       reuse for source-map-enabled builds is supported.
 - [ ] Record the chosen design in the relevant compiler/EDAG documentation before

--- a/fjs/djs/todo/investigate-edag-source-maps.md
+++ b/fjs/djs/todo/investigate-edag-source-maps.md
@@ -40,8 +40,8 @@ Questions to answer:
    identifier derivable from the EDAG without storing metadata inside it.
 
 2. **Can the standard JavaScript Source Map format be reused?**
-   Since compiled EDAGs may be emitted as DJS files, a normal source map could map
-   positions in that generated DJS text back to the source module. Determine whether
+   Since final EDAGs may be serialized as `.f.js`, a normal source map could map
+   positions in that generated DJS text back to the source modules. Determine whether
    mapping each uniquely serialized/shared EDAG node by its generated DJS position
    is sufficient, or whether graph-specific metadata is required.
 
@@ -56,12 +56,22 @@ Questions to answer:
    map itself must not participate in EDAG identity/hash.
 
 5. **Where should source-map artifacts live?**
-   Coordinate with the module-to-EDAG compilation task: if EDAGs are emitted under
-   `./.fjs/edag/`, consider adjacent sidecars such as `*.map` or a separate
-   `./.fjs/source-map/` directory. These are temporary compiler artifacts and are
-   not source-controlled.
+   Coordinate with the final EDAG output, not the temporary module cache. A final
+   `<name>.f.js` could use an adjacent `<name>.f.js.map`, or source maps could live in
+   a separate FunctionalScript-owned directory such as `./.fjs/source-map/`.
 
-6. **What metadata is required initially?**
+   The existing `./.fjs/modules/{hash}.f.js` path is a cache of temporary
+   `Module { imports, edag }` values, not a directory of final EDAG artifacts, so it
+   should not be treated as the final source-map location.
+
+6. **How should source maps interact with the module cache?**
+   The source-to-`Module` cache can skip parsing and therefore does not automatically
+   reconstruct source ranges. Until a compatible cached per-module source-map artifact
+   is designed, compilation that requests source maps should bypass that cache and
+   parse the source normally. Investigate whether a per-module mapping sidecar can
+   later make warm and cold builds produce equivalent source mappings.
+
+7. **What metadata is required initially?**
    Start with the minimum needed for diagnostics: source file and source range
    (line/column or byte/UTF-16 offsets). Names, scopes, comments, and richer debugger
    information can be deferred.
@@ -72,28 +82,35 @@ Questions to answer:
 - Do not make source metadata part of EDAG serialization or content identity.
 - Preserve semantic sharing: structurally equal but distinct nodes must not collapse
   to one source-map entry merely because their contents are equal.
+- Warm builds must not silently lose source-map information compared with cold builds.
 - The design should work with EDAG serialized as DJS and should remain extensible as
   the EDAG operation set grows.
 
 ### Tasks
 
-- [ ] Prototype mapping a compiled module EDAG to a separate source-map artifact.
-- [ ] Evaluate standard Source Map v3 against the DJS serialization approach.
+- [ ] Prototype mapping a compiled final EDAG to a separate source-map artifact.
+- [ ] Evaluate standard Source Map v3 against the final `.f.js` DJS serialization.
 - [ ] Define how shared EDAG nodes and reference occurrences map to source ranges.
 - [ ] Determine a stable external node-addressing scheme that requires no metadata in
       EDAG nodes.
-- [ ] Decide the sidecar file format, naming, and placement under the FunctionalScript
-      temporary build directory.
-- [ ] Add a small example showing source module -> EDAG DJS -> separate source map ->
-      recovered original location for an EDAG node.
+- [ ] Decide whether source-map sidecars are adjacent to final `.f.js` output or live
+      under a separate FunctionalScript build directory.
+- [ ] Investigate a compatible per-module source-map cache; until then, require source-
+      map-enabled builds to bypass the `.fjs/modules/{hash}.f.js` cache.
+- [ ] Add a small example showing source modules -> final EDAG DJS -> separate source
+      map -> recovered original location for an EDAG node.
+- [ ] Add a warm-vs-cold build proof showing source mappings are equivalent once cache
+      reuse for source-map-enabled builds is supported.
 - [ ] Record the chosen design in the relevant compiler/EDAG documentation before
       implementing full debugger/source-map support.
 
 ### Related
 
-- [`compile-modules-to-edag.md`](./compile-modules-to-edag.md) — compiles modules to
-  cacheable EDAGs before loading imports and may emit those EDAGs as DJS build
-  artifacts.
+- [`compile-modules-to-edag.md`](./compile-modules-to-edag.md) — resolves source
+  modules into one final EDAG and serializes it to `.f.js` or JSON when representable.
+- [`cache-compiled-modules.md`](./cache-compiled-modules.md) — caches temporary
+  `Module { imports, edag }` values and currently bypasses that cache when source maps
+  are requested.
 - [`../../../todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)
   — EDAG sharing and node-identity semantics.
 - [`../../../todo/edag-spec.md`](../../../todo/edag-spec.md) — future canonical EDAG

--- a/fjs/djs/todo/investigate-edag-source-maps.md
+++ b/fjs/djs/todo/investigate-edag-source-maps.md
@@ -69,7 +69,7 @@ Questions to answer:
    The source-to-`Unresolved` cache can skip parsing and therefore does not
    automatically reconstruct source ranges. Until a compatible cached source-map
    artifact is designed, compilation that requests source maps should bypass that
-   cache and parse the source normally. Investigate whether a per-unresolved mapping
+   cache and parse the source normally. Investigate whether an `Unresolved` mapping
    sidecar can later make warm and cold builds produce equivalent source mappings.
 
 7. **What metadata is required initially?**

--- a/fjs/djs/todo/investigate-edag-source-maps.md
+++ b/fjs/djs/todo/investigate-edag-source-maps.md
@@ -56,21 +56,21 @@ Questions to answer:
    map itself must not participate in EDAG identity/hash.
 
 5. **Where should source-map artifacts live?**
-   Coordinate with the final EDAG output, not the temporary unresolved-module cache.
-   A final `<name>.f.js` could use an adjacent `<name>.f.js.map`, or source maps could
-   live in a separate FunctionalScript-owned directory such as
+   Coordinate with the final EDAG output, not the temporary unresolved cache. A final
+   `<name>.f.js` could use an adjacent `<name>.f.js.map`, or source maps could live in
+   a separate FunctionalScript-owned directory such as
    `./.fjs/source-map/`.
 
    The existing `./.fjs/unresolved/{hash}.f.js` path is a cache of temporary
-   `Module { imports, edag }` values, not a directory of final EDAG artifacts, so it
-   should not be treated as the final source-map location.
+   `Unresolved { imports, edag }` values, not a directory of final EDAG artifacts, so
+   it should not be treated as the final source-map location.
 
-6. **How should source maps interact with the unresolved-module cache?**
-   The source-to-`Module` cache can skip parsing and therefore does not automatically
-   reconstruct source ranges. Until a compatible cached per-module source-map artifact
-   is designed, compilation that requests source maps should bypass that cache and
-   parse the source normally. Investigate whether a per-module mapping sidecar can
-   later make warm and cold builds produce equivalent source mappings.
+6. **How should source maps interact with the unresolved cache?**
+   The source-to-`Unresolved` cache can skip parsing and therefore does not
+   automatically reconstruct source ranges. Until a compatible cached source-map
+   artifact is designed, compilation that requests source maps should bypass that
+   cache and parse the source normally. Investigate whether a per-unresolved mapping
+   sidecar can later make warm and cold builds produce equivalent source mappings.
 
 7. **What metadata is required initially?**
    Start with the minimum needed for diagnostics: source file and source range
@@ -96,8 +96,8 @@ Questions to answer:
       EDAG nodes.
 - [ ] Decide whether source-map sidecars are adjacent to final `.f.js` output or live
       under a separate FunctionalScript build directory.
-- [ ] Investigate a compatible per-module source-map cache; until then, require source-
-      map-enabled builds to bypass the `.fjs/unresolved/{hash}.f.js` cache.
+- [ ] Investigate a compatible source-map cache for `Unresolved`; until then, require
+      source-map-enabled builds to bypass the `.fjs/unresolved/{hash}.f.js` cache.
 - [ ] Add a small example showing source modules -> final EDAG DJS -> separate source
       map -> recovered original location for an EDAG node.
 - [ ] Add a warm-vs-cold build proof showing source mappings are equivalent once cache
@@ -110,7 +110,7 @@ Questions to answer:
 - [`compile-modules-to-edag.md`](./compile-modules-to-edag.md) — resolves source
   modules into one final EDAG and serializes it to `.f.js` or JSON when representable.
 - [`cache-compiled-modules.md`](./cache-compiled-modules.md) — caches temporary
-  `Module { imports, edag }` values under `.fjs/unresolved/` and currently bypasses
+  `Unresolved { imports, edag }` values under `.fjs/unresolved/` and currently bypasses
   that cache when source maps are requested.
 - [`../../../todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)
   — EDAG sharing and node-identity semantics.

--- a/fjs/djs/todo/investigate-edag-source-maps.md
+++ b/fjs/djs/todo/investigate-edag-source-maps.md
@@ -49,17 +49,37 @@ validator, serializer, or other EDAG traversal already knows which child it is v
 so it can carry the current path in parallel with traversal without adding metadata to
 the EDAG itself.
 
-This raises an important sharing question rather than resolving it: in a DAG, one
-shared node may be reachable through multiple paths. A path therefore naturally
-identifies a traversal occurrence/reference from the root, not necessarily a unique
-node identity. The source-map design must decide how paths for shared definitions and
-shared references relate to each other.
+A path naturally identifies a traversal occurrence/reference from the root. For shared
+nodes, use a flattened index representation as a candidate way to avoid duplicating the
+same source-map payload. Conceptually, a flattened source-map entry can either contain
+the source metadata value or point to another entry index whose value should be used.
+Thus several EDAG paths that reach one shared node can converge on one source-map value
+through index references rather than repeating that value.
+
+For example, the representation might conceptually have the shape:
+
+```text
+path -> entry index
+
+entry -> source value
+      | reference to another entry index
+```
+
+The exact encoding is intentionally open. In particular, decide later whether
+references must point directly to a value-bearing entry, whether reference chains are
+allowed, and which occurrence becomes the value-bearing/canonical entry.
+
+This flattened-reference idea does not make paths into intrinsic node IDs. Paths still
+identify occurrences in a particular EDAG structure; the index references are an
+external source-map mechanism for expressing that several occurrences correspond to a
+shared node/source mapping.
 
 EDAG transformations also need source-map composition. If compilation/linking combines
 several EDAGs or constructs a new EDAG from existing EDAGs, the corresponding source
 map may need to be constructed/transformed **in parallel** so its paths describe the
-new EDAG. Do not assume a source map for an input EDAG remains valid after the EDAG is
-embedded, reordered, or otherwise transformed.
+new EDAG. A flattened representation would likewise need its entry indexes/references
+rebuilt or remapped for the new EDAG. Do not assume a source map for an input EDAG
+remains valid after the EDAG is embedded, reordered, or otherwise transformed.
 
 Questions to answer:
 
@@ -68,30 +88,36 @@ Questions to answer:
    Determine whether they are sufficient for diagnostics, execution/traversal, DJS
    serialization, and shared-node references.
 
-2. **How should sharing and multiple paths be represented?**
-   The same EDAG node can be reachable through more than one path. Determine whether
-   mappings are attached to occurrences/paths, whether one path is treated specially
-   as the defining occurrence, or whether additional graph-specific information is
-   required.
+2. **Can shared mappings use flattened index references?**
+   Investigate a flattened source-map table where a path resolves to an entry and an
+   entry either contains source metadata or redirects to another entry index. Determine
+   whether this represents shared EDAG nodes compactly and unambiguously without
+   duplicating source metadata.
 
-3. **How should source maps be transformed when EDAGs are combined?**
+3. **How should defining and reference occurrences differ?**
+   The same EDAG node can be reachable through more than one path. Determine which
+   occurrence, if any, stores the source value directly and how other paths point to
+   it. Keep open whether reference chains are useful or should be normalized to direct
+   references.
+
+4. **How should source maps be transformed when EDAGs are combined?**
    Module resolution and later EDAG transformations can create a new EDAG from one or
    more existing EDAGs. Determine how the new EDAG and its new source map are produced
    together so every retained/moved/new node occurrence receives the appropriate new
-   path and source provenance.
+   path and source provenance, and flattened references are remapped consistently.
 
-4. **Can the standard JavaScript Source Map format be reused?**
+5. **Can the standard JavaScript Source Map format be reused?**
    Since final EDAGs may be serialized as `.f.js`, a normal source map could map
    positions in that generated DJS text back to the source modules. Determine whether
    EDAG-path mappings can be converted to Source Map v3 during serialization, or
    whether graph-specific metadata is required in addition to a standard source map.
 
-5. **How stable does the mapping need to be?**
+6. **How stable does the mapping need to be?**
    Determine whether source metadata is valid only for one exact EDAG structure or
    serialized artifact, or whether some mapping can survive deterministic
    reserialization. The source map itself must not participate in EDAG identity/hash.
 
-6. **Where should source-map artifacts live?**
+7. **Where should source-map artifacts live?**
    Coordinate with the final EDAG output, not the temporary unresolved cache. A final
    `<name>.f.js` could use an adjacent `<name>.f.js.map`, or source maps could live in
    a separate FunctionalScript-owned directory such as
@@ -101,14 +127,14 @@ Questions to answer:
    `Unresolved { imports, edag }` values, not a directory of final EDAG artifacts, so
    it should not be treated as the final source-map location.
 
-7. **How should source maps interact with the unresolved cache?**
+8. **How should source maps interact with the unresolved cache?**
    The source-to-`Unresolved` cache can skip parsing and therefore does not
    automatically reconstruct source ranges. Until a compatible cached source-map
    artifact is designed, compilation that requests source maps should bypass that
    cache and parse the source normally. Investigate whether an `Unresolved` mapping
    sidecar can later make warm and cold builds produce equivalent source mappings.
 
-8. **What metadata is required initially?**
+9. **What metadata is required initially?**
    Start with the minimum needed for diagnostics: source file and source range
    (line/column or byte/UTF-16 offsets). Names, scopes, comments, and richer debugger
    information can be deferred.
@@ -121,8 +147,11 @@ Questions to answer:
   to one source-map entry merely because their contents are equal.
 - Treat an EDAG path as an external structural/traversal address; do not assume it is
   an intrinsic identity for a shared DAG node.
+- Allow a shared-node occurrence to refer to another flattened source-map entry rather
+  than duplicating its source metadata; keep the exact redirect encoding open.
 - When an operation constructs or combines EDAGs, keep source-map transformation in
-  step with the EDAG transformation rather than reusing stale paths.
+  step with the EDAG transformation and remap flattened references rather than reusing
+  stale paths/indexes.
 - Warm builds must not silently lose source-map information compared with cold builds.
 - The design should work with EDAG serialized as DJS and should remain extensible as
   the EDAG operation set grows.
@@ -132,9 +161,12 @@ Questions to answer:
 - [ ] Prototype an EDAG source map indexed by array paths such as `[1, 3, 5]`.
 - [ ] Carry the current EDAG path during a simple traversal and recover source metadata
       for the visited occurrence.
-- [ ] Define how shared EDAG nodes and multiple reference paths map to source ranges.
+- [ ] Prototype a flattened source-map table whose entries are either source values or
+      references to other entry indexes for shared EDAG nodes.
+- [ ] Compare direct-reference-only and reference-chain variants without committing to
+      either representation yet.
 - [ ] Prototype combining/transforming EDAGs while constructing the corresponding new
-      source map in parallel.
+      source map in parallel and remapping path/index references.
 - [ ] Evaluate standard Source Map v3 against EDAG-path mappings and the final `.f.js`
       DJS serialization.
 - [ ] Decide whether source-map sidecars are adjacent to final `.f.js` output or live

--- a/fjs/media/json/todo/number-edge-cases.md
+++ b/fjs/media/json/todo/number-edge-cases.md
@@ -15,6 +15,12 @@ require the default `fjs/media/json` API to mimic native `JSON.parse` /
 `JSON.stringify`. Exact native `JSON.*` compatibility is P5 follow-up work in
 [native JSON compatibility](./native-json-compatibility.md).
 
+It also does **not** own DJS `.f.js` spellings. DJS is a JavaScript-syntax
+superset and can represent values that standard JSON cannot. The DJS requirement
+to round-trip `-0`, `NaN`, `Infinity`, and `-Infinity` is tracked by
+[`compile-modules-to-edag.md`](../../../djs/todo/compile-modules-to-edag.md).
+That work must not silently redefine the standard JSON codec's policy here.
+
 The extended codec's decisions are settled and shipped (below). What remains
 open is the **standard** bigint-free codec, whose serializer still delegates
 finite-number spelling to the host's `JSON.stringify`.
@@ -102,3 +108,7 @@ or adding a separate compatible API, is deliberately deferred to P5.
   not block this investigation.
 - [`fjs/media/json/serializer/module.f.mjs`](../serializer/module.f.mjs) — current
   primitive serialization implementation to replace/self-host.
+- [`fjs/djs/todo/compile-modules-to-edag.md`](../../../djs/todo/compile-modules-to-edag.md)
+  — owns DJS `.f.js` round-tripping of special number values needed by EDAG artifacts.
+- [`fjs/djs/todo/157.md`](../../../djs/todo/157.md) — shared JSON/DJS parser and
+  serializer extraction; coordinate reusable machinery without merging codec policy.

--- a/fjs/nanvm/todo/reuse-edag-operators.md
+++ b/fjs/nanvm/todo/reuse-edag-operators.md
@@ -1,0 +1,166 @@
+## reuse-edag-operators. Reuse the canonical EDAG operator format in NaNVM
+
+**Priority:** P3
+**Status:** open
+
+**Blocked by:** [`../../djs/todo/compile-modules-to-edag.md`](../../djs/todo/compile-modules-to-edag.md)
+
+### Problem
+
+`fjs/nanvm/` has a shared operator corpus that is consumed by both the
+JavaScript proof and the Rust test generator. Today it identifies operations with a
+NaNVM-specific vocabulary:
+
+```ts
+export type Op = 'unaryPlus' | 'unaryMinus' | 'mul' | 'stringCoercion'
+```
+
+A related TODO, [`operator-test-operation-model.md`](../../../nanvm-lib/todo/operator-test-operation-model.md),
+proposes improving this by introducing another semantic operation descriptor such as:
+
+```ts
+readonly ['+', 1]
+readonly ['-', 1]
+readonly ['*', 2]
+```
+
+That fixes the current implementation-style names and exposes arity, but EDAG is now
+becoming the canonical FunctionalScript computation representation and already needs to
+own exactly this information: the operator spelling and the shape/arity of its operands.
+NaNVM should not define a second semantic operator format that can drift from EDAG.
+
+For example, EDAG distinguishes unary and binary operators by the canonical tagged-array
+shape itself:
+
+```js
+['+', a]
+['+', a, b]
+['-', a]
+['*', a, b]
+['===', a, b]
+```
+
+If EDAG later changes an operator spelling, operand shape, or validation rule, the
+NaNVM corpus should consume that change through the shared EDAG definition rather than
+requiring a parallel edit to a local `Op`/`Operation` model.
+
+### Proposal
+
+Make the canonical EDAG operation definitions in `fjs/edag/` the single source of truth
+for operator identity and operand shape, and make `fjs/nanvm/` reuse them.
+
+The exact exported EDAG API should be chosen by the EDAG implementation; this TODO does
+not introduce a second wrapper merely to prescribe names. Conceptually, NaNVM should be
+able to express a group as "cases for this canonical EDAG operation" and derive the
+required argument tuple from that operation's EDAG schema.
+
+For example, instead of locally declaring that multiplication is `['*', 2]`, the corpus
+should refer to the EDAG definition for:
+
+```js
+['*', left, right]
+```
+
+and derive that its case arguments are a two-element tuple. Unary `+` and binary `+`
+remain distinct because their EDAG operation shapes have different arities; NaNVM does
+not need a second disambiguation scheme.
+
+This does **not** mean the NaNVM corpus becomes an EDAG program or that all test values
+must be encoded as EDAG nodes. The corpus still owns test-only data such as:
+
+- case names used as stable proof/test diagnostics;
+- concrete input values and expected values;
+- `throws`, `ref`, and other test-only markers;
+- `rust` gap/reason metadata;
+- commutative-case expansion.
+
+Only the **semantic operation identity and operand contract** come from EDAG.
+
+The JavaScript proof and Rust generator remain consumers. They map a canonical EDAG
+operation to the corresponding host implementation:
+
+```text
+EDAG operation
+  -> JavaScript operator/expression used by proof.f.mjs
+  -> Rust operation/function used by rust/module.f.mjs
+```
+
+Backend names are not EDAG names. In particular, Rust identifiers such as a helper
+function name remain local to the Rust generator rather than leaking back into the
+shared corpus.
+
+### Operations not yet present in EDAG
+
+Some current NaNVM corpus operations may not yet have a canonical EDAG operation. For
+example, the current `stringCoercion` group should not cause `fjs/nanvm/` to invent a
+permanent EDAG spelling independently.
+
+When this happens, either:
+
+1. define the operation in the canonical EDAG vocabulary first, if it belongs there; or
+2. keep the NaNVM case explicitly outside the EDAG-backed groups until the EDAG design
+   reaches it.
+
+The temporary exception must be visible in the type/data model. Do not silently mix
+EDAG-backed operations and NaNVM-only semantic names into one supposedly canonical
+operation type.
+
+### Relationship to `operator-test-operation-model.md`
+
+[`nanvm-lib/todo/operator-test-operation-model.md`](../../../nanvm-lib/todo/operator-test-operation-model.md)
+contains useful requirements that still apply:
+
+- semantic operator spellings instead of implementation names;
+- arity-aware case types;
+- wrong argument counts rejected statically;
+- consumer-owned mapping to JavaScript/Rust implementations;
+- stable case names and explicit `Swapped` diagnostics.
+
+However, its proposed local `readonly [name, argsN]` operation model should be replaced
+by reuse of the EDAG operation definition once `fjs/edag/` exposes it. There should be
+one semantic operation vocabulary, not an EDAG vocabulary plus a nearly identical
+NaNVM vocabulary.
+
+### Tasks
+
+- [ ] Once `fjs/edag/` exposes canonical operation definitions, import/reuse those
+      definitions from `fjs/nanvm/`; do not duplicate EDAG operator spellings or arities.
+- [ ] Remove the local semantic `Op` union from `fjs/nanvm/types.ts` for EDAG-backed
+      operations.
+- [ ] Make NaNVM operator groups reference the canonical EDAG operation definition and
+      derive their case argument tuple/arity from its operand schema.
+- [ ] Preserve NaNVM-only test metadata (`name`, `expected`, `rust`, `commutative`, and
+      special test markers) outside the EDAG model.
+- [ ] Update `fjs/nanvm/module.f.mjs` to use EDAG operator spellings/shapes rather than
+      implementation-style names such as `unaryPlus`, `unaryMinus`, and `mul`.
+- [ ] Update `fjs/nanvm/proof.f.mjs` to dispatch from canonical EDAG operations to the
+      corresponding JavaScript expressions.
+- [ ] Update `fjs/nanvm/rust/module.f.mjs` to map canonical EDAG operations to Rust
+      expressions/function names without putting Rust naming into EDAG or the corpus.
+- [ ] Keep operations that have no canonical EDAG representation explicitly separate;
+      either add them to EDAG first or defer their migration.
+- [ ] Fold the applicable requirements from
+      `nanvm-lib/todo/operator-test-operation-model.md` into this shared-EDAG model rather
+      than implementing its independent `[name, argsN]` format.
+- [ ] Add type-level proofs that invalid operand counts are rejected through the EDAG
+      operation schema.
+- [ ] Add a coupling proof/test so an incompatible change to an EDAG operator shape
+      fails NaNVM type-checking instead of silently leaving the corpus stale.
+- [ ] Regenerate `nanvm-lib/tests/test/generated.rs` and preserve existing test
+      semantics/coverage.
+- [ ] `npx tsc`, `fjs test`, `npm run ci-update`, `cargo test`,
+      `cargo clippy -- -D warnings`, and `cargo fmt -- --check`.
+
+### Related
+
+- [`../../djs/todo/compile-modules-to-edag.md`](../../djs/todo/compile-modules-to-edag.md)
+  — introduces the canonical EDAG model consumed by DJS and this task.
+- [`../../../todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)
+  — canonical EDAG operation vocabulary and semantics.
+- [`../../../todo/edag-spec.md`](../../../todo/edag-spec.md) — eventual distilled EDAG
+  specification.
+- [`../../../nanvm-lib/todo/operator-test-operation-model.md`](../../../nanvm-lib/todo/operator-test-operation-model.md)
+  — existing NaNVM operator-corpus redesign whose local operation descriptor should be
+  replaced by EDAG reuse.
+- [`./corpus-eliminators.md`](./corpus-eliminators.md) — deduplicates test-corpus
+  eliminator rules used by the same JavaScript and Rust consumers.

--- a/todo/edag-spec.md
+++ b/todo/edag-spec.md
@@ -31,10 +31,46 @@ Stage 1 adds property access and unresolved modules; Stage 2 adds non-capturing
 functions and calls. Those TODOs define implementation order, while this file
 owns the eventual complete schema.
 
+### Module boundary
+
+Keep the canonical FunctionalScript EDAG implementation in a separate module:
+
+```text
+fjs/edag/
+```
+
+`fjs/edag/` owns the **EDAG data model itself**:
+
+- the `EDAG` and operation-related types;
+- the canonical operation tags, operand shapes, and structural entry forms;
+- the RTTI schema used to define those types;
+- EDAG validation and canonicality rules that depend only on the EDAG value.
+
+Other layers consume that module rather than defining parallel EDAG types. In
+particular, `fjs/djs/` imports `fjs/edag/` when lowering parsed DJS source to an
+EDAG.
+
+The dependency is intentionally one-way:
+
+```text
+fjs/edag/
+    ↑
+fjs/djs/
+```
+
+`fjs/edag/` must not depend on DJS parsing, module loading, or serialization.
+The temporary `Unresolved { imports, edag }` wrapper stays in the DJS/module
+compiler layer because import paths are not part of EDAG. Likewise, recursive
+module resolution, `.fjs/unresolved/` caching, and `.f.js` serialization stay
+outside `fjs/edag/`.
+
+The exact internal file split under `fjs/edag/` can be chosen during
+implementation; the directory/module boundary is the important part.
+
 ### Proposal
 
 Define the EDAG with **RTTI** ([`fjs/types/rtti`](../fjs/types/rtti/README.md)):
-an RTTI schema (an FJS module) is the specification of record, and Rust code
+an RTTI schema in `fjs/edag/` is the specification of record, and Rust code
 for the EDAG types and the `Function` constructor's input
 validation/construction is **generated** from it.
 
@@ -49,7 +85,7 @@ Why RTTI:
 - RTTI already supports the shapes an EDAG needs: structs, tuples, `or`
   (unions), and recursion via `Thunk`.
 
-The RTTI schema is the only specification of the EDAG shape;
+The RTTI schema in `fjs/edag/` is the only specification of the EDAG shape;
 [`spec/`](../spec/README.md) stays a prose overview of the levels and
 their features.
 
@@ -66,10 +102,17 @@ standard JSON numeric policy remains separate in
 
 ### Tasks
 
-- [ ] Define the EDAG schema as an RTTI schema (FJS module) covering the
-      canonical operation forms decided in
-      [`edag-stage1-discussion.md`](./edag-stage1-discussion.md), including
-      semantic node sharing without a `const_ref` EDAG node.
+- [ ] Create `fjs/edag/` as the canonical FunctionalScript EDAG module.
+- [ ] Keep the `EDAG`/operation types, canonical operation definitions, RTTI
+      schema, and EDAG-only validation in `fjs/edag/`; do not duplicate those
+      definitions under `fjs/djs/` or another consumer.
+- [ ] Keep the module dependency one-way: `fjs/djs/` may import `fjs/edag/`,
+      but `fjs/edag/` must not import DJS parser/module-loader/serializer code.
+- [ ] Keep temporary module-compilation structures such as
+      `Unresolved { imports, edag }` outside `fjs/edag/`.
+- [ ] Define the EDAG schema as an RTTI schema covering the canonical operation
+      forms decided in [`edag-stage1-discussion.md`](./edag-stage1-discussion.md),
+      including semantic node sharing without a `const_ref` EDAG node.
 - [ ] Keep the schema compatible with the staged DJS implementation in
       [`compile-modules-to-edag.md`](../fjs/djs/todo/compile-modules-to-edag.md)
       while allowing later operations to be added without changing existing
@@ -86,7 +129,8 @@ standard JSON numeric policy remains separate in
 - [`edag-stage1-discussion.md`](./edag-stage1-discussion.md) — working EDAG
   semantics, operation vocabulary, validation rules, and staging decisions.
 - [`fjs/djs/todo/compile-modules-to-edag.md`](../fjs/djs/todo/compile-modules-to-edag.md)
-  — concrete parser/module rollout for Stage 1 and Stage 2.
+  — concrete parser/module rollout for Stage 1 and Stage 2; it consumes the
+  canonical definitions from `fjs/edag/`.
 - [`fjs/djs/todo/157.md`](../fjs/djs/todo/157.md) — existing JSON/DJS
   parser/serializer structural deduplication work.
 - [`fjs/media/json/todo/number-edge-cases.md`](../fjs/media/json/todo/number-edge-cases.md)

--- a/todo/edag-spec.md
+++ b/todo/edag-spec.md
@@ -23,6 +23,14 @@ Several components must agree on the exact shape of that value:
 there is no single specification of record, so the implementations have
 nothing precise to be checked against.
 
+The working semantic design lives in
+[`edag-stage1-discussion.md`](./edag-stage1-discussion.md). The concrete DJS
+rollout is staged separately in
+[`compile-modules-to-edag.md`](../fjs/djs/todo/compile-modules-to-edag.md):
+Stage 1 adds property access and unresolved modules; Stage 2 adds non-capturing
+functions and calls. Those TODOs define implementation order, while this file
+owns the eventual complete schema.
+
 ### Proposal
 
 Define the EDAG with **RTTI** ([`fjs/types/rtti`](../fjs/types/rtti/README.md)):
@@ -48,13 +56,20 @@ their features.
 Serialization needs no separate treatment here: the EDAG is an `Any` value, so
 the generic `Any` serialization (CBOR, including the deterministic profile
 for CAVM hashing) covers it — see the P3 task and open question in
-[mvp-roadmap](../nanvm-lib/todo/mvp-roadmap.md).
+[mvp-roadmap](../nanvm-lib/todo/mvp-roadmap.md). DJS `const` declarations and
+references are a serialization mechanism for semantic node sharing, not a
+separate `const_ref` EDAG operation.
 
 ### Tasks
 
-- [ ] Define the EDAG schema as an RTTI schema (FJS module) covering all MVP
-      nodes: JSON level (§1), DJS level (§2: `const_ref`, `bigint`,
-      operators, …), FJS level (§3: function, parameters, captured consts).
+- [ ] Define the EDAG schema as an RTTI schema (FJS module) covering the
+      canonical operation forms decided in
+      [`edag-stage1-discussion.md`](./edag-stage1-discussion.md), including
+      semantic node sharing without a `const_ref` EDAG node.
+- [ ] Keep the schema compatible with the staged DJS implementation in
+      [`compile-modules-to-edag.md`](../fjs/djs/todo/compile-modules-to-edag.md)
+      while allowing later operations to be added without changing existing
+      canonical forms.
 - [ ] Implement a Rust code generator from RTTI schemas: EDAG types +
       validation of the `Any` shape accepted by the `Function` constructor
       (following the pattern of the TypeScript printer in
@@ -64,6 +79,19 @@ for CAVM hashing) covers it — see the P3 task and open question in
 
 ### Related
 
+- [`edag-stage1-discussion.md`](./edag-stage1-discussion.md) — working EDAG
+  semantics, operation vocabulary, validation rules, and staging decisions.
+- [`fjs/djs/todo/compile-modules-to-edag.md`](../fjs/djs/todo/compile-modules-to-edag.md)
+  — concrete parser/module rollout for Stage 1 and Stage 2.
+- [`spec/todo/2330-property-accessor.md`](../spec/todo/2330-property-accessor.md)
+  — property/method-access safety rules used by `.` and `.()`.
+- [`spec/todo/3110-function.md`](../spec/todo/3110-function.md) — source-level
+  function support.
+- [`spec/todo/3111-function-frame.md`](../spec/todo/3111-function-frame.md) —
+  captured-frame and VM-internal function-object design; frame support is later
+  than the initial non-capturing EDAG stage.
+- [`spec/todo/9100-call-like-instructions.md`](../spec/todo/9100-call-like-instructions.md)
+  — VM-internal lowering of calls; it is not the stable EDAG call format.
 - [nanvm-lib/todo/mvp-roadmap.md](../nanvm-lib/todo/mvp-roadmap.md) — the
   `Function` constructor and interpreter tasks are blocked by this spec.
 - [`spec/todo/serialization.md`](../spec/todo/serialization.md)

--- a/todo/edag-spec.md
+++ b/todo/edag-spec.md
@@ -58,7 +58,11 @@ the generic `Any` serialization (CBOR, including the deterministic profile
 for CAVM hashing) covers it — see the P3 task and open question in
 [mvp-roadmap](../nanvm-lib/todo/mvp-roadmap.md). DJS `const` declarations and
 references are a serialization mechanism for semantic node sharing, not a
-separate `const_ref` EDAG operation.
+separate `const_ref` EDAG operation. DJS `.f.js` parser/serializer rollout,
+including special-number round trips, belongs to
+[`compile-modules-to-edag.md`](../fjs/djs/todo/compile-modules-to-edag.md);
+standard JSON numeric policy remains separate in
+[`number-edge-cases.md`](../fjs/media/json/todo/number-edge-cases.md).
 
 ### Tasks
 
@@ -83,6 +87,10 @@ separate `const_ref` EDAG operation.
   semantics, operation vocabulary, validation rules, and staging decisions.
 - [`fjs/djs/todo/compile-modules-to-edag.md`](../fjs/djs/todo/compile-modules-to-edag.md)
   — concrete parser/module rollout for Stage 1 and Stage 2.
+- [`fjs/djs/todo/157.md`](../fjs/djs/todo/157.md) — existing JSON/DJS
+  parser/serializer structural deduplication work.
+- [`fjs/media/json/todo/number-edge-cases.md`](../fjs/media/json/todo/number-edge-cases.md)
+  — existing owner of standard JSON numeric edge-case policy.
 - [`spec/todo/2330-property-accessor.md`](../spec/todo/2330-property-accessor.md)
   — property/method-access safety rules used by `.` and `.()`.
 - [`spec/todo/3110-function.md`](../spec/todo/3110-function.md) — source-level

--- a/todo/edag-stage1-discussion.md
+++ b/todo/edag-stage1-discussion.md
@@ -199,11 +199,14 @@ node; `node` below means any of them.
 
 `["{}", ...entry]` is an ordered object-construction operation. Stage 1
 uses `[":", key, value]` entries. The entry list preserves the source
-property sequence and permits computed keys because the key is itself a
-node. Entry forms are local to the object constructor rather than general
-expressions. Later, new entry forms can be added without changing the
-outer operation; for example `["...", object]` can represent `{ ...object }`.
-Plain objects remain reserved and have no EDAG meaning yet.
+property sequence. The key position is a node so the shape can support
+computed keys later, but **current validation admits only a string-constant
+key**; arbitrary computed-key nodes stay invalid until their coercion and
+failure semantics are defined. Entry forms are local to the object
+constructor rather than general expressions. Later, new entry forms can be
+added without changing the outer operation; for example `["...", object]`
+can represent `{ ...object }`. Plain objects remain reserved and have no EDAG
+meaning yet.
 
 Tags are **JS syntax wherever JS has syntax for the operation** — hence
 `"."`, `"()"`, `".()"`, `"{}"`, `":"` and `","` above, and the operator
@@ -714,9 +717,11 @@ open:
 
 **Resolution: an object constructor is `["{}", ...entries]`, and the
 entry sequence is semantic.** Stage 1 uses one entry form,
-`[":", key, value]`. The key and value are nodes, so the representation
-supports computed keys without changing the constructor shape. Entry forms
-belong to the object constructor rather than to the general expression
+`[":", key, value]`. The key and value positions contain EDAG nodes, so
+the representation can support computed keys without changing the constructor shape;
+**current validation nevertheless accepts only string-constant keys**. Arbitrary
+computed-key nodes remain invalid until their coercion/failure semantics are defined.
+Entry forms belong to the object constructor rather than to the general expression
 vocabulary.
 
 History: this subject previously represented an object constructor as a
@@ -725,12 +730,18 @@ representation uses the tagged `["{}", ...entries]` operation, reserves plain
 objects for future use, and keeps duplicate entries so construction can follow
 JavaScript overwrite semantics and later support computed keys.
 
+Entry descriptor arrays such as `[":", key, value]` are **structural operands**, not
+independently evaluated EDAG nodes. Their container identity therefore has no semantic
+meaning and must not add another graph/hash distinction. Validation rejects reusing the
+same descriptor-array identity in more than one object-entry position. The `key` and
+`value` operands are real EDAG nodes, so their identities may be shared normally.
+
 The sequence is retained exactly as written. It matters for several
 independent reasons:
 
 - JavaScript evaluates object-literal definitions in source order;
-- duplicate and computed keys can overwrite properties created by earlier
-  entries, so the final object can depend on entry order;
+- duplicate keys and, once admitted, computed keys can overwrite properties created
+  by earlier entries, so the final object can depend on entry order;
 - insertion order of non-index string properties is observable through
   `Object.keys`, iteration, and `JSON.stringify`.
 
@@ -752,7 +763,7 @@ Sorted-key canonicalization (as `fjs compile` applies to data output,
 constructor entries.
 
 Duplicate properties are allowed, as in JavaScript; the later entry wins.
-This is also required once keys can be computed, because equality of two keys
+This is also required once computed keys are admitted, because equality of two keys
 may not be knowable during EDAG validation.
 
 The entry vocabulary is extensible. A later `["...", object]` entry can
@@ -786,9 +797,12 @@ the FJS compiler would never emit. To validate:
   subject 8);
 - unknown command tags: validation error;
 - object constructors: every `["{}", ...]` operand must be a recognized
-  entry form; stage 1 accepts `[":", key, value]`. Duplicate property
-  keys/entries are valid and are applied in order (subject 4). Plain objects
-  are not EDAG nodes;
+  entry form; stage 1 accepts `[":", key, value]` only when `key` is a
+  **string constant**. Duplicate property keys/entries are valid and are
+  applied in order (subject 4). Entry descriptor containers are structural,
+  so the same descriptor-array identity must not appear in more than one entry
+  position; key/value EDAG nodes inside descriptors may still be shared. Plain
+  objects are not EDAG nodes;
 - **property operands** of `"."` and `".()"`: a permitted string
   constant, a number constant, or a **unary** `"+"` / `"Number"` node.
   Anything else is a validation error, which is what keeps
@@ -809,8 +823,10 @@ the FJS compiler would never emit. To validate:
 - **acyclicity**: DJS cannot express cycles (const-before-use), but an
   `Any` handed to the `Function` constructor can be built by other means —
   cyclic node graphs must be rejected;
-- aliasing is *not* an error anywhere — referencing the same node from
-  many positions is the sharing mechanism (subject 1).
+- aliasing of **operation nodes** is not an error — referencing the same EDAG node
+  from many operand positions is the sharing mechanism (subject 1). Structural
+  containers that are not nodes, such as object-entry descriptors, follow their
+  operation-specific canonicality rules above instead.
 
 ### 6. Command vocabulary vs. the existing spec names
 
@@ -866,9 +882,10 @@ The earlier objection — that `["[]", a, b]` would read as both a
 two-element array and `a[b]` — disappeared with access moved to `"."`.
 
 **Decided: the object constructor is `"{}"` with ordered entries.**
-`["{}", [":", key, value], …]` preserves construction order, permits
-computed keys, and can later accept additional entry forms such as
-`["...", object]`. Plain objects are deliberately left unused by EDAG.
+`["{}", [":", key, value], …]` preserves construction order and leaves
+room for computed keys once their semantics are admitted; it can later accept
+additional entry forms such as `["...", object]`. Plain objects are
+deliberately left unused by EDAG.
 
 Word tags now survive only where JS genuinely has no expression spelling:
 `"args"`, `"frame"`, `"self"`, `"throw"`, `"own"`.

--- a/todo/edag-stage1-discussion.md
+++ b/todo/edag-stage1-discussion.md
@@ -65,7 +65,7 @@ guards, A4) are merged into the graph by the **`","` operation**:
     `false`, `undefined`, `null`, `34n`;
   - an **array** — a tagged tuple `[tag, ...operands]`; the tags are
     listed in [Operations](#operations) below.
-  Plain objects are reserved and currently have no EDAG meaning.
+- **Plain objects are reserved and currently have no EDAG meaning.**
 - operand positions hold **real references** to nodes, not indices.
   Referencing the same node from two positions is **semantic sharing**: the
   node is evaluated once and its result reused. `const x = ["{}"]` then
@@ -710,7 +710,7 @@ open:
 
 ### 4. Object constructor: ordered entries
 
-**Status:** decided
+**Status:** decided (revised)
 
 **Resolution: an object constructor is `["{}", ...entries]`, and the
 entry sequence is semantic.** Stage 1 uses one entry form,
@@ -718,6 +718,12 @@ entry sequence is semantic.** Stage 1 uses one entry form,
 supports computed keys without changing the constructor shape. Entry forms
 belong to the object constructor rather than to the general expression
 vocabulary.
+
+History: this subject previously represented an object constructor as a
+plain EDAG object and rejected duplicate keys during validation. The revised
+representation uses the tagged `["{}", ...entries]` operation, reserves plain
+objects for future use, and keeps duplicate entries so construction can follow
+JavaScript overwrite semantics and later support computed keys.
 
 The sequence is retained exactly as written. It matters for several
 independent reasons:
@@ -728,10 +734,15 @@ independent reasons:
 - insertion order of non-index string properties is observable through
   `Object.keys`, iteration, and `JSON.stringify`.
 
-Integer-index properties are enumerated first in ascending numeric order,
-regardless of insertion order, but that does not make their constructor
-entries reorderable in the representation: computed keys and overwrites can
-still make the sequence relevant.
+One caveat remains: two EDAGs that differ only in the order of distinct,
+static integer-index keys can still produce the same JavaScript value. For
+example, `["{}", [":", "2", a], [":", "1", b]]` and
+`["{}", [":", "1", b], [":", "2", a]]` both enumerate as `"1", "2"`.
+Hash-as-written still distinguishes the EDAGs, but the core invariant's
+print-run-compare test cannot distinguish this pair. Computed keys,
+duplicate keys, and key/value computation can make entry order observable;
+the caveat is specifically that not every distinct written order denotes a
+distinct JavaScript value.
 
 A4's opaque-error contract permits an engine to schedule independent key and
 value computations differently when doing so is unobservable, but the object
@@ -776,8 +787,8 @@ the FJS compiler would never emit. To validate:
 - unknown command tags: validation error;
 - object constructors: every `["{}", ...]` operand must be a recognized
   entry form; stage 1 accepts `[":", key, value]`. Duplicate property
-  values are valid and are applied in order (subject 4). Plain objects are
-  not EDAG nodes;
+  keys/entries are valid and are applied in order (subject 4). Plain objects
+  are not EDAG nodes;
 - **property operands** of `"."` and `".()"`: a permitted string
   constant, a number constant, or a **unary** `"+"` / `"Number"` node.
   Anything else is a validation error, which is what keeps
@@ -1131,6 +1142,7 @@ none of this ([Operations](#operations)).
 
 
 ### 11. `let`, loops, and tail calls
+
 **Status:** open
 
 Everything expressible by looping is expressible by recursion —

--- a/todo/edag-stage1-discussion.md
+++ b/todo/edag-stage1-discussion.md
@@ -7,6 +7,17 @@ Each subject below is resolved separately; once all are **decided**, the
 result is distilled into a concrete design in [edag-spec.md](./edag-spec.md)
 and this document is deleted.
 
+The concrete DJS rollout is tracked in
+[`compile-modules-to-edag.md`](../fjs/djs/todo/compile-modules-to-edag.md):
+Stage 1 introduces `.` and unresolved modules; Stage 2 introduces
+non-capturing `=>`, `()`, and `.()`. This document owns the EDAG semantics,
+not parser scheduling. Property/method-access safety is shared with
+[property-accessor](../spec/todo/2330-property-accessor.md); source functions
+and later captured frames are tracked by [function](../spec/todo/3110-function.md)
+and [function-frame](../spec/todo/3111-function-frame.md); VM-internal call
+lowering belongs to
+[call-like-instructions](../spec/todo/9100-call-like-instructions.md).
+
 ## Baseline: an expression DAG with anchored evaluation
 
 *This baseline supersedes the original index-based sequence proposal; the
@@ -179,7 +190,9 @@ Agreed points (not under discussion):
 ## Operations
 
 The operations we want, with their stage. Every operand is an operation
-node; `node` below means any of them.
+node; `node` below means any of them. The stage numbers match the concrete
+DJS rollout in
+[`compile-modules-to-edag.md`](../fjs/djs/todo/compile-modules-to-edag.md).
 
 ### Structural operations
 
@@ -190,12 +203,12 @@ node; `node` below means any of them.
 |`["{}", ...entry]`|`{ … }`|1|ordered object constructor; initial entry form is `[":", key, value]` (subject 4)|
 |`["args"]`|—|1|the arguments array (subject 2)|
 |`[".", object, property]`|`o.p`, `o[p]`|1|property access; `property` is restricted (see below)|
-|`["()", object, args]`|`f(...args)`|1|call; `args` is one node yielding an array|
-|`[".()", object, property, args]`|`o.p(...args)`, `o[p](...args)`|1|method call; keeps `this` binding; same `property` restriction|
+|`["()", object, args]`|`f(...args)`|2|call; `args` is one node yielding an array|
+|`[".()", object, property, args]`|`o.p(...args)`, `o[p](...args)`|2|method call; keeps `this` binding; same `property` restriction|
 |`["own", object, key]`|`Object.getOwnPropertyDescriptor(o, k)?.value`|1|own property by a computed **string**; no prototype chain|
 |`["Number", node]`|`Number(x)`|later|numeric coercion that accepts bigints, unlike unary `+`|
 |`[",", ...node, node]`|`(a, b)`|later|membership without order (subject 8)|
-|`["=>", frame, body]`|`(…) => …`|later|closures; `frame` yields the captured array (see below)|
+|`["=>", frame, body]`|`(…) => …`|2|function; initial Stage 2 accepts only an empty frame, captured frames come later|
 
 `["{}", ...entry]` is an ordered object-construction operation. Stage 1
 uses `[":", key, value]` entries. The entry list preserves the source
@@ -823,10 +836,13 @@ the FJS compiler would never emit. To validate:
 - **acyclicity**: DJS cannot express cycles (const-before-use), but an
   `Any` handed to the `Function` constructor can be built by other means —
   cyclic node graphs must be rejected;
-- aliasing of **operation nodes** is not an error — referencing the same EDAG node
-  from many operand positions is the sharing mechanism (subject 1). Structural
-  containers that are not nodes, such as object-entry descriptors, follow their
-  operation-specific canonicality rules above instead.
+- aliasing of **operation nodes is valid only within one function EDAG scope**:
+  referencing the same node from many operand positions in that scope is the sharing
+  mechanism (subject 1), but an operation-node identity must not cross a `"=>"`
+  function boundary (the closed-scope model above). Structural containers that are not
+  nodes, such as object-entry descriptors, follow their operation-specific canonicality
+  rules above instead. The initial Stage 2 validator/proofs for this boundary are tracked
+  by [`compile-modules-to-edag.md`](../fjs/djs/todo/compile-modules-to-edag.md).
 
 ### 6. Command vocabulary vs. the existing spec names
 

--- a/todo/edag-stage1-discussion.md
+++ b/todo/edag-stage1-discussion.md
@@ -205,7 +205,7 @@ DJS rollout in
 |`[".", object, property]`|`o.p`, `o[p]`|1|property access; `property` is restricted (see below)|
 |`["()", object, args]`|`f(...args)`|2|call; `args` is one node yielding an array|
 |`[".()", object, property, args]`|`o.p(...args)`, `o[p](...args)`|2|method call; keeps `this` binding; same `property` restriction|
-|`["own", object, key]`|`Object.getOwnPropertyDescriptor(o, k)?.value`|1|own property by a computed **string**; no prototype chain|
+|`["own", object, key]`|`Object.getOwnPropertyDescriptor(o, k)?.value`|later|own property by a computed **string**; no prototype chain|
 |`["Number", node]`|`Number(x)`|later|numeric coercion that accepts bigints, unlike unary `+`|
 |`[",", ...node, node]`|`(a, b)`|later|membership without order (subject 8)|
 |`["=>", frame, body]`|`(…) => …`|2|function; initial Stage 2 accepts only an empty frame, captured frames come later|
@@ -252,7 +252,7 @@ the EDAG at all.
 Unary `+` throws on a **bigint**, so `["Number", node]` exists as the
 converting alternative; it is spelled by its JS built-in, `Number(x)`.
 
-Accessing a property by a **computed string** is a different operation,
+Accessing a property by a **computed string** is a different, later operation,
 `["own", object, key]` — own properties only, no prototype chain, so a
 computed name is harmless. Its JS spelling is a pattern rather than
 syntax:

--- a/todo/edag-stage1-discussion.md
+++ b/todo/edag-stage1-discussion.md
@@ -63,15 +63,14 @@ guards, A4) are merged into the graph by the **`","` operation**:
 - an operation node is:
   - a **non-object, non-array value** — a constant: `"hello world"`, `2.5`,
     `false`, `undefined`, `null`, `34n`;
-  - an **object** — an object constructor; each property value is an
-    operation node;
   - an **array** — a tagged tuple `[tag, ...operands]`; the tags are
     listed in [Operations](#operations) below.
+  Plain objects are reserved and currently have no EDAG meaning.
 - operand positions hold **real references** to nodes, not indices.
   Referencing the same node from two positions is **semantic sharing**: the
-  node is evaluated once and its result reused. `const x = {}` then
-  `[x, x]` yields an array with `a[0] === a[1]`, while `[{}, {}]` yields
-  two distinct objects.
+  node is evaluated once and its result reused. `const x = ["{}"]` then
+  `["[]", x, x]` yields an array with `a[0] === a[1]`, while
+  `["[]", ["{}"], ["{}"]]` yields two distinct objects.
 - evaluation: the root node is established (subject 8) and its value is
   the function's result; a `","` establishes all its operands, in any
   order, possibly in parallel (A4); every node is memoized by its
@@ -116,9 +115,10 @@ represent basic blocks for local optimization. **FunctionalScript
 inverts its status.** There a DAG is *derived* from a tree by common
 subexpression elimination, and the two denote the same computation
 because sharing is unobservable — an optimization. Here the EDAG is
-**primary**: sharing is observable (`[x, x]` and `[{}, {}]` are
-different functions, subject 1), so no tree denotes what an EDAG
-denotes, and the sharing is authored rather than recovered by analysis.
+**primary**: sharing is observable (`["[]", x, x]` and
+`["[]", ["{}"], ["{}"]]` are different functions, subject 1), so no
+tree denotes what an EDAG denotes, and the sharing is authored rather
+than recovered by analysis.
 
 Related representations, for orientation: *term graphs* in the
 term-rewriting literature are the same structure (though often
@@ -186,8 +186,8 @@ node; `node` below means any of them.
 |Form|JS|Stage|Notes|
 |----|--|-----|-----|
 |`2.5`, `"a"`, `true`, `null`, `undefined`, `34n`|itself|1|constant — any non-object, non-array value|
-|`{ key: node, … }`|`{ key: … }`|1|object constructor; key order is part of the value (subject 4)|
 |`["[]", ...node]`|`[…]`|1|array constructor|
+|`["{}", ...entry]`|`{ … }`|1|ordered object constructor; initial entry form is `[":", key, value]` (subject 4)|
 |`["args"]`|—|1|the arguments array (subject 2)|
 |`[".", object, property]`|`o.p`, `o[p]`|1|property access; `property` is restricted (see below)|
 |`["()", object, args]`|`f(...args)`|1|call; `args` is one node yielding an array|
@@ -197,12 +197,20 @@ node; `node` below means any of them.
 |`[",", ...node, node]`|`(a, b)`|later|membership without order (subject 8)|
 |`["=>", frame, body]`|`(…) => …`|later|closures; `frame` yields the captured array (see below)|
 
+`["{}", ...entry]` is an ordered object-construction operation. Stage 1
+uses `[":", key, value]` entries. The entry list preserves the source
+property sequence and permits computed keys because the key is itself a
+node. Entry forms are local to the object constructor rather than general
+expressions. Later, new entry forms can be added without changing the
+outer operation; for example `["...", object]` can represent `{ ...object }`.
+Plain objects remain reserved and have no EDAG meaning yet.
+
 Tags are **JS syntax wherever JS has syntax for the operation** — hence
-`"."`, `"()"`, `".()"` and `","` above, and the operator symbols
-below. This is [DESIGN.md §8](../DESIGN.md) again: the host language
-already spells these, so the EDAG reuses the spelling instead of
-inventing a vocabulary to be memorized and translated. `".()"` reads as
-the method call it denotes, `o.p(…)`.
+`"."`, `"()"`, `".()"`, `"{}"`, `":"` and `","` above, and the operator
+symbols below. This is [DESIGN.md §8](../DESIGN.md) again: the host language
+already spells these, so the EDAG reuses the spelling instead of inventing
+a vocabulary to be memorized and translated. `".()"` reads as the method
+call it denotes, `o.p(…)`.
 
 **The property operand is restricted**, in `"."` and `".()"` alike. It
 must be one of:
@@ -700,37 +708,53 @@ open:
   shared across a function boundary, and "whose arguments?" never
   arises.
 
-### 4. Object constructor: key order and duplicate keys
+### 4. Object constructor: ordered entries
 
 **Status:** decided
 
-**Resolution: property order is semantic** — the written key order is
-part of the constructed *value*, not of the schedule: JS objects
-preserve insertion order for string keys (`Object.keys`, iteration,
-`JSON.stringify`), so reordering an object constructor's keys changes
-the resulting object.
+**Resolution: an object constructor is `["{}", ...entries]`, and the
+entry sequence is semantic.** Stage 1 uses one entry form,
+`[":", key, value]`. The key and value are nodes, so the representation
+supports computed keys without changing the constructor shape. Entry forms
+belong to the object constructor rather than to the general expression
+vocabulary.
 
-One exception, which limits the *rationale* but not the conclusion:
-**integer-index keys always come first, in ascending order**, whatever
-the source order — `Object.keys({"2":a,"1":b})` and
-`Object.keys({"1":b,"2":a})` are both `["1","2"]`. Two EDAGs differing
-only in the order of index keys are therefore one JS value with two
-hashes, which the core invariant's print-run-compare test cannot
-distinguish. The conclusion stands on the non-index cases.
+The sequence is retained exactly as written. It matters for several
+independent reasons:
 
-This holds with A4 rejected — the evaluation *order* of property
-operands is as free as any other (subject 8); what is fixed is the
-result. Sorted-key canonicalization (as `fjs compile` applies to
-data output, [spec/README.md](../spec/README.md)) must **not** be
-applied to object constructors. Duplicate keys are a validation error.
+- JavaScript evaluates object-literal definitions in source order;
+- duplicate and computed keys can overwrite properties created by earlier
+  entries, so the final object can depend on entry order;
+- insertion order of non-index string properties is observable through
+  `Object.keys`, iteration, and `JSON.stringify`.
 
-**`__proto__` is a data key, never a prototype assignment.** FS plans to
-have no prototype chains at run time, so a key `"__proto__"` denotes
-an ordinary property — and printing it (subject 12) must use the
-computed spelling `{ ["__proto__"]: … }`, the only JS form that
-reproduces the value. The identifier and string spellings assign a
-prototype instead and lose the property. This is the rule the DJS
-parser and serializer already follow —
+Integer-index properties are enumerated first in ascending numeric order,
+regardless of insertion order, but that does not make their constructor
+entries reorderable in the representation: computed keys and overwrites can
+still make the sequence relevant.
+
+A4's opaque-error contract permits an engine to schedule independent key and
+value computations differently when doing so is unobservable, but the object
+must be produced **as if the entries were applied in their EDAG order**.
+Sorted-key canonicalization (as `fjs compile` applies to data output,
+[spec/README.md](../spec/README.md)) must therefore not be applied to object
+constructor entries.
+
+Duplicate properties are allowed, as in JavaScript; the later entry wins.
+This is also required once keys can be computed, because equality of two keys
+may not be knowable during EDAG validation.
+
+The entry vocabulary is extensible. A later `["...", object]` entry can
+represent object spread, `{ ...object }`, without changing `["{}", ...]`.
+Plain objects remain reserved for a future EDAG use.
+
+**`__proto__` is a data key, never a prototype assignment.** In an EDAG
+entry, `[":", "__proto__", value]` defines an ordinary own property. When
+printing it as JavaScript (subject 12), the printer must use the computed
+spelling `{ ["__proto__"]: … }`, the only object-literal form that
+reproduces that value. The identifier and string spellings assign a prototype
+instead and lose the property. This is the rule the DJS parser and serializer
+already follow —
 [spec: the `__proto__` key](../spec/README.md#the-__proto__-key).
 
 ### 5. Validation
@@ -750,6 +774,10 @@ the FJS compiler would never emit. To validate:
   from another operand of the same `","` is redundant (well-formedness,
   subject 8);
 - unknown command tags: validation error;
+- object constructors: every `["{}", ...]` operand must be a recognized
+  entry form; stage 1 accepts `[":", key, value]`. Duplicate property
+  values are valid and are applied in order (subject 4). Plain objects are
+  not EDAG nodes;
 - **property operands** of `"."` and `".()"`: a permitted string
   constant, a number constant, or a **unary** `"+"` / `"Number"` node.
   Anything else is a validation error, which is what keeps
@@ -762,7 +790,6 @@ the FJS compiler would never emit. To validate:
   [property-accessor](../spec/todo/2330-property-accessor.md), and
   because the key is a *constant* the check happens once, at
   construction, not on every access;
-- duplicate object-constructor keys: validation error (subject 4);
 - object-constructor key `"__proto__"`: **not** a validation error — it
   denotes an ordinary own property (subject 4) — but it constrains
   printing, since `{ "__proto__": v }` as JS assigns a prototype instead
@@ -795,10 +822,10 @@ never reaches `"."` at all.
 
 **Decided for the structural tags: they are JS syntax too** —
 `[".", object, property]`, `["()", object, args]`,
-`[".()", object, property, args]`, `[",", …]`. Syntax is as much a host
-spelling as an operator symbol is, and `".()"` reads as the `o.p(…)` it
-denotes. This supersedes the `at` / `call` / `bindCall` names used
-earlier in this document.
+`[".()", object, property, args]`, `["{}", …]`, `[":", key, value]`,
+`[",", …]`. Syntax is as much a host spelling as an operator symbol is,
+and `".()"` reads as the `o.p(…)` it denotes. This supersedes the
+`at` / `call` / `bindCall` names used earlier in this document.
 
 **Decided: `"."` and `".()"`, not `"[]"` and `"[]()"`.** `"."` is the
 shorter and more readable tag, and `".()"` composes to read exactly like
@@ -818,16 +845,22 @@ an optimization:
 
 `"."` merges 2330's static-name and numeric-index commands because the
 operand restriction ([Operations](#operations)) covers both safely; the
-static/numeric split that remains is a bytecode specialization. But `own_property` cannot be folded in: it is what makes
-computed-string access *possible at all*, precisely by skipping the
-prototype chain.
+static/numeric split that remains is a bytecode specialization. But
+`own_property` cannot be folded in: it is what makes computed-string access
+*possible at all*, precisely by skipping the prototype chain.
 
 **Decided: the array constructor is `"[]"`.** Choosing `"."` for access
 freed the tag, and `[a, b]` is precisely how JS spells an array literal.
 The earlier objection — that `["[]", a, b]` would read as both a
 two-element array and `a[b]` — disappeared with access moved to `"."`.
-Word tags now survive only where JS genuinely has no expression
-spelling: `"args"`, `"frame"`, `"self"`, `"throw"`, `"own"`.
+
+**Decided: the object constructor is `"{}"` with ordered entries.**
+`["{}", [":", key, value], …]` preserves construction order, permits
+computed keys, and can later accept additional entry forms such as
+`["...", object]`. Plain objects are deliberately left unused by EDAG.
+
+Word tags now survive only where JS genuinely has no expression spelling:
+`"args"`, `"frame"`, `"self"`, `"throw"`, `"own"`.
 
 ### 7. Top-level shape of a function
 
@@ -972,9 +1005,10 @@ the **graph**, not a tree expansion:
   are **derived** from the graph, never authored (subject 1). Affects
   the CBOR task in [mvp-roadmap](../nanvm-lib/todo/mvp-roadmap.md).
 - Hash-consing / content-addressed dedup must **not** merge structurally
-  identical constructor nodes: `[{}, {}]` and `const x = {}; [x, x]` are
-  semantically different, and a naive structural hash conflates them. The
-  hash must be computed over the canonical graph serialization.
+  identical constructor nodes: `["[]", ["{}"], ["{}"]]` and
+  `const x = ["{}"]; ["[]", x, x]` are semantically different, and a
+  naive structural hash conflates them. The hash must be computed over
+  the canonical graph serialization.
 - JSON output expands sharing ([spec/README.md](../spec/README.md)) and is
   therefore not a valid EDAG carrier; DJS and tagged CBOR are.
 - Nested functions no longer pose the binders-plus-sharing difficulty:
@@ -1097,7 +1131,6 @@ none of this ([Operations](#operations)).
 
 
 ### 11. `let`, loops, and tail calls
-
 **Status:** open
 
 Everything expressible by looping is expressible by recursion —
@@ -1170,10 +1203,11 @@ What that requires of the printer:
   renders, and it is why built-in namespaces are still open in
   subject 10.
 - **Sharing must be preserved.** A node referenced twice must print as
-  one `const` used twice, never as two copies: `[x, x]` and `[{}, {}]`
-  are different functions (subject 1). This is the same graph-flattening
-  hazard as JSON output ([spec/README.md](../spec/README.md)) — a
-  printer that expands sharing silently changes semantics.
+  one `const` used twice, never as two copies: `["[]", x, x]` and
+  `["[]", ["{}"], ["{}"]]` are different functions (subject 1). This is
+  the same graph-flattening hazard as JSON output
+  ([spec/README.md](../spec/README.md)) — a printer that expands sharing
+  silently changes semantics.
 - **The printed source must be closed.** `eval` has no module scope, so
   nothing may print as a bare imported or module-level name; captured
   values are materialized in the text. This is exactly what the


### PR DESCRIPTION
## Summary

- keep the canonical EDAG data model in a separate `fjs/edag/` module: EDAG/operation types, operation definitions, RTTI schema, and EDAG-only validation live there; `fjs/djs/` consumes it through a one-way dependency
- split the module-to-EDAG work into two stages
- Stage 1 introduces EDAG property access `['.', object, property]`, then parser support for `a.b` and `a[b]`; it enforces the canonical property safety restriction, so this stage accepts permitted string constants and number constants while rejecting prohibited names and runtime-computed strings; computed-string `own` access is explicitly later
- Stage 1 uses the temporary `Unresolved { imports, edag }` type, keeps it outside EDAG and `fjs/edag/`, resolves unresolved dependencies recursively into one final EDAG, preserves diamond-import node identity through canonical-path memoization, and rejects otherwise-required unused throwing computations until anchoring exists
- make module linking scope-aware: import substitution/reachability applies only to module-scope `['args']` and stops at nested `=>` bodies so function arguments are never rebound as imports
- Stage 2 introduces non-capturing EDAG functions/calls: `['=>', ['[]'], body]`, `['()', object, args]`, and `['.()', object, property, args]`, plus parser support for the initial non-capturing `(...a) => exp` form; frame/capture support is explicitly deferred
- keep the P2 EDAG-producing path separate from the existing value-producing `transpile` / `fjs compile` contract; after the P3 interpreter exists, migrate those callers internally to compile -> EDAG -> interpret -> value without changing their public output
- require function-body EDAG scopes to be disjoint across function boundaries and scope interpreter memoization per invocation
- require DJS parser and serializer round-trip support for `Infinity`, `-Infinity`, `NaN`, and `-0`; JSON output remains allowed only when lossless
- cache unresolved values under `.fjs/unresolved/{hash}.f.js`, with `hash = CBase32(SHA256(source bytes))`
- keep `Unresolved` unchanged while carrying compiler/cache version metadata in the same cache file outside the exported value, published as one atomic entry; cache writes are best-effort and invalid artifacts are cache misses
- bypass the unresolved cache for source-map builds until compatible mapping sidecars are designed
- keep a possible second-level cache for resolved modules as future work without defining its identity yet
- keep direct EDAG interpretation as a separate P3 TODO and deterministic work/memory/stack hardening in a lower-priority TODO with an aggregate top-level budget
- add a P3 NaNVM follow-up to reuse canonical EDAG operator identity/operand shapes instead of maintaining a parallel `Op` / `[name, arity]` semantic vocabulary; NaNVM keeps only test metadata and JS/Rust backend mappings
- keep the low-priority `edagAdd` / `edagGet` function-association note, including the unresolved nested-function/frame question
- investigate path-indexed source maps using EDAG array paths such as `[1, 3, 5]`; for shared nodes, a flattened source-map entry can redirect to another entry index instead of duplicating source metadata, and EDAG transformations should rebuild/remap the source map in parallel

## Scope

Documentation/TODO only; no runtime behavior changes.

## Checks

Not run (TODO-only change).

Changelog: none