### PR TITLE
edag: add README — node forms, schema/type/proof layout, caveats

### DIFF
--- a/fjs/edag/README.md
+++ b/fjs/edag/README.md
@@ -79,7 +79,8 @@ operand list: `f(a, b)` is `['()', f, ['[]', [a, b]]]` and spread
   that boundary is tracked in
   [compile-modules-to-edag.md](../djs/todo/compile-modules-to-edag.md).
 - `[',', exps]` is a known-incomplete placeholder; the settled shape must
-  express "at least one operand, last is the result".
+  express "at least two operands, last is the result" — a single-operand
+  `,` is the identity and non-canonical.
 - `index` does not yet exclude `constructor`/`__proto__` —
   [excluded-string-values.md](../types/rtti/todo/excluded-string-values.md).
 

--- a/fjs/edag/README.md
+++ b/fjs/edag/README.md
@@ -2,9 +2,12 @@
 
 An **e**xpression **DAG** — the canonical data representation of a function
 body. A body is a single root expression node; a shared subexpression is one
-node referenced from several places, not a copy. That is what makes a
-function's identity exact: one function, one EDAG, one hash — however its
-source spelled it. This module owns the data model only: node kinds, operand
+node referenced from several places, not a copy — sharing is observable
+(`{} === {}` is `false`), so it is part of the function's meaning, not a
+serialization trick. There is no normal form: a function's hash is the
+structural identity of its graph as written, the name-erased source.
+Lowering rules make agreed-on spellings coincide; hash equality does not
+decide semantic equivalence. This module owns the data model only: node kinds, operand
 shapes, and their schema. Producers and executors are staged work that will
 consume it — the [DJS](../djs/) compiler lowering parsed modules to EDAG
 ([compile-modules-to-edag.md](../djs/todo/compile-modules-to-edag.md)), the
