### PR TITLE
edag/todo: propose optional chaining HCF design

### DIFF
--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -188,12 +188,12 @@ carries `this = a` into the call.
 after a call:
 
 ```js
-// f?.(...args)
-['?.()', f, args]
+// f?.(...callArgs)
+['?.()', f, callArgs]
 
-// f?.(...args).x
-['?.()', f, args,
-    ['.', ['it'], 'x'],
+// f?.(...callArgs).x
+['?.()', f, callArgs,
+    ['.', ['it'], x],
 ]
 
 // a?.b?.(...c).d
@@ -213,7 +213,7 @@ the root of the expression:
 // a?.b().c.d
 ['?.this', a, b,
     ['.',
-        ['.', ['()', ['it'], args], c],
+        ['.', ['()', ['it'], ['[]', []]], c],
         d,
     ],
 ]
@@ -223,8 +223,6 @@ the root of the expression:
     ['()', ['.this', ['it'], c], d],
 ]
 ```
-
-Here `args` denotes the complete argument-array operand for `b()`.
 
 #### Continuation scope and DAG identity
 

--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -46,11 +46,16 @@ Make ordinary property access return an ordinary value with no receiver HCF:
 ```
 
 Add `.this` for the exceptional case where the property result must carry
-`this = object` into an immediately following `()` or `?.()`:
+`this = object` into an immediately following call computation:
 
 ```js
 ['.this', object, property]
 ```
+
+Grouping parentheses are transparent for this rule. The relevant question is
+whether the property result is immediately consumed as the callee of `()` or
+`?.()` in the same source expression, not whether the source tokens are
+textually adjacent.
 
 Examples:
 
@@ -72,7 +77,7 @@ const x = ['.', a, b]
 ['?.()', ['.this', a, b], c]
 ```
 
-This replaces `.()`:
+This retires `.()` as a breaking EDAG vocabulary change:
 
 ```js
 // old
@@ -82,12 +87,19 @@ This replaces `.()`:
 ['()', ['.this', a, b], c]
 ```
 
-The compiler rule is local: use `.this` only when the member expression is
-immediately followed by `()` or `?.()` in the same source expression.
-Otherwise use `.`. Hidden `this` therefore does not leak through ordinary
-property nodes or arbitrary DAG sharing.
+The compiler rule is local, but it is also an EDAG validity rule. Public EDAG
+input must not be able to keep receiver HCF alive accidentally through DAG
+sharing. A `.this` node must therefore have exactly one consumer, and that
+consumer must use it as the callee operand of `()` or `?.()`. A terminal
+`?.this` node follows the same rule. A `?.this` continuation binds `['it']`
+with receiver HCF, and that HCF-bearing result must likewise be consumed once
+as the callee of `()` or `?.()` rather than used as an ordinary value.
 
-#### Optional-chain HCF: continuation + `%`
+This makes hidden `this` deliberately short-lived: ordinary `.`/`?.` values
+never carry it, while `.this`/`?.this` mark the exact source location where an
+immediately following call needs it.
+
+#### Optional-chain HCF: continuation + `it`
 
 A terminal optional property access is:
 
@@ -106,11 +118,13 @@ the chain as a continuation:
 Introduce the contextual zero-operand operation:
 
 ```js
-['%']
+['it']
 ```
 
-Inside the continuation, `%` is the value produced by the optional operation.
-Nested continuations shadow the outer `%`.
+Inside the continuation, `it` is the value produced by the optional
+operation. `['it']` has no default meaning outside such a continuation;
+using it without an enclosing continuation binding is invalid EDAG. Nested
+continuations introduce nested `it` bindings and shadow the outer binding.
 
 This keeps the property operand in its existing special `index` type instead
 of pretending that the property name is an `exp`.
@@ -123,7 +137,7 @@ For example:
 
 // a?.b.c
 ['?.', a, b,
-    ['.', ['%'], c],
+    ['.', ['it'], c],
 ]
 
 // (a?.b).c
@@ -142,18 +156,18 @@ into a call:
 ['?.this', object, property, continuation]
 ```
 
-On success, `%` in a `?.this` continuation denotes `object[property]` with
+On success, `it` in a `?.this` continuation denotes `object[property]` with
 `this = object` HCF attached.
 
 ```js
 // a?.b(...c)
 ['?.this', a, b,
-    ['()', ['%'], c],
+    ['()', ['it'], c],
 ]
 
 // a?.b?.(...c)
 ['?.this', a, b,
-    ['?.()', ['%'], c],
+    ['?.()', ['it'], c],
 ]
 ```
 
@@ -179,18 +193,18 @@ after a call:
 
 // f?.(...args).x
 ['?.()', f, args,
-    ['.', ['%'], 'x'],
+    ['.', ['it'], 'x'],
 ]
 
 // a?.b?.(...c).d
 ['?.this', a, b,
-    ['?.()', ['%'], c,
-        ['.', ['%'], d],
+    ['?.()', ['it'], c,
+        ['.', ['it'], d],
     ],
 ]
 ```
 
-The inner continuation shadows `%` with the optional call result.
+The inner continuation shadows `it` with the optional-call result.
 
 The same local `.this` rule works even when the called property is not near
 the root of the expression:
