### PR TITLE
Implement stage 1 EDAG validation and type schema

### DIFF
--- a/changelog/unreleased/1652.md
+++ b/changelog/unreleased/1652.md
@@ -1,0 +1,2 @@
+- `edag`: new module — the stage 1 EDAG node types and `validate`, the
+  canonical EDAG data model that `djs` will lower parsed modules to

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -401,7 +401,7 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
 
 #### Stage 1
 
-- [ ] Introduce `['.', object, property]` into EDAG and its validation/type schema,
+- [x] Introduce `['.', object, property]` into EDAG and its validation/type schema,
       enforcing the canonical property-operand restriction: permitted string constants,
       number constants, and only later the approved unary numeric-conversion forms when
       those operations exist.
@@ -412,10 +412,10 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
       the EDAG schema.
 - [ ] Keep `Unresolved.imports` as a source-ordered array of module paths, not a map,
       and make import parameter positions correspond to its indices.
-- [ ] Restrict initial `[':', key, value]` object-constructor validation to
+- [x] Restrict initial `[':', key, value]` object-constructor validation to
       string-constant keys; defer arbitrary computed constructor keys until their
       coercion/failure semantics are defined.
-- [ ] Treat object-entry descriptor arrays as structural/non-shareable containers;
+- [x] Treat object-entry descriptor arrays as structural/non-shareable containers;
       reject descriptor identity reuse while retaining normal sharing of their key and
       value EDAG nodes.
 - [ ] Change the DJS parser/AST object representation to retain an ordered entry list
@@ -535,6 +535,8 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
 - [`associate-edag-with-functions.md`](./associate-edag-with-functions.md) —
   low-priority note on compiling an EDAG to an executable function while retaining
   the EDAG through `edagAdd` / `edagGet` Effects.
