### PR TITLE
edag: consolidate unary/binary ops into UnaryOp/BinaryOp

### DIFF
--- a/changelog/unreleased/1660.md
+++ b/changelog/unreleased/1660.md
@@ -1,6 +1,6 @@
 - `edag`: `Add`, `Sub`, `Neg`, `Eq`, `Neq`, `Gt`, `Lt`, `Ge`, `Own`, `Fn`, `Call`, and
   `StringCast` are replaced by two generic, id-parameterized node kinds — `UnaryOp`
-  (`neg`/`String`/`Number`) and `BinaryOp` (`=>`, `own`, `()`, `===`, `!==`, `>`, `>=`,
-  `<`, `<=`, `+`, `-`, `*`, `/`, `%`, `**`, `&`, `|`, `^`, `<<`, `>>`, `>>>`, `&&`, `||`,
-  `??`) — adding `<=`, `*`, `/`, `%`, `**`, `&`, `|`, `^`, `<<`, `>>`, `>>>`, `&&`, `||`,
-  and `??` to the `exp` union for the first time
+  (`String`/`Number`/`neg`/`!`/`~`) and `BinaryOp` (`=>`, `own`, `()`, `===`, `!==`, `>`,
+  `>=`, `<`, `<=`, `+`, `-`, `*`, `/`, `%`, `**`, `&`, `|`, `^`, `<<`, `>>`, `>>>`, `&&`,
+  `||`, `??`) — adding `!`, `~`, `<=`, `*`, `/`, `%`, `**`, `&`, `|`, `^`, `<<`, `>>`,
+  `>>>`, `&&`, `||`, and `??` to the `exp` union for the first time

--- a/changelog/unreleased/1660.md
+++ b/changelog/unreleased/1660.md
@@ -1,0 +1,6 @@
+- `edag`: `Add`, `Sub`, `Neg`, `Eq`, `Neq`, `Gt`, `Lt`, `Ge`, `Own`, `Fn`, `Call`, and
+  `StringCast` are replaced by two generic, id-parameterized node kinds — `UnaryOp`
+  (`neg`/`String`/`Number`) and `BinaryOp` (`=>`, `own`, `()`, `===`, `!==`, `>`, `>=`,
+  `<`, `<=`, `+`, `-`, `*`, `/`, `%`, `**`, `&`, `|`, `^`, `<<`, `>>`, `>>>`, `&&`, `||`,
+  `??`) — adding `<=`, `*`, `/`, `%`, `**`, `&`, `|`, `^`, `<<`, `>>`, `>>>`, `&&`, `||`,
+  and `??` to the `exp` union for the first time

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -28,6 +28,7 @@
  *  Gt,
  *  Lt,
  *  Ge,
+ *  BinaryOpId,
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */
@@ -382,3 +383,14 @@ const _ge = /** @type {const} */(['>=', exp, exp])
 export const ge = _ge
 
 /** @typedef {Assert<Check3<Ge, typeof _ge, typeof ge>>} _Ge */
+
+const binaryOpId = or(
+    '===', '!==', '>', '>=', '<', '<=',
+    '+', '-', '*', '/', '%', '**',
+    '&', '|', '^', '<<', '>>', '>>>',
+    '&&', '||', '??'
+)
+
+/** @typedef {Assert<Check<BinaryOpId, typeof binaryOpId>>} _BinaryOpId */
+
+const binaryOp = /** @type {const} */([binaryOpId, exp, exp])

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -220,22 +220,6 @@ export const propertyCall = _propertyCall
  * @typedef {Assert<Check3<PropertyCall, typeof _propertyCall, typeof propertyCall>>} _PropertyCall
  */
 
-// Negation (aka a unary minus) — a word tag, `"neg"`, not `"-"`'s unary
-// arity (an earlier draft overloaded `"-"` the way JS itself does; see
-// `../../todo/edag-stage1-discussion.md`'s "Operators" section for why that
-// was dropped). `sub` and `neg` therefore don't share a tag, so — unlike a
-// shared-tag pair would — neither's position in `exp`'s `or` list matters
-// relative to the other.
-
-const _neg = /** @type {const} */(['neg', exp])
-
-/** @type {Phantom<typeof _neg, Neg>} */
-export const neg = _neg
-
-/**
- * @typedef {Assert<Check3<Neg, typeof _neg, typeof neg>>} _Neg
- */
-
 // Comma
 
 const _comma = /** @type {const} */([',', exps])

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -19,7 +19,6 @@
  *  Neg,
  *  Own,
  *  Comma,
- *  Fn,
  *  Frame,
  *  BinaryOpId,
  *  BinaryOp,
@@ -63,7 +62,6 @@ import {
  *  typeof own,
  *  typeof neg,
  *  typeof comma,
- *  typeof fn,
  *  typeof frame,
  *  typeof binaryOp,
  * ]}
@@ -81,7 +79,6 @@ export const exp = () => (['or',
     own,
     neg,
     comma,
-    fn,
     frame,
     binaryOp,
 ])
@@ -282,17 +279,6 @@ export const comma = _comma
  * @typedef {Assert<Check3<Comma, typeof _comma, typeof comma>>} _Comma
  */
 
-// Function
-
-const _fn = /** @type {const} */(['=>', exp, exp])
-
-/** @type {Phantom<typeof _fn, Fn>} */
-export const fn = _fn
-
-/**
- * @typedef {Assert<Check3<Fn, typeof _fn, typeof fn>>} _Fn
- */
-
 // Frame
 
 export const frame = /** @type {const} */(['frame'])