@@ -199,81 +213,86 @@ the root of the expression:
 // a?.b().c.d
 ['?.this', a, b,
     ['.',
-        ['.', ['()', ['%'], args], c],
+        ['.', ['()', ['it'], args], c],
         d,
     ],
 ]
 
 // a?.b.c(...d)
 ['?.', a, b,
-    ['()', ['.this', ['%'], c], d],
+    ['()', ['.this', ['it'], c], d],
 ]
 ```
 
 Here `args` denotes the complete argument-array operand for `b()`.
 
-#### `%` as the current value
+#### Continuation scope and DAG identity
 
-Make `%` a general contextual EDAG value rather than a placeholder specific to
-optional chaining.
+`it` is contextual, while EDAG evaluation memoizes operation nodes by identity.
+The continuation binding must therefore be lexical rather than a dynamic
+property of whichever consumer happens to evaluate a shared node.
 
-At the beginning of an EDAG evaluation scope:
+Each continuation owns its `it` binding. A particular `['it']` node identity
+must resolve to exactly one continuation binding. More generally, an
+operation-node subgraph whose value depends on that `it` binding must not be
+shared into a context where the same node would resolve under another `it`
+binding or with no binding. Such ambiguous sharing is invalid EDAG and must be
+rejected by the identity-aware validator.
 
-```js
-['%']
-```
+Ordinary outer nodes that do not depend on `it` may still be referenced from a
+continuation; the continuation is not a function boundary and does not require
+capturing every outer value. The exact ownership algorithm belongs with the
+identity-aware validation work, but the semantic invariant is fixed here: one
+operation-node identity cannot acquire different values merely because it is
+reached through different continuation bindings.
 
-has the value of:
-
-```js
-['.', ['args'], 0]
-```
-
-An optional continuation shadows that default with its result. A nested
-function body starts a new evaluation scope, so its `%` again denotes that
-function's first argument; an enclosing `%` must be captured explicitly if
-needed.
-
-This is also useful for curried FunctionalScript code, where unary functions
-are common. The `%` spelling follows the placeholder convention used by Hack
-pipes and the TC39 pipeline-operator proposal:
-https://github.com/tc39/proposal-pipeline-operator.
-
-Add `%` to the `op0` vocabulary alongside `args` and `frame`.
+This is analogous to the existing function-scope rule for contextual
+`['args']`/`['frame']`, but continuations introduce a narrower lexical binding
+inside one function body.
 
 ### Operation summary
 
 | EDAG operation | Meaning |
 |---|---|
 | `['.', object, property]` | property value, no receiver HCF |
-| `['.this', object, property]` | property value carrying `this = object` for an immediate call |
+| `['.this', object, property]` | property value carrying `this = object` for one immediate call |
 | `['?.', object, property]` | terminal optional property value |
-| `['?.', object, property, cont]` | optional property; `% = object[property]` inside `cont` |
-| `['?.this', object, property]` | terminal optional property carrying `this = object` on success |
-| `['?.this', object, property, cont]` | optional property; `% = object[property]` with `this = object` inside `cont` |
+| `['?.', object, property, cont]` | optional property; `it = object[property]` inside `cont` |
+| `['?.this', object, property]` | terminal optional property carrying `this = object` for one immediate call |
+| `['?.this', object, property, cont]` | optional property; `it = object[property]` with `this = object` inside `cont` |
 | `['()', callee, args]` | normal call, consuming receiver HCF when present |
 | `['?.()', callee, args]` | terminal optional call, consuming receiver HCF when present |
-| `['?.()', callee, args, cont]` | optional call; `% = call result` inside `cont` |
-| `['%']` | current value; initially `args[0]`, shadowed by optional continuations |
+| `['?.()', callee, args, cont]` | optional call; `it = call result` inside `cont` |
+| `['it']` | result bound by the nearest owning optional continuation; invalid outside one |
 
-Under this design `.()` is removed. Normal and optional method calls are
+Under this design `.()` is retired. Normal and optional method calls are
 compositions of receiver HCF (`.this` / `?.this`) with `()` / `?.()`.
+Because `.()` is already part of the documented EDAG vocabulary, removing it
+is a breaking change rather than an internal refactor.
 
 ### Tasks
 
 - [ ] Settle the exact RTTI/type shapes for terminal and continuation forms of
-      `?.`, `?.this`, and `?.()`.
-- [ ] Add `%` to `op0` and define its scope/default-value semantics.
-- [ ] Replace `.()` with `.this` + `()` in the EDAG design and update the
-      compiler/interpreter plans that currently reference `.()`.
+      `?.`, `?.this`, and `?.()` and add `it` to the contextual operation
+      vocabulary.
+- [ ] Define identity-aware continuation ownership: reject `it`-dependent
+      operation-node sharing that would give one node identity more than one
+      continuation binding.
+- [ ] Enforce receiver-HCF canonicality in public EDAG validation: `.this`,
+      terminal `?.this`, and an HCF-bearing `it` from `?.this` must each have
+      one immediate call consumer and no non-call consumer.
+- [ ] Retire `.()` as a breaking EDAG change and replace it with `.this` +
+      `()` throughout the existing design and implementation plans, including
+      `fjs/edag/README.md`, `fjs/djs/todo/interpret-edag.md`,
+      `fjs/djs/todo/compile-modules-to-edag.md`, `todo/edag-spec.md`, and
+      `todo/edag-stage1-discussion.md`.
 - [ ] Add `?.`, `?.this`, and `?.()` to the EDAG vocabulary.
-- [ ] Specify canonicality rules for receiver HCF, including that `.this` is
-      emitted only for an immediately called property result.
-- [ ] Cover at least these cases in lowering/execution tests:
-      `a.b(c)`, `const x = a.b; x(c)`, `(a.b)(c)`, `a?.b.c`, `(a?.b).c`,
-      `a?.b(c)`, `(a?.b)(c)`, `a.b?.(c)`, `a?.b?.(c)`, continued optional
-      calls, nested `%` scopes, and argument evaluation across chain/grouping
-      boundaries.
+- [ ] Cover at least these cases in lowering/execution/validation tests:
+      `a.b(c)`, `const x = a.b; x(c)`, `(a.b)(c)`, invalid shared `.this`,
+      `a?.b.c`, `(a?.b).c`, `a?.b(c)`, `(a?.b)(c)`, `a.b?.(c)`,
+      `a?.b?.(c)`, continued optional calls, nested `it` scopes, invalid
+      cross-binding `it` sharing, and argument evaluation across
+      chain/grouping boundaries.
 
 ### Related
 

--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -5,11 +5,10 @@
 
 ### Problem
 
-Property access and optional chaining both have semantics that are not fully
-represented by ordinary expression values.
+Property access and optional chaining have two different kinds of hidden
+control flow (HCF) that ordinary expression values do not represent.
 
-JavaScript property access can carry a hidden receiver into an immediately
-following call:
+A property access can carry its receiver into an immediately following call:
 
 ```js
 [42].at(0)             // 42