+- [`../../edag/README.md`](../../edag/README.md) — the canonical EDAG module:
+  stage 1 node types, the property-operand restriction, and `validate`.
 - [`todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md) — EDAG
   semantics and structural operations.
 - [`todo/edag-spec.md`](../../../todo/edag-spec.md) — future complete canonical EDAG

--- a/fjs/edag/README.md
+++ b/fjs/edag/README.md
@@ -1,0 +1,154 @@
+# EDAG — the FunctionalScript expression DAG
+
+An **EDAG** is a compiled computation written down as an ordinary
+FunctionalScript value. It is what a function *is*: the input the `Function`
+constructor accepts, what `toString(f)` prints back as source, and what the
+content hash addresses.
+
+Both halves of the name are load-bearing.
+
+- **Expression** — there are no statement nodes. `const` is sharing, `return`
+  is the root node, and every node is an expression.
+- **DAG** — an operand position holds a real reference to a node, so
+  referencing one node from two positions means *one value used twice*.
+  Sharing is semantic, not an optimization: `['[]', x, x]` builds an array
+  whose two elements are the same object, while `['[]', ['{}'], ['{}']]`
+  builds two distinct ones. No tree denotes what an EDAG denotes.
+
+The semantics are developed in
+[`todo/edag-stage1-discussion.md`](../../todo/edag-stage1-discussion.md) and
+will be distilled into [`todo/edag-spec.md`](../../todo/edag-spec.md). This
+module is the implementation of what those documents decide.
+
+## What is here, and what is deliberately not
+
+This directory owns the **EDAG data model itself**: the node types, the
+canonical operation tags and their operand shapes, the structural entry forms,
+and the validation rules that depend only on an EDAG value.
+
+Everything about getting *to* an EDAG belongs to its consumers. The dependency
+is one-way —
+
+```text
+fjs/edag/
+    ↑
+fjs/djs/
+```
+
+— so DJS parsing, module loading, the temporary `Unresolved { imports, edag }`
+wrapper, recursive import resolution, and `.f.js` serialization all stay in
+[`fjs/djs`](../djs/README.md). Import paths are not part of an EDAG, and
+nothing here may reach back for them.
+
+## Stage 1 vocabulary
+
+The rollout is staged by
+[`fjs/djs/todo/compile-modules-to-edag.md`](../djs/todo/compile-modules-to-edag.md).
+Stage 1 is what an unresolved module needs, and no more:
+
+| Form | JavaScript | Notes |
+|------|------------|-------|
+| `2.5`, `'a'`, `true`, `null`, `undefined`, `34n` | itself | a constant — any non-object, non-array value |
+| `['[]', ...node]` | `[…]` | array constructor |
+| `['{}', ...entry]` | `{ … }` | ordered object constructor; the one entry form is `[':', key, value]` |
+| `['args']` | — | the arguments array |
+| `['.', object, property]` | `o.p`, `o[p]` | property access; `property` is restricted |
+
+`['args']` is what makes stage 1 the stage that unresolved modules need: at
+module scope it is the array of imported module values, so import *i* is
+`['.', ['args'], i]` and a module compiles before any of its imports are read.
+
+Stage 2 adds `['=>', frame, body]`, `['()', object, args]`, and
+`['.()', object, property, args]`; operators, `[',', …]`, `['throw', …]`,
+`['own', …]`, `['self']`, and `['frame']` are later still. Each is an
+*addition* — operand shapes are specified per tag rather than by a global "an
+array in operand position is a tagged operation" rule, so a later operation
+with a differently shaped operand never changes an existing form.
+
+Plain objects are **reserved** and have no EDAG meaning: an object value is
+built by `['{}', …]`, so the two never compete for one spelling.
+
+## Validation is a total gate
+
+`validate` is not a sanity check on compiler output. The EDAG is a *public*
+input, so it will see graphs no FunctionalScript compiler would emit, and "our
+compiler would never produce that" is never an argument for admitting one.
+Every rule the types cannot state is enforced here — see the module JSDoc in
+[`module.f.mjs`](./module.f.mjs) for the list.
+
+Two of them deserve their reasoning here rather than at the code.
+
+### The property operand: unrepresentable, not guarded
+
+`['.', object, property]` takes a **constant** string or number. There is no
+spelling for `o[name]` with a computed `name`, so the abuse
+[2330](../../spec/todo/2330-property-accessor.md) documents —
+`f.constructor('…')`, `__proto__` — cannot be written down at all, rather than
+being written down and then checked at run time. That is a stronger property
+than a guard: nothing downstream has to remember to apply it.
+
+The permitted string constants are those not on 2330's prohibited list, which
+this module reproduces as five arrays named after the tables they come from.
+It covers the two prototype-chain names and every instance-method name 2330
+tabulates. Method names are prohibited *in a property position* whether or not
+the method has a side effect, because `a.indexOf` detached from `a` is a
+different value from the method call `a.indexOf(x)` — which is exactly why
+stage 2 introduces a separate `'.()'` operation instead of composing `'.'` with
+`'()'`.
+
+Two consequences worth stating plainly:
+
+- **Stage 1 rejects more than it eventually will.** A data property that
+  happens to be named `map` or `get` has no stage 1 spelling. The later
+  `['own', object, key]` — own properties only, no prototype chain, so a
+  computed name is harmless — is where such an access belongs. Rejecting is
+  recoverable; admitting something unsafe is not.
+- **`'.()'` will need a different, smaller list.** A method call whose whole
+  purpose is calling a method cannot inherit "no method names". Which names a
+  call position prohibits (the mutating and iterator-returning ones, by 2330's
+  side-effect columns) is settled with `'.()'` in stage 2, not assumed here.
+
+The `Function` instance properties 2330 tabulates — `name`, `prototype`,
+`caller`, `arguments`, `displayName` — are **not** on this list. Prohibiting
+`name` would reject `{ name: 'x' }.name`, an ordinary data access, and the
+escape it might otherwise open is already closed: reaching `Object` from
+`f.prototype` needs `constructor`, which is prohibited.
+
+### Entry descriptors are structural, not nodes
+
+`[':', key, value]` is an operand *of* `['{}', …]`, never evaluated on its own.
+Its container identity therefore means nothing, so validation rejects the same
+entry array appearing in two entry positions — otherwise DJS would faithfully
+preserve a distinction with no semantics, and two equivalent objects would hash
+differently. The `key` and `value` inside are ordinary nodes whose identities
+are shared as usual.
+
+Entry order is likewise semantic and never sorted: JavaScript applies
+object-literal definitions in source order, a duplicate key lets a later entry
+overwrite an earlier one, and insertion order of non-index keys is observable.
+The canonical sorting `fjs compile` applies to data output must not reach an
+object constructor's entries.
+
+## Why a hand-written validator rather than an RTTI schema
+
+[`todo/edag-spec.md`](../../todo/edag-spec.md) plans for the EDAG schema to be
+an [RTTI](../types/rtti/README.md) schema, with the Rust types and the
+`Function` constructor's validation generated from it. That is still the
+target, and it is not what stage 1 can be.
+
+RTTI describes tuples of fixed length; `['[]', ...node]` and `['{}', ...entry]`
+are variadic tuples with a tag in the head, which RTTI has no form for. More
+fundamentally, the rules that matter most here are not shape rules at all:
+acyclicity, node-identity sharing, and entry-descriptor aliasing are properties
+of the *graph*, invisible to any schema that walks a value structurally. A
+schema will eventually carry the shape half and generate the Rust half; the
+graph half stays hand-written either way.
+
+The error shape is shared rather than invented: `validate` reports RTTI's
+`{ path, message }` (`../types/rtti/common/types.ts`), with the path built from
+operand indices, so a consumer reporting an EDAG failure and one reporting a
+schema failure format the same value.
+
+`validate` also follows RTTI's `validate`, not its `parse`, in returning **the
+value it was given**. Reconstruction is not available to an EDAG reader at all:
+node identity is semantic, so a rebuilt graph is a different computation.

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -1,0 +1,252 @@
+/**
+ * The FunctionalScript EDAG (expression DAG): its stage 1 vocabulary and the
+ * validation that admits a value into it.
+ *
+ * `validate` is a **total gate**. The EDAG is the public input of the
+ * `Function` constructor, so it sees graphs no FunctionalScript compiler would
+ * ever emit, and "our compiler would not produce that" is never an argument
+ * for admitting one. Everything the shape allows and the semantics do not is
+ * rejected here:
+ *
+ * - a value with no EDAG spelling — a function, a symbol, or a plain object
+ *   (reserved, see `./types.ts`);
+ * - an unknown operation tag, or a known tag with the wrong number of
+ *   operands;
+ * - a property operand that is not a permitted string or number constant, so
+ *   prototype-chain lookup by a computed name has no spelling at all
+ *   (`propertyValidate` below);
+ * - an object entry that is not `[':', key, value]` with a string-constant
+ *   key, or one whose entry array is reused in a second entry position;
+ * - a cycle: sharing a node is how the graph is a DAG rather than a tree, but
+ *   a node reachable from itself is not a computation.
+ *
+ * A node reached twice is validated once. That is not only a cost concern —
+ * a graph sharing one node `n` times is `2^n` paths — it is also what makes
+ * the cycle check exact: a node currently *open* on the path is a cycle,
+ * while one already *done* is ordinary sharing.
+ *
+ * The stage 2 rules (a function body is a disjoint scope, so an operation node
+ * must not cross a `'=>'` boundary) arrive with `'=>'` itself.
+ *
+ * @module
+ *
+ * @import { Result } from '../types/result/types.ts'
+ * @import { ValidationError } from '../types/rtti/common/types.ts'
+ * @import { Entry, Node, Property } from './types.ts'
+ */
+
+import { error, ok } from '../types/result/module.f.mjs'
+import { isArray } from '../types/array/module.f.mjs'
+import { prependPath, verror } from '../types/rtti/common/module.f.mjs'
+
+/**
+ * The `Object.prototype` names
+ * [2330](../../spec/todo/2330-property-accessor.md) prohibits outright: each
+ * one reaches the `Function` constructor, and from there arbitrary code.
+ */
+const prototypeChainName = /** @type {const} */ ([
+    '__proto__', 'constructor',
+])
+
+/**
+ * The instance-method names 2330 tabulates for `Object`. A method name is
+ * prohibited in a *property* position whether or not the method itself has a
+ * side effect: `a.indexOf` detached from `a` is a different value from the
+ * method call `a.indexOf(x)`, which is why the EDAG has a separate `'.()'`
+ * operation for the call (stage 2).
+ */
+const objectMethodName = /** @type {const} */ ([
+    '__defineGetter__', '__defineSetter__', '__lookupGetter__',
+    '__lookupSetter__', 'hasOwnProperty', 'isPrototypeOf',
+    'propertyIsEnumerable', 'toLocaleString', 'toString', 'valueOf',
+])
+
+/**
+ * The instance-method names 2330 tabulates for `Array`. `copyWithin` is
+ * spelled `copyWith` in that table; the JavaScript name is the one that has to
+ * be unreachable.
+ */
+const arrayMethodName = /** @type {const} */ ([
+    'at', 'concat', 'copyWithin', 'entries', 'every', 'fill', 'filter', 'find',
+    'findIndex', 'findLast', 'findLastIndex', 'flat', 'flatMap', 'forEach',
+    'includes', 'indexOf', 'join', 'keys', 'lastIndexOf', 'map', 'pop', 'push',
+    'reduce', 'reduceRight', 'reverse', 'shift', 'slice', 'some', 'sort',
+    'splice', 'toReversed', 'toSorted', 'toSpliced', 'unshift', 'values',
+    'with',
+])
+
+/** The instance-method names 2330 tabulates for `Function`. */
+const functionMethodName = /** @type {const} */ (['apply', 'bind', 'call'])
+
+/**
+ * The instance-method names 2330 tabulates for `Map` and does not share with
+ * `Array`.
+ */
+const mapMethodName = /** @type {const} */ (['clear', 'delete', 'get', 'has', 'set'])
+
+/** @type {ReadonlySet<string>} */
+const prohibitedName = new Set([
+    ...prototypeChainName,
+    ...objectMethodName,
+    ...arrayMethodName,
+    ...functionMethodName,
+    ...mapMethodName,
+])
+
+/**
+ * Checks the property operand of `['.', object, property]`.
+ *
+ * A number constant is always permitted — it is an index, and no index reaches
+ * the prototype chain. A string constant is permitted unless it names one of
+ * the properties or methods
+ * [2330](../../spec/todo/2330-property-accessor.md) prohibits. Anything else —
+ * a bigint, a `null`, an operation node computing a string at run time — is
+ * rejected, which is what keeps `o[name]` for a computed `name` out of the
+ * language rather than guarded inside it.
+ *
+ * Exported because a compiler lowering source to `'.'` has to answer this
+ * question about a property *before* it has a node to validate.
+ *
+ * @type {(property: unknown) => Result<Property, ValidationError>}
+ */
+export const propertyValidate = property => {
+    if (typeof property === 'number') { return ok(property) }
+    if (typeof property !== 'string') { return verror('a property must be a string or number constant') }
+    return prohibitedName.has(property) ? verror('a prohibited property name') : ok(property)
+}
+
+/** @typedef {ReadonlySet<readonly unknown[]>} _Seen */
+
+/** @typedef {{
+ *   readonly done: _Seen
+ *   readonly open: _Seen
+ *   readonly entries: _Seen
+ * }} _State */
+
+/** @typedef {Result<_State, ValidationError>} _Result */
+
+/**
+ * Prefixes an operand index onto a failure's path, leaving a success alone.
+ * @type {<T>(key: string) => (result: Result<T, ValidationError>) => Result<T, ValidationError>}
+ */
+const atPath = key => result => {
+    const [tag, value] = result
+    return tag === 'error' ? prependPath(key, error(value)) : ok(value)
+}
+
+/**
+ * Walks the operands of `operation` from index 1, threading the state and
+ * stopping at the first failure.
+ * @type {(item: (state: _State) => (operand: unknown) => _Result) => (operation: readonly unknown[]) => (state: _State) => _Result}
+ */
+const operandsValidate = item => operation => state => {
+    let acc = state
+    for (let i = 1; i < operation.length; ++i) {
+        const [tag, value] = atPath(`${i}`)(item(acc)(operation[i]))
+        if (tag === 'error') { return error(value) }
+        acc = value
+    }
+    return ok(acc)
+}
+
+/** @type {(state: _State) => (node: unknown) => _Result} */
+const nodeValidate = state => node => {
+    switch (typeof node) {
+        case 'bigint':
+        case 'boolean':
+        case 'number':
+        case 'string':
+        case 'undefined': { return ok(state) }
+        case 'object': {
+            if (node === null) { return ok(state) }
+            return isArray(node)
+                ? operationValidate(state)(node)
+                : verror('a plain object is not an EDAG node')
+        }
+        default: { return verror('a function or a symbol is not an EDAG node') }
+    }
+}
+
+/**
+ * Validates one operation node, memoizing it and keeping it on the open path
+ * while its operands are walked.
+ * @type {(state: _State) => (operation: readonly unknown[]) => _Result}
+ */
+const operationValidate = state => operation => {
+    if (state.done.has(operation)) { return ok(state) }
+    if (state.open.has(operation)) { return verror('a cycle is not an EDAG') }
+    const opened = { ...state, open: new Set([...state.open, operation]) }
+    const [tag, value] = tagValidate(opened)(operation)
+    return tag === 'error'
+        ? error(value)
+        : ok({ ...value, open: state.open, done: new Set([...value.done, operation]) })
+}
+
+/**
+ * Operand shapes are per tag, never a global "an array in operand position is
+ * a tagged operation" rule, so a later operation with a differently shaped
+ * operand is an addition rather than a change.
+ * @type {(state: _State) => (operation: readonly unknown[]) => _Result}
+ */
+const tagValidate = state => operation => {
+    switch (operation[0]) {
+        case 'args': {
+            return operation.length === 1 ? ok(state) : verror('["args"] takes no operands')
+        }
+        case '[]': { return nodesValidate(operation)(state) }
+        case '{}': { return entriesValidate(operation)(state) }
+        case '.': {
+            if (operation.length !== 3) { return verror('["."] takes an object and a property') }
+            const [, object, property] = operation
+            const [tag, value] = atPath('2')(propertyValidate(property))
+            return tag === 'error'
+                ? error(value)
+                : atPath('1')(nodeValidate(state)(object))
+        }
+        default: { return verror('an unknown operation tag') }
+    }
+}
+
+/**
+ * Validates one `[':', key, value]` entry and records its container identity.
+ * @type {(state: _State) => (entry: unknown) => _Result}
+ */
+const entryValidate = state => entry => {
+    if (!isArray(entry)) { return verror('an object entry must be an entry descriptor') }
+    if (entry[0] !== ':') { return verror('an unknown object entry form') }
+    if (entry.length !== 3) { return verror('[":"] takes a key and a value') }
+    if (state.entries.has(entry)) { return verror('an entry descriptor is not shareable') }
+    const [, key, value] = entry
+    if (typeof key !== 'string') { return atPath('1')(verror('an entry key must be a string constant')) }
+    const recorded = { ...state, entries: new Set([...state.entries, entry]) }
+    return atPath('2')(nodeValidate(recorded)(value))
+}
+
+const nodesValidate = operandsValidate(nodeValidate)
+
+const entriesValidate = operandsValidate(entryValidate)
+
+/** @type {_State} */
+const emptyState = { done: new Set(), open: new Set(), entries: new Set() }
+
+/**
+ * Answers whether `value` is a valid EDAG, returning **the value it was
+ * given** on success — the same reference, so the sharing that makes the graph
+ * a DAG survives the check. A failure carries the offending operand's path and
+ * a short message, the shape
+ * [rtti](../types/rtti/common/types.ts) uses.
+ *
+ * Reconstructing the value instead, the way rtti's `parse` does, is not
+ * available to an EDAG reader: node identity is semantic here, so a rebuilt
+ * graph would be a different computation.
+ *
+ * @type {(value: unknown) => Result<Node, ValidationError>}
+ */
+export const validate = value => {
+    const [tag, e] = nodeValidate(emptyState)(value)
+    // The one place the type system cannot follow: `unknown` has just been
+    // walked against every rule `Node` states, and there is no runtime check
+    // left to perform. `parse`-style reconstruction, which would carry the
+    // type honestly, would lose the identities the EDAG means.
+    return tag === 'error' ? error(e) : ok(/** @type {Node} */ (value))
+}

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -1,0 +1,153 @@
+import { assertEq, assertStructurallySame } from '../asserts/module.f.mjs'
+import { propertyValidate, validate } from './module.f.mjs'
+
+/**
+ * A valid EDAG comes back as the value it was given — `assertEq`, not a
+ * structural comparison, because the identity is the point: it is what carries
+ * the graph's sharing past the check.
+ * @type {(value: unknown) => void}
+ */
+const assertValid = value => {
+    const [tag, node] = validate(value)
+    assertEq(tag, 'ok', node)
+    assertEq(node, value)
+}
+
+/** @type {(value: unknown) => (path: readonly string[]) => (message: string) => void} */
+const assertInvalid = value => path => message =>
+    assertStructurallySame(validate(value), ['error', { path, message }])
+
+const constant = {
+    bigint: () => assertValid(42n),
+    boolean: () => assertValid(false),
+    number: () => assertValid(-0),
+    string: () => assertValid('hello'),
+    undefined: () => assertValid(undefined),
+    null: () => assertValid(null),
+    // A plain object is reserved, and an object *value* is built by `['{}']`,
+    // so the two never compete for the same spelling.
+    object: () => assertInvalid({ a: 1 })([])('a plain object is not an EDAG node'),
+    function: () => assertInvalid(() => 0)([])('a function or a symbol is not an EDAG node'),
+    symbol: () => assertInvalid(Symbol())([])('a function or a symbol is not an EDAG node'),
+}
+
+const args = {
+    ok: () => assertValid(['args']),
+    operand: () => assertInvalid(['args', 0])([])('["args"] takes no operands'),
+}
+
+const arrayNode = {
+    empty: () => assertValid(['[]']),
+    elements: () => assertValid(['[]', 1, 'two', ['args']]),
+    nested: () => assertValid(['[]', ['[]', ['[]']]]),
+    element: () => assertInvalid(['[]', 0, {}])(['2'])('a plain object is not an EDAG node'),
+}
+
+const objectNode = {
+    empty: () => assertValid(['{}']),
+    entries: () => assertValid(['{}', [':', 'x', 1], [':', 'y', ['args']]]),
+    // Duplicate keys are valid and applied in order, as in JavaScript.
+    duplicate: () => assertValid(['{}', [':', 'x', 1], [':', 'x', 2]]),
+    // `__proto__` is an ordinary data key in an entry; only *printing* it
+    // needs the computed spelling.
+    proto: () => assertValid(['{}', [':', '__proto__', 1]]),
+    notEntry: () => assertInvalid(['{}', 'x'])(['1'])('an object entry must be an entry descriptor'),
+    unknownForm: () => assertInvalid(['{}', ['...', ['args']]])(['1'])('an unknown object entry form'),
+    arity: () => assertInvalid(['{}', [':', 'x']])(['1'])('[":"] takes a key and a value'),
+    key: () => assertInvalid(['{}', [':', 0, 1]])(['1', '1'])('an entry key must be a string constant'),
+    value: () => assertInvalid(['{}', [':', 'x', Symbol()]])(['1', '2'])('a function or a symbol is not an EDAG node'),
+}
+
+const property = {
+    name: () => assertValid(['.', ['args'], 'length']),
+    index: () => assertValid(['.', ['args'], 0]),
+    // The module-scope shape of an imported value: import parameter 0.
+    import: () => assertValid(['.', ['args'], 0]),
+    arity: () => assertInvalid(['.', ['args']])([])('["."] takes an object and a property'),
+    // A run-time-computed string has no spelling here at all, which is what
+    // makes prototype-chain lookup by a computed name unrepresentable.
+    computed: () => assertInvalid(['.', ['args'], ['.', ['args'], 0]])(['2'])('a property must be a string or number constant'),
+    prohibited: () => assertInvalid(['.', ['args'], 'constructor'])(['2'])('a prohibited property name'),
+    object: () => assertInvalid(['.', {}, 0])(['1'])('a plain object is not an EDAG node'),
+}
+
+const propertyOperand = {
+    number: () => assertStructurallySame(propertyValidate(1.5), ['ok', 1.5]),
+    permitted: () => {
+        assertStructurallySame(propertyValidate('length'), ['ok', 'length'])
+        assertStructurallySame(propertyValidate('size'), ['ok', 'size'])
+        assertStructurallySame(propertyValidate('x'), ['ok', 'x'])
+    },
+    prohibited: () => {
+        /** @type {(name: string) => void} */
+        const rejected = name =>
+            assertStructurallySame(propertyValidate(name), ['error', { path: [], message: 'a prohibited property name' }])
+        // one name per table 2330 tabulates
+        rejected('__proto__')
+        rejected('constructor')
+        rejected('toString')
+        rejected('map')
+        rejected('copyWithin')
+        rejected('bind')
+        rejected('get')
+    },
+    other: () =>
+        assertStructurallySame(
+            propertyValidate(0n),
+            ['error', { path: [], message: 'a property must be a string or number constant' }]),
+}
+
+const graph = {
+    // Two positions holding one node: the array's elements are the same
+    // object, and the node is validated once.
+    shared: () => {
+        const x = ['[]', 1]
+        assertValid(['[]', x, x])
+    },
+    // Sharing the key and value *nodes* of two entries stays valid; only the
+    // entry descriptor itself is not shareable.
+    sharedEntryValue: () => {
+        const v = ['[]']
+        assertValid(['{}', [':', 'x', v], [':', 'y', v]])
+    },
+    entryDescriptor: () => {
+        const e = [':', 'x', 1]
+        assertInvalid(['{}', e, e])(['2'])('an entry descriptor is not shareable')
+    },
+    // The one hostile input that cannot be written down as a literal: an EDAG
+    // is cyclic only once something mutates it into one, which is exactly why
+    // validation cannot take acyclicity on trust.
+    cycle: () => {
+        /** @type {unknown[]} */
+        const self = ['[]']
+        self[1] = self
+        assertInvalid(self)(['1'])('a cycle is not an EDAG')
+    },
+    // A node whose validation already completed is ordinary sharing when it
+    // reappears, and a cycle only while it is still open.
+    reentrant: () => {
+        /** @type {unknown[]} */
+        const inner = ['[]']
+        const outer = ['[]', inner, inner]
+        inner[1] = outer
+        assertInvalid(outer)(['1', '1'])('a cycle is not an EDAG')
+    },
+}
+
+export const proof = {
+    constant,
+    args,
+    arrayNode,
+    objectNode,
+    property,
+    propertyOperand,
+    graph,
+    unknownTag: () => assertInvalid(['?'])([])('an unknown operation tag'),
+    // The whole stage 1 vocabulary in one graph — the compiled form of
+    // `import a from './a.f.js'; const x = [a, 1]; export default {x: x, y: x}`.
+    module: () => {
+        const a = ['.', ['args'], 0]
+        const x = ['[]', a, 1]
+        assertValid(['{}', [':', 'x', x], [':', 'y', x]])
+    },
+}

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -1,0 +1,100 @@
+/**
+ * Type-level API for the FunctionalScript EDAG — an *expression DAG*: the
+ * canonical representation of a compiled computation, expressed as an ordinary
+ * FunctionalScript value.
+ *
+ * This file carries the **stage 1** vocabulary only: constants, the array and
+ * object constructors, the arguments array, and property access. Functions
+ * (`['=>', frame, body]`), calls (`['()', …]`, `['.()', …]`), operators, and
+ * `[',', …]` are later stages and are deliberately absent — see
+ * `../../todo/edag-stage1-discussion.md` for the full vocabulary and
+ * `../djs/todo/compile-modules-to-edag.md` for the rollout order.
+ *
+ * Two properties of the shape are load-bearing and cannot be read off the
+ * types:
+ *
+ * - **Sharing is semantic.** An operand position holds a real reference to a
+ *   node, so referencing one node twice means *one* value used twice:
+ *   `['[]', x, x]` builds an array whose two elements are the same object,
+ *   while `['[]', ['{}'], ['{}']]` builds two distinct ones.
+ * - **Validation is a total gate.** `Node` describes the shape a validated
+ *   EDAG has, not everything TypeScript would accept here: a prohibited
+ *   property name and a cyclic graph are both `Node`-shaped and both rejected
+ *   by `validate` in `./module.f.mjs`.
+ *
+ * @module
+ */
+
+import type { Primitive } from '../types/rtti/ts/types.ts'
+
+/**
+ * A constant node — any non-object, non-array value, denoting itself.
+ *
+ * Functions, symbols, and plain objects are not constants: the first two have
+ * no EDAG spelling at all, and plain objects are reserved for a future use
+ * (an object *value* is built by `ObjectNode`, not written down directly).
+ */
+export type Constant = Primitive
+
+/**
+ * `['args']` — the arguments array of the enclosing function scope.
+ *
+ * It is one node yielding an array, not a list of operands, so a single
+ * argument is `['.', ['args'], 0]` and forwarding the whole array is free.
+ * At module scope it is the imported-module array; inside a (stage 2)
+ * function body it is that invocation's arguments instead.
+ */
+export type ArgsNode = readonly ['args']
+
+/** `['[]', ...node]` — an array constructor. */
+export type ArrayNode = readonly ['[]', ...Node[]]
+
+/**
+ * `['{}', ...entry]` — an ordered object constructor.
+ *
+ * The entry sequence is retained exactly as written: JavaScript applies
+ * object-literal definitions in source order, duplicate keys let a later entry
+ * overwrite an earlier one, and insertion order of non-index keys is
+ * observable. Entries are therefore never sorted.
+ */
+export type ObjectNode = readonly ['{}', ...Entry[]]
+
+/**
+ * `[':', key, value]` — one entry of an object constructor.
+ *
+ * An entry is a **structural operand** of `['{}', …]`, not a node: it is never
+ * evaluated on its own, so its container identity carries no meaning and one
+ * entry array must not appear in two entry positions. Its `key` and `value`
+ * are ordinary nodes whose identities may be shared as usual.
+ *
+ * The key position is a node in the wider design so that computed keys can be
+ * admitted later without changing the constructor's shape; stage 1 spells it
+ * as a `string` because a string constant is all validation accepts —
+ * arbitrary key expressions need `ToPropertyKey` coercion and failure
+ * semantics first. `'__proto__'` is an ordinary data key here, never a
+ * prototype assignment.
+ */
+export type Entry = readonly [':', string, Node]
+
+/**
+ * The property operand of `['.', object, property]`.
+ *
+ * A *constant* string or number, so the name is known when the graph is
+ * validated rather than computed while it runs. That is what makes
+ * prototype-chain lookup by a computed name unrepresentable rather than
+ * merely checked. Not every `Property` is permitted: `validate` also rejects
+ * the prohibited names — see `propertyValidate` in `./module.f.mjs`.
+ *
+ * Later stages widen this to the unary `['+', node]` / `['Number', node]`
+ * forms, each guaranteed to yield a number or throw.
+ */
+export type Property = string | number
+
+/** `['.', object, property]` — property access, JavaScript's `o.p` / `o[p]`. */
+export type PropertyNode = readonly ['.', Node, Property]
+
+/** A tagged operation node: everything that is not a constant. */
+export type Operation = ArgsNode | ArrayNode | ObjectNode | PropertyNode
+
+/** Any EDAG node — the operand type of every operation. */
+export type Node = Constant | Operation

--- a/todo/edag-spec.md
+++ b/todo/edag-spec.md
@@ -102,7 +102,9 @@ standard JSON numeric policy remains separate in
 
 ### Tasks
 
-- [ ] Create `fjs/edag/` as the canonical FunctionalScript EDAG module.
+- [x] Create `fjs/edag/` as the canonical FunctionalScript EDAG module.
+      Its stage 1 node types and `validate` are in place; the stage 2 forms
+      and the RTTI schema below are still open.
 - [ ] Keep the `EDAG`/operation types, canonical operation definitions, RTTI
       schema, and EDAG-only validation in `fjs/edag/`; do not duplicate those
       definitions under `fjs/djs/` or another consumer.


### PR DESCRIPTION
## Summary

This PR introduces the FunctionalScript EDAG (expression DAG) module as the canonical representation of compiled computations. It implements stage 1 of the EDAG vocabulary with complete validation, type definitions, and comprehensive test coverage.

## Key Changes

- **New module `fjs/edag/`**: Establishes the EDAG as a public input format for the `Function` constructor
  - `module.f.mjs`: Total-gate validator that enforces all structural and graph-level rules
  - `types.ts`: TypeScript type definitions for stage 1 nodes (constants, arrays, objects, property access, arguments)
  - `README.md`: Comprehensive documentation of the EDAG design, vocabulary, and validation philosophy
  - `proof.f.mjs`: Extensive test suite covering all node types, validation rules, and edge cases

- **Stage 1 vocabulary** (constants, `['[]']`, `['{}']`, `['args']`, `['.']`):
  - Validates node identity and sharing semantics (DAG structure)
  - Rejects cycles, non-shareable entry descriptors, and computed property names
  - Enforces prohibited property names from spec 2330 (prototype chain and method names)
  - Returns validated values with identity preserved (not reconstructed)

- **Validation as a total gate**: Rejects everything the shape allows but semantics do not:
  - Functions, symbols, and plain objects (reserved for future use)
  - Unknown operation tags or wrong operand counts
  - Computed property names (keeping prototype-chain abuse unrepresentable)
  - Cyclic graphs and reused entry descriptors

- **Documentation**: Explains why hand-written validation is necessary (RTTI cannot express variadic tuples or graph properties), the staged rollout plan, and the reasoning behind key restrictions.

## Notable Implementation Details

- **Memoization with cycle detection**: Nodes are validated once and tracked in `done` and `open` sets to distinguish cycles from ordinary sharing
- **Path-based error reporting**: Failures include operand indices for precise error location, matching RTTI's error shape
- **Property validation exported separately**: Compilers can validate properties before constructing nodes
- **Entry descriptor aliasing prevention**: Same entry array cannot appear in multiple entry positions, but key/value nodes within entries can be shared normally

https://claude.ai/code/session_01VU9hb7sbrDwt5VrVDfeWRy