### PR TITLE
bnf/ll1: add an SSN grammar proof

### DIFF
--- a/fjs/bnf/ll1/proof.f.mjs
+++ b/fjs/bnf/ll1/proof.f.mjs
@@ -3,6 +3,7 @@
  * @import { RuleSet } from '../data/types.ts'
  * @import { CodePointMeta } from '../descent/types.ts'
  * @import { Rule as FRule } from '../types.ts'
+ * @import { Match } from './types.ts'
  * @import { MatchResult } from './types.ts'
  */
 
@@ -17,6 +18,15 @@ import { deterministic, showAst } from '../testlib.f.mjs'
 
 /** @type {(cp: CodePoint) => CodePointMeta<unknown>} */
 const mapCodePoint = cp => [cp, undefined]
+
+/** @type {(mr: MatchResult) => boolean} */
+const isMatchSuccess = ([, success, remainder]) => success && remainder?.length === 0
+
+/** @type {(m: Match) => (s: string, success: boolean) => void} */
+const expectMatch = m => (s, success) => {
+    const mr = m('', toArray(stringToCodePointList(s)))
+    assertEq(isMatchSuccess(mr), success, mr)
+}
 
 /**
  * One grammar matched by both backends, which must build the same AST for it:
@@ -588,17 +598,11 @@ export const proof = {
     ssn: () => {
         const ws = repeat0Plus(' ')
         const d = range('09')
-        const r = (/** @type {number} */n) => repeat(n)(d)
         const ssn = /** @type {const} */([
-            ws, r(3), ws, '-', ws, r(2), ws, '-', ws, r(4), ws])
+            ws, repeat(3)(d), ws, '-', ws, repeat(2)(d), ws, '-', ws, repeat(4)(d), ws])
 
         const m = parser(ssn) // must not throw 'can not merge'
-
-        /** @type {(s: string, success: boolean) => void} */
-        const expect = (s, success) => {
-            const mr = m('', toArray(stringToCodePointList(s)))
-            assertEq(mr[1] && mr[2]?.length === 0, success, mr)
-        }
+        const expect = expectMatch(m)
 
         expect('123-45-6789', true)
         expect('  123  - 45 - 6789 ', true)

