### PR TITLE
edag: add own, neg, sub nodes (rename plus to add)

### DIFF
--- a/changelog/unreleased/1656.md
+++ b/changelog/unreleased/1656.md
@@ -1,3 +1,3 @@
-- `edag`: rename `Plus` to `Add`; add `Sub` (binary `-`), both in the `exp` union
-- `edag`: add `Own` (`['own', exp, exp]`) and `Neg` (`['neg', exp]`) exports — not yet
-  part of the `exp` union
+- `edag`: rename `Plus` to `Add`; add `Sub` (binary `-`), `Own` (`['own', exp, exp]`),
+  and `Neg` (`['-', exp]`, unary negation — arity, not tag, distinguishes it from
+  `Sub`), all four now in the `exp` union

--- a/changelog/unreleased/1656.md
+++ b/changelog/unreleased/1656.md
@@ -1,0 +1,3 @@
+- `edag`: rename `Plus` to `Add`; add `Sub` (binary `-`), both in the `exp` union
+- `edag`: add `Own` (`['own', exp, exp]`) and `Neg` (`['neg', exp]`) exports — not yet
+  part of the `exp` union

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -236,7 +236,7 @@ export const propertyCall = _propertyCall
  * @typedef {Assert<Check<PropertyCall, typeof propertyCall>>} _PropertyCall1
  */
 
-// own
+// own, `const own = (a, b) => Object.getOwnPropertyDescriptor(a, k)?.value`
 
 const _own = /** @type {const} */(['own', exp, exp])
 

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -16,8 +16,9 @@
  *  Object,
  *  PropertyCall,
  *  UndefinedOp,