@@ -48,8 +51,11 @@ property, bypassing the prototype chain (including `__proto__` — see the
   Deliberate in RTTI
   ([Structs and tuples are open](../types/rtti/README.md#structs-and-tuples-are-open));
   exact arity is future work ([close-type.md](../types/rtti/todo/close-type.md)).
-- `validate`/`parse` are not identity-aware: cycles are not rejected and
-  sharing is not preserved —
+- Neither `validate` nor `parse` is identity-aware, each in its own way:
+  `validate` returns the original value — sharing intact — but re-walks a
+  shared subgraph once per incoming edge (exponential in depth) and
+  overflows the stack on a cycle instead of rejecting it; `parse` rebuilds
+  every container, so sharing is lost —
   [identity-aware-parse.md](../types/rtti/todo/identity-aware-parse.md).
 - `[',', exps]` is a known-incomplete placeholder; the settled shape must
   express "at least one operand, last is the result".

--- a/fjs/edag/README.md
+++ b/fjs/edag/README.md
@@ -4,7 +4,10 @@ An **e**xpression **DAG** — the canonical data representation of a function
 body. A body is a single root expression node; a shared subexpression is one
 node referenced from several places, not a copy — sharing is observable
 (`{} === {}` is `false`), so it is part of the function's meaning, not a
-serialization trick. There is no normal form: a function's hash is the
+serialization trick. Evaluation memoizes every node by identity within one
+invocation — shared nodes evaluate once, and each call starts fresh — per
+the baseline in
+[edag-stage1-discussion.md](../../todo/edag-stage1-discussion.md). There is no normal form: a function's hash is the
 structural identity of its graph as written, the name-erased source.
 Lowering rules make agreed-on spellings coincide; hash equality does not
 decide semantic equivalence. This module owns the data model only: node kinds, operand

--- a/fjs/edag/README.md
+++ b/fjs/edag/README.md
@@ -18,12 +18,15 @@ The shape is defined once, as an [RTTI](../types/rtti/) schema in
 [module.f.mjs](module.f.mjs) — the specification of record, checkable at
 runtime with `validate(exp)`. [types.ts](types.ts) carries the same shape at
 the type level, pinned against the schema with `Assert<Check<...>>` so the
-two cannot drift. [proof.f.mjs](proof.f.mjs) pins the runtime behavior of
-every node kind.
+two cannot drift — exact up to one known approximation: the static tuples
+are closed while the runtime ones are open (see Caveats).
+[proof.f.mjs](proof.f.mjs) pins the runtime behavior of every node kind.
 
 ## Nodes
 
-A node is a primitive or a tagged tuple `[tag, ...operands]`.
+A node is a primitive or a tagged tuple `[tag, ...operands]`. This table is
+an overview; the contract of record for each node is the JSDoc on its export
+in [module.f.mjs](module.f.mjs).
 
 | form | meaning |
 |---|---|
@@ -51,6 +54,10 @@ property, bypassing the prototype chain (including `__proto__` — see the
   Deliberate in RTTI
   ([Structs and tuples are open](../types/rtti/README.md#structs-and-tuples-are-open));
   exact arity is future work ([close-type.md](../types/rtti/todo/close-type.md)).
+  The static types render the closed approximation — TypeScript cannot carry
+  the open tuple mapping generically (`TupleTs` in
+  [ts/types.ts](../types/rtti/ts/types.ts)) — so that same runtime-valid
+  `['args', 'extra']` is not assignable to `Args`.
 - Neither `validate` nor `parse` is identity-aware, each in its own way:
   `validate` returns the original value — sharing intact — but re-walks a
   shared subgraph once per incoming edge (exponential in depth) and

--- a/fjs/edag/README.md
+++ b/fjs/edag/README.md
@@ -38,7 +38,7 @@ record for each node is the JSDoc on its export in
 | `null`, `boolean`, `number`, `string`, `bigint` | itself |
 | `['undefined']` | `undefined` — tagged, because a bare `undefined` is indistinguishable from a missing tuple position |
 | `['[]', exps]` | array literal |
-| `['{}', properties]`, each `[':', key, value]` | object literal; the key is an `exp`, one form for `a:`, `"a":`, and computed `[exp]:` keys |
+| `['{}', properties]`, each `[':', key, value]` | object literal; ordered entries applied in written order, duplicates allowed with the later winning; the key is an `exp`, one form for `a:`, `"a":`, and computed `[exp]:` keys; the `:` descriptor is a structural operand, not a node — only its key and value are |
 | `['args']` | the function's arguments |
 | `['frame']` | the captured frame |
 | `['.', exp, index]` | property access: `exp0[exp1]` |
@@ -78,9 +78,11 @@ operand list: `f(a, b)` is `['()', f, ['[]', [a, b]]]` and spread
   never across a `=>` boundary — goes unchecked. The Stage 2 validator for
   that boundary is tracked in
   [compile-modules-to-edag.md](../djs/todo/compile-modules-to-edag.md).
-- `[',', exps]` is a known-incomplete placeholder; the settled shape must
-  express "at least two operands, last is the result" — a single-operand
-  `,` is the identity and non-canonical.
+- `[',', exps]` is a known-incomplete placeholder; the settled contract must
+  express "at least two operands, last is the result, each pre-result
+  operand a true root" — a single-operand `,` is the identity, an operand
+  reachable from a sibling of the same `,` a redundant anchor, both
+  non-canonical.
 - `index` does not yet exclude `constructor`/`__proto__` —
   [excluded-string-values.md](../types/rtti/todo/excluded-string-values.md).
 

--- a/fjs/edag/README.md
+++ b/fjs/edag/README.md
@@ -16,7 +16,7 @@ one-way by design: `fjs/edag` imports nothing from them.
 
 The shape is defined once, as an [RTTI](../types/rtti/) schema in
 [module.f.mjs](module.f.mjs) — the specification of record, checkable at
-runtime with `validate(exp)`. [types.ts](types.ts) carries the same shape at
+runtime with `validate(exp)` (shape only — see Caveats). [types.ts](types.ts) carries the same shape at
 the type level, pinned against the schema with `Assert<Check<...>>` so the
 two cannot drift — exact up to one known approximation: the static tuples
 are closed while the runtime ones are open (see Caveats).
@@ -72,6 +72,12 @@ operand list: `f(a, b)` is `['()', f, ['[]', [a, b]]]` and spread
   overflows the stack on a cycle instead of rejecting it; `parse` rebuilds
   every container, so sharing is lost —
   [identity-aware-parse.md](../types/rtti/todo/identity-aware-parse.md).
+  So `validate` is shape validation, not complete EDAG validation:
+  identity-dependent canonicality — acyclicity, and the rule that an
+  operation-node identity may be shared only within one function's scope,
+  never across a `=>` boundary — goes unchecked. The Stage 2 validator for
+  that boundary is tracked in
+  [compile-modules-to-edag.md](../djs/todo/compile-modules-to-edag.md).
 - `[',', exps]` is a known-incomplete placeholder; the settled shape must
   express "at least one operand, last is the result".
 - `index` does not yet exclude `constructor`/`__proto__` —

--- a/fjs/edag/README.md
+++ b/fjs/edag/README.md
@@ -20,7 +20,9 @@ runtime with `validate(exp)`. [types.ts](types.ts) carries the same shape at
 the type level, pinned against the schema with `Assert<Check<...>>` so the
 two cannot drift — exact up to one known approximation: the static tuples
 are closed while the runtime ones are open (see Caveats).
-[proof.f.mjs](proof.f.mjs) pins the runtime behavior of every node kind.
+[proof.f.mjs](proof.f.mjs) pins what the schema accepts and rejects, node
+kind by node kind — validation behavior, not execution semantics — with
+`comma` excepted until its placeholder shape settles.
 
 ## Nodes
 
@@ -37,7 +39,7 @@ in [module.f.mjs](module.f.mjs).
 | `['args']` | the function's arguments |
 | `['frame']` | the captured frame |
 | `['.', exp, index]` | property access: `exp0[exp1]` |
-| `['.()', exp, index, exp]` | property call: `exp0[exp1](exp2)` |
+| `['.()', exp, index, exp]` | property call: `exp0[exp1](...exp2)` |
 | `[',', exps]` | comma: establish all operands, take the value of the last |
 | `[id, exp]` | unary operation, `id` one of `String` `Number` `neg` `!` `~` |
 | `[id, exp, exp]` | binary operation, `id` one of `=>` `own` `()` `===` `!==` `>` `>=` `<` `<=` `+` `-` `*` `/` `%` `**` `&` `|` `^` `<<` `>>` `>>>` `&&` `||` `??` |
@@ -46,7 +48,10 @@ An `index` — the property operand of `.` and `.()` — is a `string`, a
 `number`, or `['Number', exp]`, a computed index cast to a number. Among the
 binary ids, `=>` builds a function, `()` calls one, and `own` reads an own
 property, bypassing the prototype chain (including `__proto__` — see the
-`ownJs` proof).
+`ownJs` proof). A call's arguments — `()`'s second operand and `.()`'s last
+— are one node evaluating to the complete argument array, not a literal
+operand list: `f(a, b)` is `['()', f, ['[]', [a, b]]]` and spread
+`f(...xs)` is `['()', f, xs]`.
 
 ## Caveats
 

--- a/fjs/edag/README.md
+++ b/fjs/edag/README.md
@@ -5,9 +5,10 @@ body. A body is a single root expression node; a shared subexpression is one
 node referenced from several places, not a copy — sharing is observable
 (`{} === {}` is `false`), so it is part of the function's meaning, not a
 serialization trick. Evaluation memoizes every node by identity within one
-invocation — shared nodes evaluate once, and each call starts fresh — per
-the baseline in
-[edag-stage1-discussion.md](../../todo/edag-stage1-discussion.md). There is no normal form: a function's hash is the
+invocation — shared nodes evaluate once, per the baseline in
+[edag-stage1-discussion.md](../../todo/edag-stage1-discussion.md), and each
+call starts fresh, per the per-invocation memo scope in
+[interpret-edag.md](../djs/todo/interpret-edag.md). There is no normal form: a function's hash is the
 structural identity of its graph as written, the name-erased source.
 Lowering rules make agreed-on spellings coincide; hash equality does not
 decide semantic equivalence. This module owns the data model only: node kinds, operand

--- a/fjs/edag/README.md
+++ b/fjs/edag/README.md
@@ -1,0 +1,64 @@
+# EDAG
+
+An **e**xpression **DAG** — the canonical data representation of a function
+body. A body is a single root expression node; a shared subexpression is one
+node referenced from several places, not a copy. That is what makes a
+function's identity exact: one function, one EDAG, one hash — however its
+source spelled it. This module owns the data model only: node kinds, operand
+shapes, and their schema. Producers and executors are staged work that will
+consume it — the [DJS](../djs/) compiler lowering parsed modules to EDAG
+([compile-modules-to-edag.md](../djs/todo/compile-modules-to-edag.md)), the
+interpreter and Rust code generation executing it — and the dependency is
+one-way by design: `fjs/edag` imports nothing from them.
+
+The shape is defined once, as an [RTTI](../types/rtti/) schema in
+[module.f.mjs](module.f.mjs) — the specification of record, checkable at
+runtime with `validate(exp)`. [types.ts](types.ts) carries the same shape at
+the type level, pinned against the schema with `Assert<Check<...>>` so the
+two cannot drift. [proof.f.mjs](proof.f.mjs) pins the runtime behavior of
+every node kind.
+
+## Nodes
+
+A node is a primitive or a tagged tuple `[tag, ...operands]`.
+
+| form | meaning |
+|---|---|
+| `null`, `boolean`, `number`, `string`, `bigint` | itself |
+| `['undefined']` | `undefined` — tagged, because a bare `undefined` is indistinguishable from a missing tuple position |
+| `['[]', exps]` | array literal |
+| `['{}', properties]`, each `[':', key, value]` | object literal; the key is an `exp`, one form for `a:`, `"a":`, and computed `[exp]:` keys |
+| `['args']` | the function's arguments |
+| `['frame']` | the captured frame |
+| `['.', exp, index]` | property access: `exp0[exp1]` |
+| `['.()', exp, index, exp]` | property call: `exp0[exp1](exp2)` |
+| `[',', exps]` | comma: establish all operands, take the value of the last |
+| `[id, exp]` | unary operation, `id` one of `String` `Number` `neg` `!` `~` |
+| `[id, exp, exp]` | binary operation, `id` one of `=>` `own` `()` `===` `!==` `>` `>=` `<` `<=` `+` `-` `*` `/` `%` `**` `&` `|` `^` `<<` `>>` `>>>` `&&` `||` `??` |
+
+An `index` — the property operand of `.` and `.()` — is a `string`, a
+`number`, or `['Number', exp]`, a computed index cast to a number. Among the
+binary ids, `=>` builds a function, `()` calls one, and `own` reads an own
+property, bypassing the prototype chain (including `__proto__` — see the
+`ownJs` proof).
+
+## Caveats
+
+- Tuples are open on the trailing side: `['args', 'extra']` validates.
+  Deliberate in RTTI
+  ([Structs and tuples are open](../types/rtti/README.md#structs-and-tuples-are-open));
+  exact arity is future work ([close-type.md](../types/rtti/todo/close-type.md)).
+- `validate`/`parse` are not identity-aware: cycles are not rejected and
+  sharing is not preserved —
+  [identity-aware-parse.md](../types/rtti/todo/identity-aware-parse.md).
+- `[',', exps]` is a known-incomplete placeholder; the settled shape must
+  express "at least one operand, last is the result".
+- `index` does not yet exclude `constructor`/`__proto__` —
+  [excluded-string-values.md](../types/rtti/todo/excluded-string-values.md).
+
+## Design
+
+The semantics and operation vocabulary are decided subject by subject in
+[edag-stage1-discussion.md](../../todo/edag-stage1-discussion.md); the module
+boundary and the plan for generating the Rust types from this schema live in
+[edag-spec.md](../../todo/edag-spec.md).

--- a/fjs/edag/README.md
+++ b/fjs/edag/README.md
@@ -30,8 +30,9 @@ A node is a primitive or a tagged tuple `[tag, ...operands]`. In the schema
 and the type-level API, operation nodes are grouped by their `exp`-operand
 count — `op0` (`undefined`, `args`, `frame`), `op1` (unary), `op2` (binary)
 — not by semantic category. This table is an overview; the contract of
-record for each node is the JSDoc on its export in
-[module.f.mjs](module.f.mjs).
+record for each node is the JSDoc in [module.f.mjs](module.f.mjs) — on the
+node's export and, for the operations, on the `op0Id`/`op1Id`/`op2Id`
+vocabularies.
 
 | form | meaning |
 |---|---|
@@ -45,7 +46,7 @@ record for each node is the JSDoc on its export in
 | `['.()', exp, index, exp]` | property call: `exp0[exp1](...exp2)` |
 | `[',', exps]` | comma: establish all operands, take the value of the last |
 | `[id, exp]` | unary operation, `id` one of `String` `Number` `neg` `!` `~` |
-| `[id, exp, exp]` | binary operation, `id` one of `=>` `own` `()` `===` `!==` `>` `>=` `<` `<=` `+` `-` `*` `/` `%` `**` `&` `|` `^` `<<` `>>` `>>>` `&&` `||` `??` |
+| `[id, exp, exp]` | binary operation, `id` one of `=>` `own` `()` `===` `!==` `>` `>=` `<` `<=` `+` `-` `*` `/` `%` `**` `&` `\|` `^` `<<` `>>` `>>>` `&&` `\|\|` `??` |
 
 An `index` — the property operand of `.` and `.()` — is a `string`, a
 `number`, or `['Number', exp]`, a computed index cast to a number. Among the

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -284,9 +284,11 @@ export const op1 = _op1
  * one — its second operand is one node evaluating to the complete argument
  * array, not a literal operand list: `f(a, b)` is
  * `['()', f, ['[]', [a, b]]]`, spread `f(...xs)` is `['()', f, xs]`. `own`
- * is exactly `Object.getOwnPropertyDescriptor(object, key)?.value` with a
- * computed string key — no key coercion, no getter invocation, no prototype
- * chain (`ownJs` in `./proof.f.mjs`; the Operations table in
+ * is exactly `Object.getOwnPropertyDescriptor(object, key)?.value` — no
+ * getter invocation, no prototype chain — where the key operand must
+ * evaluate to a string: a runtime-value constraint the shape-only schema
+ * cannot express, owned by complete EDAG validation like the other
+ * identity/value rules (`ownJs` in `./proof.f.mjs`; the Operations table in
  * `../../todo/edag-stage1-discussion.md`). The rest are the JS comparison,
  * arithmetic, bitwise, and logical operators they name — with `&&`/`||`/`??`
  * short-circuiting exactly as in JS: their right operand is conditional,

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -196,8 +196,12 @@ const _propertyCall = /** @type {const} */(['.()', exp, index, exp])
 
 /**
  * ```js
- * exp0[exp1](exp2)
+ * exp0[exp1](...exp2)
  * ```
+ *
+ * A method call, keeping the `this` binding. The last operand is one node
+ * evaluating to the complete argument array, not a literal operand list —
+ * the same convention as `()` (see `binaryOpId`).
  *
  * @type {Phantom<typeof _propertyCall, PropertyCall>}
  */
@@ -258,10 +262,13 @@ export const unaryOp = _unaryOp
 // Binary Operations
 
 /**
- * `=>` builds a function from a frame and a body, `()` calls one, and `own`
- * reads an own property, bypassing the prototype chain — including
- * `__proto__` (`ownJs` in `./proof.f.mjs`). The rest are the JS comparison,
- * arithmetic, bitwise, and logical operators they name.
+ * `=>` builds a function from a frame and a body. `()` calls one — its
+ * second operand is one node evaluating to the complete argument array, not
+ * a literal operand list: `f(a, b)` is `['()', f, ['[]', [a, b]]]`, spread
+ * `f(...xs)` is `['()', f, xs]`. `own` reads an own property, bypassing the
+ * prototype chain — including `__proto__` (`ownJs` in `./proof.f.mjs`). The
+ * rest are the JS comparison, arithmetic, bitwise, and logical operators
+ * they name.
  */
 export const binaryOpId = or(
     '=>', 'own', '()',

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -255,16 +255,20 @@ export const op1 = _op1
 // Binary Operations
 
 /**
- * `=>` builds a function from a frame and a body. `()` calls one — its
- * second operand is one node evaluating to the complete argument array, not
- * a literal operand list: `f(a, b)` is `['()', f, ['[]', [a, b]]]`, spread
- * `f(...xs)` is `['()', f, xs]`. `own` reads an own property, bypassing the
- * prototype chain — including `__proto__` (`ownJs` in `./proof.f.mjs`). The
- * rest are the JS comparison, arithmetic, bitwise, and logical operators
- * they name — with `&&`/`||`/`??` short-circuiting exactly as in JS: their
- * right operand is conditional, never established eagerly. That laziness is
- * positional, not nodal — the same node referenced from an eager position
- * elsewhere is still evaluated there.
+ * `=>` builds a function from a frame and a body: the frame operand is one
+ * node evaluated in the enclosing scope, while the body is the inner
+ * function's graph — deferred, never established when the closure is built,
+ * only on each call, against that function's own `args`/`frame`. `()` calls
+ * one — its second operand is one node evaluating to the complete argument
+ * array, not a literal operand list: `f(a, b)` is
+ * `['()', f, ['[]', [a, b]]]`, spread `f(...xs)` is `['()', f, xs]`. `own`
+ * reads an own property, bypassing the prototype chain — including
+ * `__proto__` (`ownJs` in `./proof.f.mjs`). The rest are the JS comparison,
+ * arithmetic, bitwise, and logical operators they name — with `&&`/`||`/`??`
+ * short-circuiting exactly as in JS: their right operand is conditional,
+ * never established eagerly. All this laziness is positional, not nodal —
+ * the same node referenced from an eager position elsewhere is still
+ * evaluated there.
  */
 export const op2Id = or(
     '=>', 'own', '()',

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -108,8 +108,9 @@ export const array = /** @type {const} */(['[]', exps])
  * and conforming VMs may legally differ on it. Only the `key` and `value`
  * operands are real nodes, their identities shared normally.
  *
- * The key stays `exp`, not narrowed to a string constant — see
- * `../../todo/edag-stage1-discussion.md` subject 4.
+ * The key stays `exp`, not narrowed to a string constant, and its evaluated
+ * value is coerced via JS `ToPropertyKey` when the property is defined —
+ * see `../../todo/edag-stage1-discussion.md` subject 4.
  */
 export const property = /** @type {const} */([':', exp, exp])
 

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -131,6 +131,13 @@ export const property = /** @type {const} */([':', exp, exp])
  * overwrites), and duplicate keys are allowed with the later entry winning,
  * which is also required once computed keys are admitted, since key
  * equality may not be decidable at validation time.
+ *
+ * `__proto__` is a data key, never a prototype assignment: an entry whose
+ * key evaluates to `__proto__` defines an ordinary own property, and a
+ * printer must spell it computed — `{ ["__proto__"]: value }`, the only
+ * object-literal form that reproduces it; the identifier and string
+ * spellings assign a prototype instead and lose the property. See "the
+ * `__proto__` key" in `../../spec/README.md`.
  */
 export const object = /** @type {const} */(['{}', rttiArray(property)])
 

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -260,7 +260,10 @@ export const op1 = _op1
  * `f(...xs)` is `['()', f, xs]`. `own` reads an own property, bypassing the
  * prototype chain — including `__proto__` (`ownJs` in `./proof.f.mjs`). The
  * rest are the JS comparison, arithmetic, bitwise, and logical operators
- * they name.
+ * they name — with `&&`/`||`/`??` short-circuiting exactly as in JS: their
+ * right operand is conditional, never established eagerly. That laziness is
+ * positional, not nodal — the same node referenced from an eager position
+ * elsewhere is still evaluated there.
  */
 export const op2Id = or(
     '=>', 'own', '()',

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -287,9 +287,10 @@ export const op1 = _op1
  * is exactly `Object.getOwnPropertyDescriptor(object, key)?.value` — no
  * getter invocation, no prototype chain — where the key operand must
  * evaluate to a string: a runtime-value constraint the shape-only schema
- * cannot express, owned by complete EDAG validation like the other
- * identity/value rules (`ownJs` in `./proof.f.mjs`; the Operations table in
- * `../../todo/edag-stage1-discussion.md`). The rest are the JS comparison,
+ * cannot express — a computed key's value is only known at execution, so
+ * upholding it falls to the executor (`ownJs` in `./proof.f.mjs`; the
+ * Operations table in `../../todo/edag-stage1-discussion.md`). The rest
+ * are the JS comparison,
  * arithmetic, bitwise, and logical operators they name — with `&&`/`||`/`??`
  * short-circuiting exactly as in JS: their right operand is conditional,
  * never established eagerly. All this laziness is positional, not nodal —

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -102,6 +102,12 @@ export const array = /** @type {const} */(['[]', exps])
 // Property
 
 /**
+ * A structural operand of `object`, not an independently evaluated EDAG
+ * node: nothing ever evaluates a descriptor as a value, so whether one is
+ * shared by reference or written twice with equal content is unobservable,
+ * and conforming VMs may legally differ on it. Only the `key` and `value`
+ * operands are real nodes, their identities shared normally.
+ *
  * The key stays `exp`, not narrowed to a string constant — see
  * `../../todo/edag-stage1-discussion.md` subject 4.
  */
@@ -119,6 +125,12 @@ export const property = /** @type {const} */([':', exp, exp])
  *     [exp2]: exp3,
  * }
  * ```
+ *
+ * The entries are an ordered sequence, applied as if in written order —
+ * never sorted or deduplicated: order is observable (enumeration,
+ * overwrites), and duplicate keys are allowed with the later entry winning,
+ * which is also required once computed keys are admitted, since key
+ * equality may not be decidable at validation time.
  */
 export const object = /** @type {const} */(['{}', rttiArray(property)])
 
@@ -203,8 +215,11 @@ const _comma = /** @type {const} */([',', exps])
  * Establishes all of its operands and takes the value of the last one; the
  * earlier operands exist for their throw-potential only. The shape is a
  * known-incomplete placeholder — it cannot yet say "at least two operands,
- * last is the result" (a single-operand `,` is the identity and
- * non-canonical); see the header of `./proof.f.mjs`.
+ * last is the result, each pre-result operand a true root (not reachable
+ * from another operand of the same `,`)". A single-operand `,` is the
+ * identity and a reachable operand a redundant anchor — both non-canonical,
+ * each splitting one function into two hashes. See the header of
+ * `./proof.f.mjs`.
  *
  * @type {Phantom<typeof _comma, Comma>}
  */

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -78,6 +78,15 @@ export const exp = () => (['or',
 
 // Undefined
 
+/**
+ * ```js
+ * undefined
+ * ```
+ *
+ * Tagged, unlike the other primitives: a bare `undefined` is
+ * indistinguishable from a missing tuple position ("Structs and tuples are
+ * open" in `../types/rtti/README.md`), so it gets a node of its own.
+ */
 export const undefinedOp = /** @type {const} */(['undefined'])
 
 /** @typedef {Assert<Check<UndefinedOp, typeof undefinedOp>>} _UndefinedOp */
@@ -202,7 +211,18 @@ export const propertyCall = _propertyCall
 
 const _comma = /** @type {const} */([',', exps])
 
-/** @type {Phantom<typeof _comma, Comma>} */
+/**
+ * ```js
+ * (exp0, exp1, exp2)
+ * ```
+ *
+ * Establishes all of its operands and takes the value of the last one; the
+ * earlier operands exist for their throw-potential only. The shape is a
+ * known-incomplete placeholder — it cannot yet say "at least one operand,
+ * last is the result"; see the header of `./proof.f.mjs`.
+ *
+ * @type {Phantom<typeof _comma, Comma>}
+ */
 export const comma = _comma
 
 /**
@@ -211,12 +231,19 @@ export const comma = _comma
 
 // Frame
 
+/**
+ * The function's captured-consts frame, the way `args` is for the arguments.
+ */
 export const frame = /** @type {const} */(['frame'])
 
 /** @typedef {Assert<Check<Frame, typeof frame>>} _Frame */
 
 // Unary Operations
 
+/**
+ * `String`/`Number` are casts, `neg` is arithmetic negation (a word tag —
+ * `-` is binary subtraction), `!` is logical and `~` bitwise not.
+ */
 export const unaryOpId = or('String', 'Number', 'neg', '!', '~')
 
 /** @typedef {Assert<Check<UnaryOpId, typeof unaryOpId>>} _UnaryOpId */
@@ -230,6 +257,12 @@ export const unaryOp = _unaryOp
 
 // Binary Operations
 
+/**
+ * `=>` builds a function from a frame and a body, `()` calls one, and `own`
+ * reads an own property, bypassing the prototype chain — including
+ * `__proto__` (`ownJs` in `./proof.f.mjs`). The rest are the JS comparison,
+ * arithmetic, bitwise, and logical operators they name.
+ */
 export const binaryOpId = or(
     '=>', 'own', '()',
     '===', '!==', '>', '>=', '<', '<=',

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -284,8 +284,10 @@ export const op1 = _op1
  * one — its second operand is one node evaluating to the complete argument
  * array, not a literal operand list: `f(a, b)` is
  * `['()', f, ['[]', [a, b]]]`, spread `f(...xs)` is `['()', f, xs]`. `own`
- * reads an own property, bypassing the prototype chain — including
- * `__proto__` (`ownJs` in `./proof.f.mjs`). The rest are the JS comparison,
+ * is exactly `Object.getOwnPropertyDescriptor(object, key)?.value` with a
+ * computed string key — no key coercion, no getter invocation, no prototype
+ * chain (`ownJs` in `./proof.f.mjs`; the Operations table in
+ * `../../todo/edag-stage1-discussion.md`). The rest are the JS comparison,
  * arithmetic, bitwise, and logical operators they name — with `&&`/`||`/`??`
  * short-circuiting exactly as in JS: their right operand is conditional,
  * never established eagerly. All this laziness is positional, not nodal —

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -202,8 +202,9 @@ const _comma = /** @type {const} */([',', exps])
  *
  * Establishes all of its operands and takes the value of the last one; the
  * earlier operands exist for their throw-potential only. The shape is a
- * known-incomplete placeholder — it cannot yet say "at least one operand,
- * last is the result"; see the header of `./proof.f.mjs`.
+ * known-incomplete placeholder — it cannot yet say "at least two operands,
+ * last is the result" (a single-operand `,` is the identity and
+ * non-canonical); see the header of `./proof.f.mjs`.
  *
  * @type {Phantom<typeof _comma, Comma>}
  */

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -3,8 +3,9 @@
  * a value nested through several kinds to exercise the mutual recursion.
  * Exception: `comma` has no section yet — its shape (`[',', exps]`) is a
  * known-incomplete placeholder pending a redesign that can express "at
- * least two operands, last is the result" (a single-operand `,` is the
- * identity and non-canonical), not a settled node to pin.
+ * least two operands, last is the result, each pre-result operand a true
+ * root" (a single-operand `,` is the identity, a reachable operand a
+ * redundant anchor — both non-canonical), not a settled node to pin.
  *
  * @import { ValidationError } from '../types/rtti/common/types.ts'
  * @import { Unknown } from '../types/rtti/ts/types.ts'

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -3,7 +3,8 @@
  * a value nested through several kinds to exercise the mutual recursion.
  * Exception: `comma` has no section yet — its shape (`[',', exps]`) is a
  * known-incomplete placeholder pending a redesign that can express "at
- * least one operand, last is the result", not a settled node to pin.
+ * least two operands, last is the result" (a single-operand `,` is the
+ * identity and non-canonical), not a settled node to pin.
  *
  * @import { ValidationError } from '../types/rtti/common/types.ts'
  * @import { Unknown } from '../types/rtti/ts/types.ts'

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -3,7 +3,10 @@
  * node kind — see the union immediately below for the current list, rather
  * than enumerating it here too, where it silently drifts stale as nodes are
  * added — each pinned against its rtti schema in the sibling module with
- * `Assert<Check<..., typeof ...>>`.
+ * `Assert<Check<..., typeof ...>>`. The pin is exact up to tuple openness:
+ * the schema accepts trailing extras (`['args', 'extra']` validates) while
+ * these tuples are closed — the rendering approximation documented at
+ * `TupleTs` in `../types/rtti/ts/types.ts`.
  */
 
 // exp


### PR DESCRIPTION
`fjs/edag` had no README. This adds one — more signal, less noise — and, per review, moves the per-node contract into the export JSDoc so the emitted declarations carry it.

- `README.md`: what an EDAG is — a DAG of operation nodes where sharing is semantic and there is no normal form, the hash taking the graph as written; where the shape is defined (rtti schema in `module.f.mjs`, `types.ts` pinned with `Assert<Check<...>>`, validation behavior pinned in `proof.f.mjs`); a node overview table; caveats (open tuples and the closed static approximation, shape-only non-identity-aware `validate`/`parse`, the `,` placeholder, the `index` denylist gap); and design pointers.
- `module.f.mjs`, `types.ts`, `proof.f.mjs` (comment-only): the per-node contract as export JSDoc — entry ordering and `__proto__`-as-data-key on `object`, structural-operand status on `property`, the argument-array call convention and positional laziness (`&&`/`||`/`??` short-circuit, the deferred `=>` body) on `op2Id`, the settled comma contract (at least two operands, last is the result, pre-result operands true roots), and the closed-tuple approximation note in the `types.ts` header.

Changelog: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZc969jxnjqBeq8vDZtPLJ