@@ -302,6 +288,7 @@ export const frame = /** @type {const} */(['frame'])
 //
 
 export const binaryOpId = or(
+    '=>',
     '===', '!==', '>', '>=', '<', '<=',
     '+', '-', '*', '/', '%', '**',
     '&', '|', '^', '<<', '>>', '>>>',

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -255,6 +255,8 @@ export const frame = /** @type {const} */(['frame'])
 
 export const unaryOpId = or('neg')
 
+export const unaryOp = /** @type {const} */([unaryOpId, exp])
+
 // Binary Operations
 
 export const binaryOpId = or(

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -225,7 +225,7 @@ const _unaryOp = /** @type {const} */([unaryOpId, exp])
 /** @type {Phantom<typeof _unaryOp, UnaryOp>} */
 export const unaryOp = _unaryOp
 
-/** @typedef {Assert<Check<UnaryOp, typeof unaryOp>>} _UnaryOp */
+/** @typedef {Assert<Check3<UnaryOp, typeof _unaryOp, typeof unaryOp>>} _UnaryOp */
 
 // Binary Operations
 

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -17,7 +17,6 @@
  *  PropertyCall,
  *  UndefinedOp,
  *  Neg,
- *  Own,
  *  Comma,
  *  Frame,
  *  BinaryOpId,
@@ -59,7 +58,6 @@ import {
  *  typeof propertyAccessor,
  *  typeof call,
  *  typeof propertyCall,
- *  typeof own,
  *  typeof neg,
  *  typeof comma,
  *  typeof frame,
@@ -76,7 +74,6 @@ export const exp = () => (['or',
     propertyAccessor,
     call,
     propertyCall,
-    own,
     neg,
     comma,
     frame,
@@ -241,17 +238,6 @@ export const propertyCall = _propertyCall
  * @typedef {Assert<Check3<PropertyCall, typeof _propertyCall, typeof propertyCall>>} _PropertyCall
  */
 
-// own, `const own = (a, b) => Object.getOwnPropertyDescriptor(a, k)?.value`
-
-const _own = /** @type {const} */(['own', exp, exp])
-
-/** @type {Phantom<typeof _own, Own>} */
-export const own = _own
-
-/**
- * @typedef {Assert<Check3<Own, typeof _own, typeof own>>} _Own
- */
-
 // Negation (aka a unary minus) — a word tag, `"neg"`, not `"-"`'s unary
 // arity (an earlier draft overloaded `"-"` the way JS itself does; see
 // `../../todo/edag-stage1-discussion.md`'s "Operators" section for why that
@@ -288,7 +274,7 @@ export const frame = /** @type {const} */(['frame'])
 //
 
 export const binaryOpId = or(
-    '=>',
+    '=>', 'own',
     '===', '!==', '>', '>=', '<', '<=',
     '+', '-', '*', '/', '%', '**',
     '&', '|', '^', '<<', '>>', '>>>',

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -65,6 +65,7 @@ import {
  *  typeof comma,
  *  typeof fn,
  *  typeof frame,
+ *  typeof binaryOp,
  * ]}
  */
 export const exp = () => (['or',
@@ -82,6 +83,7 @@ export const exp = () => (['or',
     comma,
     fn,
     frame,
+    binaryOp,
 ])
 
 /** @typedef {Assert<Check<Exp, typeof exp>>} _ExpAssert */
@@ -308,6 +310,9 @@ export const binaryOpId = or(
 
 /** @typedef {Assert<Check<BinaryOpId, typeof binaryOpId>>} _BinaryOpId */
 
-export const binaryOp = /** @type {const} */([binaryOpId, exp, exp])
+const _binaryOp = /** @type {const} */([binaryOpId, exp, exp])
 
-/** @typedef {Assert<Check<BinaryOp, typeof binaryOp>>} _BinaryOp */
+/** @type {Phantom<typeof _binaryOp, BinaryOp>} */
+export const binaryOp = _binaryOp
+
+/** @typedef {Assert<Check3<BinaryOp, typeof _binaryOp, typeof binaryOp>>} _BinaryOp */

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -29,6 +29,7 @@
  *  Lt,
  *  Ge,
  *  BinaryOpId,
+ *  BinaryOp,
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */
@@ -384,7 +385,7 @@ export const ge = _ge
 
 /** @typedef {Assert<Check3<Ge, typeof _ge, typeof ge>>} _Ge */
 
-const binaryOpId = or(
+export const binaryOpId = or(
     '===', '!==', '>', '>=', '<', '<=',
     '+', '-', '*', '/', '%', '**',
     '&', '|', '^', '<<', '>>', '>>>',
@@ -393,4 +394,6 @@ const binaryOpId = or(
 
 /** @typedef {Assert<Check<BinaryOpId, typeof binaryOpId>>} _BinaryOpId */
 
-const binaryOp = /** @type {const} */([binaryOpId, exp, exp])
+export const binaryOp = /** @type {const} */([binaryOpId, exp, exp])
+
+/** @typedef {Assert<Check<BinaryOp, typeof binaryOp>>} _BinaryOp */

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -217,7 +217,7 @@ export const frame = /** @type {const} */(['frame'])
 
 // Unary Operations
 
-export const unaryOpId = or('neg', 'String', 'Number')
+export const unaryOpId = or('String', 'Number', 'neg', '!', '~')
 
 /** @typedef {Assert<Check<UnaryOpId, typeof unaryOpId>>} _UnaryOpId */
 

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -15,7 +15,6 @@
  *  Object,
  *  PropertyCall,
  *  UndefinedOp,
- *  Neg,
  *  Comma,
  *  Frame,
  *  BinaryOpId,
@@ -239,7 +238,7 @@ export const frame = /** @type {const} */(['frame'])
 
 // Unary Operations
 
-export const unaryOpId = or('neg')
+export const unaryOpId = or('neg', 'String', 'Number')
 
 /** @typedef {Assert<Check<UnaryOpId, typeof unaryOpId>>} _UnaryOpId */
 

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -34,9 +34,10 @@ import {
 } from "../types/rtti/module.f.mjs";
 
 /**
- * `args`, `propertyAccessor`, `call`, and `propertyCall` (like `array`/`object`)
- * are open on trailing/extra elements — see "Structs and tuples are open" in
- * `../types/rtti/README.md`. Exact arity is tracked as future work in
+ * `args`, `propertyAccessor`, `propertyCall`, and `unaryOp`/`binaryOp` (like
+ * `array`/`object`) are open on trailing/extra elements — see "Structs and
+ * tuples are open" in `../types/rtti/README.md`. Exact arity is tracked as
+ * future work in
  * `../types/rtti/todo/close-type.md`, not implemented here yet.
  *
  * Do not call `parse(exp)` or rely on `validate(exp)` rejecting cycles

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -16,18 +16,11 @@
  *  Object,
  *  PropertyCall,
  *  UndefinedOp,
- *  Add,
- *  Sub,
  *  Neg,
  *  Own,
  *  Comma,
  *  Fn,
  *  Frame,
- *  Eq,
- *  Neq,
- *  Gt,
- *  Lt,
- *  Ge,
  *  BinaryOpId,
  *  BinaryOp,
  * } from './types.ts'
@@ -68,17 +61,10 @@ import {
  *  typeof call,
  *  typeof propertyCall,
  *  typeof own,
- *  typeof add,
- *  typeof sub,
  *  typeof neg,
  *  typeof comma,
  *  typeof fn,
  *  typeof frame,
- *  typeof eq,
- *  typeof neq,
- *  typeof gt,
- *  typeof lt,
- *  typeof ge
  * ]}
  */
 export const exp = () => (['or',
@@ -92,17 +78,10 @@ export const exp = () => (['or',
     call,
     propertyCall,
     own,
-    add,
-    sub,
     neg,
     comma,
     fn,
     frame,
-    eq,
-    neq,
-    gt,
-    lt,
-    ge,
 ])
 
 /** @typedef {Assert<Check<Exp, typeof exp>>} _ExpAssert */
@@ -274,28 +253,6 @@ export const own = _own
  * @typedef {Assert<Check3<Own, typeof _own, typeof own>>} _Own
  */
 
-// Binary +
-
-const _add = /** @type {const} */(['+', exp, exp])
-
-/** @type {Phantom<typeof _add, Add>} */
-export const add = _add
-
-/**
- * @typedef {Assert<Check3<Add, typeof _add, typeof add>>} _Add
- */
-
-// Binary -
-
-const _sub = /** @type {const} */(['-', exp, exp])
-
-/** @type {Phantom<typeof _sub, Sub>} */
-export const sub = _sub
-
-/**
- * @typedef {Assert<Check3<Sub, typeof _sub, typeof sub>>} _Sub
- */
-
 // Negation (aka a unary minus) — a word tag, `"neg"`, not `"-"`'s unary
 // arity (an earlier draft overloaded `"-"` the way JS itself does; see
 // `../../todo/edag-stage1-discussion.md`'s "Operators" section for why that
@@ -340,50 +297,7 @@ export const frame = /** @type {const} */(['frame'])
 
 /** @typedef {Assert<Check<Frame, typeof frame>>} _Frame */
 
-// ===
-
-const _eq = /** @type {const} */(['===', exp, exp])
-
-/** @type {Phantom<typeof _eq, Eq>} */
-export const eq = _eq
-
-/** @typedef {Assert<Check3<Eq, typeof _eq, typeof eq>>} _Eq */
-
-// !==
-
-const _neq = /** @type {const} */(['!==', exp, exp])
-
-/** @type {Phantom<typeof _neq, Neq>} */
-export const neq = _neq
-
-/** @typedef {Assert<Check3<Neq, typeof _neq, typeof neq>>} _Neq */
-
-// >
-
-const _gt = /** @type {const} */(['>', exp, exp])
-
-/** @type {Phantom<typeof _gt, Gt>} */
-export const gt = _gt
-
-/** @typedef {Assert<Check3<Gt, typeof _gt, typeof gt>>} _Gt */
-
-// <
-
-const _lt = /** @type {const} */(['<', exp, exp])
-
-/** @type {Phantom<typeof _lt, Lt>} */
-export const lt = _lt
-
-/** @typedef {Assert<Check3<Lt, typeof _lt, typeof lt>>} _Lt */
-
-// >=
-
-const _ge = /** @type {const} */(['>=', exp, exp])
-
-/** @type {Phantom<typeof _ge, Ge>} */
-export const ge = _ge
-
-/** @typedef {Assert<Check3<Ge, typeof _ge, typeof ge>>} _Ge */
+//
 
 export const binaryOpId = or(
     '===', '!==', '>', '>=', '<', '<=',

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -10,7 +10,6 @@
  *  Primitive,
  *  Property,
  *  NumberCast,
- *  StringCast,
  *  PropertyAccessor,
  *  Object,
  *  PropertyCall,

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -6,7 +6,6 @@
  * @import {
  *  Args,
  *  Array,
- *  Call,
  *  Exp,
  *  Primitive,
  *  Property,
@@ -252,7 +251,11 @@ export const frame = /** @type {const} */(['frame'])
 
 /** @typedef {Assert<Check<Frame, typeof frame>>} _Frame */
 
-//
+// Unary Operations
+
+export const unaryOpId = or('neg')
+
+// Binary Operations
 
 export const binaryOpId = or(
     '=>', 'own', '()',

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -53,8 +53,6 @@ import {
  *  typeof array,
  *  typeof object,
  *  typeof args,
- *  typeof numberCast,
- *  typeof stringCast,
  *  typeof propertyAccessor,
  *  typeof propertyCall,
  *  typeof comma,
@@ -68,8 +66,6 @@ export const exp = () => (['or',
     array,
     object,
     args,
-    numberCast,
-    stringCast,
     propertyAccessor,
     propertyCall,
     comma,
@@ -154,23 +150,6 @@ export const numberCast = _numberCast
 
 /**
  * @typedef {Assert<Check3<NumberCast, typeof _numberCast, typeof numberCast>>} _NumberCast
- */
-
-// String
-
-const _stringCast = /** @type {const} */(['String', exp])
-
-/**
- * ```js
- * String(exp)
- * ```
- *
- * @type {Phantom<typeof _stringCast, StringCast>}
- */
-export const stringCast = _stringCast
-
-/**
- * @typedef {Assert<Check3<StringCast, typeof _stringCast, typeof stringCast>>} _StringCast
  */
 
 // Index

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -20,6 +20,8 @@
  *  Frame,
  *  BinaryOpId,
  *  BinaryOp,
+ *  UnaryOpId,
+ *  UnaryOp,
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */
@@ -255,7 +257,11 @@ export const frame = /** @type {const} */(['frame'])
 
 export const unaryOpId = or('neg')
 
+/** @typedef {Assert<Check<UnaryOpId, typeof unaryOpId>>} _UnaryOpId */
+
 export const unaryOp = /** @type {const} */([unaryOpId, exp])
+
+/** @typedef {Assert<Check<UnaryOp, typeof unaryOp>>} _UnaryOp */
 
 // Binary Operations
 

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -58,10 +58,10 @@ import {
  *  typeof stringCast,
  *  typeof propertyAccessor,
  *  typeof propertyCall,
- *  typeof neg,
  *  typeof comma,
  *  typeof frame,
  *  typeof binaryOp,
+ *  typeof unaryOp,
  * ]}
  */
 export const exp = () => (['or',
@@ -73,10 +73,10 @@ export const exp = () => (['or',
     stringCast,
     propertyAccessor,
     propertyCall,
-    neg,
     comma,
     frame,
     binaryOp,
+    unaryOp,
 ])
 
 /** @typedef {Assert<Check<Exp, typeof exp>>} _ExpAssert */
@@ -259,7 +259,10 @@ export const unaryOpId = or('neg')
 
 /** @typedef {Assert<Check<UnaryOpId, typeof unaryOpId>>} _UnaryOpId */
 
-export const unaryOp = /** @type {const} */([unaryOpId, exp])
+const _unaryOp = /** @type {const} */([unaryOpId, exp])
+
+/** @type {Phantom<typeof _unaryOp, UnaryOp>} */
+export const unaryOp = _unaryOp
 
 /** @typedef {Assert<Check<UnaryOp, typeof unaryOp>>} _UnaryOp */
 

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -56,7 +56,6 @@ import {
  *  typeof numberCast,
  *  typeof stringCast,
  *  typeof propertyAccessor,
- *  typeof call,
  *  typeof propertyCall,
  *  typeof neg,
  *  typeof comma,
@@ -72,7 +71,6 @@ export const exp = () => (['or',
     numberCast,
     stringCast,
     propertyAccessor,
-    call,
     propertyCall,
     neg,
     comma,
@@ -204,23 +202,6 @@ export const propertyAccessor = _propertyAccessor
  * @typedef {Assert<Check3<PropertyAccessor, typeof _propertyAccessor, typeof propertyAccessor>>} _PropertyAccessor
  */
 
-// Call
-
-const _call = /** @type {const} */(['()', exp, exp])
-
-/**
- * ```js
- * exp0(exp1)
- * ```
- *
- * @type {Phantom<typeof _call, Call>}
- */
-export const call = _call
-
-/**
- * @typedef {Assert<Check3<Call, typeof _call, typeof call>>} _Call
- */
-
 // Property Call
 
 const _propertyCall = /** @type {const} */(['.()', exp, index, exp])
@@ -274,7 +255,7 @@ export const frame = /** @type {const} */(['frame'])
 //
 
 export const binaryOpId = or(
-    '=>', 'own',
+    '=>', 'own', '()',
     '===', '!==', '>', '>=', '<', '<=',
     '+', '-', '*', '/', '%', '**',
     '&', '|', '^', '<<', '>>', '>>>',

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -43,7 +43,7 @@ const vBinaryOpId = value => validate(binaryOpId)(value)
 /** Every id `unaryOp` currently accepts — kept as a literal list, not derived
  * from `unaryOpId`, so deleting one from the schema reddens exactly its own
  * assertion below rather than silently shrinking this list too. */
-const unaryOpIds = /** @type {const} */ (['neg', 'String', 'Number'])
+const unaryOpIds = /** @type {const} */ (['String', 'Number', 'neg', '!', '~'])
 
 /** Same purpose as `unaryOpIds`, for `binaryOp`. */
 const binaryOpIds = /** @type {const} */ ([
@@ -155,7 +155,7 @@ export const proof = {
     unaryOp: {
         ok: () => {
             // Every id `unaryOp` accepts, pinned individually: deleting any
-            // one of these three from `unaryOpId` reddens exactly this loop,
+            // one of these five from `unaryOpId` reddens exactly this loop,
             // not some other assertion that happens to still pass.
             for (const id of unaryOpIds) {
                 assertOk(v([id, 1]))
@@ -171,7 +171,7 @@ export const proof = {
         extraTailIsIgnored: () => assertOk(v(['neg', 1, 'extra'])),
         error: () => assertNoMatch(v(['negz', 1])),
         // `unaryOpId` is a real constraint, not a stand-in for `string`: an
-        // id outside its three members is rejected, both directly and as
+        // id outside its five members is rejected, both directly and as
         // part of a full `exp` value.
         unknownIdIsRejected: () => {
             assertNoMatch(vUnaryOpId('xyz'))

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -12,7 +12,7 @@
 
 import { validate } from '../types/rtti/validate/module.f.mjs'
 import { assert, assertEq, assertStructurallySame } from '../asserts/module.f.mjs'
-import { exp } from './module.f.mjs'
+import { exp, unaryOpId, binaryOpId } from './module.f.mjs'
 
 /** @type {(r: readonly [string, unknown]) => void} */
 const assertOk = ([k]) => { assertEq(k, 'ok', 'expected ok') }
@@ -33,6 +33,26 @@ const assertNoMatch = r => {
 
 /** @type {(value: Unknown) => readonly [string, unknown]} */
 const v = value => validate(exp)(value)
+
+/** @type {(value: Unknown) => readonly [string, unknown]} */
+const vUnaryOpId = value => validate(unaryOpId)(value)
+
+/** @type {(value: Unknown) => readonly [string, unknown]} */
+const vBinaryOpId = value => validate(binaryOpId)(value)
+
+/** Every id `unaryOp` currently accepts — kept as a literal list, not derived
+ * from `unaryOpId`, so deleting one from the schema reddens exactly its own
+ * assertion below rather than silently shrinking this list too. */
+const unaryOpIds = /** @type {const} */ (['neg', 'String', 'Number'])
+
+/** Same purpose as `unaryOpIds`, for `binaryOp`. */
+const binaryOpIds = /** @type {const} */ ([
+    '=>', 'own', '()',
+    '===', '!==', '>', '>=', '<', '<=',
+    '+', '-', '*', '/', '%', '**',
+    '&', '|', '^', '<<', '>>', '>>>',
+    '&&', '||', '??',
+])
 
 export const proof = {
     primitive: {
@@ -92,38 +112,6 @@ export const proof = {
             assertNoMatch(v(['argz']))
         },
     },
-    numberCast: {
-        ok: () => {
-            assertOk(v(['Number', 'x']))
-            assertOk(v(['Number', ['args']])) // an exp nested inside the cast
-        },
-        // A missing operand reads as `undefined`, which is no longer a
-        // valid bare `exp` (see `undefinedOp`) — so this is a real error,
-        // not the open-tail case `args` has. An extra trailing operand is
-        // still ignored, same as `args`.
-        missingTailIsError: () => assertNoMatch(v(['Number'])),
-        extraTailIsIgnored: () => assertOk(v(['Number', 'x', 'extra'])),
-        // `numberCast` composes through `exp`'s recursion like any other node.
-        asArrayElement: () => assertOk(v(['[]', [['Number', 1]]])),
-        asCallee: () => assertOk(v(['()', ['Number', 1], 2])),
-        error: () => assertNoMatch(v(['Numberz', 'x'])),
-    },
-    stringCast: {
-        ok: () => {
-            assertOk(v(['String', 'x']))
-            assertOk(v(['String', ['args']])) // an exp nested inside the cast
-        },
-        // A missing operand reads as `undefined`, which is no longer a
-        // valid bare `exp` (see `undefinedOp`) — so this is a real error,
-        // not the open-tail case `args` has. An extra trailing operand is
-        // still ignored, same as `args`.
-        missingTailIsError: () => assertNoMatch(v(['String'])),
-        extraTailIsIgnored: () => assertOk(v(['String', 'x', 'extra'])),
-        // `stringCast` composes through `exp`'s recursion like any other node.
-        asArrayElement: () => assertOk(v(['[]', [['String', 1]]])),
-        asCallee: () => assertOk(v(['()', ['String', 1], 2])),
-        error: () => assertNoMatch(v(['Stringz', 'x'])),
-    },
     propertyAccessor: {
         ok: () => {
             assertOk(v(['.', 'a', 'b']))
@@ -145,95 +133,14 @@ export const proof = {
             assertNoMatch(v(['.', 'a', true]))
         },
     },
-    call: {
-        ok: () => assertOk(v(['()', 'f', 1])),
-        // A missing operand reads as `undefined`, no longer a valid bare
-        // `exp` — see `undefinedOp`.
-        missingTailIsError: () => assertNoMatch(v(['()', 'f'])),
-        error: () => assertNoMatch(v(['(x)', 'f', 1])),
-    },
     propertyCall: {
         ok: () => assertOk(v(['.()', 'o', 'k', 1])),
         error: () => {
             assertNoMatch(v(['.(x)', 'o', 'k', 1]))
             // The third operand missing reads as `undefined` — an error,
-            // same as `call`'s `missingTailIsError`.
+            // same as `unaryOp`/`binaryOp`'s `missingTailIsError`.
             assertNoMatch(v(['.()', 'o', 'k']))
         },
-    },
-    own: {
-        ok: () => assertOk(v(['own', 'o', 'k'])),
-        // A missing operand reads as `undefined`, no longer a valid bare
-        // `exp` — see `undefinedOp`.
-        missingTailIsError: () => assertNoMatch(v(['own', 'o'])),
-        extraTailIsIgnored: () => assertOk(v(['own', 'o', 'k', 'extra'])),
-        error: () => assertNoMatch(v(['ownz', 'o', 'k'])),
-        // `own`'s point is bypassing the prototype chain — including the
-        // `__proto__` special case a computed key already avoids in JS.
-        // Demonstrates the pattern `own` denotes; not a schema check.
-        js: () => {
-            /** @type {<T>(a: StringMap<T>, k: string) => T|undefined } */
-            const own = (a, k) => Object.getOwnPropertyDescriptor(a, k)?.value
-            const a = { ['__proto__']: 42 }
-            assertEq(own(a, '__proto__'), 42)
-            assertEq(own(a, 'x'), undefined)
-        },
-    },
-    add: {
-        ok: () => {
-            assertOk(v(['+', 1, 2]))
-            assertOk(v(['+', ['+', 1, 2], 3])) // an exp nested inside an operand
-        },
-        // A missing operand reads as `undefined`, no longer a valid bare
-        // `exp` — see `undefinedOp`. True whether one or both are missing.
-        missingTailIsError: () => {
-            assertNoMatch(v(['+', 1]))
-            assertNoMatch(v(['+']))
-        },
-        extraTailIsIgnored: () => assertOk(v(['+', 1, 2, 3])),
-        error: () => assertNoMatch(v(['+z', 1, 2])),
-    },
-    sub: {
-        ok: () => {
-            assertOk(v(['-', 1, 2]))
-            assertOk(v(['-', ['-', 1, 2], 3])) // an exp nested inside an operand
-        },
-        // A missing operand reads as `undefined`, no longer a valid bare
-        // `exp` — see `undefinedOp`. `neg` is a distinct word tag (`"neg"`,
-        // not `"-"`), so this doesn't fall through to it — unlike `add`
-        // and `numberCast`, there's no other alternative tagged `"-"` at
-        // all, missing one or two operands is equally an error.
-        missingTailIsError: () => {
-            assertNoMatch(v(['-', 1]))
-            assertNoMatch(v(['-']))
-        },
-        extraTailIsIgnored: () => assertOk(v(['-', 1, 2, 3])),
-        error: () => assertNoMatch(v(['-z', 1, 2])),
-    },
-    neg: {
-        ok: () => {
-            assertOk(v(['neg', 1]))
-            assertOk(v(['neg', ['neg', 1]])) // an exp nested inside the operand
-        },
-        // A missing operand reads as `undefined`, no longer a valid bare
-        // `exp` — see `undefinedOp`.
-        missingTailIsError: () => assertNoMatch(v(['neg'])),
-        extraTailIsIgnored: () => assertOk(v(['neg', 1, 'extra'])),
-        error: () => assertNoMatch(v(['negz', 1])),
-    },
-    fn: {
-        ok: () => {
-            assertOk(v(['=>', 1, 2]))
-            assertOk(v(['=>', 1, ['=>', 1, 2]])) // an exp nested inside an operand
-        },
-        // A missing operand reads as `undefined`, no longer a valid bare
-        // `exp` — see `undefinedOp`. True whether one or both are missing.
-        missingTailIsError: () => {
-            assertNoMatch(v(['=>', 1]))
-            assertNoMatch(v(['=>']))
-        },
-        extraTailIsIgnored: () => assertOk(v(['=>', 1, 2, 'extra'])),
-        error: () => assertNoMatch(v(['=>z', 1, 2])),
     },
     frame: {
         ok: () => assertOk(v(['frame'])),
@@ -245,75 +152,68 @@ export const proof = {
             assertNoMatch(v(['framez']))
         },
     },
-    eq: {
+    unaryOp: {
         ok: () => {
-            assertOk(v(['===', 1, 2]))
-            assertOk(v(['===', ['===', 1, 2], 3])) // an exp nested inside an operand
+            // Every id `unaryOp` accepts, pinned individually: deleting any
+            // one of these three from `unaryOpId` reddens exactly this loop,
+            // not some other assertion that happens to still pass.
+            for (const id of unaryOpIds) {
+                assertOk(v([id, 1]))
+            }
+            assertOk(v(['neg', ['neg', 1]])) // an exp nested inside the operand
+            // Composes through `exp`'s recursion like any other node.
+            assertOk(v(['[]', [['Number', 1]]]))
+            assertOk(v(['()', ['Number', 1], 2]))
         },
         // A missing operand reads as `undefined`, no longer a valid bare
-        // `exp` — see `undefinedOp`. True whether one or both are missing.
-        missingTailIsError: () => {
-            assertNoMatch(v(['===', 1]))
-            assertNoMatch(v(['===']))
+        // `exp` — see `undefinedOp`.
+        missingTailIsError: () => assertNoMatch(v(['neg'])),
+        extraTailIsIgnored: () => assertOk(v(['neg', 1, 'extra'])),
+        error: () => assertNoMatch(v(['negz', 1])),
+        // `unaryOpId` is a real constraint, not a stand-in for `string`: an
+        // id outside its three members is rejected, both directly and as
+        // part of a full `exp` value.
+        unknownIdIsRejected: () => {
+            assertNoMatch(vUnaryOpId('xyz'))
+            assertNoMatch(v(['xyz', 1]))
         },
-        extraTailIsIgnored: () => assertOk(v(['===', 1, 2, 3])),
-        error: () => assertNoMatch(v(['===z', 1, 2])),
+        // `own`'s point is bypassing the prototype chain — including the
+        // `__proto__` special case a computed key already avoids in JS.
+        // Demonstrates the pattern `['own', ...]` (a `binaryOp` id) denotes;
+        // not a schema check.
+        ownJs: () => {
+            /** @type {<T>(a: StringMap<T>, k: string) => T|undefined } */
+            const own = (a, k) => Object.getOwnPropertyDescriptor(a, k)?.value
+            const a = { ['__proto__']: 42 }
+            assertEq(own(a, '__proto__'), 42)
+            assertEq(own(a, 'x'), undefined)
+        },
     },
-    neq: {
+    binaryOp: {
         ok: () => {
-            assertOk(v(['!==', 1, 2]))
-            assertOk(v(['!==', ['!==', 1, 2], 3])) // an exp nested inside an operand
+            // Every id `binaryOp` accepts, pinned individually — including
+            // the fourteen this PR adds (`<=`, `*`, `/`, `%`, `**`, `&`, `|`,
+            // `^`, `<<`, `>>`, `>>>`, `&&`, `||`, `??`), which had no proof
+            // at all before this: deleting any one of the twenty-four from
+            // `binaryOpId` reddens exactly this loop.
+            for (const id of binaryOpIds) {
+                assertOk(v([id, 1, 2]))
+            }
+            assertOk(v(['+', ['+', 1, 2], 3])) // an exp nested inside an operand
         },
         // A missing operand reads as `undefined`, no longer a valid bare
         // `exp` — see `undefinedOp`. True whether one or both are missing.
         missingTailIsError: () => {
-            assertNoMatch(v(['!==', 1]))
-            assertNoMatch(v(['!==']))
+            assertNoMatch(v(['+', 1]))
+            assertNoMatch(v(['+']))
         },
-        extraTailIsIgnored: () => assertOk(v(['!==', 1, 2, 3])),
-        error: () => assertNoMatch(v(['!==z', 1, 2])),
-    },
-    gt: {
-        ok: () => {
-            assertOk(v(['>', 1, 2]))
-            assertOk(v(['>', ['>', 1, 2], 3])) // an exp nested inside an operand
+        extraTailIsIgnored: () => assertOk(v(['+', 1, 2, 3])),
+        error: () => assertNoMatch(v(['+z', 1, 2])),
+        // Same point as `unaryOp`'s: `binaryOpId` constrains membership.
+        unknownIdIsRejected: () => {
+            assertNoMatch(vBinaryOpId('xyz'))
+            assertNoMatch(v(['xyz', 1, 2]))
         },
-        // A missing operand reads as `undefined`, no longer a valid bare
-        // `exp` — see `undefinedOp`. True whether one or both are missing.
-        missingTailIsError: () => {
-            assertNoMatch(v(['>', 1]))
-            assertNoMatch(v(['>']))
-        },
-        extraTailIsIgnored: () => assertOk(v(['>', 1, 2, 3])),
-        error: () => assertNoMatch(v(['>z', 1, 2])),
-    },
-    lt: {
-        ok: () => {
-            assertOk(v(['<', 1, 2]))
-            assertOk(v(['<', ['<', 1, 2], 3])) // an exp nested inside an operand
-        },
-        // A missing operand reads as `undefined`, no longer a valid bare
-        // `exp` — see `undefinedOp`. True whether one or both are missing.
-        missingTailIsError: () => {
-            assertNoMatch(v(['<', 1]))
-            assertNoMatch(v(['<']))
-        },
-        extraTailIsIgnored: () => assertOk(v(['<', 1, 2, 3])),
-        error: () => assertNoMatch(v(['<z', 1, 2])),
-    },
-    ge: {
-        ok: () => {
-            assertOk(v(['>=', 1, 2]))
-            assertOk(v(['>=', ['>=', 1, 2], 3])) // an exp nested inside an operand
-        },
-        // A missing operand reads as `undefined`, no longer a valid bare
-        // `exp` — see `undefinedOp`. True whether one or both are missing.
-        missingTailIsError: () => {
-            assertNoMatch(v(['>=', 1]))
-            assertNoMatch(v(['>=']))
-        },
-        extraTailIsIgnored: () => assertOk(v(['>=', 1, 2, 3])),
-        error: () => assertNoMatch(v(['>=z', 1, 2])),
     },
     // `f(args)[k](obj.a)` in AST form — exercises the mutual recursion through
     // `exp` rather than any one node kind in isolation.

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -71,11 +71,6 @@ export type PropertyAccessor = readonly['.', Exp, Index]
 
 export type PropertyCall = readonly['.()', Exp, Index, Exp]
 
-// negation (aka a unary minus — a word tag, `"neg"`, not `"-"`'s unary
-// arity, so it doesn't share a tag with `Sub`)
-
-export type Neg = readonly['neg', Exp]
-
 // Comma
 
 export type Comma = readonly[',', Exps]

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -16,7 +16,6 @@ export type Exp =
     | NumberCast
     | StringCast
     | PropertyAccessor
-    | Call
     | PropertyCall
     | Neg
     | Comma
@@ -68,10 +67,6 @@ export type Index = number | NumberCast | string
 
 export type PropertyAccessor = readonly['.', Exp, Index]
 
-// call
-
-export type Call = readonly['()', Exp, Exp]
-
 // propertyCall
 
 export type PropertyCall = readonly['.()', Exp, Index, Exp]
@@ -100,7 +95,7 @@ export type Frame = readonly['frame']
 // BinaryOpNames
 
 export type BinaryOpId =
-    | '=>'  | 'own'
+    | '=>'  | 'own' | '()'
     | '===' | '!==' | '>' | '>=' | '<'  | '<='
     | '+'   | '-'   | '*' | '/'  | '%'  | '**'
     | '&'   | '|'   | '^' | '<<' | '>>' | '>>>'

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -82,7 +82,7 @@ export type Frame = readonly['frame']
 // UnaryOpIds
 
 export type UnaryOpId =
-    | 'neg'
+    | 'neg' | 'String' | 'Number'
 
 export type UnaryOp = readonly[UnaryOpId, Exp]
 

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -17,10 +17,10 @@ export type Exp =
     | StringCast
     | PropertyAccessor
     | PropertyCall
-    | Neg
     | Comma
     | Frame
     | BinaryOp
+    | UnaryOp
 
 // undefinedOp
 

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -13,8 +13,6 @@ export type Exp =
     | Array
     | Object
     | Args
-    | NumberCast
-    | StringCast
     | PropertyAccessor
     | PropertyCall
     | Comma
@@ -53,10 +51,6 @@ export type Args = readonly['args']
 // Number
 
 export type NumberCast = readonly['Number', Exp]
-
-// String
-
-export type StringCast = readonly['String', Exp]
 
 // Index — shape only; see `index` in `module.f.mjs` for what this doesn't
 // cover (e.g. denylisted property names like `constructor`)

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -84,7 +84,14 @@ export type Comma = readonly[',', Exps]
 
 export type Frame = readonly['frame']
 
-// BinaryOpNames
+// UnaryOpIds
+
+export type UnaryOpId =
+    | 'neg'
+
+export type UnaryOp = readonly[UnaryOp, Exp]
+
+// BinaryOpIds
 
 export type BinaryOpId =
     | '=>'  | 'own' | '()'

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -22,6 +22,7 @@ export type Exp =
     | Comma
     | Fn
     | Frame
+    | BinaryOp
 
 // undefinedOp
 

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -18,7 +18,6 @@ export type Exp =
     | PropertyAccessor
     | Call
     | PropertyCall
-    | Own
     | Neg
     | Comma
     | Frame
@@ -77,10 +76,6 @@ export type Call = readonly['()', Exp, Exp]
 
 export type PropertyCall = readonly['.()', Exp, Index, Exp]
 
-// own
-
-export type Own = readonly ['own', Exp, Exp]
-
 // Binary +
 
 export type Add = readonly['+', Exp, Exp]
@@ -105,7 +100,7 @@ export type Frame = readonly['frame']
 // BinaryOpNames
 
 export type BinaryOpId =
-    | '=>'
+    | '=>'  | 'own'
     | '===' | '!==' | '>' | '>=' | '<'  | '<='
     | '+'   | '-'   | '*' | '/'  | '%'  | '**'
     | '&'   | '|'   | '^' | '<<' | '>>' | '>>>'

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -18,17 +18,10 @@ export type Exp =
     | Call
     | PropertyCall
     | Own
-    | Add
-    | Sub
     | Neg
     | Comma
     | Fn
     | Frame
-    | Eq
-    | Neq
-    | Gt
-    | Lt
-    | Ge
 
 // undefinedOp
 

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -71,14 +71,6 @@ export type PropertyAccessor = readonly['.', Exp, Index]
 
 export type PropertyCall = readonly['.()', Exp, Index, Exp]
 
-// Binary +
-
-export type Add = readonly['+', Exp, Exp]
-
-// Binary -
-
-export type Sub = readonly['-', Exp, Exp]
-
 // negation (aka a unary minus — a word tag, `"neg"`, not `"-"`'s unary
 // arity, so it doesn't share a tag with `Sub`)
 

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -83,10 +83,10 @@ export type UnaryOp = readonly[UnaryOpId, Exp]
 // BinaryOpIds
 
 export type BinaryOpId =
-    | '=>'  | 'own' | '()'
-    | '===' | '!==' | '>' | '>=' | '<'  | '<='
-    | '+'   | '-'   | '*' | '/'  | '%'  | '**'
-    | '&'   | '|'   | '^' | '<<' | '>>' | '>>>'
-    | '&&'  | '||'  | '??'
+    | '=>' | 'own' | '()'
+    | '===' | '!==' | '>' | '>=' | '<' | '<='
+    | '+' | '-' | '*' | '/' | '%' | '**'
+    | '&' | '|' | '^' | '<<' | '>>' | '>>>'
+    | '&&' | '||' | '??'
 
 export type BinaryOp = readonly[BinaryOpId, Exp, Exp]

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -107,26 +107,6 @@ export type Fn = readonly['=>', Exp, Exp]
 
 export type Frame = readonly['frame']
 
-// Eq
-
-export type Eq = readonly['===', Exp, Exp]
-
-// Neq
-
-export type Neq = readonly['!==', Exp, Exp]
-
-// Gt
-
-export type Gt = readonly['>', Exp, Exp]
-
-// Lt
-
-export type Lt = readonly['<', Exp, Exp]
-
-// Ge
-
-export type Ge = readonly['>=', Exp, Exp]
-
 // BinaryOpNames
 
 export type BinaryOpId =

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -139,3 +139,5 @@ export type BinaryOpId =
     | '+'   | '-'   | '*' | '/'  | '%'  | '**'
     | '&'   | '|'   | '^' | '<<' | '>>' | '>>>'
     | '&&'  | '||'  | '??'
+
+export type BinaryOp = readonly[BinaryOpId, Exp, Exp]

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -76,7 +76,7 @@ export type Frame = readonly['frame']
 // UnaryOpIds
 
 export type UnaryOpId =
-    | 'neg' | 'String' | 'Number'
+    | 'String' | 'Number' | 'neg' | '!' | '~'
 
 export type UnaryOp = readonly[UnaryOpId, Exp]
 

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -131,3 +131,11 @@ export type Lt = readonly['<', Exp, Exp]
 // Ge
 
 export type Ge = readonly['>=', Exp, Exp]
+
+// BinaryOpNames
+
+export type BinaryOpId =
+    | '===' | '!==' | '>' | '>=' | '<'  | '<='
+    | '+'   | '-'   | '*' | '/'  | '%'  | '**'
+    | '&'   | '|'   | '^' | '<<' | '>>' | '>>>'
+    | '&&'  | '||'  | '??'

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -89,7 +89,7 @@ export type Frame = readonly['frame']
 export type UnaryOpId =
     | 'neg'
 
-export type UnaryOp = readonly[UnaryOp, Exp]
+export type UnaryOp = readonly[UnaryOpId, Exp]
 
 // BinaryOpIds
 

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -21,7 +21,6 @@ export type Exp =
     | Own
     | Neg
     | Comma
-    | Fn
     | Frame
     | BinaryOp
 
@@ -99,10 +98,6 @@ export type Neg = readonly['neg', Exp]
 
 export type Comma = readonly[',', Exps]
 
-// Fn
-
-export type Fn = readonly['=>', Exp, Exp]
-
 // Frame
 
 export type Frame = readonly['frame']
@@ -110,6 +105,7 @@ export type Frame = readonly['frame']
 // BinaryOpNames
 
 export type BinaryOpId =
+    | '=>'
     | '===' | '!==' | '>' | '>=' | '<'  | '<='
     | '+'   | '-'   | '*' | '/'  | '%'  | '**'
     | '&'   | '|'   | '^' | '<<' | '>>' | '>>>'

--- a/fjs/types/phantom/types.ts
+++ b/fjs/types/phantom/types.ts
@@ -29,7 +29,7 @@ export type { phantomKey }
  * wrong `T`) and one against the phantom-wrapped export (catches the export
  * and the raw thunk drifting apart), using `Check` from
  * `fjs/types/rtti/ts/types.ts`. See `fjs/edag/module.f.mjs`
- * (`propertyAccessor`/`call`/`propertyCall`) for the pattern:
+ * (`propertyAccessor`/`propertyCall`/`binaryOp`) for the pattern:
  *
  * ```ts
  * const rawThunk = () => [...] as const

--- a/fjs/types/rtti/todo/close-type.md
+++ b/fjs/types/rtti/todo/close-type.md
@@ -132,8 +132,8 @@ spellings of the same set must not compare unequal. `['close', S]` and
   — the RTTI-aware JSON parser reuses `../parse/module.f.mjs`'s container
   behavior, so it needs a `close` case too; whichever lands second picks it up.
 - [`../../../edag/module.f.mjs`](../../../edag/module.f.mjs) — `args`,
-  `propertyAccessor`, `call`, and `propertyCall` are fixed-arity nodes that
-  are open today only because every rtti tuple is; once EDAG values are
+  `propertyAccessor`, `propertyCall`, and `unaryOp`/`binaryOp` are fixed-arity
+  nodes that are open today only because every rtti tuple is; once EDAG values are
   content-addressed, exact arity for these becomes a correctness requirement,
   not just a nicety, and `close` is what states it.
 - `../data/types.ts:22-55` — `ArraySet` / `ObjectSet`; the `rest` field this


### PR DESCRIPTION
## Summary
- **Consolidates ~13 individually-defined node kinds into two generic, id-parameterized schemas.** `Add`, `Sub`, `Neg`, `Eq`, `Neq`, `Gt`, `Lt`, `Ge`, `Own`, `Fn`, `Call`, and `StringCast` are gone as standalone types/exports; in their place, `UnaryOpId = 'String' | 'Number' | 'neg' | '!' | '~'` + `UnaryOp = readonly[UnaryOpId, Exp]`, and `BinaryOpId` (a 24-member literal union) + `BinaryOp = readonly[BinaryOpId, Exp, Exp]`. `NumberCast` stays as its own type/export — `index`'s definition still needs it standalone (`or(numberCast, string, number)`), even though `'Number'` is also a `UnaryOpId` member.
- **This also lands ~16 operator ids that had no node at all before**, in one shot: `!`, `~`, `<=`, `*`, `/`, `%`, `**`, `&`, `|`, `^`, `<<`, `>>`, `>>>`, `&&`, `||`, `??` — the full unary/arithmetic/bitwise/logical set from `edag-stage1-discussion.md`'s Operators table, now all reachable through `unaryOp`/`binaryOp`.
- **Fixed a build-breaking dangling import**: `module.f.mjs` still imported `StringCast` from `types.ts`, which no longer exports it post-consolidation.
- **`proof.f.mjs` is rewritten to match.** Its ~13 old sections named node kinds this PR deletes and only exercised 10 of `binaryOp`'s 24 ids — the new ones had no coverage at all, and deleting any of them from `binaryOpId`/`unaryOpId` left `tsc`/the suite/`cov` all green (verified this against `'**'` and, after `!`/`~` landed, `'~'` too, before writing/updating the fix each time). Replaced with `unaryOp:`/`binaryOp:` sections that loop over an explicit id list per kind, so each id's removal reddens its own assertion, plus an `unknownIdIsRejected` case on both (checking `unaryOpId`/`binaryOpId` directly and through a full `exp` value) — previously nothing pinned that the id schema constrains membership rather than behaving like a bare `string`. Also fixed three stale `call` references left over from the consolidation (`module.f.mjs`'s doc comment, `phantom/types.ts`'s `Phantom` example, and `rtti/todo/close-type.md`).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run cov` — 3069/3069 tests, 100% lines/branches/functions
- [x] `npm run ci-update` — no diff

Changelog:
- `edag`: `Add`, `Sub`, `Neg`, `Eq`, `Neq`, `Gt`, `Lt`, `Ge`, `Own`, `Fn`, `Call`, and
  `StringCast` are replaced by two generic, id-parameterized node kinds — `UnaryOp`
  (`String`/`Number`/`neg`/`!`/`~`) and `BinaryOp` (`=>`, `own`, `()`, `===`, `!==`, `>`,
  `>=`, `<`, `<=`, `+`, `-`, `*`, `/`, `%`, `**`, `&`, `|`, `^`, `<<`, `>>`, `>>>`, `&&`,
  `||`, `??`) — adding `!`, `~`, `<=`, `*`, `/`, `%`, `**`, `&`, `|`, `^`, `<<`, `>>`,
  `>>>`, `&&`, `||`, and `??` to the `exp` union for the first time

No `**BREAKING CHANGES:**` marker: per the established precedent on #1658/#1656, nothing
in `fjs/edag/` has ever been published (`npm pack functionalscript@latest` has zero
`fjs/edag/*` entries), so renaming/consolidating its exports within this same unreleased
cycle breaks no shipped consumer.