@@ -19,50 +18,39 @@ const at = [42].at
 at(0)                   // throws
 ```
 
-Optional chaining has a different hidden control flow: an optional step can
-skip the rest of the syntactic chain, but grouping ends that chain:
+Optional chaining can skip the rest of the syntactic chain, but grouping ends
+that chain:
 
 ```js
 undefined?.a.b          // undefined
 (undefined?.a).b        // throws
 ```
 
-These are independent rules. Parentheses preserve the receiver/reference
-needed by a call, but terminate optional-chain short-circuiting.
+The rules are independent: parentheses preserve the receiver needed by a
+call, but terminate optional-chain short-circuiting.
 
 The current EDAG vocabulary has `.` for property access, `()` for calls, and
-`.()` for property calls. Extending `.()` by multiplying combined operators
-for every plain/optional property and plain/optional call combination does
-not scale well. Naively nesting single-step optional operations does not work
-either: it would make `a?.b.c` behave like `(a?.b).c`.
-
-This proposal represents the two hidden control flows separately:
-
-1. receiver (`this`) HCF is exceptional and explicitly marked on the property
-   operation that is immediately consumed by a call;
-2. optional-chain HCF is structural: the optional operation owns the rest of
-   the chain as a continuation.
+`.()` for property calls. Extending `.()` with a combined operator for every
+plain/optional property and plain/optional call combination does not scale.
+Naively nesting single-step optional operations does not work either, because
+it would make `a?.b.c` behave like `(a?.b).c`.
 
 ### Proposal
 
-#### Property values are unbound by default
+#### Receiver HCF: `.this`
 
-Change `.` to mean an ordinary property value with no receiver HCF:
+Make ordinary property access return an ordinary value with no receiver HCF:
 
 ```js
 ['.', object, property]
 ```
 
-Add `.this` for the exceptional case where the property result must carry its
-receiver into an immediately following `()` or `?.()`:
+Add `.this` for the exceptional case where the property result must carry
+`this = object` into an immediately following `()` or `?.()`:
 
 ```js
 ['.this', object, property]
 ```
-
-The source compiler uses `.this` only when that member expression is the
-callee of an immediately following normal or optional call in the same
-expression. Otherwise it uses `.`.
 
 Examples:
 
@@ -84,7 +72,7 @@ const x = ['.', a, b]
 ['?.()', ['.this', a, b], c]
 ```
 
-This removes the need for `.()`:
+This replaces `.()`:
 
 ```js
 // old
@@ -94,55 +82,45 @@ This removes the need for `.()`:
 ['()', ['.this', a, b], c]
 ```
 
-The important invariant is that hidden `this` does not leak from an ordinary
-property node and therefore cannot accidentally survive through EDAG sharing.
-Only `.this` explicitly produces it, and the compiler emits `.this` only when
-the receiver has a known immediate consumer.
+The compiler rule is local: use `.this` only when the member expression is
+immediately followed by `()` or `?.()` in the same source expression.
+Otherwise use `.`. Hidden `this` therefore does not leak through ordinary
+property nodes or arbitrary DAG sharing.
 
-This is preferable to putting an "unbind" flag on a later call: a property
-node can have multiple consumers in a DAG, and every consumer should not have
-to remember whether it is allowed to use a receiver left behind by some
-producer.
+#### Optional-chain HCF: continuation + `%`
 
-#### Optional property access owns a continuation
-
-A terminal optional property access remains compact:
+A terminal optional property access is:
 
 ```js
 // a?.b
 ['?.', a, b]
 ```
 
-But if the source optional chain continues, `?.` owns a continuation:
+If the optional chain continues, the optional operation owns the remainder of
+the chain as a continuation:
 
 ```js
 ['?.', object, property, continuation]
 ```
 
-Its semantics are conceptually:
-
-```js
-const base = object
-if (base === null || base === undefined) {
-    return undefined
-}
-const value = base[property]
-return continuation(value)
-```
-
-The continuation must be represented as EDAG without turning a property
-`index` into an ordinary `exp`. Introduce a contextual zero-operand operation:
+Introduce the contextual zero-operand operation:
 
 ```js
 ['%']
 ```
 