--- a/fjs/bnf/ll1/proof.f.mjs
+++ b/fjs/bnf/ll1/proof.f.mjs
@@ -251,13 +251,7 @@ export const proof = {
         },
         () => {
             const m = parser(option('a'))
-
-            const isSuccess = (/** @type {MatchResult} */mr) => mr[1] && mr[2]?.length === 0
-            /** @type {(s: string, success: boolean) => void} */
-            const expect = (s, success) => {
-                const mr = m('', toArray(stringToCodePointList(s)))
-                assertEq(isSuccess(mr), success, mr)
-            }
+            const expect = expectMatch(m)
 
             expect('a', true)
             expect('', true)
@@ -278,12 +272,10 @@ export const proof = {
 
             const m = parser(value)
 
-            /** @type {(mr: MatchResult) => boolean} */
-            const isSuccess = mr => mr[1] && mr[2]?.length === 0
             /** @type {(s: string, success: boolean) => void} */
             const expect = (s, success) => {
                 const mr = m('value', toArray(stringToCodePointList(s)))
-                assertEq(isSuccess(mr), success, mr)
+                assertEq(isMatchSuccess(mr), success, mr)
             }
 
             expect('', false)
@@ -315,7 +307,7 @@ export const proof = {
             /** @type {(s: string) => void} */
             const expectNoMatch = s => {
                 const mr = ml(entry, toArray(stringToCodePointList(s)))
-                assertEq(mr[1] && mr[2]?.length === 0, false, s)
+                assertEq(isMatchSuccess(mr), false, s)
             }
 
             expectSameAst('   true   ')
@@ -580,12 +572,7 @@ export const proof = {
         const ws = option(' ')
         const value = () => ({ array: ['[', value, ']'], leaf: 'a' })
         const m = parser([ws, value, ws]) // must not throw 'can not merge'
-
-        /** @type {(s: string, success: boolean) => void} */
-        const expect = (s, success) => {
-            const mr = m('', toArray(stringToCodePointList(s)))
-            assertEq(mr[1] && mr[2]?.length === 0, success, mr)
-        }
+        const expect = expectMatch(m)
 
         expect('a', true)
         expect(' a ', true)

--- a/fjs/bnf/ll1/proof.f.mjs
+++ b/fjs/bnf/ll1/proof.f.mjs
@@ -8,7 +8,7 @@
 
 import { stringToCodePointList } from '../../text/utf16/module.f.mjs'
 import { map, toArray } from '../../types/list/module.f.mjs'
-import { commaJoin0Plus, eof, option, range, repeat0Plus, set } from '../module.f.mjs'
+import { commaJoin0Plus, eof, option, range, repeat, repeat0Plus, set } from '../module.f.mjs'
 import { toData } from '../data/module.f.mjs'
 import { descentParser } from '../descent/module.f.mjs'
 import { dispatchMap, parser, parserRuleSet } from './module.f.mjs'
@@ -584,4 +584,28 @@ export const proof = {
         expect(' [[a]] ', true)
         expect('b', false)
     },
+    // A Social Security Number, `ddd-dd-dddd`.
+    ssn: () => {
+        const ws = repeat0Plus(' ')
+        const d = range('09')
+        const r = (/** @type {number} */n) => repeat(n)(d)
+        const ssn = /** @type {const} */([
+            ws, r(3), ws, '-', ws, r(2), ws, '-', ws, r(4), ws])
+
+        const m = parser(ssn) // must not throw 'can not merge'
+
+        /** @type {(s: string, success: boolean) => void} */
+        const expect = (s, success) => {
+            const mr = m('', toArray(stringToCodePointList(s)))
+            assertEq(mr[1] && mr[2]?.length === 0, success, mr)
+        }
+
+        expect('123-45-6789', true)
+        expect('  123  - 45 - 6789 ', true)
+        expect('22', false) // too short
+        expect('123456789', false) // no dashes
+        expect('123-3456-78', false) // wrong grouping
+        expect('123-345-6789', false) // wrong grouping
+        expect('12a-34-5678', false) // a letter where a digit is required
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `proof.ssn` to `fjs/bnf/ll1/proof.f.mjs`: a small LL(1) grammar for a Social Security Number, `ddd-dd-dddd` — `[ws, repeat(3)(d), ws, '-', ws, repeat(2)(d), ws, '-', ws, repeat(4)(d), ws]` where `d = range('09')` and `ws = repeat0Plus(' ')` — exercising the same `parser`/`expect` pattern the file's other tests already use. The `ws` tolerance is load-bearing: it's what lets `'  123  - 45 - 6789 '` accept.
- This started as an uncommitted, unnamed scratch test (`tn`/`tfn`) with a real bug: `expect('123-34-5678', false)` — but `'123-34-5678'` is a validly-shaped `ddd-dd-dddd` string, and actually parses `ok`. Confirmed by running the grammar directly outside the test harness before touching anything. The grammar itself was already correct; only the scratch test's own expectation was wrong, and it never made it into a commit — so there's no `false`→`true` diff here, only the finished, correct `ssn` proof.
- Renamed to `ssn`, with `'123-45-6789'` as the primary (accepting) example, and rounded out coverage with a few more negative cases: too short, no dashes, two different wrong-grouping shapes (`ddd-dddd-dd`, `ddd-ddd-dddd`), and a letter where a digit is required.
- Also extracts `isMatchSuccess`/`expectMatch` (module-scope helpers introduced in #1664 for the `ssn` proof) and reuses them in the four other sections of this file that were duplicating the same success-check/`expect` pattern, per review feedback.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run cov` — 100% lines/branches/functions (`bnf/ll1` at 100%)
- [x] `npm run ci-update` — no diff

Changelog: none — test-only change, no source behavior or public API is touched.
