### PR TITLE
Refactor match validation logic into reusable helper functions

### DIFF
--- a/fjs/bnf/ll1/proof.f.mjs
+++ b/fjs/bnf/ll1/proof.f.mjs
@@ -3,6 +3,7 @@
  * @import { RuleSet } from '../data/types.ts'
  * @import { CodePointMeta } from '../descent/types.ts'
  * @import { Rule as FRule } from '../types.ts'
+ * @import { Match } from './types.ts'
  * @import { MatchResult } from './types.ts'
  */
 
@@ -17,6 +18,15 @@ import { deterministic, showAst } from '../testlib.f.mjs'
 
 /** @type {(cp: CodePoint) => CodePointMeta<unknown>} */
 const mapCodePoint = cp => [cp, undefined]
+
+/** @type {(mr: MatchResult) => boolean} */
+const isMatchSuccess = ([, success, remainder]) => success && remainder?.length === 0
+
+/** @type {(m: Match) => (s: string, success: boolean) => void} */
+const expectMatch = m => (s, success) => {
+    const mr = m('', toArray(stringToCodePointList(s)))
+    assertEq(isMatchSuccess(mr), success, mr)
+}
 
 /**
  * One grammar matched by both backends, which must build the same AST for it:
@@ -588,17 +598,11 @@ export const proof = {
     ssn: () => {
         const ws = repeat0Plus(' ')
         const d = range('09')
-        const r = (/** @type {number} */n) => repeat(n)(d)
         const ssn = /** @type {const} */([
-            ws, r(3), ws, '-', ws, r(2), ws, '-', ws, r(4), ws])
+            ws, repeat(3)(d), ws, '-', ws, repeat(2)(d), ws, '-', ws, repeat(4)(d), ws])
 
         const m = parser(ssn) // must not throw 'can not merge'
-
-        /** @type {(s: string, success: boolean) => void} */
-        const expect = (s, success) => {
-            const mr = m('', toArray(stringToCodePointList(s)))
-            assertEq(mr[1] && mr[2]?.length === 0, success, mr)
-        }
+        const expect = expectMatch(m)
 
         expect('123-45-6789', true)
         expect('  123  - 45 - 6789 ', true)


### PR DESCRIPTION
## Summary
This PR extracts common match validation and testing logic into reusable helper functions to reduce code duplication and improve maintainability.

## Key Changes
- Added `isMatchSuccess` helper function to encapsulate match result validation logic (checking if match succeeded and consumed all input)
- Added `expectMatch` higher-order function that creates a test assertion function for a given parser, eliminating the need to duplicate match validation code in test cases
- Refactored the `ssn` test case to use the new `expectMatch` helper instead of inline match validation
- Simplified the SSN grammar definition by inlining the `r` helper function calls directly into the rule array

## Implementation Details
- `isMatchSuccess` takes a `MatchResult` tuple and returns a boolean indicating successful complete match
- `expectMatch` is a curried function that takes a `Match` parser and returns a function that validates a string against that parser with an expected success/failure outcome
- The refactoring maintains identical test behavior while reducing the test code footprint and making the validation logic reusable across other test cases

https://claude.ai/code/session_012ayNqueF5Cxj9ATuKxAmij