-Inside an optional continuation, `%` is the value produced by the optional
-operation. Nested continuations shadow the outer `%`.
+Inside the continuation, `%` is the value produced by the optional operation.
+Nested continuations shadow the outer `%`.
+
+This keeps the property operand in its existing special `index` type instead
+of pretending that the property name is an `exp`.
 
 For example:
 
 ```js
+// a.b.c
+['.', ['.', a, b], c]
+
 // a?.b.c
 ['?.', a, b,
     ['.', ['%'], c],
@@ -152,29 +130,20 @@ For example:
 ['.', ['?.', a, b], c]
 ```
 
-The first form keeps `.c` inside the optional-chain HCF, so it is skipped when
-`a` is nullish. The second form uses the terminal `?.`; the outer `.` sees the
-ordinary `undefined` result and throws.
+The continuation is the optional-chain boundary. If `a` is nullish in the
+second example, the continuation is not evaluated. In the third example the
+terminal `?.` produces ordinary `undefined`, so the outer `.` throws.
 
-This structural continuation is the optional-chain boundary. No optional HCF
-has to escape from one evaluated EDAG node and be rediscovered by a later
-consumer.
-
-#### Optional property access with `this`
-
-Add `?.this` for an optional property step whose resulting property reference
-must carry its receiver into a call:
+Add `?.this` when an optional property result must also carry its receiver
+into a call:
 
 ```js
 ['?.this', object, property]
 ['?.this', object, property, continuation]
 ```
 
-On a successful property access, `%` in the continuation denotes the property
-value with `this = object` HCF attached. A following `()` or `?.()` consumes
-that receiver.
-
-Examples:
+On success, `%` in a `?.this` continuation denotes `object[property]` with
+`this = object` HCF attached.
 
 ```js
 // a?.b(...c)
@@ -188,11 +157,9 @@ Examples:
 ]
 ```
 
-If `a` is nullish, neither call arguments nor any later continuation nodes are
-evaluated.
+If `a` is nullish, neither the arguments nor the continuation are evaluated.
 
-A terminal `?.this` is useful when grouping ends the optional chain but the
-result is still immediately called:
+A terminal `?.this` handles grouping correctly:
 
 ```js
 // (a?.b)(...c)
@@ -200,31 +167,16 @@ result is still immediately called:
 ```
 
 If `a` is nullish, terminal `?.this` returns ordinary `undefined`; the outer
-normal call evaluates `c` and then throws. If `a` is non-nullish, the result
-carries `this = a`, so the call has the same receiver as JavaScript.
+normal call evaluates `c` and throws. If `a` is non-nullish, the result still
+carries `this = a` into the call.
 
-This is the key distinction between the two HCFs: grouping terminates the
-optional continuation but does not unbind a member reference.
-
-#### Optional calls can also own continuations
-
-`?.()` is the optional-call analogue. The terminal form is:
+`?.()` follows the same continuation rule when an optional chain continues
+after a call:
 
 ```js
 // f?.(...args)
 ['?.()', f, args]
-```
 
-If an optional chain continues after the call, `?.()` can own a continuation
-and rebind `%` to the call result:
-
-```js
-['?.()', callee, args, continuation]
-```
-
-For example:
-
-```js
 // f?.(...args).x
 ['?.()', f, args,
     ['.', ['%'], 'x'],
@@ -238,54 +190,32 @@ For example:
 ]
 ```
 
-In the second example, the outer `?.this` binds `%` to `a.b` with `this = a`.
-The inner `?.()` consumes that receiver if `a.b` is callable and non-nullish,
-then its continuation shadows `%` with the call result before evaluating
-`.d`.
+The inner continuation shadows `%` with the optional call result.
 
-Longer chains need no special root rule. For example, in:
+The same local `.this` rule works even when the called property is not near
+the root of the expression:
 
 ```js
-a?.b().c.d
-```
-
-`b` is the only property immediately followed by a call, so it is the only
-step that needs receiver HCF. Conceptually:
-
-```js
+// a?.b().c.d
 ['?.this', a, b,
     ['.',
         ['.', ['()', ['%'], args], c],
         d,
     ],
 ]
-```
 
-where `args` denotes the complete argument-array operand for `b()`.
-
-Likewise:
-
-```js
-a?.b.c(...d)
-```
-
-needs receiver HCF only for `c`:
-
-```js
+// a?.b.c(...d)
 ['?.', a, b,
     ['()', ['.this', ['%'], c], d],
 ]
 ```
 
-The compiler rule is therefore local: a property step uses `.this` or
-`?.this` exactly when that step is immediately followed by `()` or `?.()` in
-the same source expression. It does not need to discover where the complete
-expression or optional chain ends.
+Here `args` denotes the complete argument-array operand for `b()`.
 
-### `%` as the current value
+#### `%` as the current value
 
-Rather than making `%` meaningful only inside optional chaining, make it a
-general contextual EDAG value.
+Make `%` a general contextual EDAG value rather than a placeholder specific to
+optional chaining.
 
 At the beginning of an EDAG evaluation scope:
 
