### PR TITLE
edag: add the frame read-form; revert Fn's frame restriction

### DIFF
--- a/changelog/unreleased/1658.md
+++ b/changelog/unreleased/1658.md
@@ -1,0 +1,5 @@
+- `edag`: `Fn`'s first operand is `Exp` again (unrestricted) — the `null`-placeholder
+  restriction from #1657 is reverted. `Frame`/`frame` is repurposed for a new, separate
+  `exp` alternative: the `['frame']` read-form (the captured-consts frame array, the way
+  `['args']` is for the arguments array) — unrelated to the previous meaning of the same
+  name

--- a/changelog/unreleased/1658.md
+++ b/changelog/unreleased/1658.md
@@ -1,5 +1,5 @@
-- `edag`: `Fn`'s first operand is `Exp` again (unrestricted) — the `null`-placeholder
-  restriction from #1657 is reverted. `Frame`/`frame` is repurposed for a new, separate
-  `exp` alternative: the `['frame']` read-form (the captured-consts frame array, the way
-  `['args']` is for the arguments array) — unrelated to the previous meaning of the same
-  name
+- **BREAKING CHANGES:** `edag`: `Fn`'s first operand is `Exp` again (unrestricted) — the
+  `null`-placeholder restriction from #1657 is reverted. `Frame`/`frame` is repurposed
+  for a new, separate `exp` alternative: the `['frame']` read-form (the captured-consts
+  frame array, the way `['args']` is for the arguments array) — unrelated to, and
+  incompatible with, the previous `null`-only meaning of the same name

--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -221,14 +221,16 @@ Introduce the function operation into EDAG:
 ['=>', frame, body]
 ```
 
-**Stage 2 does not implement frames/captures.** The `frame` operand is present in the
-operation shape so later frame support does not require changing `=>`, but Stage 2
-uses `null` as a placeholder for it and does not introduce `['frame']` access. Source
+**Stage 2 does not implement frames/captures.** This is a restriction on *this task's*
+compiler and interpreter, not on the EDAG schema: `frame` is a general `exp` in
+`fjs/edag/module.f.mjs`, and `['frame']` is already a validated node there, ahead of
+any consumer using either. Something not implemented in a parser or interpreter doesn't
+mean it's absent from the EDAG definition — the schema is free to change independently
+of what a given task supports. Stage 2's parser only ever emits a placeholder frame and
+its interpreter (`interpret-edag.md`) only ever accepts that placeholder; source
 functions that capture values from an enclosing function/module scope are outside this
-stage. `frame` is expected to become an `Exp` once frame/capture design lands — a bare
-value for one capture, an array node for several — decided by whatever constructs the
-function, not by `=>`'s shape. For the initial canonical form, a function is therefore
-represented with the placeholder frame, for example:
+stage. For the initial canonical form, a function is therefore represented with the
+placeholder frame, for example:
 
 ```js
 ['=>', null, body]
@@ -280,8 +282,9 @@ The staged work builds on the basic structural forms already being defined for E
 - the argument array: `['args']`;
 - Stage 1 property access: `['.', object, property]`, with the restricted property
   operands described above;
-- Stage 2 non-capturing functions: `['=>', null, body]` (`null` is a placeholder for
-  `frame`, not yet a real operand);
+- Stage 2 non-capturing functions: `['=>', null, body]` (`frame` is a general `exp` in
+  the schema; `null` is what *this task's* parser and interpreter are scoped to, not a
+  schema-level restriction);
 - Stage 2 calls: `['()', object, args]` and
   `['.()', object, property, args]`, with `.()` using the same property restriction as
   `.`;
