### PR TITLE
edag: add spread node for array/object literals

### DIFF
--- a/changelog/unreleased/1665.md
+++ b/changelog/unreleased/1665.md
@@ -1,3 +1,10 @@
 - `edag`: adds a `spread` node (`['...', exp]`), usable as an array element or
   object property via new `items`/`properties` unions that `array`/`object`
   entries now accept alongside plain expressions.
+- `edag`: the `Phantom` recursion break moves to `exp` alone. `numberCast`,
+  `propertyAccessor`, `propertyCall`, `comma`, `op0`, `op1`, and `op2` are no
+  longer `Phantom`-wrapped — one wrapper on the union they all recurse
+  through is enough to cut the cycle. Their derived types are unchanged
+  (each is still pinned with `Check`), so `Ts<typeof op2>` and friends
+  resolve as before; only a consumer reading the annotation back out of
+  those exports via `phantomKey` sees a difference.

--- a/changelog/unreleased/1665.md
+++ b/changelog/unreleased/1665.md
@@ -1,0 +1,3 @@
+- `edag`: adds a `spread` node (`['...', exp]`), usable as an array element or
+  object property via new `items`/`properties` unions that `array`/`object`
+  entries now accept alongside plain expressions.

--- a/changelog/unreleased/1665.md
+++ b/changelog/unreleased/1665.md
@@ -6,9 +6,9 @@
   `op1`, and `op2` are no longer `Phantom`-wrapped — one wrapper on the union
   they all recurse through is enough to cut the cycle. Their runtime values
   and derived types are unchanged (each is still pinned with `Check`), so
-  `Ts<typeof op2>` and friends resolve as before. What breaks is the
-  documented `phantomKey` extraction: `typeof op2 extends { [phantomKey]?:
-  infer T } ? T : never` yielded `Op2` and now yields `never`, so an indexed
-  access or conditional type built on it fails to compile. Read those types
-  from `fjs/edag/types.ts` — `Op2`, `Comma`, … — or derive them with
-  `Ts<typeof op2>`, both unaffected.
+  applying `Ts` to `typeof op2` and friends resolves as before. What breaks
+  is the documented `phantomKey` extraction: `typeof op2 extends {
+  [phantomKey]?: infer T } ? T : never` yielded `Op2` and now yields
+  `never`, so an indexed access or conditional type built on it fails to
+  compile. Read those types from `fjs/edag/types.ts` — `Op2`, `Comma`, … —
+  or derive them by applying `Ts` to `typeof op2`; both are unaffected.

--- a/changelog/unreleased/1665.md
+++ b/changelog/unreleased/1665.md
@@ -1,10 +1,14 @@
 - `edag`: adds a `spread` node (`['...', exp]`), usable as an array element or
   object property via new `items`/`properties` unions that `array`/`object`
   entries now accept alongside plain expressions.
-- `edag`: the `Phantom` recursion break moves to `exp` alone. `numberCast`,
-  `propertyAccessor`, `propertyCall`, `comma`, `op0`, `op1`, and `op2` are no
-  longer `Phantom`-wrapped — one wrapper on the union they all recurse
-  through is enough to cut the cycle. Their derived types are unchanged
-  (each is still pinned with `Check`), so `Ts<typeof op2>` and friends
-  resolve as before; only a consumer reading the annotation back out of
-  those exports via `phantomKey` sees a difference.
+- **BREAKING CHANGES:** `edag`: the `Phantom` recursion break moves to `exp`
+  alone. `numberCast`, `propertyAccessor`, `propertyCall`, `comma`, `op0`,
+  `op1`, and `op2` are no longer `Phantom`-wrapped — one wrapper on the union
+  they all recurse through is enough to cut the cycle. Their runtime values
+  and derived types are unchanged (each is still pinned with `Check`), so
+  `Ts<typeof op2>` and friends resolve as before. What breaks is the
+  documented `phantomKey` extraction: `typeof op2 extends { [phantomKey]?:
+  infer T } ? T : never` yielded `Op2` and now yields `never`, so an indexed
+  access or conditional type built on it fails to compile. Read those types
+  from `fjs/edag/types.ts` — `Op2`, `Comma`, … — or derive them with
+  `Ts<typeof op2>`, both unaffected.

--- a/fjs/edag/README.md
+++ b/fjs/edag/README.md
@@ -42,8 +42,8 @@ vocabularies.
 |---|---|
 | `null`, `boolean`, `number`, `string`, `bigint` | itself |
 | `['undefined']` | `undefined` — tagged, because a bare `undefined` is indistinguishable from a missing tuple position |