@@ -299,18 +229,17 @@ has the value of:
 ['.', ['args'], 0]
 ```
 
-An optional continuation temporarily shadows that default with the result of
-its optional property access or optional call. A nested function body starts
-a new evaluation scope, so its `%` again denotes that function's first
-argument; the enclosing `%` is available only if explicitly captured in the
-function frame.
+An optional continuation shadows that default with its result. A nested
+function body starts a new evaluation scope, so its `%` again denotes that
+function's first argument; an enclosing `%` must be captured explicitly if
+needed.
 
 This is also useful for curried FunctionalScript code, where unary functions
 are common. The `%` spelling follows the placeholder convention used by Hack
 pipes and the TC39 pipeline-operator proposal:
 https://github.com/tc39/proposal-pipeline-operator.
 
-`%` should be added to the `op0` vocabulary alongside `args` and `frame`.
+Add `%` to the `op0` vocabulary alongside `args` and `frame`.
 
 ### Operation summary
 
@@ -327,38 +256,8 @@ https://github.com/tc39/proposal-pipeline-operator.
 | `['?.()', callee, args, cont]` | optional call; `% = call result` inside `cont` |
 | `['%']` | current value; initially `args[0]`, shadowed by optional continuations |
 
-Under this design `.()` is removed; normal and optional method calls are
-compositions of property-reference HCF with `()` / `?.()`.
-
-### Alternatives considered
-
-#### Explicit unbind/value operator
-
-A separate operation could strip receiver HCF when a member value is stored:
-
-```js
-[',', ['.this', a, b]]
-```
-
-A unary comma is a plausible "materialize value" operation because JavaScript
-already demonstrates the behavior with `(0, obj.method)()`. This is
-semantically direct, but it adds nodes at every value boundary and can
-redundantly clear `this` when no receiver exists.
-
-#### `.;` / `?.;`
-
-Another option is to make `.` / `?.` propagate receiver HCF and use `.;` /
-`?.;` for the ordinary value forms. This keeps the choice at the producer,
-but makes HCF propagation the default. The proposal above reverses that:
-plain `.` / `?.` are safe ordinary values, while the exceptional forms are
-visibly named `.this` / `?.this`.
-
-#### `;()` / `;?.()`
-
-Putting the unbind choice on call operators makes tracking less local. A
-shared producer could still carry receiver HCF, and another consumer could
-accidentally use it by forgetting the `;`. The proposal instead ensures that
-ordinary property nodes never carry receiver HCF in the first place.
+Under this design `.()` is removed. Normal and optional method calls are
+compositions of receiver HCF (`.this` / `?.this`) with `()` / `?.()`.
 
 ### Tasks
 
@@ -368,16 +267,13 @@ ordinary property nodes never carry receiver HCF in the first place.
 - [ ] Replace `.()` with `.this` + `()` in the EDAG design and update the
       compiler/interpreter plans that currently reference `.()`.
 - [ ] Add `?.`, `?.this`, and `?.()` to the EDAG vocabulary.
-- [ ] Specify validation/canonicality rules for receiver HCF, including that
-      `.this` is emitted only for an immediately called property result.
-- [ ] Cover at least these lowering/execution cases:
-      - `a.b(c)` vs `const x = a.b; x(c)` vs `(a.b)(c)`;
-      - `a?.b.c` vs `(a?.b).c`;
-      - `a?.b(c)` vs `(a?.b)(c)`;
-      - `a.b?.(c)` and `a?.b?.(c)`;
-      - optional calls followed by more property/call steps;
-      - nested optional chains and `%` shadowing;
-      - argument evaluation on short-circuited vs grouped optional calls.
+- [ ] Specify canonicality rules for receiver HCF, including that `.this` is
+      emitted only for an immediately called property result.
+- [ ] Cover at least these cases in lowering/execution tests:
+      `a.b(c)`, `const x = a.b; x(c)`, `(a.b)(c)`, `a?.b.c`, `(a?.b).c`,
+      `a?.b(c)`, `(a?.b)(c)`, `a.b?.(c)`, `a?.b?.(c)`, continued optional
+      calls, nested `%` scopes, and argument evaluation across chain/grouping
+      boundaries.
 
 ### Related
 
@@ -385,4 +281,4 @@ ordinary property nodes never carry receiver HCF in the first place.
   currently introduces unconditional `.`/`()`/`.()` and should follow the
   settled operation vocabulary here.
 - [`edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md) — the
-  broader EDAG operation vocabulary and hidden-control-flow design context.
+  broader EDAG operation vocabulary and HCF design context.

--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -1,144 +1,388 @@
-## Optional chaining and unbind
+## Optional chaining and hidden control flow
 
 **Priority:** P4
 **Status:** open
 
 ### Problem
 
-The EDAG operation vocabulary (`.`, `()`, `.()`) has no representation for
-JavaScript's optional chaining (`a?.b`, `a?.(b)`, and three of the four
-`a.b(c)` variants that mix a plain/optional property step with a
-plain/optional call step — the fourth, both-plain, is already `.()`) or for
-unbinding a method reference from its receiver. Parenthesizing a
-member expression does **not** unbind it — `(obj.method)(0)` still calls with
-`obj` as `this`, same as `obj.method(0)`, since `()` is pure grouping. Only
-*extracting* the method into a value unbinds it: `const x = obj.method; x(0)`
-loses `this` and throws for a receiver-dependent method. Both chaining and
-unbind are real ECMAScript semantics a `.`/`()`/`.()`-based EDAG needs once
-source compilation covers general method-call chains, not just the
-unconditional forms already in
-[`compile-modules-to-edag.md`](../../djs/todo/compile-modules-to-edag.md).
+Property access and optional chaining both have semantics that are not fully
+represented by ordinary expression values.
 