- *  Plus,
- *  Minus
+ *  Add,
+ *  Sub,
+ *  Neg
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */
@@ -29,7 +30,6 @@ import {
     or,
     string,
     array as rttiArray,
-    option,
 } from "../types/rtti/module.f.mjs";
 
 /**
@@ -56,7 +56,8 @@ import {
  *  typeof propertyAccessor,
  *  typeof call,
  *  typeof propertyCall,
- *  typeof plus,
+ *  typeof add,
+ *  typeof sub,
  * ]}
  */
 export const exp = () => (['or',
@@ -69,7 +70,8 @@ export const exp = () => (['or',
     propertyAccessor,
     call,
     propertyCall,
-    plus,
+    add,
+    sub,
 ])
 
 /** @typedef {Assert<Check<Exp, typeof exp>>} _ExpAssert */
@@ -233,25 +235,33 @@ export const propertyCall = _propertyCall
  * @typedef {Assert<Check<PropertyCall, typeof propertyCall>>} _PropertyCall1
  */
 
-// +
+// Binary +
 
-const _plus = /** @type {const} */(['+', exp, exp])
+const _add = /** @type {const} */(['+', exp, exp])
 
-/** @type {Phantom<typeof _plus, Plus>} */
-export const plus = _plus
-
-/**
- * @typedef {Assert<Check<Plus, typeof _plus>>} _Plus0
- * @typedef {Assert<Check<Plus, typeof plus>>} _Plus1
- */
-
-// -
-
-export const _minus = /** @type {const} */(['-', exp, option(exp)])
-
-export const minus = _minus
+/** @type {Phantom<typeof _add, Add>} */
+export const add = _add
 
 /**
- * @typedef {Assert<Check<Minus, typeof _minus>>} _Minus0
- * @typedef {Assert<Check<Minus, typeof minus>>} _Minus1
+ * @typedef {Assert<Check<Add, typeof _add>>} _Add0
+ * @typedef {Assert<Check<Add, typeof add>>} _Add1
  */
+
+// Binary -
+
+const _sub = /** @type {const} */(['-', exp, exp])
+
+/** @type {Phantom<typeof _sub, Sub>} */
+export const sub = _sub
+
+/**
+ * @typedef {Assert<Check<Sub, typeof _sub>>} _Minus0
+ * @typedef {Assert<Check<Sub, typeof sub>>} _Minus1
+ */
+
+// Negation (aka a unary minus)
+
+const _neg = /** @type {const} */(['neg', exp])
+
+/** @type {Phantom<typeof _neg, Neg>} */
+export const neg = _neg

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -17,6 +17,7 @@
  *  PropertyCall,
  *  UndefinedOp,
  *  Plus,
+ *  Minus
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */
@@ -28,6 +29,7 @@ import {
     or,
     string,
     array as rttiArray,
+    option,
 } from "../types/rtti/module.f.mjs";
 
 /**
@@ -241,4 +243,15 @@ export const plus = _plus
 /**
  * @typedef {Assert<Check<Plus, typeof _plus>>} _Plus0
  * @typedef {Assert<Check<Plus, typeof plus>>} _Plus1
+ */
+
+// -
+
+export const _minus = /** @type {const} */(['-', exp, option(exp)])
+
+export const minus = _minus
+
+/**
+ * @typedef {Assert<Check<Minus, typeof _minus>>} _Minus0
+ * @typedef {Assert<Check<Minus, typeof minus>>} _Minus1
  */

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -18,7 +18,8 @@
  *  UndefinedOp,
  *  Add,
  *  Sub,
- *  Neg
+ *  Neg,
+ Own
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */
@@ -233,6 +234,18 @@ export const propertyCall = _propertyCall
 /**
  * @typedef {Assert<Check<PropertyCall, typeof _propertyCall>>} _PropertyCall0
  * @typedef {Assert<Check<PropertyCall, typeof propertyCall>>} _PropertyCall1
+ */
+
+// own
+
+const _own = /** @type {const} */(['own', exp, exp])
+
+/** @type {Phantom<typeof _own, Own>} */
+export const own = _own
+
+/**
+ * @typedef {Assert<Check<Own, typeof _own>>} _Own0
+ * @typedef {Assert<Check<Own, typeof own>>} _Own1
  */
 
 // Binary +

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -278,8 +278,8 @@ const _sub = /** @type {const} */(['-', exp, exp])
 export const sub = _sub
 
 /**
- * @typedef {Assert<Check<Sub, typeof _sub>>} _Minus0
- * @typedef {Assert<Check<Sub, typeof sub>>} _Minus1
+ * @typedef {Assert<Check<Sub, typeof _sub>>} _Sub0
+ * @typedef {Assert<Check<Sub, typeof sub>>} _Sub1
  */
 
 // Negation (aka a unary minus) — tagged `"-"`, same as `sub`; arity

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -19,7 +19,7 @@
  *  Add,
  *  Sub,
  *  Neg,
- Own
+ *  Own,
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */
@@ -57,8 +57,10 @@ import {
  *  typeof propertyAccessor,
  *  typeof call,
  *  typeof propertyCall,
+ *  typeof own,
  *  typeof add,
  *  typeof sub,
+ *  typeof neg,
  * ]}
  */
 export const exp = () => (['or',
@@ -71,8 +73,16 @@ export const exp = () => (['or',
     propertyAccessor,
     call,
     propertyCall,
+    own,
     add,
     sub,
+    // `neg` must be tried after `sub`: both are tagged `"-"`, and a tuple's
+    // trailing positions are open (see the module doc comment above), so
+    // `neg`'s one-operand schema would also match `['-', a, b]` — silently
+    // dropping `b` — if it were checked first. `or` returns the first match
+    // (`../types/rtti/common/module.f.mjs`'s `orVisit`), so this order is
+    // load-bearing, not cosmetic.
+    neg,
 ])
 
 /** @typedef {Assert<Check<Exp, typeof exp>>} _ExpAssert */
@@ -272,9 +282,15 @@ export const sub = _sub
  * @typedef {Assert<Check<Sub, typeof sub>>} _Minus1
  */
 
-// Negation (aka a unary minus)
+// Negation (aka a unary minus) — tagged `"-"`, same as `sub`; arity
+// distinguishes them (see the ordering note on `exp` above)
 
-const _neg = /** @type {const} */(['neg', exp])
+const _neg = /** @type {const} */(['-', exp])
 
 /** @type {Phantom<typeof _neg, Neg>} */
 export const neg = _neg
+
+/**
+ * @typedef {Assert<Check<Neg, typeof _neg>>} _Neg0
+ * @typedef {Assert<Check<Neg, typeof neg>>} _Neg1
+ */

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -4,6 +4,7 @@
  *
  * @import { ValidationError } from '../types/rtti/common/types.ts'
  * @import { Unknown } from '../types/rtti/ts/types.ts'
+ * @import { StringMap } from '../types/object/types.ts'
  */
 
 import { validate } from '../types/rtti/validate/module.f.mjs'
@@ -181,4 +182,16 @@ export const proof = {
         ])
         assertOk(v(value))
     },
+    own: {
+        js: () => {
+            /** @type {<T>(a: StringMap<T>, k: string) => T|undefined } */
+            const own = (a, k) => Object.getOwnPropertyDescriptor(a, k)?.value
+            //
+            const a = { ['__proto__']: 42 }
+            const v = own(a, '__proto__')
+            assertEq(v, 42)
+            const x = own(a, 'x')
+            assertEq(x, undefined)
+        }
+    }
 }

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -8,6 +8,7 @@
  */
 
 import { validate } from '../types/rtti/validate/module.f.mjs'