-| `['[]', items]`, each an `exp` or a `spread` | array literal; `[a, ...b]` splices `b`'s elements in at that position |
-| `['{}', properties]`, each `[':', key, value]` or a `spread` | object literal; ordered entries applied in written order, duplicates allowed with the later winning; the key is an `exp`, one form for `a:`, `"a":`, and computed `[exp]:` keys; the `:` descriptor is a structural operand, not a node — only its key and value are; `{...a}` splices `a`'s own properties in at that position |
+| `['[]', items[]]`, each an `exp` or a `spread` | array literal; `[a, ...b]` splices `b`'s elements in at that position |
+| `['{}', properties[]]`, each `[':', key, value]` or a `spread` | object literal; ordered entries applied in written order, duplicates allowed with the later winning; the key is an `exp`, one form for `a:`, `"a":`, and computed `[exp]:` keys; the `:` descriptor is a structural operand, not a node — only its key and value are; `{...a}` splices `a`'s own properties in at that position |
 | `['...', exp]` | spread — only valid as an `items`/`properties` entry above, never a top-level `Exp` |
 | `['args']` | the function's arguments |
 | `['frame']` | the captured frame |
@@ -52,6 +52,12 @@ vocabularies.
 | `[',', exps]` | comma: establish all operands, take the value of the last |
 | `[id, exp]` | unary operation, `id` one of `String` `Number` `neg` `!` `~` |
 | `[id, exp, exp]` | binary operation, `id` one of `=>` `own` `()` `===` `!==` `>` `>=` `<` `<=` `+` `-` `*` `/` `%` `**` `&` `\|` `^` `<<` `>>` `>>>` `&&` `\|\|` `??` |
+
+A `[]` suffix in the form column marks an operand that is an array of the
+named schema, not one of it: `['[]', items[]]` holds a whole array of
+`items`, and `exps` is likewise `exp[]`. The distinction is easy to lose in
+prose and load-bearing in the schema — a single element where the array
+belongs still validates plenty of values, just the wrong ones.
 
 An `index` — the property operand of `.` and `.()` — is a `string`, a
 `number`, or `['Number', exp]`, a computed index cast to a number. Among the

--- a/fjs/edag/README.md
+++ b/fjs/edag/README.md
@@ -42,8 +42,9 @@ vocabularies.
 |---|---|
 | `null`, `boolean`, `number`, `string`, `bigint` | itself |
 | `['undefined']` | `undefined` — tagged, because a bare `undefined` is indistinguishable from a missing tuple position |
-| `['[]', exps]` | array literal |
-| `['{}', properties]`, each `[':', key, value]` | object literal; ordered entries applied in written order, duplicates allowed with the later winning; the key is an `exp`, one form for `a:`, `"a":`, and computed `[exp]:` keys; the `:` descriptor is a structural operand, not a node — only its key and value are |
+| `['[]', items]`, each an `exp` or a `spread` | array literal; `[a, ...b]` splices `b`'s elements in at that position |
+| `['{}', properties]`, each `[':', key, value]` or a `spread` | object literal; ordered entries applied in written order, duplicates allowed with the later winning; the key is an `exp`, one form for `a:`, `"a":`, and computed `[exp]:` keys; the `:` descriptor is a structural operand, not a node — only its key and value are; `{...a}` splices `a`'s own properties in at that position |
+| `['...', exp]` | spread — only valid as an `items`/`properties` entry above, never a top-level `Exp` |
 | `['args']` | the function's arguments |
 | `['frame']` | the captured frame |
 | `['.', exp, index]` | property access: `exp0[exp1]` |

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -60,7 +60,7 @@ import {
  *  typeof op0,
  * ]}
  */