-### Scratches
-
-Not a proposal — exploratory notes and behavior examples only, written while
-poking at the problem. Nothing below is a settled operation shape; see
-"Tasks" for what actually comes next.
-
-#### 3 Main Operations
-
-##### Chaining for `a.b`
-
-|  |        |      |
-|--|--------|------|
-|1.| `a .b` | `.`  |
-|2.| `a?.b` | `?.` |
-
-##### Chaining for `a(b)`
-
-|  |          |        |
-|--|----------|--------|
-|1.| `a  (b)` | `()`   |
-|2.| `a?.(b)` | `?.()` |
-
-##### Chaining for `a.b()`
-
-```js
-['.()', exp0, prop, args] // exp0.prop(args)
-```
-
-|  |             |          |
-|--|-------------|----------|
-|1.| `a .b  (c)` | `.()`    |
-|2.| `a?.b  (c)` | `?.()`   |
-|3.| `a .b?.(c)` | `.?.()`  |
-|4.| `a?.b?.(c)` | `?.?.()` |
-
-#### Unbind
-
-##### Chaining for `a.b`
-
-|  |        |      |
-|--|--------|------|
-|1.| `a .b` | `.`  |
-|2.| `a?.b` | `?.` |
-
-##### Chaining for `a(b)`
-
-|  |          |        |
-|--|----------|--------|
-|1.| `a  (b)` | `()`   |
-|2.| `a?.(b)` | `?.()` |
-
-##### Unbind
-
-`['unbind', exp]`
-
-#### Examples
+JavaScript property access can carry a hidden receiver into an immediately
+following call:
 
 ```js
 [42].at(0)             // 42
-
 ([42].at)(0)           // 42
 
-const x = [42].at
-x(0)                   // throws
-
-undefined.a            // throws
-
-undefined?.a.b         // undefined
-
-(undefined?.a).b       // throws
-
-const y = undefined?.a
-y.b                    // throws
+const at = [42].at
+at(0)                   // throws
 ```
 
-|                      |      |                          |           |
-|----------------------|------|--------------------------|-----------|
-|`[42].at(0)`          |`42`  |`undefined?.a.b`          |`undefined`|
-|`([42].at)(0)`        |`42`  |`(undefined?.a).b`        |throws     |
-|`const x=[42].at;x(0)`|throws|`const x=undefined?.a;x.b`|throws     |
+Optional chaining has a different hidden control flow: an optional step can
+skip the rest of the syntactic chain, but grouping ends that chain:
 
-**Open question: parens mean opposite things in the two columns above, and
-that's not a table-formatting accident — it's two different ECMAScript
-rules.** For unbind (left column), `()` is pure grouping: `(obj.method)`
-denotes the exact same reference as `obj.method`, so calling it preserves
-`this` either way — parens are transparent. For optional chaining (right
-column), `?.` short-circuits the *entire syntactic chain it heads*, not just
-its own operand: `undefined?.a.b` never evaluates `.b` at all and the whole
-expression is `undefined`, but `(undefined?.a).b` evaluates `undefined?.a` to
-`undefined` *inside* the parens, closing off the chain, and then applies a
-plain `.b` to that `undefined` *outside* it — which throws. Parens are a hard
-boundary for optional chaining, unlike for unbind.
+```js
+undefined?.a.b          // undefined
+(undefined?.a).b        // throws
+```
 