@@ -455,9 +458,12 @@ task; see [`bound-edag-interpreter-resources.md`](./bound-edag-interpreter-resou
 
 #### Stage 2
 
-- [ ] Introduce `['=>', frame, body]` into EDAG and its validation/type schema, with
-      Stage 2 using the placeholder `null` for `frame`.
-- [ ] Do **not** introduce `['frame']` or captured-variable access in Stage 2.
+- [x] `['=>', frame, body]` is in the EDAG validation/type schema (`fjs/edag/`), with
+      `frame` a general `exp` there and `['frame']` itself a separate validated node —
+      neither restricted to Stage 2's scope.
+- [ ] Stage 2's own parser and interpreter are narrower than the schema: emit/accept
+      only the placeholder `null` for `frame`, and do **not** emit or interpret
+      `['frame']` or other captured-variable access.
 - [ ] Introduce parser support for the initial non-capturing `(...a) => exp` function
       form; reject functions that require captures.
 - [ ] Validate that a nested function body is a disjoint EDAG scope: operation nodes

--- a/fjs/djs/todo/interpret-edag.md
+++ b/fjs/djs/todo/interpret-edag.md
@@ -53,10 +53,11 @@ As the compiler lands the staged operators, the direct interpreter should suppor
 same EDAG forms: Stage 1 adds `.` property access; Stage 2 adds non-capturing `=>`, `()`,
 and `.()`.
 
-Stage 2 deliberately has **no frame support**. `['=>', frame, body]` is accepted only
-with `frame` as the placeholder `null` (`fjs/edag/module.f.mjs`'s `frame`, expected to
-become an `Exp` once frame/capture design lands); `['frame']` is not part of the Stage 2
-interpreter subset. Captured closures are deferred to later work.
+Stage 2 deliberately has **no frame support** — a restriction on *this interpreter*, not
+on the EDAG schema: `fjs/edag/module.f.mjs` already validates `frame` as a general `exp`
+and `['frame']` as its own node, ahead of any interpreter using either. This interpreter
+accepts only the placeholder `null` for `frame` and does not evaluate `['frame']`.
+Captured closures are deferred to later work.
 
 A function body is a separate EDAG scope. Validation before interpretation must reject
 operation-node identities shared across function boundaries; otherwise a single

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -65,7 +65,8 @@ import {
  *  typeof sub,
  *  typeof neg,
  *  typeof comma,
- *  typeof fn
+ *  typeof fn,
+ *  typeof frame
  * ]}
  */
 export const exp = () => (['or',
@@ -84,6 +85,7 @@ export const exp = () => (['or',
     neg,
     comma,
     fn,
+    frame,
 ])
 
 /** @typedef {Assert<Check<Exp, typeof exp>>} _ExpAssert */

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -21,7 +21,8 @@
  *  Neg,
  *  Own,
  *  Comma,
- *  Fn
+ *  Fn,
+ *  Frame,
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */
@@ -313,3 +314,9 @@ export const fn = _fn
 /**
  * @typedef {Assert<Check3<Fn, typeof _fn, typeof fn>>} _Fn
  */
+
+// Frame
+
+export const frame = /** @type {const} */(['frame'])
+
+/** @typedef {Assert<Check<Frame, typeof frame>>} _Frame */

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -307,13 +307,18 @@ export const comma = _comma
 // Function
 
 /**
+ * The frame *construction* expression — evaluated in the enclosing scope
+ * when the function value is created, building the array `['frame']` reads
+ * inside the body (a hidden parameter, the way `this` is, but explicit and
+ * per-function). AST analysis extends this expression whenever the body
+ * references an external const, so it always builds exactly the values the
+ * body captures. See "Frame construction mirrors a call" in
+ * `../../todo/edag-stage1-discussion.md`.
+ *
  * A placeholder, not yet a real operand: Stage 2 doesn't implement
- * frames/captures, so `frame` is `null` for now. It is expected to become
- * an `Exp` once frame/capture design lands — a bare value for one capture,
- * an array node for several — decided by whatever constructs `Fn`, not by
- * this shape. The operand is present in `=>`'s shape today so that switch
- * doesn't require changing `=>` itself. See
- * `../djs/todo/compile-modules-to-edag.md`.
+ * frames/captures, so `frameCtor` is `null` for now — the operand exists in
+ * `=>`'s shape today so that later switch to a real `Exp` doesn't require
+ * changing `=>` itself. See `../djs/todo/compile-modules-to-edag.md`.
  */
 export const frameCtor = null
 

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -21,7 +21,6 @@
  *  Neg,
  *  Own,
  *  Comma,
- *  FrameCtor,
  *  Fn
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
@@ -306,25 +305,7 @@ export const comma = _comma
 
 // Function
 
-/**
- * The frame *construction* expression — evaluated in the enclosing scope
- * when the function value is created, building the array `['frame']` reads
- * inside the body (a hidden parameter, the way `this` is, but explicit and
- * per-function). AST analysis extends this expression whenever the body
- * references an external const, so it always builds exactly the values the
- * body captures. See "Frame construction mirrors a call" in
- * `../../todo/edag-stage1-discussion.md`.
- *
- * A placeholder, not yet a real operand: Stage 2 doesn't implement
- * frames/captures, so `frameCtor` is `null` for now — the operand exists in
- * `=>`'s shape today so that later switch to a real `Exp` doesn't require
- * changing `=>` itself. See `../djs/todo/compile-modules-to-edag.md`.
- */
-export const frameCtor = null
-
-/** @typedef {Assert<Check<FrameCtor, typeof frameCtor>>} _FrameCtor */
-
-const _fn = /** @type {const} */(['=>', frameCtor, exp])
+const _fn = /** @type {const} */(['=>', exp, exp])
 
 /** @type {Phantom<typeof _fn, Fn>} */
 export const fn = _fn

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -21,7 +21,7 @@
  *  Neg,
  *  Own,
  *  Comma,
- *  Frame,
+ *  FrameCtor,
  *  Fn
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
@@ -315,11 +315,11 @@ export const comma = _comma
  * doesn't require changing `=>` itself. See
  * `../djs/todo/compile-modules-to-edag.md`.
  */
-export const frame = null
+export const frameCtor = null
 
-/** @typedef {Assert<Check<Frame, typeof frame>>} _Frame */
+/** @typedef {Assert<Check<FrameCtor, typeof frameCtor>>} _FrameCtor */
 
-const _fn = /** @type {const} */(['=>', frame, exp])
+const _fn = /** @type {const} */(['=>', frameCtor, exp])
 
 /** @type {Phantom<typeof _fn, Fn>} */
 export const fn = _fn

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -227,10 +227,10 @@ export const proof = {
             assertOk(v(['=>', null, ['=>', null, 1]])) // an exp nested inside the body
         },
         // A missing operand reads as `undefined`, no longer a valid bare
-        // `exp` — see `undefinedOp`. True of the body. The frame position
-        // is a placeholder (`null`, see `frame` in module.f.mjs) checked by
-        // exact equality (`Object.is`), so `undefined` fails it too, same
-        // conclusion by a different rule.
+        // `exp` — see `undefinedOp`. True of the body. The frame-ctor
+        // position is a placeholder (`null`, see `frameCtor` in
+        // module.f.mjs) checked by exact equality (`Object.is`), so
+        // `undefined` fails it too, same conclusion by a different rule.
         missingTailIsError: () => {
             assertNoMatch(v(['=>', null]))
             assertNoMatch(v(['=>']))
@@ -238,8 +238,8 @@ export const proof = {
         extraTailIsIgnored: () => assertOk(v(['=>', null, 1, 'extra'])),
         error: () => {
             assertNoMatch(v(['=>z', null, 1]))
-            // Unlike the array-shaped frame this replaced, exact equality
-            // means anything but `null` is rejected outright — no
+            // Unlike the array-shaped frame-ctor this replaced, exact
+            // equality means anything but `null` is rejected outright — no
             // open-tail-style looseness to pin here.
             assertNoMatch(v(['=>', 0, 1]))
             assertNoMatch(v(['=>', ['[]', []], 1]))

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -235,6 +235,16 @@ export const proof = {
         extraTailIsIgnored: () => assertOk(v(['=>', 1, 2, 'extra'])),
         error: () => assertNoMatch(v(['=>z', 1, 2])),
     },
+    frame: {
+        ok: () => assertOk(v(['frame'])),
+        // Tuples are open on the trailing side — an element past the schema's
+        // own entries is never visited, so it can't fail validation.
+        extraTailIsIgnored: () => assertOk(v(['frame', 'ignored'])),
+        error: () => {
+            assertNoMatch(v([]))
+            assertNoMatch(v(['framez']))
+        },
+    },
     // `f(args)[k](obj.a)` in AST form — exercises the mutual recursion through
     // `exp` rather than any one node kind in isolation.
     nested: () => {

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -223,27 +223,17 @@ export const proof = {
     },
     fn: {
         ok: () => {
-            assertOk(v(['=>', null, 1]))
-            assertOk(v(['=>', null, ['=>', null, 1]])) // an exp nested inside the body
+            assertOk(v(['=>', 1, 2]))
+            assertOk(v(['=>', 1, ['=>', 1, 2]])) // an exp nested inside an operand
         },
         // A missing operand reads as `undefined`, no longer a valid bare
-        // `exp` — see `undefinedOp`. True of the body. The frame-ctor
-        // position is a placeholder (`null`, see `frameCtor` in
-        // module.f.mjs) checked by exact equality (`Object.is`), so
-        // `undefined` fails it too, same conclusion by a different rule.
+        // `exp` — see `undefinedOp`. True whether one or both are missing.
         missingTailIsError: () => {
-            assertNoMatch(v(['=>', null]))
+            assertNoMatch(v(['=>', 1]))
             assertNoMatch(v(['=>']))
         },
-        extraTailIsIgnored: () => assertOk(v(['=>', null, 1, 'extra'])),
-        error: () => {
-            assertNoMatch(v(['=>z', null, 1]))
-            // Unlike the array-shaped frame-ctor this replaced, exact
-            // equality means anything but `null` is rejected outright — no
-            // open-tail-style looseness to pin here.
-            assertNoMatch(v(['=>', 0, 1]))
-            assertNoMatch(v(['=>', ['[]', []], 1]))
-        },
+        extraTailIsIgnored: () => assertOk(v(['=>', 1, 2, 'extra'])),
+        error: () => assertNoMatch(v(['=>z', 1, 2])),
     },
     // `f(args)[k](obj.a)` in AST form — exercises the mutual recursion through
     // `exp` rather than any one node kind in isolation.

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -23,6 +23,7 @@ export type Exp =
     | Neg
     | Comma
     | Fn
+    | Frame
 
 // undefinedOp
 

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -98,12 +98,6 @@ export type Neg = readonly['neg', Exp]
 
 export type Comma = readonly[',', Exps]
 
-// the frame *construction* expression, evaluated in the enclosing scope to
-// build what `['frame']` reads inside the body — `null` for now (Stage 2
-// doesn't implement frames/captures); see `frameCtor` in module.f.mjs
-
-export type FrameCtor = null
-
 // Fn
 
-export type Fn = readonly['=>', FrameCtor, Exp]
+export type Fn = readonly['=>', Exp, Exp]

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -98,10 +98,9 @@ export type Neg = readonly['neg', Exp]
 
 export type Comma = readonly[',', Exps]
 
-// a frame — `null` for now (Stage 2 doesn't implement frames/captures), a
-// placeholder for a later `Exp` once frame/capture design lands: a bare
-// value for one capture, an array node for several, decided by whatever
-// constructs `Fn`, not by this shape
+// the frame *construction* expression, evaluated in the enclosing scope to
+// build what `['frame']` reads inside the body — `null` for now (Stage 2
+// doesn't implement frames/captures); see `frameCtor` in module.f.mjs
 
 export type FrameCtor = null
 

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -101,3 +101,7 @@ export type Comma = readonly[',', Exps]
 // Fn
 
 export type Fn = readonly['=>', Exp, Exp]
+
+// Frame
+
+export type Frame = readonly['frame']

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -103,8 +103,8 @@ export type Comma = readonly[',', Exps]
 // value for one capture, an array node for several, decided by whatever
 // constructs `Fn`, not by this shape
 
-export type Frame = null
+export type FrameCtor = null
 
 // Fn
 
-export type Fn = readonly['=>', Frame, Exp]
+export type Fn = readonly['=>', FrameCtor, Exp]

--- a/todo/edag-stage1-discussion.md
+++ b/todo/edag-stage1-discussion.md
@@ -197,6 +197,15 @@ DJS rollout in
 
 ### Structural operations
 
+**"Stage" names which compiler/interpreter task is scoped to emit or consume an
+operation — not when the EDAG schema itself admits it.** The schema
+(`fjs/edag/module.f.mjs`) doesn't have to wait for a task before defining a shape, and
+in practice it doesn't: `"own"`, `"Number"`, `"String"`, `","`, `"=>"`, and `["frame"]`
+are all marked `later` below, yet all are already validated by `exp` today. A node
+being schema-valid says nothing about whether any parser emits it or any interpreter
+executes it — that's what the `Stage`/`later` marker tracks, and the schema is free to
+change independently of both.
+
 |Form|JS|Stage|Notes|
 |----|--|-----|-----|
 |`2.5`, `"a"`, `true`, `null`, `34n`|itself|1|constant — any non-object, non-array value|
@@ -211,7 +220,7 @@ DJS rollout in
 |`["Number", node]`|`Number(x)`|later|numeric coercion that accepts bigints, unlike unary `+`|
 |`["String", node]`|`String(x)`|later|string coercion|
 |`[",", ...node, node]`|`(a, b)`|later|membership without order (subject 8)|
-|`["=>", frame, body]`|`(…) => …`|2|function; initial Stage 2 accepts only an empty frame, captured frames come later|
+|`["=>", frame, body]`|`(…) => …`|2|function; `frame` is a general `exp` in the schema — Stage 2's own compiler/interpreter scope is narrower and only emits/accepts a placeholder for it, captured frames come later|
 
 `["{}", ...entry]` is an ordered object-construction operation. Stage 1
 uses `[":", key, value]` entries. The entry list preserves the source

--- a/todo/edag-stage1-discussion.md
+++ b/todo/edag-stage1-discussion.md
@@ -200,11 +200,12 @@ DJS rollout in
 **"Stage" names which compiler/interpreter task is scoped to emit or consume an
 operation — not when the EDAG schema itself admits it.** The schema
 (`fjs/edag/module.f.mjs`) doesn't have to wait for a task before defining a shape, and
-in practice it doesn't: `"own"`, `"Number"`, `"String"`, `","`, `"=>"`, and `["frame"]`
-are all marked `later` below, yet all are already validated by `exp` today. A node
-being schema-valid says nothing about whether any parser emits it or any interpreter
-executes it — that's what the `Stage`/`later` marker tracks, and the schema is free to
-change independently of both.
+in practice it doesn't: `"own"`, `"Number"`, `"String"`, and `","` are marked `later`
+below, `"=>"` is marked a not-yet-implemented Stage 2, and `["frame"]` is marked `later`
+too (further down, under [Operations](#operations)) — yet all are already validated by
+`exp` today. A node being schema-valid says nothing about whether any parser emits it or
+any interpreter executes it — that's what the `Stage`/`later` marker tracks, and the
+schema is free to change independently of both.
 
 |Form|JS|Stage|Notes|
 |----|--|-----|-----|


### PR DESCRIPTION
## Summary
- **`Fn`'s first operand reverts to plain `Exp`** (`['=>', exp, exp]`), undoing the `null`-placeholder restriction (`Fn = ['=>', Frame, Exp]`, `Frame = null`) that shipped in #1657. `proof.f.mjs`'s `fn:` section is rewritten to the same two-generic-operand pattern `add`/`call` use, dropping the `null`-specific assertions that no longer hold (`['=>', 0, 1]` and array-shaped second... first operands are `ok` again, not errors).
- **`Frame`/`frame` is repurposed** for a new, unrelated `exp` alternative: the `['frame']` read-form — the captured-consts frame array a function body reads from, the same way `['args']` is the arguments array (see "Frame construction mirrors a call" in `todo/edag-stage1-discussion.md`). It's a bare 1-tag `Const` tuple, same pattern as `args`, and is now wired into the `exp` union / `Exp` type. Added a `frame:` proof section mirroring `args:`'s exactly (ok, extraTailIsIgnored, error).
- Net effect on the design: the frame-*construction* expression that used to occupy `Fn`'s first operand (`frame`/`frameCtor` across the last few iterations) doesn't exist as a distinct concept right now — `Fn`'s first operand is unrestricted `Exp` again, and the design's `["frame"]` *read* form exists as its own top-level node instead. How the two reconnect (an actual frame-construction operand on `=>`) is still open.
- A review comment argued `Fn` should stay restricted until frame design lands. Per the author's reply, that's backwards: the EDAG schema doesn't have to wait for a compiler/interpreter task before defining a shape, and in practice it doesn't — `own`/`Number`/`String`/`,` are marked `later` in `edag-stage1-discussion.md`'s Stage column, `=>` is marked a not-yet-implemented Stage 2, and `["frame"]` is marked `later` further down under Operations — yet all are already validated by `exp` today. Reworded the frame-specific passages in `edag-stage1-discussion.md`, `compile-modules-to-edag.md`, and `interpret-edag.md` to say which layer each restriction actually belongs to, instead of reverting the code.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run cov` — 3094/3094 tests, 100% lines/branches/functions
- [x] `npm run ci-update` — no diff

Changelog:
- **BREAKING CHANGES:** `edag`: `Fn`'s first operand is `Exp` again (unrestricted) — the
  `null`-placeholder restriction from #1657 is reverted. `Frame`/`frame` is repurposed
  for a new, separate `exp` alternative: the `['frame']` read-form (the captured-consts
  frame array, the way `['args']` is for the arguments array) — unrelated to, and
  incompatible with, the previous `null`-only meaning of the same name