-export const exp = () => (['or',
+const _exp = () => (['or',
     primitive,
     array,
     object,
@@ -72,7 +72,10 @@ export const exp = () => (['or',
     op0,
 ])
 
-/** @typedef {Assert<Check<Exp, typeof exp>>} _ExpAssert */
+/** @type {Phantom<typeof _exp, Exp>} */
+export const exp = _exp
+
+/** @typedef {Assert<Check3<Exp, typeof _exp, typeof exp>>} _ExpAssert */
 
 // Primitive
 
@@ -104,14 +107,18 @@ export const items = or(exp, spread)
 
 // Array
 
+const _array = /** @type {const} */(['[]', items])
+
 /**
  * ```js
  * [exp0, exp1]
  * ```
+ *
+ * @typedef {Phantom<typeof _array, Array>}
  */
-export const array = /** @type {const} */(['[]', exps])
+export const array = _array
 
-/** @typedef {Assert<Check<Array, typeof array>>} _Array */
+/** @typedef {Assert<Check3<Array, typeof _array, typeof array>>} _Array */
 
 // Property
 

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -19,8 +19,8 @@
  *  Op1,
  *  Op0Id,
  *  Op0,
- Spread,
- Items,
+ *  Spread,
+ *  Items,
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -118,7 +118,7 @@ export const items = or(exp, spread)
  * [exp0, exp1]
  * ```
  */
-export const array = /** @type {const} */(['[]', items])
+export const array = /** @type {const} */(['[]', rttiArray(items)])
 
 /** @typedef {Assert<Check<Array, typeof array>>} _Array */
 

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -148,7 +148,7 @@ export const properties = or(property, spread)
  * }
  * ```
  */
-export const object = /** @type {const} */(['{}', rttiArray(property)])
+export const object = /** @type {const} */(['{}', rttiArray(properties)])
 
 /** @typedef {Assert<Check<Object, typeof object>>} _Object */
 

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -104,14 +104,24 @@ export const exps = rttiArray(exp)
 
 /** @typedef {Assert<Check<Exps, typeof exps>>} _Exps */
 
-// ...
+// Spread
 
+/**
+ * ```js
+ * [...exp]  // as an array item, through `items` — see `array`
+ * {...exp}  // as an object property, through `properties` — see `object`
+ * ```
+ *
+ * Not a top-level `Exp`: `spread` only appears as an `items`/`properties`
+ * alternative, never as an operand an operation node can hold directly.
+ */
 export const spread = /** @type {const} */(['...', exp])
 
 /** @typedef {Assert<Check<Spread, typeof spread>>} _Spread */
 
-// items
+// Items
 
+/** An array element: a plain `exp`, or a `spread` splicing another array in. */
 export const items = or(exp, spread)
 
 /** @typedef {Assert<Check<Items, typeof items>>} _Items */
@@ -121,6 +131,7 @@ export const items = or(exp, spread)
 /**
  * ```js
  * [exp0, exp1]
+ * [exp0, ...exp1]
  * ```
  */
 export const array = /** @type {const} */(['[]', rttiArray(items)])
@@ -146,6 +157,7 @@ export const property = /** @type {const} */([':', exp, exp])
 
 // Properties
 
+/** An object entry: a plain `property`, or a `spread` splicing another object in. */
 export const properties = or(property, spread)
 
 /** @typedef {Assert<Check<Properties, typeof properties>>} _Properties */
@@ -158,6 +170,7 @@ export const properties = or(property, spread)
  *     a: exp0,
  *     "a": exp1,
  *     [exp2]: exp3,
+ *     ...exp4,
  * }
  * ```
  *

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -204,25 +204,19 @@ export const index = or(numberCast, string, number)
 
 // Property Accessor
 
-const _propertyAccessor = /** @type {const} */(['.', exp, index])
-
 /**
  * ```js
  * exp0[exp1]
  * exp0.exp1
  * ```
- *
- * @type {Phantom<typeof _propertyAccessor, PropertyAccessor>}
  */
-export const propertyAccessor = _propertyAccessor
+export const propertyAccessor = /** @type {const} */(['.', exp, index])
 
 /**
- * @typedef {Assert<Check3<PropertyAccessor, typeof _propertyAccessor, typeof propertyAccessor>>} _PropertyAccessor
+ * @typedef {Assert<Check<PropertyAccessor, typeof propertyAccessor>>} _PropertyAccessor
  */
 
 // Property Call
-
-const _propertyCall = /** @type {const} */(['.()', exp, index, exp])
 
 /**
  * ```js
@@ -232,18 +226,14 @@ const _propertyCall = /** @type {const} */(['.()', exp, index, exp])
  * A method call, keeping the `this` binding. The last operand is one node
  * evaluating to the complete argument array, not a literal operand list —
  * the same convention as `()` (see `op2Id`).
- *
- * @type {Phantom<typeof _propertyCall, PropertyCall>}
  */
-export const propertyCall = _propertyCall
+export const propertyCall = /** @type {const} */(['.()', exp, index, exp])
 
 /**
- * @typedef {Assert<Check3<PropertyCall, typeof _propertyCall, typeof propertyCall>>} _PropertyCall
+ * @typedef {Assert<Check<PropertyCall, typeof propertyCall>>} _PropertyCall
  */
 
 // Comma
-
-const _comma = /** @type {const} */([',', exps])
 
 /**
  * ```js
@@ -258,13 +248,11 @@ const _comma = /** @type {const} */([',', exps])
  * identity and a reachable operand a redundant anchor — both non-canonical,
  * each splitting one function into two hashes. See the header of
  * `./proof.f.mjs`.
- *
- * @type {Phantom<typeof _comma, Comma>}
  */
-export const comma = _comma
+export const comma = /** @type {const} */([',', exps])
 
 /**
- * @typedef {Assert<Check3<Comma, typeof _comma, typeof comma>>} _Comma
+ * @typedef {Assert<Check<Comma, typeof comma>>} _Comma
  */
 
 // No-Args Operations
@@ -281,12 +269,9 @@ export const op0Id = or('undefined', 'args', 'frame')
 
 /** @typedef {Assert<Check<Op0Id, typeof op0Id>>} _Op0Id */
 
-const _op0 = /** @type {const} */([op0Id])
+export const op0 = /** @type {const} */([op0Id])
 
-/** @type {Phantom<typeof _op0, Op0>} */
-export const op0 = _op0
-
-/** @typedef {Assert<Check3<Op0, typeof _op0, typeof op0>>} _Op0 */
+/** @typedef {Assert<Check<Op0, typeof op0>>} _Op0 */
 
 // Unary Operations
 
@@ -298,12 +283,9 @@ export const op1Id = or('String', 'Number', 'neg', '!', '~')
 
 /** @typedef {Assert<Check<Op1Id, typeof op1Id>>} _Op1Id */
 
-const _op1 = /** @type {const} */([op1Id, exp])
+export const op1 = /** @type {const} */([op1Id, exp])
 
-/** @type {Phantom<typeof _op1, Op1>} */
-export const op1 = _op1
-
-/** @typedef {Assert<Check3<Op1, typeof _op1, typeof op1>>} _Op1 */
+/** @typedef {Assert<Check<Op1, typeof op1>>} _Op1 */
 
 // Binary Operations
 
@@ -338,9 +320,6 @@ export const op2Id = or(
 
 /** @typedef {Assert<Check<Op2Id, typeof op2Id>>} _Op2Id */
 
-const _op2 = /** @type {const} */([op2Id, exp, exp])
+export const op2 = /** @type {const} */([op2Id, exp, exp])
 
-/** @type {Phantom<typeof _op2, Op2>} */
-export const op2 = _op2
-
-/** @typedef {Assert<Check3<Op2, typeof _op2, typeof op2>>} _Op2 */
+/** @typedef {Assert<Check<Op2, typeof op2>>} _Op2 */

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -179,19 +179,15 @@ export const object = /** @type {const} */(['{}', rttiArray(properties)])
 
 // Number
 
-const _numberCast = /** @type {const} */(['Number', exp])
-
 /**
  * ```js
  * Number(exp)
  * ```
- *
- * @type {Phantom<typeof _numberCast, NumberCast>}
  */
-export const numberCast = _numberCast
+export const numberCast = /** @type {const} */(['Number', exp])
 
 /**
- * @typedef {Assert<Check3<NumberCast, typeof _numberCast, typeof numberCast>>} _NumberCast
+ * @typedef {Assert<Check<NumberCast, typeof numberCast>>} _NumberCast
  */
 
 // Index

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -19,6 +19,8 @@
  *  Op1,
  *  Op0Id,
  *  Op0,
+ Spread,
+ Items,
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */
@@ -87,6 +89,18 @@ export const primitive = or(null, boolean, number, string, bigint)
 /** @typedef {Assert<Check<Primitive, typeof primitive>>} _Primitive */
 
 const exps = rttiArray(exp)
+
+// ...
+
+export const spread = /** @type {const} */(['...', exp])
+
+/** @typedef {Assert<Check<Spread, typeof spread>>} _Spread */
+
+// items
+
+export const items = or(exp, spread)
+
+/** @typedef {Assert<Check<Items, typeof items>>} _Items */
 
 // Array
 

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -50,17 +50,10 @@ import {
 // Exp
 
 /**
- * This return type has to be written out explicitly, not left to
- * `@type {const}`: `_exp`'s return recurses through `array`/`object`/`op0`
- * and the rest below, each of which refers back to `exp` — a cycle only a
- * named, forward-referencing signature like this one can close. `@type
- * {const}` can't apply to the arrow function itself (a const assertion only
- * accepts literal expressions, not function expressions — TS1355), and
- * putting it on just the returned array literal instead still leaves the
- * enclosing recursive return type to be inferred, which TypeScript can't do
- * through the cycle: declaration emit falls back to an elided `any` at the
- * recursive edge (e.g. `array`'s second element becomes
- * `readonly ["[]", any]`) instead of the real recursive type.
+ * Written out explicitly, not `@type {const}`: that can't apply to the
+ * arrow function itself (TS1355, literals only), and applied to just the
+ * returned array it still can't resolve the cycle back through `array`/
+ * `object`/`op0`/... to `exp` — declaration emit elides it to `any`.
  *
  * @type {() => readonly['or',
  *  typeof primitive,

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -21,7 +21,8 @@
  *  Op0,
  *  Spread,
  *  Items,
- Properties,
+ *  Properties,
+ *  Exps,
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */
@@ -92,7 +93,11 @@ export const primitive = or(null, boolean, number, string, bigint)
 
 /** @typedef {Assert<Check<Primitive, typeof primitive>>} _Primitive */
 
-const exps = rttiArray(exp)
+// Exps
+
+export const exps = rttiArray(exp)
+
+/** @typedef {Assert<Check<Exps, typeof exps>>} _Exps */
 
 // ...
 
@@ -108,18 +113,14 @@ export const items = or(exp, spread)
 
 // Array
 
-const _array = /** @type {const} */(['[]', items])
-
 /**
  * ```js
  * [exp0, exp1]
  * ```
- *
- * @typedef {Phantom<typeof _array, Array>}
  */
-export const array = _array
+export const array = /** @type {const} */(['[]', items])
 
-/** @typedef {Assert<Check3<Array, typeof _array, typeof array>>} _Array */
+/** @typedef {Assert<Check<Array, typeof array>>} _Array */
 
 // Property
 

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -21,6 +21,7 @@
  *  Op0,
  *  Spread,
  *  Items,
+ Properties,
  * } from './types.ts'
  * @import { Phantom } from '../types/phantom/types.ts'
  */
@@ -129,6 +130,12 @@ export const array = _array
 export const property = /** @type {const} */([':', exp, exp])
 
 /** @typedef {Assert<Check<Property, typeof property>>} _Property */
+
+// Properties
+
+export const properties = or(property, spread)
+
+/** @typedef {Assert<Check<Properties, typeof properties>>} _Properties */
 
 // Object — same nesting as `array` above, one position further in
 

--- a/fjs/edag/module.f.mjs
+++ b/fjs/edag/module.f.mjs
@@ -50,6 +50,18 @@ import {
 // Exp
 
 /**
+ * This return type has to be written out explicitly, not left to
+ * `@type {const}`: `_exp`'s return recurses through `array`/`object`/`op0`
+ * and the rest below, each of which refers back to `exp` — a cycle only a
+ * named, forward-referencing signature like this one can close. `@type
+ * {const}` can't apply to the arrow function itself (a const assertion only
+ * accepts literal expressions, not function expressions — TS1355), and
+ * putting it on just the returned array literal instead still leaves the
+ * enclosing recursive return type to be inferred, which TypeScript can't do
+ * through the cycle: declaration emit falls back to an elided `any` at the
+ * recursive edge (e.g. `array`'s second element becomes
+ * `readonly ["[]", any]`) instead of the real recursive type.
+ *
  * @type {() => readonly['or',
  *  typeof primitive,
  *  typeof array,

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -1,11 +1,14 @@
 /**
  * Runtime behavior of the edag `exp` schema — one section per node kind, plus
  * a value nested through several kinds to exercise the mutual recursion.
- * Exception: `comma` has no section yet — its shape (`[',', exps]`) is a
- * known-incomplete placeholder pending a redesign that can express "at
+ * Exception: `comma` has no section of its own — its shape (`[',', exps]`) is
+ * a known-incomplete placeholder pending a redesign that can express "at
  * least two operands, last is the result, each pre-result operand a true
  * root" (a single-operand `,` is the identity, a reachable operand a
- * redundant anchor — both non-canonical), not a settled node to pin.
+ * redundant anchor — both non-canonical), not a settled node to pin. The
+ * `exps` section does validate `,`-tagged values, but only to reach `exps`,
+ * which `comma` is now the sole route to; it pins the operand array's
+ * element schema, and claims nothing about what a `,` means.
  *
  * @import { ValidationError } from '../types/rtti/common/types.ts'
  * @import { Unknown } from '../types/rtti/ts/types.ts'
@@ -112,6 +115,23 @@ export const proof = {
             assertNoMatch(v(['{}', [[':', 'a']]])) // missing the value
             assertNoMatch(v(['{}', [['...']]])) // spread missing its operand
         },
+    },
+    // `comma` is `exps`'s only route now that `array` holds `rttiArray(items)`,
+    // so these pin `exps` — an array of `exp`, not a single one — through it.
+    // The `,` node's own contract is still unsettled (see the module note
+    // above); nothing here depends on it beyond the tag and the operand slot.
+    exps: {
+        ok: () => {
+            assertOk(v([',', []]))
+            assertOk(v([',', [1, 'a', true]]))
+            assertOk(v([',', [['[]', []]]])) // an exp nested inside the operands
+        },
+        // The operand is the array, not one `exp` in its place — the
+        // single-vs-array slip that `array` carried until this branch. A
+        // bare string is a valid `exp`, so were `exps` a single `exp` this
+        // would validate.
+        singleExpIsError: () => assertNoMatch(v([',', 'not-an-array'])),
+        error: () => assertNoMatch(v([',', [{}]])),
     },
     propertyAccessor: {
         ok: () => {

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -88,21 +88,29 @@ export const proof = {
             assertOk(v(['[]', []]))
             assertOk(v(['[]', [1, 'a', true]]))
             assertOk(v(['[]', [1, ['[]', [2, 3]]]])) // an exp nested inside the elements
+            // `spread` (`['...', exp]`) is not a top-level `exp` alternative —
+            // it's only reachable as an `items` alternative here, or as a
+            // `properties` alternative below in `object`.
+            assertOk(v(['[]', [1, ['...', 2]]])) // a spread element among plain elements
         },
         error: () => {
             assertNoMatch(v(['[]', 'not-an-array']))
             assertNoMatch(v(['[]', [1, {}]]))
+            assertNoMatch(v(['[]', [['...']]])) // spread missing its operand
+            assertNoMatch(v(['[]', [['..', 2]]])) // wrong tag, not `...`
         },
     },
     object: {
         ok: () => {
             assertOk(v(['{}', []]))
             assertOk(v(['{}', [[':', 'a', 1], [':', 'b', 'x']]]))
+            assertOk(v(['{}', [[':', 'a', 1], ['...', 2]]])) // a spread entry among plain properties
         },
         error: () => {
             assertNoMatch(v(['{}', [[':', 'a', {}]]])) // bad value
             assertNoMatch(v(['{}', [['a', 1]]])) // missing the `:` tag
             assertNoMatch(v(['{}', [[':', 'a']]])) // missing the value
+            assertNoMatch(v(['{}', [['...']]])) // spread missing its operand
         },
     },
     propertyAccessor: {

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -45,7 +45,7 @@ export type Items = Exp | Spread
 
 // array
 
-export type Array = readonly['[]', Items]
+export type Array = readonly['[]', readonly Items[]]
 
 // property
 

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -42,7 +42,7 @@ export type Items = Exp | Spread
 
 // array
 
-export type Array = readonly['[]', Exps]
+export type Array = readonly['[]', Items]
 
 // property
 

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -32,6 +32,14 @@ export type Primitive = null | boolean | number | string | bigint
 
 export type Exps = readonly Exp[]
 
+// spread
+
+export type Spread = readonly['...', Exp]
+
+// array items
+
+export type Items = Exp | Spread
+
 // array
 
 export type Array = readonly['[]', Exps]

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -54,7 +54,7 @@ export type Properties = Property | Spread
 
 // object
 
-export type Object = readonly['{}', readonly Property[]]
+export type Object = readonly['{}', readonly Properties[]]
 
 // Number
 

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -48,6 +48,10 @@ export type Array = readonly['[]', Items]
 
 export type Property = readonly[':', Exp, Exp]
 
+// properties
+
+export type Properties = Property | Spread
+
 // object
 
 export type Object = readonly['{}', readonly Property[]]

--- a/fjs/types/phantom/types.ts
+++ b/fjs/types/phantom/types.ts
@@ -28,14 +28,17 @@ export type { phantomKey }
  * un-annotated `rawThunk` (forces the real structural check, catching a
  * wrong `T`) and one against the phantom-wrapped export (catches the export
  * and the raw thunk drifting apart), using `Check` from
- * `fjs/types/rtti/ts/types.ts`. See `fjs/edag/module.f.mjs`
- * (`propertyAccessor`/`propertyCall`/`op2`) for the pattern:
+ * `fjs/types/rtti/ts/types.ts` — or `Check3`, which pairs the two into one
+ * assert. See `fjs/edag/module.f.mjs` (`_exp`/`exp`) for the pattern:
  *
  * ```ts
  * const rawThunk = () => [...] as const
  * export const thunk: Phantom<typeof rawThunk, MyType> = rawThunk
- * type _Check0 = Assert<Check<MyType, typeof rawThunk>>
- * type _Check1 = Assert<Check<MyType, typeof thunk>>
+ * type _Check = Assert<Check3<MyType, typeof rawThunk, typeof thunk>>
  * ```
+ *
+ * One phantom per recursive cycle is enough: `fjs/edag` wraps only `exp`,
+ * the union every node kind recurses through, and the node schemas
+ * themselves stay un-phantomed, each pinned with a plain `Check`.
  */
 export type Phantom<S, T> = S & { readonly [phantomKey]?: T }

--- a/fjs/types/rtti/ts/types.ts
+++ b/fjs/types/rtti/ts/types.ts
@@ -150,12 +150,21 @@ export type StructTs<T extends Struct> =
  * type _Check1 = Assert<Check<MyType, typeof my>>
  * ```
  *
- * See `fjs/edag/module.f.mjs` for this in practice. Note also that the phantom
- * branch below does `Exclude<O, undefined>`, so a `MyType` that legitimately
- * includes bare `undefined` at its top level will never satisfy `_Check1` —
- * phantom-wrap the recursive node type itself (e.g. `PropertyAccessor`, which
- * has no top-level `undefined`), not a wider union (`Exp`) that folds
- * `undefined` in through one of its members.
+ * {@link Check3} is the same pair written once:
+ *
+ * ```ts
+ * type _Check = Assert<Check3<MyType, typeof myThunk, typeof my>>
+ * ```
+ *
+ * See `fjs/edag/module.f.mjs` (`_exp`/`exp`) for this in practice. Note also
+ * that the phantom branch below does `Exclude<O, undefined>`, so a `MyType`
+ * that includes bare `undefined` at its top level will never satisfy
+ * `_Check1`. That is a constraint on the wrapped type, not on how wide it
+ * is: a union is fine when no member contributes a top-level `undefined` —
+ * `fjs/edag` wraps `Exp`, the whole node union, because its `undefined` is
+ * the tagged `['undefined']` rather than the bare value. Wrap one type per
+ * recursive cycle, and if the natural one does carry a top-level
+ * `undefined`, wrap a narrower node type inside the cycle instead.
  *
  * @example
  * ```ts
@@ -200,6 +209,13 @@ export type Ts<T extends Type> =
  */
 export type Check<A, B extends Type> = Equal<A, Ts<B>>
 
+/**
+ * The two-assert `Phantom` pattern from the {@link Ts} doc, in one
+ * assert: `T` is both `Ts<R0>` (the raw thunk, forcing the structural walk)
+ * and `Ts<R1>` (the phantom-wrapped export). Checking only the wrapped
+ * export is a tautology — `Ts<>` short-circuits to the annotation — so the
+ * `R0` half is what gives this teeth.
+ */
 export type Check3<T, R0 extends Type, R1 extends Type> = And<Equal<T, Ts<R0>>, Equal<T, Ts<R1>>>
 
 // Fast-path: Ts<any> resolves to Unknown without TS2589 overflow.


### PR DESCRIPTION
## Summary
- **Adds a `spread` node (`['...', exp]`)**, usable as an array element or object property. New `items = or(exp, spread)` and `properties = or(property, spread)` unions widen `array`'s and `object`'s entry types accordingly (`Array`/`Object` in `types.ts` go from arrays of `Exp`/`Property` entries to arrays of `Items`/`Properties`).
- **Fixes `array`'s entry schema**, which had regressed to validating a single `items` value instead of an array of them (`['[]', items]` → `['[]', rttiArray(items)]`) while this branch was in progress — caught before merge by comparing against `object`'s already-correct `rttiArray(properties)` sibling line, verified empirically, and confirmed necessary to keep the pre-existing `array`/`object` proof sections green.
- **Consolidates the `Phantom` recursion break onto `exp` alone — a breaking type change.** `numberCast`, `propertyAccessor`, `propertyCall`, `comma`, `op0`, `op1`, and `op2` lose their `Phantom` wrappers — one wrapper on the union every node kind recurses through is enough to cut the cycle — and each keeps a plain `Check` pin. `exp` itself moves to the `_exp`/`exp` split and upgrades its pin from `Check` to `Check3`, which checks both the raw thunk and the wrapped export; the old single `Check` on the wrapped export alone was a tautology, since `Ts` short-circuits to the annotation. Runtime values are untouched (`_op2` was already the tuple, not a thunk) and applying `Ts` to `typeof op2` resolves as before, but the documented `phantomKey` extraction on those exports now yields `never` where it yielded `Op2`, so the changelog entry carries `**BREAKING CHANGES:**` and names the migration. No importer in this repo is affected — `Ts` is the only `phantomKey` consumer and handles both shapes.
- **Re-pins `exps` at runtime.** Now that `array` holds `rttiArray(items)`, `comma` is `exps`'s only route and had no proof section, so nothing exercised `exps` at runtime — gutting it to `rttiArray(primitive)` left the whole suite green (only the type-level pins caught it). A new `exps` proof section reaches it through `comma`, pinning the operand as an array of `exp` rather than one; it claims nothing about what a `,` means, which is still an unsettled placeholder.
- **`proof.f.mjs`'s `array`/`object` sections gain spread coverage** (a spread element/property validates; a spread missing its operand or with the wrong tag doesn't) — verified by mutation: temporarily excluding `spread` from `items`/`properties`, or corrupting its tag, reddens exactly these new assertions and nothing else.
- **Docs follow the code.** `spread`, `items`, and `properties` get JSDoc stating the container-only restriction, and `fjs/edag/README.md`'s node table gains a `['...', exp]` row and spells `array`/`object`'s operands as arrays (`items[]`/`properties[]`) rather than single elements. The `Phantom` consolidation falsified two cross-references, both now corrected: `fjs/types/phantom/types.ts` cited `propertyAccessor`/`propertyCall`/`op2` as the pattern's exemplar, and `fjs/types/rtti/ts/types.ts` said to wrap the recursive node type "not a wider union (`Exp`)". That last rule was really about a top-level bare `undefined`, which `Exp` does not have — its `undefined` is the tagged `['undefined']` — so the doc now states the actual constraint and cites `_exp`/`exp`. `Check3` gains a doc comment.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run cov` — 3068/3068 tests, 100% lines/branches/functions
- [x] `npm run ci-update` — no diff
- [x] Mutation-tested the new proof assertions (excluded `spread` from `items`/`properties`, corrupted its tag) — each mutation reddened exactly the assertion meant to catch it
- [x] Mutation-tested the new `exps` section: `exps` → `rttiArray(primitive)` reddens `exps.ok`, `exps` → `exp` reddens `exps.ok` and `exps.singleExpIsError`; both left the suite green before this section existed
- [x] Confirmed the `Phantom` break is real by compiling the `phantomKey` conditional extraction against an `Op2` on both revisions — compiles on `c66e861`, `TS2322` at this head

Changelog:
- `edag`: adds a `spread` node (`['...', exp]`), usable as an array element or
  object property via new `items`/`properties` unions that `array`/`object`
  entries now accept alongside plain expressions.
- **BREAKING CHANGES:** `edag`: the `Phantom` recursion break moves to `exp`
  alone. `numberCast`, `propertyAccessor`, `propertyCall`, `comma`, `op0`,
  `op1`, and `op2` are no longer `Phantom`-wrapped — one wrapper on the union
  they all recurse through is enough to cut the cycle. Their runtime values
  and derived types are unchanged (each is still pinned with `Check`), so
  applying `Ts` to `typeof op2` and friends resolves as before. What breaks
  is the documented `phantomKey` extraction: `typeof op2 extends {
  [phantomKey]?: infer T } ? T : never` yielded `Op2` and now yields
  `never`, so an indexed access or conditional type built on it fails to
  compile. Read those types from `fjs/edag/types.ts` — `Op2`, `Comma`, … —
  or derive them by applying `Ts` to `typeof op2`; both are unaffected.