-This matters for how multi-step chains compile, not just for parenthesized
-ones: representing `a?.b.c` by nesting single-step nodes the way `.()`/`()`
-already nest (a `.c` node wrapping a `?.b` node, each evaluated and applied in
-turn) would evaluate `?.b` down to a concrete `undefined` value *before* the
-outer `.c` node ever runs — which is exactly the parenthesized `(a?.b).c`
-behavior (throws), not the correct unparenthesized `a?.b.c` behavior
-(`undefined`, no throw). Naive per-step nesting cannot represent chain-wide
-short-circuit propagation; whatever operation shape lands for `?.` needs to
-address this before implementation, not assume single-step nesting composes
-the way `.`/`()` already do.
+These are independent rules. Parentheses preserve the receiver/reference
+needed by a call, but terminate optional-chain short-circuiting.
+
+The current EDAG vocabulary has `.` for property access, `()` for calls, and
+`.()` for property calls. Extending `.()` by multiplying combined operators
+for every plain/optional property and plain/optional call combination does
+not scale well. Naively nesting single-step optional operations does not work
+either: it would make `a?.b.c` behave like `(a?.b).c`.
+
+This proposal represents the two hidden control flows separately:
+
+1. receiver (`this`) HCF is exceptional and explicitly marked on the property
+   operation that is immediately consumed by a call;
+2. optional-chain HCF is structural: the optional operation owns the rest of
+   the chain as a continuation.
+
+### Proposal
+
+#### Property values are unbound by default
+
+Change `.` to mean an ordinary property value with no receiver HCF:
+
+```js
+['.', object, property]
+```
+
+Add `.this` for the exceptional case where the property result must carry its
+receiver into an immediately following `()` or `?.()`:
+
+```js
+['.this', object, property]
+```
+
+The source compiler uses `.this` only when that member expression is the
+callee of an immediately following normal or optional call in the same
+expression. Otherwise it uses `.`.
+
+Examples:
+
+```js
+// a.b
+['.', a, b]
+
+// a.b(...c)
+['()', ['.this', a, b], c]
+
+// (a.b)(...c)
+['()', ['.this', a, b], c]
+
+// const x = a.b; x(...c)
+const x = ['.', a, b]
+['()', x, c]
+
+// a.b?.(...c)
+['?.()', ['.this', a, b], c]
+```
+
+This removes the need for `.()`:
+
+```js
+// old
+['.()', a, b, c]
+
+// proposed
+['()', ['.this', a, b], c]
+```
+
+The important invariant is that hidden `this` does not leak from an ordinary
+property node and therefore cannot accidentally survive through EDAG sharing.
+Only `.this` explicitly produces it, and the compiler emits `.this` only when
+the receiver has a known immediate consumer.
+
+This is preferable to putting an "unbind" flag on a later call: a property
+node can have multiple consumers in a DAG, and every consumer should not have
+to remember whether it is allowed to use a receiver left behind by some
+producer.
+
+#### Optional property access owns a continuation
+
+A terminal optional property access remains compact:
+
+```js
+// a?.b
+['?.', a, b]
+```
+
+But if the source optional chain continues, `?.` owns a continuation:
+
+```js
+['?.', object, property, continuation]
+```
+
+Its semantics are conceptually:
+
+```js
+const base = object
+if (base === null || base === undefined) {
+    return undefined
+}
+const value = base[property]
+return continuation(value)
+```
+
+The continuation must be represented as EDAG without turning a property
+`index` into an ordinary `exp`. Introduce a contextual zero-operand operation:
+
+```js
+['%']
+```
+
+Inside an optional continuation, `%` is the value produced by the optional
+operation. Nested continuations shadow the outer `%`.
+
+For example:
+
+```js
+// a?.b.c
+['?.', a, b,
+    ['.', ['%'], c],
+]
+
+// (a?.b).c
+['.', ['?.', a, b], c]
+```
+
+The first form keeps `.c` inside the optional-chain HCF, so it is skipped when
+`a` is nullish. The second form uses the terminal `?.`; the outer `.` sees the
+ordinary `undefined` result and throws.
+
+This structural continuation is the optional-chain boundary. No optional HCF
+has to escape from one evaluated EDAG node and be rediscovered by a later
+consumer.
+
+#### Optional property access with `this`
+
+Add `?.this` for an optional property step whose resulting property reference
+must carry its receiver into a call:
+
+```js
+['?.this', object, property]
+['?.this', object, property, continuation]
+```
+
+On a successful property access, `%` in the continuation denotes the property
+value with `this = object` HCF attached. A following `()` or `?.()` consumes
+that receiver.
+
+Examples:
+
+```js
+// a?.b(...c)
+['?.this', a, b,
+    ['()', ['%'], c],
+]
+
+// a?.b?.(...c)
+['?.this', a, b,
+    ['?.()', ['%'], c],
+]
+```
+
+If `a` is nullish, neither call arguments nor any later continuation nodes are
+evaluated.
+
+A terminal `?.this` is useful when grouping ends the optional chain but the
+result is still immediately called:
+
+```js
+// (a?.b)(...c)
+['()', ['?.this', a, b], c]
+```
+
+If `a` is nullish, terminal `?.this` returns ordinary `undefined`; the outer
+normal call evaluates `c` and then throws. If `a` is non-nullish, the result
+carries `this = a`, so the call has the same receiver as JavaScript.
+
+This is the key distinction between the two HCFs: grouping terminates the
+optional continuation but does not unbind a member reference.
+
+#### Optional calls can also own continuations
+
+`?.()` is the optional-call analogue. The terminal form is:
+
+```js
+// f?.(...args)
+['?.()', f, args]
+```
+
+If an optional chain continues after the call, `?.()` can own a continuation
+and rebind `%` to the call result:
+
+```js
+['?.()', callee, args, continuation]
+```
+
+For example:
+
+```js
+// f?.(...args).x
+['?.()', f, args,
+    ['.', ['%'], 'x'],
+]
+
+// a?.b?.(...c).d
+['?.this', a, b,
+    ['?.()', ['%'], c,
+        ['.', ['%'], d],
+    ],
+]
+```
+
+In the second example, the outer `?.this` binds `%` to `a.b` with `this = a`.
+The inner `?.()` consumes that receiver if `a.b` is callable and non-nullish,
+then its continuation shadows `%` with the call result before evaluating
+`.d`.
+
+Longer chains need no special root rule. For example, in:
+
+```js
+a?.b().c.d
+```
+
+`b` is the only property immediately followed by a call, so it is the only
+step that needs receiver HCF. Conceptually:
+
+```js
+['?.this', a, b,
+    ['.',
+        ['.', ['()', ['%'], args], c],
+        d,
+    ],
+]
+```
+
+where `args` denotes the complete argument-array operand for `b()`.
+
+Likewise:
+
+```js
+a?.b.c(...d)
+```
+
+needs receiver HCF only for `c`:
+
+```js
+['?.', a, b,
+    ['()', ['.this', ['%'], c], d],
+]
+```
+
+The compiler rule is therefore local: a property step uses `.this` or
+`?.this` exactly when that step is immediately followed by `()` or `?.()` in
+the same source expression. It does not need to discover where the complete
+expression or optional chain ends.
+
+### `%` as the current value
+
+Rather than making `%` meaningful only inside optional chaining, make it a
+general contextual EDAG value.
+
+At the beginning of an EDAG evaluation scope:
+
+```js
+['%']
+```
+
+has the value of:
+
+```js
+['.', ['args'], 0]
+```
+
+An optional continuation temporarily shadows that default with the result of
+its optional property access or optional call. A nested function body starts
+a new evaluation scope, so its `%` again denotes that function's first
+argument; the enclosing `%` is available only if explicitly captured in the
+function frame.
+
+This is also useful for curried FunctionalScript code, where unary functions
+are common. The `%` spelling follows the placeholder convention used by Hack
+pipes and the TC39 pipeline-operator proposal:
+https://github.com/tc39/proposal-pipeline-operator.
+
+`%` should be added to the `op0` vocabulary alongside `args` and `frame`.
+
+### Operation summary
+
+| EDAG operation | Meaning |
+|---|---|
+| `['.', object, property]` | property value, no receiver HCF |
+| `['.this', object, property]` | property value carrying `this = object` for an immediate call |
+| `['?.', object, property]` | terminal optional property value |
+| `['?.', object, property, cont]` | optional property; `% = object[property]` inside `cont` |
+| `['?.this', object, property]` | terminal optional property carrying `this = object` on success |
+| `['?.this', object, property, cont]` | optional property; `% = object[property]` with `this = object` inside `cont` |
+| `['()', callee, args]` | normal call, consuming receiver HCF when present |
+| `['?.()', callee, args]` | terminal optional call, consuming receiver HCF when present |
+| `['?.()', callee, args, cont]` | optional call; `% = call result` inside `cont` |
+| `['%']` | current value; initially `args[0]`, shadowed by optional continuations |
+
+Under this design `.()` is removed; normal and optional method calls are
+compositions of property-reference HCF with `()` / `?.()`.
+
+### Alternatives considered
+
+#### Explicit unbind/value operator
+
+A separate operation could strip receiver HCF when a member value is stored:
+
+```js
+[',', ['.this', a, b]]
+```
+
+A unary comma is a plausible "materialize value" operation because JavaScript
+already demonstrates the behavior with `(0, obj.method)()`. This is
+semantically direct, but it adds nodes at every value boundary and can
+redundantly clear `this` when no receiver exists.
+
+#### `.;` / `?.;`
+
+Another option is to make `.` / `?.` propagate receiver HCF and use `.;` /
+`?.;` for the ordinary value forms. This keeps the choice at the producer,
+but makes HCF propagation the default. The proposal above reverses that:
+plain `.` / `?.` are safe ordinary values, while the exceptional forms are
+visibly named `.this` / `?.this`.
+
+#### `;()` / `;?.()`
+
+Putting the unbind choice on call operators makes tracking less local. A
+shared producer could still carry receiver HCF, and another consumer could
+accidentally use it by forgetting the `;`. The proposal instead ensures that
+ordinary property nodes never carry receiver HCF in the first place.
 
 ### Tasks
 