+import { parse } from '../types/rtti/parse/module.f.mjs'
 import { assert, assertEq, assertStructurallySame } from '../asserts/module.f.mjs'
 import { exp } from './module.f.mjs'
 
@@ -30,6 +31,9 @@ const assertNoMatch = r => {
 
 /** @type {(value: Unknown) => readonly [string, unknown]} */
 const v = value => validate(exp)(value)
+
+/** @type {(value: Unknown) => readonly [string, unknown]} */
+const p = value => parse(exp)(value)
 
 export const proof = {
     primitive: {
@@ -158,7 +162,25 @@ export const proof = {
             assertNoMatch(v(['.()', 'o', 'k']))
         },
     },
-    plus: {
+    own: {
+        ok: () => assertOk(v(['own', 'o', 'k'])),
+        // A missing operand reads as `undefined`, no longer a valid bare
+        // `exp` — see `undefinedOp`.
+        missingTailIsError: () => assertNoMatch(v(['own', 'o'])),
+        extraTailIsIgnored: () => assertOk(v(['own', 'o', 'k', 'extra'])),
+        error: () => assertNoMatch(v(['ownz', 'o', 'k'])),
+        // `own`'s point is bypassing the prototype chain — including the
+        // `__proto__` special case a computed key already avoids in JS.
+        // Demonstrates the pattern `own` denotes; not a schema check.
+        js: () => {
+            /** @type {<T>(a: StringMap<T>, k: string) => T|undefined } */
+            const own = (a, k) => Object.getOwnPropertyDescriptor(a, k)?.value
+            const a = { ['__proto__']: 42 }
+            assertEq(own(a, '__proto__'), 42)
+            assertEq(own(a, 'x'), undefined)
+        },
+    },
+    add: {
         ok: () => {
             assertOk(v(['+', 1, 2]))
             assertOk(v(['+', ['+', 1, 2], 3])) // an exp nested inside an operand
@@ -172,6 +194,39 @@ export const proof = {
         extraTailIsIgnored: () => assertOk(v(['+', 1, 2, 3])),
         error: () => assertNoMatch(v(['+z', 1, 2])),
     },
+    sub: {
+        ok: () => {
+            assertOk(v(['-', 1, 2]))
+            assertOk(v(['-', ['-', 1, 2], 3])) // an exp nested inside an operand
+        },
+        extraTailIsIgnored: () => assertOk(v(['-', 1, 2, 3])),
+        error: () => assertNoMatch(v(['-z', 1, 2])),
+        // Unlike `add`, a missing second operand is *not* an error here:
+        // `sub` and `neg` share the `"-"` tag, and `or` tries `sub` (two
+        // operands) before falling through to `neg` (one) — see `neg`
+        // below and the ordering note on `exp` in module.f.mjs.
+        oneOperandFallsThroughToNeg: () => assertOk(v(['-', 1])),
+        // `validate` returns the input unchanged regardless of which `or`
+        // alternative matched, so it can't tell `sub` matching first from
+        // `neg` matching first (open-tailed, `neg` would also accept
+        // `['-', 1, 2]` and just ignore the second operand). `parse`
+        // rebuilds only the matched schema's own declared positions, so it
+        // is what actually distinguishes them: if `neg` were tried before
+        // `sub`, this would rebuild `['-', 1]`, silently dropping `2`.
+        binaryMatchesSubNotNeg: () => {
+            const [tag, r] = p(['-', 1, 2])
+            assertEq(tag, 'ok')
+            assertStructurallySame(r, ['-', 1, 2], 'expected sub, not neg, to match first')
+        },
+    },
+    neg: {
+        ok: () => {
+            assertOk(v(['-', 1]))
+            assertOk(v(['-', ['-', 1]])) // an exp nested inside the operand
+        },
+        // With no operands at all, both `sub` and `neg` fail to match.
+        error: () => assertNoMatch(v(['-'])),
+    },
     // `f(args)[k](obj.a)` in AST form — exercises the mutual recursion through
     // `exp` rather than any one node kind in isolation.
     nested: () => {
@@ -182,16 +237,4 @@ export const proof = {
         ])
         assertOk(v(value))
     },
-    own: {
-        js: () => {
-            /** @type {<T>(a: StringMap<T>, k: string) => T|undefined } */
-            const own = (a, k) => Object.getOwnPropertyDescriptor(a, k)?.value
-            //
-            const a = { ['__proto__']: 42 }
-            const v = own(a, '__proto__')
-            assertEq(v, 42)
-            const x = own(a, 'x')
-            assertEq(x, undefined)
-        }
-    }
 }

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -73,3 +73,7 @@ export type PropertyCall = readonly['.()', Exp, Index, Exp]
 // +
 
 export type Plus = readonly['+', Exp, Exp]
+
+// -
+
+export type Minus = readonly['-', Exp, Exp | undefined]

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -19,8 +19,10 @@ export type Exp =
     | PropertyAccessor
     | Call
     | PropertyCall
+    | Own
     | Add
     | Sub
+    | Neg
 
 // undefinedOp
 
@@ -83,6 +85,6 @@ export type Add = readonly['+', Exp, Exp]
 
 export type Sub = readonly['-', Exp, Exp]
 
-// negation
+// negation (aka a unary minus — arity, not tag, distinguishes it from `Sub`)
 
-export type Neg = readonly['neg', Exp]
+export type Neg = readonly['-', Exp]

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -19,7 +19,8 @@ export type Exp =
     | PropertyAccessor
     | Call
     | PropertyCall
-    | Plus
+    | Add
+    | Sub
 
 // undefinedOp
 
@@ -70,10 +71,14 @@ export type Call = readonly['()', Exp, Exp]
 
 export type PropertyCall = readonly['.()', Exp, Index, Exp]
 
-// +
+// Binary +
 
-export type Plus = readonly['+', Exp, Exp]
+export type Add = readonly['+', Exp, Exp]
 
-// -
+// Binary -
 
-export type Minus = readonly['-', Exp, Exp | undefined]
+export type Sub = readonly['-', Exp, Exp]
+
+// negation
+
+export type Neg = readonly['neg', Exp]

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -71,6 +71,10 @@ export type Call = readonly['()', Exp, Exp]
 
 export type PropertyCall = readonly['.()', Exp, Index, Exp]
 
+// own
+
+export type Own = readonly ['own', Exp, Exp]
+
 // Binary +
 
 export type Add = readonly['+', Exp, Exp]


### PR DESCRIPTION
## Summary
- Rename `fjs/edag`'s `Plus` to `Add` (no shape change: `['+', exp, exp]`) and add `Sub` — binary `-` (`['-', exp, exp]`), `Own` — own-property access (`['own', exp, exp]`, the design doc's planned `["own", object, key]`), and `Neg` — unary negation (`['-', exp]`). All four are wired into the `exp` union / `Exp` type, so e.g. `validate(exp)(['-', 1, 2])` and `validate(exp)(['own', 'o', 'k'])` are now `ok` where `main` gives `no match`.
- `Neg` and `Sub` share the `'-'` tag on purpose (arity distinguishes unary negation from binary subtraction, per `todo/edag-stage1-discussion.md`'s Operators table). This is order-sensitive in `exp`'s `or` list: tuples are open-tailed here, so `Neg`'s one-operand schema would also match `['-', a, b]` and silently drop `b` if tried before `Sub`. Verified this empirically (a standalone `or(neg, sub)` vs `or(sub, neg)` comparison) before placing `neg` after `sub` and documenting why in a comment. `proof.f.mjs`'s `sub.binaryMatchesSubNotNeg` pins it with `parse` rather than `validate`, since `validate` returns the input unchanged regardless of which alternative matched and so can't actually distinguish the two.
- `proof.f.mjs` now has one section per union member (13/13): `add:` (renamed from the stale `plus:`), new `sub:`/`neg:`/`own:` sections with ok/error/nested-composition cases. `own:` validates the actual `['own', exp, exp]` schema through `validate(exp)`, alongside (not instead of) the existing `Object.getOwnPropertyDescriptor` demonstration.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run cov` — 3086/3086 tests, 100% lines/branches/functions
- [x] `npm run ci-update` — no diff

Changelog:
- `edag`: rename `Plus` to `Add`; add `Sub` (binary `-`), `Own` (`['own', exp, exp]`),
  and `Neg` (`['-', exp]`, unary negation — arity, not tag, distinguishes it from
  `Sub`), all four now in the `exp` union
