### PR TITLE
edag: add comparison operators (===, !==, >, <, >=)

### DIFF
--- a/changelog/unreleased/1659.md
+++ b/changelog/unreleased/1659.md
@@ -1,0 +1,2 @@
+- `edag`: add `Eq` (`===`), `Neq` (`!==`), `Gt` (`>`), `Lt` (`<`), and `Ge` (`>=`)
+  comparison nodes, all now in the `exp` union

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -26,6 +26,7 @@
  *  Eq,
  *  Neq,
  *  Gt,
+ *  Lt,
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */
@@ -72,7 +73,8 @@ import {
  *  typeof frame,
  *  typeof eq,
  *  typeof neq,
- *  typeof gt
+ *  typeof gt,
+ *  typeof lt
  * ]}
  */
 export const exp = () => (['or',
@@ -95,6 +97,7 @@ export const exp = () => (['or',
     eq,
     neq,
     gt,
+    lt,
 ])
 
 /** @typedef {Assert<Check<Exp, typeof exp>>} _ExpAssert */
@@ -358,3 +361,12 @@ const _gt = /** @type {const} */(['>', exp, exp])
 export const gt = _gt
 
 /** @typedef {Assert<Check3<Gt, typeof _gt, typeof gt>>} _Gt */
+
+// <
+
+const _lt = /** @type {const} */(['<', exp, exp])
+
+/** @type {Phantom<typeof _lt, Lt>} */
+export const lt = _lt
+
+/** @typedef {Assert<Check3<Lt, typeof _lt, typeof lt>>} _Lt */

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -27,6 +27,7 @@
  *  Neq,
  *  Gt,
  *  Lt,
+ *  Ge,
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */
@@ -74,7 +75,8 @@ import {
  *  typeof eq,
  *  typeof neq,
  *  typeof gt,
- *  typeof lt
+ *  typeof lt,
+ *  typeof ge
  * ]}
  */
 export const exp = () => (['or',
@@ -98,6 +100,7 @@ export const exp = () => (['or',
     neq,
     gt,
     lt,
+    ge,
 ])
 
 /** @typedef {Assert<Check<Exp, typeof exp>>} _ExpAssert */
@@ -370,3 +373,12 @@ const _lt = /** @type {const} */(['<', exp, exp])
 export const lt = _lt
 
 /** @typedef {Assert<Check3<Lt, typeof _lt, typeof lt>>} _Lt */
+
+// >=
+
+const _ge = /** @type {const} */(['>=', exp, exp])
+
+/** @type {Phantom<typeof _ge, Ge>} */
+export const ge = _ge
+
+/** @typedef {Assert<Check3<Ge, typeof _ge, typeof ge>>} _Ge */

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -24,6 +24,7 @@
  *  Fn,
  *  Frame,
  *  Eq,
+ Neq,
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */
@@ -68,7 +69,8 @@ import {
  *  typeof comma,
  *  typeof fn,
  *  typeof frame,
- *  typeof eq
+ *  typeof eq,
+ *  typeof neq
  * ]}
  */
 export const exp = () => (['or',
@@ -89,6 +91,7 @@ export const exp = () => (['or',
     fn,
     frame,
     eq,
+    neq,
 ])
 
 /** @typedef {Assert<Check<Exp, typeof exp>>} _ExpAssert */
@@ -334,3 +337,12 @@ const _eq = /** @type {const} */(['===', exp, exp])
 export const eq = _eq
 
 /** @typedef {Assert<Check3<Eq, typeof _eq, typeof eq>>} _Eq */
+
+// !==
+
+const _neq = /** @type {const} */(['!==', exp, exp])
+
+/** @type {Phantom<typeof _neq, Neq>} */
+export const neq = _neq
+
+/** @typedef {Assert<Check3<Neq, typeof _neq, typeof neq>>} _Neq */

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -67,7 +67,8 @@ import {
  *  typeof neg,
  *  typeof comma,
  *  typeof fn,
- *  typeof frame
+ *  typeof frame,
+ *  typeof eq
  * ]}
  */
 export const exp = () => (['or',
@@ -87,6 +88,7 @@ export const exp = () => (['or',
     comma,
     fn,
     frame,
+    eq,
 ])
 
 /** @typedef {Assert<Check<Exp, typeof exp>>} _ExpAssert */
@@ -326,6 +328,9 @@ export const frame = /** @type {const} */(['frame'])
 
 // ===
 
-export const eq = /** @type {const} */(['===', exp, exp])
+const _eq = /** @type {const} */(['===', exp, exp])
 
-/** @typedef {Assert<Check<Eq, typeof eq>>} _Eq */
+/** @type {Phantom<typeof _eq, Eq>} */
+export const eq = _eq
+
+/** @typedef {Assert<Check3<Eq, typeof _eq, typeof eq>>} _Eq */

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -24,7 +24,8 @@
  *  Fn,
  *  Frame,
  *  Eq,
- Neq,
+ *  Neq,
+ *  Gt,
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */
@@ -70,7 +71,8 @@ import {
  *  typeof fn,
  *  typeof frame,
  *  typeof eq,
- *  typeof neq
+ *  typeof neq,
+ *  typeof gt
  * ]}
  */
 export const exp = () => (['or',
@@ -92,6 +94,7 @@ export const exp = () => (['or',
     frame,
     eq,
     neq,
+    gt,
 ])
 
 /** @typedef {Assert<Check<Exp, typeof exp>>} _ExpAssert */
@@ -346,3 +349,12 @@ const _neq = /** @type {const} */(['!==', exp, exp])
 export const neq = _neq
 
 /** @typedef {Assert<Check3<Neq, typeof _neq, typeof neq>>} _Neq */
+
+// >
+
+const _gt = /** @type {const} */(['>', exp, exp])
+
+/** @type {Phantom<typeof _gt, Gt>} */
+export const gt = _gt
+
+/** @typedef {Assert<Check3<Gt, typeof _gt, typeof gt>>} _Gt */

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -23,6 +23,7 @@
  *  Comma,
  *  Fn,
  *  Frame,
+ *  Eq,
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */
@@ -322,3 +323,9 @@ export const fn = _fn
 export const frame = /** @type {const} */(['frame'])
 
 /** @typedef {Assert<Check<Frame, typeof frame>>} _Frame */
+
+// ===
+
+export const eq = /** @type {const} */(['===', exp, exp])
+
+/** @typedef {Assert<Check<Eq, typeof eq>>} _Eq */

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -245,6 +245,48 @@ export const proof = {
             assertNoMatch(v(['framez']))
         },
     },
+    eq: {
+        ok: () => {
+            assertOk(v(['===', 1, 2]))
+            assertOk(v(['===', ['===', 1, 2], 3])) // an exp nested inside an operand
+        },
+        // A missing operand reads as `undefined`, no longer a valid bare
+        // `exp` — see `undefinedOp`. True whether one or both are missing.
+        missingTailIsError: () => {
+            assertNoMatch(v(['===', 1]))
+            assertNoMatch(v(['===']))
+        },
+        extraTailIsIgnored: () => assertOk(v(['===', 1, 2, 3])),
+        error: () => assertNoMatch(v(['===z', 1, 2])),
+    },
+    neq: {
+        ok: () => {
+            assertOk(v(['!==', 1, 2]))
+            assertOk(v(['!==', ['!==', 1, 2], 3])) // an exp nested inside an operand
+        },
+        // A missing operand reads as `undefined`, no longer a valid bare
+        // `exp` — see `undefinedOp`. True whether one or both are missing.
+        missingTailIsError: () => {
+            assertNoMatch(v(['!==', 1]))
+            assertNoMatch(v(['!==']))
+        },
+        extraTailIsIgnored: () => assertOk(v(['!==', 1, 2, 3])),
+        error: () => assertNoMatch(v(['!==z', 1, 2])),
+    },
+    gt: {
+        ok: () => {
+            assertOk(v(['>', 1, 2]))
+            assertOk(v(['>', ['>', 1, 2], 3])) // an exp nested inside an operand
+        },
+        // A missing operand reads as `undefined`, no longer a valid bare
+        // `exp` — see `undefinedOp`. True whether one or both are missing.
+        missingTailIsError: () => {
+            assertNoMatch(v(['>', 1]))
+            assertNoMatch(v(['>']))
+        },
+        extraTailIsIgnored: () => assertOk(v(['>', 1, 2, 3])),
+        error: () => assertNoMatch(v(['>z', 1, 2])),
+    },
     // `f(args)[k](obj.a)` in AST form — exercises the mutual recursion through
     // `exp` rather than any one node kind in isolation.
     nested: () => {

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -287,6 +287,20 @@ export const proof = {
         extraTailIsIgnored: () => assertOk(v(['>', 1, 2, 3])),
         error: () => assertNoMatch(v(['>z', 1, 2])),
     },
+    lt: {
+        ok: () => {
+            assertOk(v(['<', 1, 2]))
+            assertOk(v(['<', ['<', 1, 2], 3])) // an exp nested inside an operand
+        },
+        // A missing operand reads as `undefined`, no longer a valid bare
+        // `exp` — see `undefinedOp`. True whether one or both are missing.
+        missingTailIsError: () => {
+            assertNoMatch(v(['<', 1]))
+            assertNoMatch(v(['<']))
+        },
+        extraTailIsIgnored: () => assertOk(v(['<', 1, 2, 3])),
+        error: () => assertNoMatch(v(['<z', 1, 2])),
+    },
     // `f(args)[k](obj.a)` in AST form — exercises the mutual recursion through
     // `exp` rather than any one node kind in isolation.
     nested: () => {

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -301,6 +301,20 @@ export const proof = {
         extraTailIsIgnored: () => assertOk(v(['<', 1, 2, 3])),
         error: () => assertNoMatch(v(['<z', 1, 2])),
     },
+    ge: {
+        ok: () => {
+            assertOk(v(['>=', 1, 2]))
+            assertOk(v(['>=', ['>=', 1, 2], 3])) // an exp nested inside an operand
+        },
+        // A missing operand reads as `undefined`, no longer a valid bare
+        // `exp` — see `undefinedOp`. True whether one or both are missing.
+        missingTailIsError: () => {
+            assertNoMatch(v(['>=', 1]))
+            assertNoMatch(v(['>=']))
+        },
+        extraTailIsIgnored: () => assertOk(v(['>=', 1, 2, 3])),
+        error: () => assertNoMatch(v(['>=z', 1, 2])),
+    },
     // `f(args)[k](obj.a)` in AST form — exercises the mutual recursion through
     // `exp` rather than any one node kind in isolation.
     nested: () => {

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -25,6 +25,7 @@ export type Exp =
     | Fn
     | Frame
     | Eq
+    | Neq
 
 // undefinedOp
 
@@ -111,3 +112,7 @@ export type Frame = readonly['frame']
 // Eq
 
 export type Eq = readonly['===', Exp, Exp]
+
+// Neq
+
+export type Neq = readonly['!==', Exp, Exp]

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -1,8 +1,9 @@
 /**
  * Type-level API for `fjs/edag/module.f.mjs`: `Exp`, the union of every EDAG
- * node kind (`Primitive`, `Array`, `Object`, `Args`, `NumberCast`,
- * `PropertyAccessor`, `Call`, `PropertyCall`), each pinned against its rtti
- * schema in the sibling module with `Assert<Check<..., typeof ...>>`.
+ * node kind — see the union immediately below for the current list, rather
+ * than enumerating it here too, where it silently drifts stale as nodes are
+ * added — each pinned against its rtti schema in the sibling module with
+ * `Assert<Check<..., typeof ...>>`.
  */
 
 // exp

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -26,6 +26,7 @@ export type Exp =
     | Frame
     | Eq
     | Neq
+    | Gt
 
 // undefinedOp
 
@@ -116,3 +117,7 @@ export type Eq = readonly['===', Exp, Exp]
 // Neq
 
 export type Neq = readonly['!==', Exp, Exp]
+
+// Gt
+
+export type Gt = readonly['>', Exp, Exp]

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -28,6 +28,7 @@ export type Exp =
     | Neq
     | Gt
     | Lt
+    | Ge
 
 // undefinedOp
 
@@ -126,3 +127,7 @@ export type Gt = readonly['>', Exp, Exp]
 // Lt
 
 export type Lt = readonly['<', Exp, Exp]
+
+// Ge
+
+export type Ge = readonly['>=', Exp, Exp]

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -27,6 +27,7 @@ export type Exp =
     | Eq
     | Neq
     | Gt
+    | Lt
 
 // undefinedOp
 
@@ -121,3 +122,7 @@ export type Neq = readonly['!==', Exp, Exp]
 // Gt
 
 export type Gt = readonly['>', Exp, Exp]
+
+// Lt
+
+export type Lt = readonly['<', Exp, Exp]

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -106,3 +106,7 @@ export type Fn = readonly['=>', Exp, Exp]
 // Frame
 
 export type Frame = readonly['frame']
+
+// Eq
+
+export type Eq = readonly['===', Exp, Exp]

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -24,6 +24,7 @@ export type Exp =
     | Comma
     | Fn
     | Frame
+    | Eq
 
 // undefinedOp
 


### PR DESCRIPTION
## Summary
- Add five binary comparison nodes to `fjs/edag`, all following the same `Phantom`+`Check3`-pinned pattern as `add`/`sub`: `Eq` (`['===', exp, exp]`), `Neq` (`['!==', exp, exp]`), `Gt` (`['>', exp, exp]`), `Lt` (`['<', exp, exp]`), and `Ge` (`['>=', exp, exp]`). All five are wired into the `exp` union / `Exp` type — 21 members at this head, 21 distinct tags, no collisions — and each has a full `proof.f.mjs` section (ok/nested, missing-operand error, extra-tail-ignored, wrong-tag error) mirroring `add`'s exactly.
- Fixed the `@import` block's `Neq` line along the way, which was missing its leading `*` (same recurring typo the `Own`/`neg` lines had earlier in this stack).
- No `<=` (a natural sixth) yet — not added since it wasn't asked for; happy to add it the same way.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run cov` — 3114/3114 tests, 100% lines/branches/functions
- [x] `npm run ci-update` — no diff

Changelog:
- `edag`: add `Eq` (`===`), `Neq` (`!==`), `Gt` (`>`), `Lt` (`<`), and `Ge` (`>=`)
  comparison nodes, all now in the `exp` union
