### PR TITLE
edag: add Comma and Fn nodes; introduce Check3

### DIFF
--- a/changelog/unreleased/1657.md
+++ b/changelog/unreleased/1657.md
@@ -1,6 +1,7 @@
 - `edag`: add `Own` (`['own', exp, exp]`), `Add`/`Sub` (binary `+`/`-`), `Neg`
   (`['neg', exp]`, unary negation — a word tag, not `"-"`'s unary arity), `Comma`
-  (`[',', exps]`), and `Fn` (`['=>', frame, exp]`, non-capturing function; `frame`
-  accepts only the empty `['[]']`), all now in the `exp` union
+  (`[',', exps]`), and `Fn` (`['=>', frame, exp]`, non-capturing function; `frame` is
+  `Array`-shaped, the canonical form being the empty `['[]', []]`), all now in the
+  `exp` union
 - `types/rtti/ts`: new `Check3<T, R0, R1>` type; `types/ts`: new `And<A, B>` boolean
   type-level helper

--- a/changelog/unreleased/1657.md
+++ b/changelog/unreleased/1657.md
@@ -1,7 +1,6 @@
-- `edag`: add `Own` (`['own', exp, exp]`), `Add`/`Sub` (binary `+`/`-`), `Neg`
-  (`['neg', exp]`, unary negation — a word tag, not `"-"`'s unary arity), `Comma`
-  (`[',', exps]`), and `Fn` (`['=>', frame, exp]`, non-capturing function; `frame` is
-  `null` for now, a placeholder until frame/capture design lands), all now in the
-  `exp` union
+- `edag`: add `Comma` (`[',', exps]`) and `Fn` (`['=>', frame, exp]`, non-capturing
+  function) to the `exp` union, plus the `Frame` placeholder type (`null` for now,
+  until frame/capture design lands). Retags `Neg` (shipped in #1656 as `['-', exp]`)
+  to `['neg', exp]` — a word tag, not `"-"`'s unary arity
 - `types/rtti/ts`: new `Check3<T, R0, R1>` type; `types/ts`: new `And<A, B>` boolean
   type-level helper

--- a/changelog/unreleased/1657.md
+++ b/changelog/unreleased/1657.md
@@ -1,0 +1,6 @@
+- `edag`: add `Own` (`['own', exp, exp]`), `Add`/`Sub` (binary `+`/`-`), `Neg`
+  (`['neg', exp]`, unary negation — a word tag, not `"-"`'s unary arity), `Comma`
+  (`[',', exps]`), and `Fn` (`['=>', frame, exp]`, non-capturing function; `frame`
+  accepts only the empty `['[]']`), all now in the `exp` union
+- `types/rtti/ts`: new `Check3<T, R0, R1>` type; `types/ts`: new `And<A, B>` boolean
+  type-level helper

--- a/changelog/unreleased/1657.md
+++ b/changelog/unreleased/1657.md
@@ -1,7 +1,7 @@
 - `edag`: add `Own` (`['own', exp, exp]`), `Add`/`Sub` (binary `+`/`-`), `Neg`
   (`['neg', exp]`, unary negation — a word tag, not `"-"`'s unary arity), `Comma`
   (`[',', exps]`), and `Fn` (`['=>', frame, exp]`, non-capturing function; `frame` is
-  `Array`-shaped, the canonical form being the empty `['[]', []]`), all now in the
+  `null` for now, a placeholder until frame/capture design lands), all now in the
   `exp` union
 - `types/rtti/ts`: new `Check3<T, R0, R1>` type; `types/ts`: new `And<A, B>` boolean
   type-level helper

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -187,7 +187,7 @@ array described above. A nested `['=>', frame, body]` introduces a new function 
 where `['args']` means that function invocation's arguments instead. Module linking must
 therefore never descend into a nested function `body` while substituting module import
 parameters. The `frame` operand belongs to the enclosing scope and may be traversed
-there; Stage 2 restricts it to the empty `['[]', []]` form anyway. Import reachability checks
+there; Stage 2 uses the placeholder `null` for it anyway. Import reachability checks
 must use the same scope boundary so function-local `['args']` nodes cannot be mistaken
 for module import parameters.
 
@@ -223,13 +223,15 @@ Introduce the function operation into EDAG:
 
 **Stage 2 does not implement frames/captures.** The `frame` operand is present in the
 operation shape so later frame support does not require changing `=>`, but Stage 2
-accepts only an empty frame and does not introduce `['frame']` access. Source functions
-that capture values from an enclosing function/module scope are outside this stage.
-For the initial canonical form, a function is therefore represented with an empty frame,
-for example:
+uses `null` as a placeholder for it and does not introduce `['frame']` access. Source
+functions that capture values from an enclosing function/module scope are outside this
+stage. `frame` is expected to become an `Exp` once frame/capture design lands — a bare
+value for one capture, an array node for several — decided by whatever constructs the
+function, not by `=>`'s shape. For the initial canonical form, a function is therefore
+represented with the placeholder frame, for example:
 
 ```js
-['=>', ['[]', []], body]
+['=>', null, body]
 ```
 
 Then introduce the initial non-capturing arrow-function form into the parser:
@@ -278,7 +280,8 @@ The staged work builds on the basic structural forms already being defined for E
 - the argument array: `['args']`;
 - Stage 1 property access: `['.', object, property]`, with the restricted property
   operands described above;
-- Stage 2 non-capturing functions: `['=>', ['[]', []], body]`;
+- Stage 2 non-capturing functions: `['=>', null, body]` (`null` is a placeholder for
+  `frame`, not yet a real operand);
 - Stage 2 calls: `['()', object, args]` and
   `['.()', object, property, args]`, with `.()` using the same property restriction as
   `.`;
@@ -453,7 +456,7 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
 #### Stage 2
 
 - [ ] Introduce `['=>', frame, body]` into EDAG and its validation/type schema, with
-      Stage 2 restricted to the canonical empty frame `['[]', []]`.
+      Stage 2 using the placeholder `null` for `frame`.
 - [ ] Do **not** introduce `['frame']` or captured-variable access in Stage 2.
 - [ ] Introduce parser support for the initial non-capturing `(...a) => exp` function
       form; reject functions that require captures.

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -187,7 +187,7 @@ array described above. A nested `['=>', frame, body]` introduces a new function 
 where `['args']` means that function invocation's arguments instead. Module linking must
 therefore never descend into a nested function `body` while substituting module import
 parameters. The `frame` operand belongs to the enclosing scope and may be traversed
-there; Stage 2 restricts it to the empty `['[]']` form anyway. Import reachability checks
+there; Stage 2 restricts it to the empty `['[]', []]` form anyway. Import reachability checks
 must use the same scope boundary so function-local `['args']` nodes cannot be mistaken
 for module import parameters.
 
@@ -229,7 +229,7 @@ For the initial canonical form, a function is therefore represented with an empt
 for example:
 
 ```js
-['=>', ['[]'], body]
+['=>', ['[]', []], body]
 ```
 
 Then introduce the initial non-capturing arrow-function form into the parser:
@@ -278,7 +278,7 @@ The staged work builds on the basic structural forms already being defined for E
 - the argument array: `['args']`;
 - Stage 1 property access: `['.', object, property]`, with the restricted property
   operands described above;
-- Stage 2 non-capturing functions: `['=>', ['[]'], body]`;
+- Stage 2 non-capturing functions: `['=>', ['[]', []], body]`;
 - Stage 2 calls: `['()', object, args]` and
   `['.()', object, property, args]`, with `.()` using the same property restriction as
   `.`;
@@ -453,7 +453,7 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
 #### Stage 2
 
 - [ ] Introduce `['=>', frame, body]` into EDAG and its validation/type schema, with
-      Stage 2 restricted to the canonical empty frame `['[]']`.
+      Stage 2 restricted to the canonical empty frame `['[]', []]`.
 - [ ] Do **not** introduce `['frame']` or captured-variable access in Stage 2.
 - [ ] Introduce parser support for the initial non-capturing `(...a) => exp` function
       form; reject functions that require captures.

--- a/fjs/djs/todo/interpret-edag.md
+++ b/fjs/djs/todo/interpret-edag.md
@@ -54,7 +54,8 @@ same EDAG forms: Stage 1 adds `.` property access; Stage 2 adds non-capturing `=
 and `.()`.
 
 Stage 2 deliberately has **no frame support**. `['=>', frame, body]` is accepted only
-with the canonical empty frame `['[]']`; `['frame']` is not part of the Stage 2
+with `frame` as the placeholder `null` (`fjs/edag/module.f.mjs`'s `frame`, expected to
+become an `Exp` once frame/capture design lands); `['frame']` is not part of the Stage 2
 interpreter subset. Captured closures are deferred to later work.
 
 A function body is a separate EDAG scope. Validation before interpretation must reject
@@ -93,7 +94,7 @@ hardening TODO after the baseline interpreter exists.
 - [ ] Interpret EDAG operations directly; do not generate JavaScript from EDAG and run
       it through the host JavaScript engine.
 - [ ] Support Stage 1 `['.', object, property]` property access.
-- [ ] Support Stage 2 `['=>', ['[]'], body]`, `['()', object, args]`, and
+- [ ] Support Stage 2 `['=>', null, body]`, `['()', object, args]`, and
       `['.()', object, property, args]` when those operators land.
 - [ ] Do **not** implement `['frame']` or non-empty closure frames in Stage 2.
 - [ ] Memoize results by EDAG node identity within one evaluation context so shared

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -279,8 +279,8 @@ export const sub = _sub
 
 // Negation (aka a unary minus) — a word tag, `"neg"`, not `"-"`'s unary
 // arity (an earlier draft overloaded `"-"` the way JS itself does; see
-// `todo/edag-stage1-discussion.md`'s "Operators" section for why that was
-// dropped). `sub` and `neg` therefore don't share a tag, so — unlike a
+// `../../todo/edag-stage1-discussion.md`'s "Operators" section for why that
+// was dropped). `sub` and `neg` therefore don't share a tag, so — unlike a
 // shared-tag pair would — neither's position in `exp`'s `or` list matters
 // relative to the other.
 
@@ -313,7 +313,7 @@ export const comma = _comma
  * an array node for several — decided by whatever constructs `Fn`, not by
  * this shape. The operand is present in `=>`'s shape today so that switch
  * doesn't require changing `=>` itself. See
- * `../../djs/todo/compile-modules-to-edag.md`.
+ * `../djs/todo/compile-modules-to-edag.md`.
  */
 export const frame = null
 

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -63,6 +63,7 @@ import {
  *  typeof add,
  *  typeof sub,
  *  typeof neg,
+ *  typeof comma
  * ]}
  */
 export const exp = () => (['or',
@@ -78,13 +79,8 @@ export const exp = () => (['or',
     own,
     add,
     sub,
-    // `neg` must be tried after `sub`: both are tagged `"-"`, and a tuple's
-    // trailing positions are open (see the module doc comment above), so
-    // `neg`'s one-operand schema would also match `['-', a, b]` — silently
-    // dropping `b` — if it were checked first. `or` returns the first match
-    // (`../types/rtti/common/module.f.mjs`'s `orVisit`), so this order is
-    // load-bearing, not cosmetic.
     neg,
+    comma,
 ])
 
 /** @typedef {Assert<Check<Exp, typeof exp>>} _ExpAssert */
@@ -281,7 +277,7 @@ export const sub = _sub
 // Negation (aka a unary minus) — tagged `"-"`, same as `sub`; arity
 // distinguishes them (see the ordering note on `exp` above)
 
-const _neg = /** @type {const} */(['-', exp])
+const _neg = /** @type {const} */(['neg', exp])
 
 /** @type {Phantom<typeof _neg, Neg>} */
 export const neg = _neg

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -2,8 +2,8 @@
  * @module
  *
  * @import { Assert } from '../asserts/types.ts'
+ * @import { Check, Check3 } from '../types/rtti/ts/types.ts'
  * @import {
- *  Check,
  *  Args,
  *  Array,
  *  Call,
@@ -20,7 +20,8 @@
  *  Sub,
  *  Neg,
  *  Own,
- Comma,
+ *  Comma,
+ *  Fn
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */
@@ -161,8 +162,7 @@ const _numberCast = /** @type {const} */(['Number', exp])
 export const numberCast = _numberCast
 
 /**
- * @typedef {Assert<Check<NumberCast, typeof _numberCast>>} _NumberCast0
- * @typedef {Assert<Check<NumberCast, typeof numberCast>>} _NumberCast1
+ * @typedef {Assert<Check3<NumberCast, typeof _numberCast, typeof numberCast>>} _NumberCast
  */
 
 // String
@@ -179,8 +179,7 @@ const _stringCast = /** @type {const} */(['String', exp])
 export const stringCast = _stringCast
 
 /**
- * @typedef {Assert<Check<StringCast, typeof _stringCast>>} _StringCast0
- * @typedef {Assert<Check<StringCast, typeof stringCast>>} _StringCast1
+ * @typedef {Assert<Check3<StringCast, typeof _stringCast, typeof stringCast>>} _StringCast
  */
 
 // Index
@@ -209,8 +208,7 @@ const _propertyAccessor = /** @type {const} */(['.', exp, index])
 export const propertyAccessor = _propertyAccessor
 
 /**
- * @typedef {Assert<Check<PropertyAccessor, typeof _propertyAccessor>>} _PropertyAccessor0
- * @typedef {Assert<Check<PropertyAccessor, typeof propertyAccessor>>} _PropertyAccessor1
+ * @typedef {Assert<Check3<PropertyAccessor, typeof _propertyAccessor, typeof propertyAccessor>>} _PropertyAccessor
  */
 
 // Call
@@ -227,8 +225,7 @@ const _call = /** @type {const} */(['()', exp, exp])
 export const call = _call
 
 /**
- * @typedef {Assert<Check<Call, typeof _call>>} _Call0
- * @typedef {Assert<Check<Call, typeof call>>} _Call1
+ * @typedef {Assert<Check3<Call, typeof _call, typeof call>>} _Call
  */
 
 // Property Call
@@ -245,8 +242,7 @@ const _propertyCall = /** @type {const} */(['.()', exp, index, exp])
 export const propertyCall = _propertyCall
 
 /**
- * @typedef {Assert<Check<PropertyCall, typeof _propertyCall>>} _PropertyCall0
- * @typedef {Assert<Check<PropertyCall, typeof propertyCall>>} _PropertyCall1
+ * @typedef {Assert<Check3<PropertyCall, typeof _propertyCall, typeof propertyCall>>} _PropertyCall
  */
 
 // own, `const own = (a, b) => Object.getOwnPropertyDescriptor(a, k)?.value`
@@ -257,8 +253,7 @@ const _own = /** @type {const} */(['own', exp, exp])
 export const own = _own
 
 /**
- * @typedef {Assert<Check<Own, typeof _own>>} _Own0
- * @typedef {Assert<Check<Own, typeof own>>} _Own1
+ * @typedef {Assert<Check3<Own, typeof _own, typeof own>>} _Own
  */
 
 // Binary +
@@ -269,8 +264,7 @@ const _add = /** @type {const} */(['+', exp, exp])
 export const add = _add
 
 /**
- * @typedef {Assert<Check<Add, typeof _add>>} _Add0
- * @typedef {Assert<Check<Add, typeof add>>} _Add1
+ * @typedef {Assert<Check3<Add, typeof _add, typeof add>>} _Add
  */
 
 // Binary -
@@ -281,8 +275,7 @@ const _sub = /** @type {const} */(['-', exp, exp])
 export const sub = _sub
 
 /**
- * @typedef {Assert<Check<Sub, typeof _sub>>} _Sub0
- * @typedef {Assert<Check<Sub, typeof sub>>} _Sub1
+ * @typedef {Assert<Check3<Sub, typeof _sub, typeof sub>>} _Sub
  */
 
 // Negation (aka a unary minus) — tagged `"-"`, same as `sub`; arity
@@ -294,8 +287,7 @@ const _neg = /** @type {const} */(['-', exp])
 export const neg = _neg
 
 /**
- * @typedef {Assert<Check<Neg, typeof _neg>>} _Neg0
- * @typedef {Assert<Check<Neg, typeof neg>>} _Neg1
+ * @typedef {Assert<Check3<Neg, typeof _neg, typeof neg>>} _Neg
  */
 
 // Comma
@@ -306,6 +298,16 @@ const _comma = /** @type {const} */([',', exps])
 export const comma = _comma
 
 /**
- * @typedef {Assert<Check<Comma, typeof _comma>>} _Comma0
- * @typedef {Assert<Check<Comma, typeof comma>>} _Comma1
+ * @typedef {Assert<Check3<Comma, typeof _comma, typeof comma>>} _Comma
+ */
+
+// Function
+
+const _fn = /** @type {const} */(['=>', exp, exp])
+
+/** @type {Phantom<typeof _fn, Fn>} */
+export const fn = _fn
+
+/**
+ * @typedef {Assert<Check3<Fn, typeof _fn, typeof fn>>} _Fn
  */

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -63,7 +63,8 @@ import {
  *  typeof add,
  *  typeof sub,
  *  typeof neg,
- *  typeof comma
+ *  typeof comma,
+ *  typeof fn
  * ]}
  */
 export const exp = () => (['or',
@@ -81,6 +82,7 @@ export const exp = () => (['or',
     sub,
     neg,
     comma,
+    fn,
 ])
 
 /** @typedef {Assert<Check<Exp, typeof exp>>} _ExpAssert */

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -20,6 +20,7 @@
  *  Sub,
  *  Neg,
  *  Own,
+ Comma,
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */
@@ -99,6 +100,8 @@ export const primitive = or(undefinedOp, null, boolean, number, string, bigint)
 
 /** @typedef {Assert<Check<Primitive, typeof primitive>>} _Primitive */
 
+const exps = rttiArray(exp)
+
 // Array
 
 /**
@@ -106,7 +109,7 @@ export const primitive = or(undefinedOp, null, boolean, number, string, bigint)
  * [exp0, exp1]
  * ```
  */
-export const array = /** @type {const} */(['[]', rttiArray(exp)])
+export const array = /** @type {const} */(['[]', exps])
 
 /** @typedef {Assert<Check<Array, typeof array>>} _Array */
 
@@ -293,4 +296,16 @@ export const neg = _neg
 /**
  * @typedef {Assert<Check<Neg, typeof _neg>>} _Neg0
  * @typedef {Assert<Check<Neg, typeof neg>>} _Neg1
+ */
+
+// Comma
+
+const _comma = /** @type {const} */([',', exps])
+
+/** @type {Phantom<typeof _comma, Comma>} */
+export const comma = _comma
+
+/**
+ * @typedef {Assert<Check<Comma, typeof _comma>>} _Comma0
+ * @typedef {Assert<Check<Comma, typeof comma>>} _Comma1
  */

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -307,23 +307,17 @@ export const comma = _comma
 // Function
 
 /**
- * Same shape as `array` — a frame's contents are captured bindings, and an
- * empty one is spelled the same way an empty array node is, `['[]', []]`.
- * A distinct type from `Array` even so, so that later frame/capture support
- * can diverge from `array`'s shape without changing `=>`'s own shape.
- * Stage 2 doesn't implement frames/captures yet, so the compiler only ever
- * emits the empty form — validation doesn't enforce that here, same as
- * every other exact-arity gap tracked by `../types/rtti/todo/close-type.md`.
- * See `../../djs/todo/compile-modules-to-edag.md`.
+ * A placeholder, not yet a real operand: Stage 2 doesn't implement
+ * frames/captures, so `frame` is `null` for now. It is expected to become
+ * an `Exp` once frame/capture design lands — a bare value for one capture,
+ * an array node for several — decided by whatever constructs `Fn`, not by
+ * this shape. The operand is present in `=>`'s shape today so that switch
+ * doesn't require changing `=>` itself. See
+ * `../../djs/todo/compile-modules-to-edag.md`.
  */
-const _frame = /** @type {const} */(['[]', []])
+export const frame = null
 
-/** @type {Phantom<typeof _frame, Frame>} */
-export const frame = _frame
-
-/**
- * @typedef {Assert<Check3<Frame, typeof _frame, typeof frame>>} _Frame
- */
+/** @typedef {Assert<Check<Frame, typeof frame>>} _Frame */
 
 const _fn = /** @type {const} */(['=>', frame, exp])
 

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -307,12 +307,16 @@ export const comma = _comma
 // Function
 
 /**
- * Stage 2 accepts only the empty frame — `['[]']`, not the `array` node
- * `['[]', []]` — since it doesn't implement frames/captures yet; the
- * operand exists so later frame support doesn't require changing `=>`'s
- * shape. See `../../djs/todo/compile-modules-to-edag.md`.
+ * Same shape as `array` — a frame's contents are captured bindings, and an
+ * empty one is spelled the same way an empty array node is, `['[]', []]`.
+ * A distinct type from `Array` even so, so that later frame/capture support
+ * can diverge from `array`'s shape without changing `=>`'s own shape.
+ * Stage 2 doesn't implement frames/captures yet, so the compiler only ever
+ * emits the empty form — validation doesn't enforce that here, same as
+ * every other exact-arity gap tracked by `../types/rtti/todo/close-type.md`.
+ * See `../../djs/todo/compile-modules-to-edag.md`.
  */
-const _frame = /** @type {const} */(['[]'])
+const _frame = /** @type {const} */(['[]', exps])
 
 /** @type {Phantom<typeof _frame, Frame>} */
 export const frame = _frame

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -316,7 +316,7 @@ export const comma = _comma
  * every other exact-arity gap tracked by `../types/rtti/todo/close-type.md`.
  * See `../../djs/todo/compile-modules-to-edag.md`.
  */
-const _frame = /** @type {const} */(['[]', exps])
+const _frame = /** @type {const} */(['[]', []])
 
 /** @type {Phantom<typeof _frame, Frame>} */
 export const frame = _frame

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -21,6 +21,7 @@
  *  Neg,
  *  Own,
  *  Comma,
+ *  Frame,
  *  Fn
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
@@ -276,8 +277,12 @@ export const sub = _sub
  * @typedef {Assert<Check3<Sub, typeof _sub, typeof sub>>} _Sub
  */
 
-// Negation (aka a unary minus) — tagged `"-"`, same as `sub`; arity
-// distinguishes them (see the ordering note on `exp` above)
+// Negation (aka a unary minus) — a word tag, `"neg"`, not `"-"`'s unary
+// arity (an earlier draft overloaded `"-"` the way JS itself does; see
+// `todo/edag-stage1-discussion.md`'s "Operators" section for why that was
+// dropped). `sub` and `neg` therefore don't share a tag, so — unlike a
+// shared-tag pair would — neither's position in `exp`'s `or` list matters
+// relative to the other.
 
 const _neg = /** @type {const} */(['neg', exp])
 
@@ -301,7 +306,22 @@ export const comma = _comma
 
 // Function
 
-const _fn = /** @type {const} */(['=>', exp, exp])
+/**
+ * Stage 2 accepts only the empty frame — `['[]']`, not the `array` node
+ * `['[]', []]` — since it doesn't implement frames/captures yet; the
+ * operand exists so later frame support doesn't require changing `=>`'s
+ * shape. See `../../djs/todo/compile-modules-to-edag.md`.
+ */
+const _frame = /** @type {const} */(['[]'])
+
+/** @type {Phantom<typeof _frame, Frame>} */
+export const frame = _frame
+
+/**
+ * @typedef {Assert<Check3<Frame, typeof _frame, typeof frame>>} _Frame
+ */
+
+const _fn = /** @type {const} */(['=>', frame, exp])
 
 /** @type {Phantom<typeof _fn, Fn>} */
 export const fn = _fn

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -220,29 +220,34 @@ export const proof = {
     },
     fn: {
         ok: () => {
-            assertOk(v(['=>', ['[]'], 1]))
-            assertOk(v(['=>', ['[]'], ['=>', ['[]'], 1]])) // an exp nested inside the body
+            assertOk(v(['=>', ['[]', []], 1]))
+            assertOk(v(['=>', ['[]', []], ['=>', ['[]', []], 1]])) // an exp nested inside the body
         },
         // A missing operand reads as `undefined`, no longer a valid bare
-        // `exp`/`Frame` — see `undefinedOp`. True whether one or both are
-        // missing.
+        // `exp`/`Frame` — see `undefinedOp`. True of the body, and of the
+        // frame's own elements position (`isArray(undefined)` is false, so
+        // that's a structural mismatch rather than a missing-`exp` one, but
+        // still an error either way).
         missingTailIsError: () => {
+            assertNoMatch(v(['=>', ['[]', []]]))
             assertNoMatch(v(['=>', ['[]']]))
             assertNoMatch(v(['=>']))
         },
-        extraTailIsIgnored: () => assertOk(v(['=>', ['[]'], 1, 'extra'])),
+        extraTailIsIgnored: () => assertOk(v(['=>', ['[]', []], 1, 'extra'])),
         error: () => {
-            assertNoMatch(v(['=>z', ['[]'], 1]))
-            // The frame must be tagged `'[]'` — a wrong tag never matches,
-            // unlike the open-trailing-content case below.
-            assertNoMatch(v(['=>', ['x'], 1]))
+            assertNoMatch(v(['=>z', ['[]', []], 1]))
+            // The frame must be tagged `'[]'` — a wrong tag is a real
+            // error, unlike the non-empty-elements case below.
+            assertNoMatch(v(['=>', ['x', []], 1]))
         },
-        // `frame`'s schema (`['[]']`) is a one-entry tuple, so — same
-        // "trailing positions are open" rule as every other node here —
-        // content after the tag is never visited and can't reject. Not a
+        // `frame` has the same shape as `array`, and array length isn't a
+        // constraint this rtti system can express (same gap
+        // `../types/rtti/todo/close-type.md` tracks for exact arity, one
+        // level down) — so a non-empty frame validates structurally even
+        // though Stage 2's compiler only ever emits the empty one. Not a
         // gap specific to `frame`; pinning it so a future reader doesn't
         // mistake it for one.
-        nonEmptyFrameContentIsIgnored: () => assertOk(v(['=>', ['[]', 'ignored'], 1])),
+        nonEmptyFrameIsAccepted: () => assertOk(v(['=>', ['[]', [1, 2]], 1])),
     },
     // `f(args)[k](obj.a)` in AST form — exercises the mutual recursion through
     // `exp` rather than any one node kind in isolation.

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -8,7 +8,6 @@
  */
 
 import { validate } from '../types/rtti/validate/module.f.mjs'
-import { parse } from '../types/rtti/parse/module.f.mjs'
 import { assert, assertEq, assertStructurallySame } from '../asserts/module.f.mjs'
 import { exp } from './module.f.mjs'
 
@@ -31,9 +30,6 @@ const assertNoMatch = r => {
 
 /** @type {(value: Unknown) => readonly [string, unknown]} */
 const v = value => validate(exp)(value)
-
-/** @type {(value: Unknown) => readonly [string, unknown]} */
-const p = value => parse(exp)(value)
 
 export const proof = {
     primitive: {
@@ -199,33 +195,54 @@ export const proof = {
             assertOk(v(['-', 1, 2]))
             assertOk(v(['-', ['-', 1, 2], 3])) // an exp nested inside an operand
         },
+        // A missing operand reads as `undefined`, no longer a valid bare
+        // `exp` — see `undefinedOp`. `neg` is a distinct word tag (`"neg"`,
+        // not `"-"`), so this doesn't fall through to it — unlike `add`
+        // and `numberCast`, there's no other alternative tagged `"-"` at
+        // all, missing one or two operands is equally an error.
+        missingTailIsError: () => {
+            assertNoMatch(v(['-', 1]))
+            assertNoMatch(v(['-']))
+        },
         extraTailIsIgnored: () => assertOk(v(['-', 1, 2, 3])),
         error: () => assertNoMatch(v(['-z', 1, 2])),
-        // Unlike `add`, a missing second operand is *not* an error here:
-        // `sub` and `neg` share the `"-"` tag, and `or` tries `sub` (two
-        // operands) before falling through to `neg` (one) — see `neg`
-        // below and the ordering note on `exp` in module.f.mjs.
-        oneOperandFallsThroughToNeg: () => assertOk(v(['neg', 1])),
-        // `validate` returns the input unchanged regardless of which `or`
-        // alternative matched, so it can't tell `sub` matching first from
-        // `neg` matching first (open-tailed, `neg` would also accept
-        // `['-', 1, 2]` and just ignore the second operand). `parse`
-        // rebuilds only the matched schema's own declared positions, so it
-        // is what actually distinguishes them: if `neg` were tried before
-        // `sub`, this would rebuild `['-', 1]`, silently dropping `2`.
-        binaryMatchesSubNotNeg: () => {
-            const [tag, r] = p(['-', 1, 2])
-            assertEq(tag, 'ok')
-            assertStructurallySame(r, ['-', 1, 2], 'expected sub, not neg, to match first')
-        },
     },
     neg: {
         ok: () => {
             assertOk(v(['neg', 1]))
             assertOk(v(['neg', ['neg', 1]])) // an exp nested inside the operand
         },
-        // With no operands at all, both `sub` and `neg` fail to match.
-        error: () => assertNoMatch(v(['-'])),
+        // A missing operand reads as `undefined`, no longer a valid bare
+        // `exp` — see `undefinedOp`.
+        missingTailIsError: () => assertNoMatch(v(['neg'])),
+        extraTailIsIgnored: () => assertOk(v(['neg', 1, 'extra'])),
+        error: () => assertNoMatch(v(['negz', 1])),
+    },
+    fn: {
+        ok: () => {
+            assertOk(v(['=>', ['[]'], 1]))
+            assertOk(v(['=>', ['[]'], ['=>', ['[]'], 1]])) // an exp nested inside the body
+        },
+        // A missing operand reads as `undefined`, no longer a valid bare
+        // `exp`/`Frame` — see `undefinedOp`. True whether one or both are
+        // missing.
+        missingTailIsError: () => {
+            assertNoMatch(v(['=>', ['[]']]))
+            assertNoMatch(v(['=>']))
+        },
+        extraTailIsIgnored: () => assertOk(v(['=>', ['[]'], 1, 'extra'])),
+        error: () => {
+            assertNoMatch(v(['=>z', ['[]'], 1]))
+            // The frame must be tagged `'[]'` — a wrong tag never matches,
+            // unlike the open-trailing-content case below.
+            assertNoMatch(v(['=>', ['x'], 1]))
+        },
+        // `frame`'s schema (`['[]']`) is a one-entry tuple, so — same
+        // "trailing positions are open" rule as every other node here —
+        // content after the tag is never visited and can't reject. Not a
+        // gap specific to `frame`; pinning it so a future reader doesn't
+        // mistake it for one.
+        nonEmptyFrameContentIsIgnored: () => assertOk(v(['=>', ['[]', 'ignored'], 1])),
     },
     // `f(args)[k](obj.a)` in AST form — exercises the mutual recursion through
     // `exp` rather than any one node kind in isolation.

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -1,6 +1,9 @@
 /**
  * Runtime behavior of the edag `exp` schema — one section per node kind, plus
  * a value nested through several kinds to exercise the mutual recursion.
+ * Exception: `comma` has no section yet — its shape (`[',', exps]`) is a
+ * known-incomplete placeholder pending a redesign that can express "at
+ * least one operand, last is the result", not a settled node to pin.
  *
  * @import { ValidationError } from '../types/rtti/common/types.ts'
  * @import { Unknown } from '../types/rtti/ts/types.ts'

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -220,34 +220,27 @@ export const proof = {
     },
     fn: {
         ok: () => {
-            assertOk(v(['=>', ['[]', []], 1]))
-            assertOk(v(['=>', ['[]', []], ['=>', ['[]', []], 1]])) // an exp nested inside the body
+            assertOk(v(['=>', null, 1]))
+            assertOk(v(['=>', null, ['=>', null, 1]])) // an exp nested inside the body
         },
         // A missing operand reads as `undefined`, no longer a valid bare
-        // `exp`/`Frame` — see `undefinedOp`. True of the body, and of the
-        // frame's own elements position (`isArray(undefined)` is false, so
-        // that's a structural mismatch rather than a missing-`exp` one, but
-        // still an error either way).
+        // `exp` — see `undefinedOp`. True of the body. The frame position
+        // is a placeholder (`null`, see `frame` in module.f.mjs) checked by
+        // exact equality (`Object.is`), so `undefined` fails it too, same
+        // conclusion by a different rule.
         missingTailIsError: () => {
-            assertNoMatch(v(['=>', ['[]', []]]))
-            assertNoMatch(v(['=>', ['[]']]))
+            assertNoMatch(v(['=>', null]))
             assertNoMatch(v(['=>']))
         },
-        extraTailIsIgnored: () => assertOk(v(['=>', ['[]', []], 1, 'extra'])),
+        extraTailIsIgnored: () => assertOk(v(['=>', null, 1, 'extra'])),
         error: () => {
-            assertNoMatch(v(['=>z', ['[]', []], 1]))
-            // The frame must be tagged `'[]'` — a wrong tag is a real
-            // error, unlike the non-empty-elements case below.
-            assertNoMatch(v(['=>', ['x', []], 1]))
+            assertNoMatch(v(['=>z', null, 1]))
+            // Unlike the array-shaped frame this replaced, exact equality
+            // means anything but `null` is rejected outright — no
+            // open-tail-style looseness to pin here.
+            assertNoMatch(v(['=>', 0, 1]))
+            assertNoMatch(v(['=>', ['[]', []], 1]))
         },
-        // `frame` has the same shape as `array`, and array length isn't a
-        // constraint this rtti system can express (same gap
-        // `../types/rtti/todo/close-type.md` tracks for exact arity, one
-        // level down) — so a non-empty frame validates structurally even
-        // though Stage 2's compiler only ever emits the empty one. Not a
-        // gap specific to `frame`; pinning it so a future reader doesn't
-        // mistake it for one.
-        nonEmptyFrameIsAccepted: () => assertOk(v(['=>', ['[]', [1, 2]], 1])),
     },
     // `f(args)[k](obj.a)` in AST form — exercises the mutual recursion through
     // `exp` rather than any one node kind in isolation.

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -205,7 +205,7 @@ export const proof = {
         // `sub` and `neg` share the `"-"` tag, and `or` tries `sub` (two
         // operands) before falling through to `neg` (one) — see `neg`
         // below and the ordering note on `exp` in module.f.mjs.
-        oneOperandFallsThroughToNeg: () => assertOk(v(['-', 1])),
+        oneOperandFallsThroughToNeg: () => assertOk(v(['neg', 1])),
         // `validate` returns the input unchanged regardless of which `or`
         // alternative matched, so it can't tell `sub` matching first from
         // `neg` matching first (open-tailed, `neg` would also accept
@@ -221,8 +221,8 @@ export const proof = {
     },
     neg: {
         ok: () => {
-            assertOk(v(['-', 1]))
-            assertOk(v(['-', ['-', 1]])) // an exp nested inside the operand
+            assertOk(v(['neg', 1]))
+            assertOk(v(['neg', ['neg', 1]])) // an exp nested inside the operand
         },
         // With no operands at all, both `sub` and `neg` fail to match.
         error: () => assertNoMatch(v(['-'])),

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -3,9 +3,9 @@
  * node kind (`Primitive`, `Array`, `Object`, `Args`, `NumberCast`,
  * `PropertyAccessor`, `Call`, `PropertyCall`), each pinned against its rtti
  * schema in the sibling module with `Assert<Check<..., typeof ...>>`.
+ *
+ * @module
  */
-
-export type { Check } from "../types/rtti/ts/types.ts"
 
 // exp
 
@@ -96,3 +96,7 @@ export type Neg = readonly['-', Exp]
 // Comma
 
 export type Comma = readonly[',', Exps]
+
+// Fn
+
+export type Fn = readonly['=>', Exp, Exp]

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -98,11 +98,12 @@ export type Neg = readonly['neg', Exp]
 
 export type Comma = readonly[',', Exps]
 
-// a frame — same shape as `Array`; see `frame` in module.f.mjs for why it's
-// still its own type, and why Stage 2's "empty only" restriction isn't
-// encoded in this shape
+// a frame — `null` for now (Stage 2 doesn't implement frames/captures), a
+// placeholder for a later `Exp` once frame/capture design lands: a bare
+// value for one capture, an array node for several, decided by whatever
+// constructs `Fn`, not by this shape
 
-export type Frame = readonly['[]', readonly[]]
+export type Frame = null
 
 // Fn
 

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -23,6 +23,7 @@ export type Exp =
     | Add
     | Sub
     | Neg
+    | Comma
 
 // undefinedOp
 
@@ -91,7 +92,7 @@ export type Sub = readonly['-', Exp, Exp]
 
 // negation (aka a unary minus — arity, not tag, distinguishes it from `Sub`)
 
-export type Neg = readonly['-', Exp]
+export type Neg = readonly['neg', Exp]
 
 // Comma
 

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -102,7 +102,7 @@ export type Comma = readonly[',', Exps]
 // still its own type, and why Stage 2's "empty only" restriction isn't
 // encoded in this shape
 
-export type Frame = readonly['[]', Exps]
+export type Frame = readonly['[]', readonly[]]
 
 // Fn
 

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -24,6 +24,7 @@ export type Exp =
     | Sub
     | Neg
     | Comma
+    | Fn
 
 // undefinedOp
 

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -89,7 +89,8 @@ export type Add = readonly['+', Exp, Exp]
 
 export type Sub = readonly['-', Exp, Exp]
 
-// negation (aka a unary minus — arity, not tag, distinguishes it from `Sub`)
+// negation (aka a unary minus — a word tag, `"neg"`, not `"-"`'s unary
+// arity, so it doesn't share a tag with `Sub`)
 
 export type Neg = readonly['neg', Exp]
 
@@ -97,6 +98,11 @@ export type Neg = readonly['neg', Exp]
 
 export type Comma = readonly[',', Exps]
 
+// the empty frame — the only frame Stage 2 accepts; see `frame` in
+// module.f.mjs
+
+export type Frame = readonly['[]']
+
 // Fn
 
-export type Fn = readonly['=>', Exp, Exp]
+export type Fn = readonly['=>', Frame, Exp]

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -3,8 +3,6 @@
  * node kind (`Primitive`, `Array`, `Object`, `Args`, `NumberCast`,
  * `PropertyAccessor`, `Call`, `PropertyCall`), each pinned against its rtti
  * schema in the sibling module with `Assert<Check<..., typeof ...>>`.
- *
- * @module
  */
 
 // exp

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -98,10 +98,11 @@ export type Neg = readonly['neg', Exp]
 
 export type Comma = readonly[',', Exps]
 
-// the empty frame — the only frame Stage 2 accepts; see `frame` in
-// module.f.mjs
+// a frame — same shape as `Array`; see `frame` in module.f.mjs for why it's
+// still its own type, and why Stage 2's "empty only" restriction isn't
+// encoded in this shape
 
-export type Frame = readonly['[]']
+export type Frame = readonly['[]', Exps]
 
 // Fn
 

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -32,9 +32,13 @@ export type UndefinedOp = readonly['undefined']
 
 export type Primitive = UndefinedOp | null | boolean | number | string | bigint
 
+// expressions
+
+export type Exps = readonly Exp[]
+
 // array
 
-export type Array = readonly['[]', readonly Exp[]]
+export type Array = readonly['[]', Exps]
 
 // property
 
@@ -88,3 +92,7 @@ export type Sub = readonly['-', Exp, Exp]
 // negation (aka a unary minus — arity, not tag, distinguishes it from `Sub`)
 
 export type Neg = readonly['-', Exp]
+
+// Comma
+
+export type Comma = readonly[',', Exps]

--- a/fjs/nanvm/todo/reuse-edag-operators.md
+++ b/fjs/nanvm/todo/reuse-edag-operators.md
@@ -29,11 +29,10 @@ becoming the canonical FunctionalScript computation representation and already n
 own exactly this information: the operator spelling and the shape/arity of its operands.
 NaNVM should not define a second semantic operator format that can drift from EDAG.
 
-For example, EDAG distinguishes unary and binary operators by the canonical tagged-array
-shape itself:
+For example, EDAG operations have the canonical tagged-array shape itself:
 
 ```js
-['-', a]
+['neg', a]
 ['-', a, b]
 ['*', a, b]
 ['===', a, b]
@@ -60,11 +59,15 @@ should refer to the EDAG definition for:
 ['*', left, right]
 ```
 
-and derive that its case arguments are a two-element tuple. Unary `-` (negation) and
-binary `-` (subtraction) remain distinct because their EDAG operation shapes have
-different arities; NaNVM does not need a second disambiguation scheme. (The EDAG has no
-unary `+` — see `edag-stage1-discussion.md`'s "Operators" table — so NaNVM's own
-`unaryPlus` op, if kept, has no EDAG operation to derive its shape from.)
+and derive that its case arguments are a two-element tuple. Negation and binary `-`
+(subtraction) don't share a tag — negation is `"neg"`, not an arity-overloaded `"-"` (an
+earlier draft spelled it `['-', a]`, matching JS's own overloading of unary and binary
+`-`, but the design settled on a distinct word tag instead specifically so no `or`
+alternative's position is order-sensitive relative to another; see
+`edag-stage1-discussion.md`'s "Operators" section). NaNVM therefore does not need an
+arity-disambiguation scheme at all: every EDAG tag is unique, so deriving operand shape
+from a tag lookup is unambiguous. (The EDAG also has no unary `+` — same section — so
+NaNVM's own `unaryPlus` op, if kept, has no EDAG operation to derive its shape from.)
 
 This does **not** mean the NaNVM corpus becomes an EDAG program or that all test values
 must be encoded as EDAG nodes. The corpus still owns test-only data such as:

--- a/fjs/types/rtti/ts/types.ts
+++ b/fjs/types/rtti/ts/types.ts
@@ -10,7 +10,7 @@
  * @module
  */
 
-import type { Equal } from '../../ts/types.ts'
+import type { And, Equal } from '../../ts/types.ts'
 import type { Tag0, Tag1, Const, Or, String as RttiString, Struct, Tuple, Type, ConstObject } from '../types.ts'
 import type { Assert } from '../../../asserts/types.ts'
 import type { phantomKey } from '../../phantom/types.ts'
@@ -200,61 +200,59 @@ export type Ts<T extends Type> =
  */
 export type Check<A, B extends Type> = Equal<A, Ts<B>>
 
+export type Check3<T, R0 extends Type, R1 extends Type> = And<Equal<T, Ts<R0>>, Equal<T, Ts<R1>>>
+
 // Fast-path: Ts<any> resolves to Unknown without TS2589 overflow.
-type _any = Assert<Equal<Ts<any>, Unknown>>
+type _any = Assert<Check<Unknown, any>>
 
-type _null = Assert<Equal<Ts<null>, null>>
-type _undefined = Assert<Equal<Ts<undefined>, undefined>>
+type _null = Assert<Check<null, null>>
+type _undefined = Assert<Check<undefined, undefined>>
 
-type _true = Assert<Equal<Ts<true>, true>>
-type _32 = Assert<Equal<Ts<32>, 32>>
-type _42n = Assert<Equal<Ts<42n>, 42n>>
-type _hello = Assert<Equal<Ts<'hello'>, 'hello'>>
+type _true = Assert<Check<true, true>>
+type _32 = Assert<Check<32, 32>>
+type _42n = Assert<Check<42n, 42n>>
+type _hello = Assert<Check<'hello', 'hello'>>
 
-type _tuple = Assert<Equal<Ts<readonly[12, true]>, readonly[12, true]>>
-type _struct = Assert<Equal<
-    Ts<{ readonly a: 'hello', readonly b: readonly[]}>,
+type _tuple = Assert<Check<readonly[12, true], readonly[12, true]>>
+type _struct = Assert<Check<
+    { readonly a: 'hello', readonly b: readonly[]},
     { readonly a: 'hello', readonly b: readonly[]}
 >>
-type _structOption = Assert<Equal<
-    Ts<{ readonly a: RttiString, readonly b: Or<readonly[RttiString, undefined]> }>,
-    { readonly a: string } & { readonly b?: string | undefined }
+type _structOption = Assert<Check<
+    { readonly a: string } & { readonly b?: string | undefined },
+    { readonly a: RttiString, readonly b: Or<readonly[RttiString, undefined]> }
 >>
 
-type _const = Assert<Equal<Ts<() => readonly['const', 12]>, 12>>
+type _const = Assert<Check<12, () => readonly['const', 12]>>
 
-type _boolean = Assert<Equal<Ts<() => readonly['boolean']>, boolean>>
-type _number = Assert<Equal<Ts<() => readonly['number']>, number>>
-type _string = Assert<Equal<Ts<() => readonly['string']>, string>>
-type _bigint = Assert<Equal<Ts<() => readonly['bigint']>, bigint>>
+type _boolean = Assert<Check<boolean, () => readonly['boolean']>>
+type _number = Assert<Check<number, () => readonly['number']>>
+type _string = Assert<Check<string, () => readonly['string']>>
+type _bigint = Assert<Check<bigint, () => readonly['bigint']>>
 
 type _unknown = Assert<Equal<Ts<() => readonly['unknown']>, Unknown>>
 
-type _array = Assert<Equal<Ts<
-    () => readonly['array', 12]>,
-    readonly 12[]
->>
-type _record = Assert<Equal<
-    Ts<() => readonly['record', () => readonly['boolean']]>,
-    StringMap<boolean>
->>
+type _array = Assert<Check<
+    readonly 12[],
+    () => readonly['array', 12]>>
 
-type _tupleString = Assert<Equal<
-    Ts<readonly[() => readonly['string']]>,
-    readonly[string]
->>
+type _record = Assert<Check<
+    StringMap<boolean>,
+    () => readonly['record', () => readonly['boolean']]>>
 
-type _orConst = Assert<Equal<
-    Ts<() => readonly['or', false, 42, 'hello']>,
-    false | 42 | 'hello'
->>
+type _tupleString = Assert<Check<
+    readonly[string],
+    readonly[() => readonly['string']]>>
 
-type _orStringNumber = Assert<Equal<
-    Ts<() => readonly['or', 13, () => readonly['string']]>,
-    13 | string
->>
+type _orConst = Assert<Check<
+    false | 42 | 'hello',
+    () => readonly['or', false, 42, 'hello']>>
+
+type _orStringNumber = Assert<Check<
+    13 | string,
+    () => readonly['or', 13, () => readonly['string']]>>
 
 type _SelfArray = readonly _SelfArray[]
 type _SelfArrayType = () => readonly['array', _SelfArrayType]
 
-type _selfArray = Assert<Equal<Ts<_SelfArrayType>, _SelfArray>>
+type _selfArray = Assert<Check<_SelfArray, _SelfArrayType>>

--- a/fjs/types/ts/types.ts
+++ b/fjs/types/ts/types.ts
@@ -12,6 +12,14 @@ export type Equal<A, B> =
         ? true
         : false
 
+export type And<A extends boolean, B extends boolean> =
+    [A, B] extends [true, true] ? true : false
+
+type _AndFF = Assert<Equal<And<false, false>, false>>
+type _AndFT = Assert<Equal<And<false, true>, false>>
+type _AndTF = Assert<Equal<And<true, false>, false>>
+type _AndTT = Assert<Equal<And<true, true>, true>>
+
 /**
  * A `struct` field: the key, its type expression, and — when the third
  * element is `true` — an optional-key marker (`"key"?: type`).

--- a/todo/edag-stage1-discussion.md
+++ b/todo/edag-stage1-discussion.md
@@ -297,14 +297,20 @@ Symbol tags never collide with word tags, so both live in one namespace.
 
 ### Operators
 
-**Arity distinguishes unary from binary**: `["-", a]` is negation and
-`["-", a, b]` is subtraction — the same overloading JS itself uses, and
-unambiguous because no JS operator has two different meanings at the
-same arity.
+**Negation is a word tag, `"neg"`, not `"-"`'s unary arity.** An earlier
+draft of this document overloaded `"-"` by arity instead — `["-", a]`
+negation, `["-", a, b]` subtraction — the same overloading JS itself
+uses for its own `-`. The `fjs/edag` prototype decided against that: a
+tag shared between two `exp` alternatives at different arities makes a
+tuple-typed `or`'s alternative order load-bearing (trailing positions
+are open here, so the one-operand form would also match a two-operand
+value unless checked after it), and this avoids that constraint for no
+loss — `neg` simply joins `"args"`/`"own"` as a tag that doesn't reuse
+its JS spelling.
 
 |Symbols|Arity|JS|Lazy|Notes|
 |-------|-----|--|----|-----|
-|`-`|1|`-a`|no|negation; no unary `+` — [property-accessor](../spec/todo/2330-property-accessor.md)'s run-time-index coercion is `"Number"`, not an operator|
+|`neg`|1|`-a`|no|negation, tagged `"neg"` (see above), not `"-"`; no unary `+` — [property-accessor](../spec/todo/2330-property-accessor.md)'s run-time-index coercion is `"Number"`, not an operator|
 |`!` `~`|1|`!a`, `~a`|no|unary only|
 |`+` `-` `*` `/` `%` `**`|2|`a + b`|no|arithmetic|
 |`===` `!==` `<` `<=` `>` `>=`|2|`a === b`|no|`==` and `!=` are not allowed by [operators](../spec/todo/2340-operators.md)|


### PR DESCRIPTION
## Summary
- `own`, `add`, `sub`, `neg`, `comma`, and `fn` are now all wired into the `exp` union / `Exp` type (this landed in commits after the PR was opened) — `validate(exp)` and `parse(exp)` reach all six, including nested composition. Note `own`/`add`/`sub`/`neg` themselves shipped earlier, in the parent `edag3` PR (#1656); what this PR actually adds is `Comma`, `Fn`, and `Frame`, plus retagging `Neg`.
- **`neg`'s tag reverted from `"-"` (as shipped in #1656) to `"neg"`** (a word tag, not `"-"`'s unary arity — the arity-overload design was reconsidered). This removes the load-bearing `or`-list ordering that a shared tag with `sub` required — confirmed by reversing the entire 15-entry `or` list and re-running the suite: still 3091/3091, since no two tags collide anymore. `todo/edag-stage1-discussion.md`'s "Operators" section is updated to match, and `proof.f.mjs`'s `sub`/`neg` sections are rewritten (dropping the now-moot `parse`-based tag-disambiguation test) to reflect that they no longer share a tag.
- **`Fn`'s frame operand went through two iterations.** First restricted to an `Array`-shaped `['[]', exps]` — but that couldn't enforce "empty" (array length isn't a constraint this rtti system can express) or even valid content (a literal `[]` at that position is itself a zero-entry tuple schema, so it only checked "is an array", not what's in it — verified empirically). Settled, per the author, on `Frame = null`: a placeholder, not a real operand yet, expected to become `Exp` once frame/capture design lands (a bare value for one capture, an array node for several, decided by whatever constructs `Fn`). `Object.is`-based exact-match means this one *does* actually reject anything else, including the old array-shaped form and a wider `Exp` type — both checked. `proof.f.mjs`'s `fn:` section and the `compile-modules-to-edag.md` examples are updated to match.
- **`comma`'s definition is deliberately left untouched**, per the author's inline reply: its current shape (`[',', exps]`, one array position holding every operand undifferentiated) needs to change — RTTI can't spell the spec's flat `[",", ...asserts, result]` directly (`types/rtti/todo/prefix-then-rest-tuple.md` covers why generally), and `validate(exp)([',', []])` being `ok` despite a comma with no operands having no result is a concrete symptom of the same gap (design requires at least two). Not fixing this myself — same open design call, not a separate bug. `proof.f.mjs`'s header comment now says so explicitly instead of overclaiming "one section per node kind".
- **Not doing identity-aware function-scope validation in this PR.** `validate(exp)` accepts a node shared between an enclosing scope and inside an `['=>', ...]` body, which the design says must be rejected. `fjs/edag/module.f.mjs`'s own doc comment already says why: neither `validate` nor `parse` here is identity-aware, and `../types/rtti/todo/identity-aware-parse.md` owns that gap. `Fn` is the first node that actually creates a scope boundary to enforce, but the fix belongs in that TODO's scope.
- Fixed two wrong relative paths in `module.f.mjs`'s doc comments (`../../djs/todo/...` should be `../djs/todo/...`; a bare `todo/edag-stage1-discussion.md` should be `../../todo/edag-stage1-discussion.md`, matching the correct reference two nodes up).
- Removed the stray `@module` tag `types.ts` had picked up (reserved for package entry points, not type companions) — already fixed by the time I looked.
- The `Check` re-export codex flagged as a breaking removal from `edag/types.ts` is intentional — this repo doesn't re-export.
- Introduces `types/rtti/ts`'s `Check3<T, R0, R1>` (`And<Check<T,R0>, Check<T,R1>>`) and `types/ts`'s `And<A, B>` boolean-AND helper, collapsing `fjs/edag/module.f.mjs`'s two-line-per-node `_X0`/`_X1` `Assert<Check<...>>` pins into one `_X` per node.

Known, disclosed: `changelog/unreleased/1656.md` (merged) still describes `Neg` as `['-', exp]`; this PR's own entry accurately describes the retag, but the two unreleased entries will render together describing the same node incompatibly. `changelog/README.md`'s "a PR touches its own file and nothing else" argues against editing the merged one now — noted, not fixed.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run cov` — 3091/3091 tests, 100% lines/branches/functions
- [x] `npm run ci-update` — no diff

Changelog:
- `edag`: add `Comma` (`[',', exps]`) and `Fn` (`['=>', frame, exp]`, non-capturing
  function) to the `exp` union, plus the `Frame` placeholder type (`null` for now,
  until frame/capture design lands). Retags `Neg` (shipped in #1656 as `['-', exp]`)
  to `['neg', exp]` — a word tag, not `"-"`'s unary arity
- `types/rtti/ts`: new `Check3<T, R0, R1>` type; `types/ts`: new `And<A, B>` boolean
  type-level helper