-The scratches above surfaced real edge cases faster than they surfaced a
-design — the next step is investigation, not implementation.
-
-- [ ] Investigate optional chaining and unbind thoroughly: enumerate the
-      edge cases (chain-wide short-circuit propagation past multiple steps,
-      see "Open question" above; parens as a hard boundary for chaining vs.
-      pure grouping for unbind; interaction with `??`/other operators;
-      anything else the scratches above didn't cover) and come up with a
-      concrete proposal for the EDAG operation shape(s) — not assuming
-      single-step nesting composes the way `.`/`()` already do.
+- [ ] Settle the exact RTTI/type shapes for terminal and continuation forms of
+      `?.`, `?.this`, and `?.()`.
+- [ ] Add `%` to `op0` and define its scope/default-value semantics.
+- [ ] Replace `.()` with `.this` + `()` in the EDAG design and update the
+      compiler/interpreter plans that currently reference `.()`.
+- [ ] Add `?.`, `?.this`, and `?.()` to the EDAG vocabulary.
+- [ ] Specify validation/canonicality rules for receiver HCF, including that
+      `.this` is emitted only for an immediately called property result.
+- [ ] Cover at least these lowering/execution cases:
+      - `a.b(c)` vs `const x = a.b; x(c)` vs `(a.b)(c)`;
+      - `a?.b.c` vs `(a?.b).c`;
+      - `a?.b(c)` vs `(a?.b)(c)`;
+      - `a.b?.(c)` and `a?.b?.(c)`;
+      - optional calls followed by more property/call steps;
+      - nested optional chains and `%` shadowing;
+      - argument evaluation on short-circuited vs grouped optional calls.
 
 ### Related
 
 - [`compile-modules-to-edag.md`](../../djs/todo/compile-modules-to-edag.md) —
-  Stage 2's unconditional `.`/`()`/`.()` call/method-call work this extends.
+  currently introduces unconditional `.`/`()`/`.()` and should follow the
+  settled operation vocabulary here.
 - [`edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md) — the
-  broader EDAG operation vocabulary this joins.
+  broader EDAG operation vocabulary and hidden-control-flow design context.


### PR DESCRIPTION
## Summary

- make ordinary `.` / `?.` produce plain property values and introduce `.this` / `?.this` only where receiver HCF is required by an immediate call computation
- retire `.()` as a breaking EDAG vocabulary change in favor of composing `.this` with `()`
- represent optional-chain HCF structurally with continuations and a scoped `['it']` placeholder
- make `['it']` valid only inside an owning optional continuation, with identity-aware validation for ambiguous cross-binding sharing
- make `.this` / terminal `?.this` placement a public EDAG validation invariant, not only a compiler convention
- document grouping, optional-call, nested-chain, and argument-evaluation edge cases

This PR only rewrites the design TODO; implementation remains in the task list.

Changelog: none