### PR TITLE
edag/todo: use lambda operators for optional chaining

### DIFF
--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -32,94 +32,113 @@ non-`Exp` lambda operators.
 
 ### Proposal
 
-#### Lambda continuations
+#### Recursive lambda continuations
 
-An optional operator owns a continuation: an ordered array of lambda
-operations. A lambda operation takes the previous chain value implicitly,
-so it does not need a placeholder such as `['it']`.
+A lambda operation takes the previous chain value implicitly, so it does not
+need a placeholder such as `['it']`. Every lambda operation also owns the next
+lambda operation in the chain. The continuation is therefore a linked list of
+lambda nodes rather than an array of sibling operations.
 
 ```js
 // a?.b.c
-['?.', a, b, [
-    ['|.', c],
-]]
+['?.', a, b,
+    ['|.', c, null],
+]
 ```
 
 Conceptually:
 
 ```text
 a?.b
-   |.c
+   |.c -> null
 ```
 
-Lambda operations are structural continuation steps, not independently
+Lambda operations are structural continuation nodes, not independently
 shareable EDAG computations:
 
 ```text
-Exp       = ordinary EDAG computation; may be shared and memoized by identity
-LambdaOp  = continuation step; not Exp; cannot be extracted/shared as const
-Continuation = readonly LambdaOp[]
+Exp    = ordinary EDAG computation; may be shared and memoized by identity
+Lambda = continuation node; not Exp; cannot be extracted/shared as const
+Cont   = Lambda | null
 ```
 
-This distinction is important for HCF. A lambda step has one structural input
-from its owning chain, so receiver state never has to live in an independently
-shareable node.
+All four lambda forms have a continuation edge:
+
+```js
+['|.', property, cont]
+['|()', args, cont]
+['|?.', property, cont]
+['|?.()', args, cont]
+```
+
+This matches the EDAG model: a node references the nodes needed to continue its
+computation. A lambda chain is structurally:
+
+```text
+Lambda -> Lambda -> Lambda -> null
+```
+
+There are no sibling lambda operations, so there is no separate rule such as
+"an optional lambda must be the last element of an array." The continuation
+edge is exactly the rest of the chain.
 
 #### Optional-chain boundaries
 
-Every optional operator has a continuation operand: `?.`, `?.()`, `this?.()`,
-`|?.`, and `|?.()`. An empty continuation means the optional HCF ends
-immediately after that operation.
+The optional expression operators `?.`, `?.()`, and `this?.()` have a `Cont`
+operand. The optional lambda operators `|?.` and `|?.()` likewise use their
+normal lambda continuation edge as the region they own. `null` means the HCF
+ends immediately after that operation.
 
 ```js
 // a?.b
-['?.', a, b, []]
+['?.', a, b, null]
 
 // f?.(...a)
-['?.()', f, a, []]
+['?.()', f, a, null]
 
 // lambda ?.b
-['|?.', b, []]
+['|?.', b, null]
 
 // lambda ?.(...a)
-['|?.()', a, []]
+['|?.()', a, null]
 ```
 
-Nested optional chains own nested continuations. This makes the HCF boundary
-structural rather than inferred from neighboring operations.
+Nested optional chains own nested continuation links. This makes the HCF
+boundary structural rather than inferred from neighboring operations.
 
 ```js
 // a?.b.c?.d.e
-['?.', a, b, [
-    ['|.', c],
-    ['|?.', d, [
-        ['|.', e],
-    ]],
-]]
+['?.', a, b,
+    ['|.', c,
+        ['|?.', d,
+            ['|.', e, null],
+        ],
+    ],
+]
 ```
 
 Here `.e` is skipped when the value before `?.d` is nullish.
 
-If grouping terminates that optional chain, the inner optional operation gets
-an empty continuation and subsequent computation is outside that HCF region.
-For example, the general distinction is:
+If grouping terminates that optional chain, the optional operation gets
+`null`; subsequent computation is outside that HCF region. The general
+distinction is:
 
 ```js
-['|?.', d, [
-    ['|.', e],
-]] // ?.d.e
+['|?.', d,
+    ['|.', e, null],
+] // ?.d.e
 
-['|?.', d, []] // (?.d), continuation ends here
+['|?.', d, null] // (?.d), optional HCF ends here
 ```
 
 #### Receiver HCF inside lambda chains
 
 Property steps establish receiver state for structural lambda evaluation.
-For a successful full-form optional property with a non-empty continuation,
+For a successful full-form optional property with a non-null continuation,
 that continuation starts with both the property value and its receiver:
 
 ```text
-['?.', object, property, continuation]
+['?.', object, property, cont]
 
 value = object[property]
 this  = object
@@ -128,7 +147,7 @@ this  = object
 The receiver exists only inside the structural continuation. The final result
 of `?.` does not carry receiver HCF outside that continuation.
 
-The property lambda operators likewise always establish receiver state:
+The property lambda operators likewise establish receiver state:
 
 ```text
 |.   property access + receiver
@@ -141,6 +160,9 @@ The call lambda operators consume propagated receiver state when present:
 |()    call current value with propagated `this` if present
 |?.()  optional call current value with propagated `this` if present
 ```
+
+Their continuation, when present, receives the call result as the new current
+value after that receiver has been consumed.
 
 By contrast, the non-lambda call operators never consume propagated receiver
 state:
@@ -157,9 +179,9 @@ For example:
 
 ```js
 // a?.b?.(...c)
-['?.', a, b, [
-    ['|?.()', c, []],
-]]
+['?.', a, b,
+    ['|?.()', c, null],
+]
 ```
 
 On the successful branch, `?.` enters its continuation with `value = a.b` and
@@ -169,10 +191,11 @@ A longer chain works the same way:
 
 ```js
 // a?.b.c(...d)
-['?.', a, b, [
-    ['|.', c],
-    ['|()', d],
-]]
+['?.', a, b,
+    ['|.', c,
+        ['|()', d, null],
+    ],
+]
 ```
 
 Evaluation is conceptually:
@@ -222,38 +245,38 @@ receiver of the final property reference. Represent such calls with `this()` /
 
 ```js
 ['this()', input, lambda, args]
-['this?.()', input, lambda, args, continuation]
+['this?.()', input, lambda, args, cont]
 ```
 
 The first operand is the initial input to `lambda`; it is not necessarily the
-receiver of the final call. `lambda` can be any of the four lambda forms:
+receiver of the final call. `lambda` can start with any of the four lambda
+forms, each of which can recursively continue with another lambda:
 
 ```js
-['|.', property]
-['|?.', property, continuation]
-['|()', args]
-['|?.()', args, continuation]
+['|.', property, cont]
+['|?.', property, cont]
+['|()', args, cont]
+['|?.()', args, cont]
 ```
 
-`this()` / `this?.()` evaluate the whole lambda operation, including any
-nested continuation. If that evaluation reaches a final property reference,
-the outer call uses the final receiver propagated by the lambda rather than
-the original `input`.
+`this()` / `this?.()` evaluate the whole lambda chain. If that evaluation
+reaches a final property reference, the outer call uses the final receiver
+propagated by the lambda rather than the original `input`.
 
 Examples:
 
 ```js
 // a.b()
-['this()', a, ['|.', b], args]
+['this()', a, ['|.', b, null], args]
 
 // (a?.b)()
-['this()', a, ['|?.', b, []], args]
+['this()', a, ['|?.', b, null], args]
 
 // a.b?.()
-['this?.()', a, ['|.', b], args, []]
+['this?.()', a, ['|.', b, null], args, null]
 
 // (a?.b)?.()
-['this?.()', a, ['|?.', b, []], args, []]
+['this?.()', a, ['|?.', b, null], args, null]
 ```
 
 For a longer property chain, the final receiver comes from the continuation:
@@ -262,9 +285,9 @@ For a longer property chain, the final receiver comes from the continuation:
 // (a?.b.c)(...d)
 ['this()',
     a,
-    ['|?.', b, [
-        ['|.', c],
-    ]],
+    ['|?.', b,
+        ['|.', c, null],
+    ],
     d,
 ]
 ```
@@ -273,8 +296,8 @@ Conceptually:
 
 ```text
 input = a
-|?.b  -> value = a.b,   this = a
-|.c   -> value = a.b.c, this = a.b
+|?.b   -> value = a.b,   this = a
+|.c    -> value = a.b.c, this = a.b
 this() -> call a.b.c with this = a.b
 ```
 
@@ -286,9 +309,9 @@ reference used by the outer `this()` call:
 // (a?.(...b).c)(...d)
 ['this()',
     a,
-    ['|?.()', b, [
-        ['|.', c],
-    ]],
+    ['|?.()', b,
+        ['|.', c, null],
+    ],
     d,
 ]
 ```
@@ -303,11 +326,13 @@ been consumed:
 ```js
 // (a?.c.d.e(...f))(...g)
 ['()',
-    ['?.', a, c, [
-        ['|.', d],
-        ['|.', e],
-        ['|()', f],
-    ]],
+    ['?.', a, c,
+        ['|.', d,
+            ['|.', e,
+                ['|()', f, null],
+            ],
+        ],
+    ],
     g,
 ]
 ```
@@ -319,12 +344,13 @@ The outer call is `()`, not `this()`, because `|()` consumed the receiver of
 
 ```js
 // a?.b?.(...c).d(...f)
-['?.', a, b, [
-    ['|?.()', c, [
-        ['|.', d],
-        ['|()', f],
-    ]],
-]]
+['?.', a, b,
+    ['|?.()', c,
+        ['|.', d,
+            ['|()', f, null],
+        ],
+    ],
+]
 ```
 
 On the successful property branch, the first `?.` enters its continuation
@@ -337,10 +363,11 @@ preserving the receiver produced by the lambda:
 
 ```js
 // (a?.b)?.(...c).d(...f)
-['this?.()', a, ['|?.', b, []], c, [
-    ['|.', d],
-    ['|()', f],
-]]
+['this?.()', a, ['|?.', b, null], c,
+    ['|.', d,
+        ['|()', f, null],
+    ],
+]
 ```
 
 This structural difference directly represents the parentheses.
@@ -349,12 +376,15 @@ This structural difference directly represents the parentheses.
 
 The ordinary and lambda forms are:
 
-|JS         |exp                           |lambda                   |
-|-----------|------------------------------|-------------------------|
-|`a.b`      |`['.', a:exp, b:exp]`         |`['\|.', b:exp]`         |
-|`a(...b)`  |`['()', a:exp, b:exp]`        |`['\|()', b:exp]`        |
-|`a?.b`     |`['?.', a:exp, b:exp, cont]`  |`['\|?.', b:exp, cont]`  |
-|`a?.(...b)`|`['?.()', a:exp, b:exp, cont]`|`['\|?.()', b:exp, cont]`|
+|JS         |exp                           |lambda                         |
+|-----------|------------------------------|-------------------------------|
+|`a.b`      |`['.', a:exp, b:exp]`         |`['\|.', b:exp, cont]`         |
+|`a(...b)`  |`['()', a:exp, b:exp]`        |`['\|()', b:exp, cont]`        |
+|`a?.b`     |`['?.', a:exp, b:exp, cont]`  |`['\|?.', b:exp, cont]`        |
+|`a?.(...b)`|`['?.()', a:exp, b:exp, cont]`|`['\|?.()', b:exp, cont]`      |
+
+Here `cont` is `lambda | null`. Unlike the expression forms, **all four lambda
+forms always have a continuation operand**, including `|.` and `|()`.
 
 The `this` call forms bridge an explicit input expression to a lambda:
 
@@ -363,48 +393,38 @@ The `this` call forms bridge an explicit input expression to a lambda:
 |`(aO)(...b)`  |`['this()', a:exp, O:lambda, b:exp]`        |
 |`(aO)?.(...b)`|`['this?.()', a:exp, O:lambda, b:exp, cont]`|
 
-The continuation rule is uniform:
-
-```text
-?.        ?.()        this?.()
-|?.       |?.()
-```
-
-have continuations, while:
-
-```text
-.         ()          this()
-|.        |()
-```
-
-do not.
-
 ### Why this is preferable to `it` / `.this`
 
 - ordinary `Exp` nodes remain context-independent and safely shareable;
 - lambda operators cannot escape as const computations, so their implicit
   input and receiver are structurally unambiguous;
+- a lambda chain is represented by node references, matching the EDAG model;
+- every lambda owns exactly one continuation edge, so optional HCF ownership
+  requires no sibling-order validation rule;
 - `this` propagation and consumption are determined by the operator family;
 - non-lambda `()` / `?.()` never receive propagated `this`;
 - `this()` / `this?.()` consume the final receiver produced by their lambda,
   independent of the lambda's root form or continuation depth;
-- optional-chain boundaries are explicit nested continuation arrays;
+- optional-chain boundaries are explicit recursive continuation links;
 - no placeholder binding or identity-aware `it` ownership is needed;
 - no compiler lookahead is needed to decide whether a property node should
   carry `this`.
 
 ### Tasks
 
-- [ ] Replace the previous `it` / `.this` proposal with the lambda-operation
-      type model: `LambdaOp` and `Continuation`.
+- [ ] Replace the previous `it` / `.this` proposal with the recursive lambda
+      type model: `Lambda` and `Cont = Lambda | null`.
 - [ ] Define exact RTTI shapes for all ten operators and enforce fixed arity.
-- [ ] Make `LambdaOp` a structural type that is not an `Exp` and cannot be
+      Every lambda form must have its `Cont` operand.
+- [ ] Make `Lambda` a structural type that is not an `Exp` and cannot be
       independently shared/memoized as a computation node.
+- [ ] Define execution semantics for recursive lambda continuation links,
+      including optional HCF ownership and `null` termination.
 - [ ] Define execution semantics for receiver propagation into continuations,
       through `|.` / `|?.`, and consumption by `|()` / `|?.()`; ordinary
       `()` / `?.()` must never consume propagated receiver state.
-- [ ] Define `this()` / `this?.()` for all four `LambdaOp` forms, using the
-      final receiver produced by the whole lambda operation rather than the
+- [ ] Define `this()` / `this?.()` for all four `Lambda` root forms, using the
+      final receiver produced by the whole lambda chain rather than the
       initial input.
 - [ ] Update existing EDAG/compiler/interpreter design documents to the new
       vocabulary after the shapes are settled.

--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -114,22 +114,58 @@ For example, the general distinction is:
 
 #### Receiver HCF inside lambda chains
 
-The property lambda operators always establish receiver state:
+Property steps establish receiver state for structural lambda evaluation.
+For a successful full-form optional property with a non-empty continuation,
+that continuation starts with both the property value and its receiver:
+
+```text
+['?.', object, property, continuation]
+
+value = object[property]
+this  = object
+```
+
+The receiver exists only inside the structural continuation. The final result
+of `?.` does not carry receiver HCF outside that continuation.
+
+The property lambda operators likewise always establish receiver state:
 
 ```text
 |.   property access + receiver
 |?.  optional property access + receiver
 ```
 
-The call lambda operators consume that receiver when present:
+The call lambda operators consume propagated receiver state when present:
 
 ```text
-|()    call
-|?.()  optional call
+|()    call current value with propagated `this` if present
+|?.()  optional call current value with propagated `this` if present
 ```
 
-No lookahead or lookbehind is required. Each operator has fixed HCF behavior.
+By contrast, the non-lambda call operators never consume propagated receiver
+state:
+
+```text
+()     call with no propagated `this`
+?.()   optional call with no propagated `this`
+```
+
+No lookahead or lookbehind is required. The call family itself determines
+whether propagated receiver state may be consumed.
+
 For example:
+
+```js
+// a?.b?.(...c)
+['?.', a, b, [
+    ['|?.()', c, []],
+]]
+```
+
+On the successful branch, `?.` enters its continuation with `value = a.b` and
+`this = a`, so `|?.()` calls `a.b` with `this = a`.
+
+A longer chain works the same way:
 
 ```js
 // a?.b.c(...d)
@@ -142,7 +178,7 @@ For example:
 Evaluation is conceptually:
 
 ```text
-current = a.b
+current = a.b, this = a
 |.c     -> value = current.c, this = current
 |() d   -> call value with the propagated this
 ```
@@ -156,16 +192,27 @@ a
 |() -> call a.b.c with this = a.b
 ```
 
-Ordinary explicit property operators do **not** carry `this`:
+The three call families therefore have distinct receiver behavior:
+
+```text
+() / ?.()           never receive propagated `this`
+|() / |?.()         receive propagated `this` when present
+this() / this?.()   use their explicit receiver semantics
+```
+
+Ordinary explicit property values still do not carry receiver state as
+independently shareable `Exp` values:
 
 ```text
 .    -> ordinary property value, no this
-?.   -> optional property value, no this
+?.   -> optional property value, no this after its continuation ends
 |.   -> lambda property value + this
 |?.  -> lambda optional property value + this
 ```
 
-Thus `?` controls optional HCF only; it does not imply receiver propagation.
+Thus `?` controls optional HCF only; receiver propagation comes from property
+steps entering structural lambda evaluation, and only lambda calls consume
+that propagated receiver.
 
 #### Calls with an explicit receiver
 
@@ -235,7 +282,7 @@ been consumed:
 ```
 
 The outer call is `()`, not `this()`, because `|()` consumed the receiver of
-`.e`.
+`.e`. As a non-lambda call, `()` never receives propagated receiver state.
 
 #### Larger examples
 
@@ -249,8 +296,10 @@ The outer call is `()`, not `this()`, because `|()` consumed the receiver of
 ]]
 ```
 
-The first optional property owns the rest of the chain. The optional call owns
-`.d(...f)`, so when `a.b` is nullish, `c`, `.d`, and `f` are skipped.
+On the successful property branch, the first `?.` enters its continuation
+with `value = a.b` and `this = a`. The optional lambda call consumes that
+receiver. It also owns `.d(...f)`, so when `a.b` is nullish, `c`, `.d`, and
+`f` are skipped.
 
 Grouping moves the optional call outside the optional-property HCF while still
 preserving `this = a`:
@@ -281,15 +330,15 @@ Not every Cartesian-product cell is meaningful. The populated operators are:
 | Operator | Shape | `this` | Optional HCF | Meaning |
 |---|---|---|---|---|
 | `.` | `['.', object, property]` | no | no | property access |
-| `?.` | `['?.', object, property, continuation]` | no | yes | optional property access |
-| `()` | `['()', callee, args]` | no | no | call |
-| `?.()` | `['?.()', callee, args, continuation]` | no | yes | optional call |
+| `?.` | `['?.', object, property, continuation]` | seeds continuation receiver | yes | optional property access |
+| `()` | `['()', callee, args]` | never | no | call |
+| `?.()` | `['?.()', callee, args, continuation]` | never | yes | optional call |
 | `this()` | `['this()', receiver, propertyLambda, args]` | explicit | no | property-derived call with explicit receiver |
 | `this?.()` | `['this?.()', receiver, propertyLambda, args, continuation]` | explicit | yes | optional property-derived call with explicit receiver |
 | `|.` | `['|.', property]` | propagated | no | lambda property access |
 | `|?.` | `['|?.', property, continuation]` | propagated | yes | lambda optional property access |
-| `|()` | `['|()', args]` | consumes propagated receiver | no | lambda call |
-| `|?.()` | `['|?.()', args, continuation]` | consumes propagated receiver | yes | lambda optional call |
+| `|()` | `['|()', args]` | consumes propagated receiver if present | no | lambda call |
+| `|?.()` | `['|?.()', args, continuation]` | consumes propagated receiver if present | yes | lambda optional call |
 
 The continuation rule is uniform:
 
@@ -312,7 +361,8 @@ do not.
 - ordinary `Exp` nodes remain context-independent and safely shareable;
 - lambda operators cannot escape as const computations, so their implicit
   input and receiver are structurally unambiguous;
-- `this` propagation is known from the current operator alone;
+- `this` propagation and consumption are determined by the operator family;
+- non-lambda `()` / `?.()` never receive propagated `this`;
 - optional-chain boundaries are explicit nested continuation arrays;
 - no placeholder binding or identity-aware `it` ownership is needed;
 - no compiler lookahead is needed to decide whether a property node should
@@ -325,8 +375,9 @@ do not.
 - [ ] Define exact RTTI shapes for all ten operators and enforce fixed arity.
 - [ ] Make `LambdaOp` a structural type that is not an `Exp` and cannot be
       independently shared/memoized as a computation node.
-- [ ] Define execution semantics for receiver propagation through `|.` /
-      `|?.` and consumption by `|()` / `|?.()`.
+- [ ] Define execution semantics for receiver propagation into continuations,
+      through `|.` / `|?.`, and consumption by `|()` / `|?.()`; ordinary
+      `()` / `?.()` must never consume propagated receiver state.
 - [ ] Define `this()` / `this?.()` with `PropertyLambda` restricted to `|.` /
       `|?.`.
 - [ ] Update existing EDAG/compiler/interpreter design documents to the new

--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -345,31 +345,23 @@ preserving the receiver produced by the lambda:
 
 This structural difference directly represents the parentheses.
 
-### Operator tensor
+### Operator forms
 
-The vocabulary can be viewed as a sparse tensor of four dimensions:
+The ordinary and lambda forms are:
 
-```text
-input       : explicit | lambda (`|`)
-optional    : normal   | `?`
-operation   : property (`.`) | call (`()`)
-receiver    : normal   | `this` call
-```
+|JS         |exp                           |lambda                   |
+|-----------|------------------------------|-------------------------|
+|`a.b`      |`['.', a:exp, b:exp]`         |`['\|.', b:exp]`         |
+|`a(...b)`  |`['()', a:exp, b:exp]`        |`['\|()', b:exp]`        |
+|`a?.b`     |`['?.', a:exp, b:exp, cont]`  |`['\|?.', b:exp, cont]`  |
+|`a?.(...b)`|`['?.()', a:exp, b:exp, cont]`|`['\|?.()', b:exp, cont]`|
 
-Not every Cartesian-product cell is meaningful. The populated operators are:
+The `this` call forms bridge an explicit input expression to a lambda:
 
-| Operator | Shape | `this` | Optional HCF | Meaning |
-|---|---|---|---|---|
-| `.` | `['.', object, property]` | no | no | property access |
-| `?.` | `['?.', object, property, continuation]` | seeds continuation receiver | yes | optional property access |
-| `()` | `['()', callee, args]` | never | no | call |
-| `?.()` | `['?.()', callee, args, continuation]` | never | yes | optional call |
-| `this()` | `['this()', input, lambda, args]` | final lambda receiver | no | call lambda result with its final receiver |
-| `this?.()` | `['this?.()', input, lambda, args, continuation]` | final lambda receiver | yes | optional call of lambda result with its final receiver |
-| `|.` | `['|.', property]` | propagated | no | lambda property access |
-| `|?.` | `['|?.', property, continuation]` | propagated | yes | lambda optional property access |
-| `|()` | `['|()', args]` | consumes propagated receiver if present | no | lambda call |
-| `|?.()` | `['|?.()', args, continuation]` | consumes propagated receiver if present | yes | lambda optional call |
+|JS            |exp                                         |
+|--------------|--------------------------------------------|
+|`(aO)(...b)`  |`['this()', a:exp, O:lambda, b:exp]`        |
+|`(aO)?.(...b)`|`['this?.()', a:exp, O:lambda, b:exp, cont]`|
 
 The continuation rule is uniform:
 

--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -5,297 +5,340 @@
 
 ### Problem
 
-Property access and optional chaining have two different kinds of hidden
-control flow (HCF) that ordinary expression values do not represent.
+Property access and optional chaining have two independent kinds of hidden
+control flow (HCF):
 
-A property access can carry its receiver into an immediately following call:
+1. optional chaining can skip the rest of a syntactic chain;
+2. a property reference can carry its receiver into a following call as
+   `this`.
 
-```js
-[42].at(0)             // 42
-([42].at)(0)           // 42
-
-const at = [42].at
-at(0)                   // throws
-```
-
-Optional chaining can skip the rest of the syntactic chain, but grouping ends
-that chain:
+Parentheses affect them differently:
 
 ```js
 undefined?.a.b          // undefined
 (undefined?.a).b        // throws
+
+[42].at(0)              // 42
+([42].at)(0)            // 42
+const at = [42].at
+at(0)                    // throws
 ```
 
-The rules are independent: parentheses preserve the receiver needed by a
-call, but terminate optional-chain short-circuiting.
-
-The current EDAG vocabulary has `.` for property access, `()` for calls, and
-`.()` for property calls. Extending `.()` with a combined operator for every
-plain/optional property and plain/optional call combination does not scale.
-Naively nesting single-step optional operations does not work either, because
-it would make `a?.b.c` behave like `(a?.b).c`.
+The previous proposal represented these with contextual `it` and `.this`
+operations. That makes ordinary EDAG nodes context-sensitive and introduces
+extra identity/sharing constraints. Instead, keep ordinary `Exp` nodes
+context-independent and represent the inside of an optional chain with
+non-`Exp` lambda operators.
 
 ### Proposal
 
-#### Receiver HCF: `.this`
+#### Lambda continuations
 
-Make ordinary property access return an ordinary value with no receiver HCF:
-
-```js
-['.', object, property]
-```
-
-Add `.this` for the exceptional case where the property result must carry
-`this = object` into an immediately following call computation:
+An optional operator owns a continuation: an ordered array of lambda
+operations. A lambda operation takes the previous chain value implicitly,
+so it does not need a placeholder such as `['it']`.
 
 ```js
-['.this', object, property]
+// a?.b.c
+['?.', a, b, [
+    ['|.', c],
+]]
 ```
 
-Grouping parentheses are transparent for this rule. The relevant question is
-whether the property result is immediately consumed as the callee of `()` or
-`?.()` in the same source expression, not whether the source tokens are
-textually adjacent.
+Conceptually:
+
+```text
+a?.b
+   |.c
+```
+
+Lambda operations are structural continuation steps, not independently
+shareable EDAG computations:
+
+```text
+Exp       = ordinary EDAG computation; may be shared and memoized by identity
+LambdaOp  = continuation step; not Exp; cannot be extracted/shared as const
+Continuation = readonly LambdaOp[]
+```
+
+This distinction is important for HCF. A lambda step has one structural input
+from its owning chain, so receiver state never has to live in an independently
+shareable node.
+
+#### Optional-chain boundaries
+
+Every operator whose operation starts with `?` or `|?` has a continuation
+operand. An empty continuation means the optional HCF ends immediately after
+that operation.
+
+```js
+// a?.b
+['?.', a, b, []]
+
+// f?.(...a)
+['?.()', f, a, []]
+
+// lambda ?.b
+['|?.', b, []]
+
+// lambda ?.(...a)
+['|?.()', a, []]
+```
+
+Nested optional chains own nested continuations. This makes the HCF boundary
+structural rather than inferred from neighboring operations.
+
+```js
+// a?.b.c?.d.e
+['?.', a, b, [
+    ['|.', c],
+    ['|?.', d, [
+        ['|.', e],
+    ]],
+]]
+```
+
+Here `.e` is skipped when the value before `?.d` is nullish.
+
+If grouping terminates that optional chain, the inner optional operation gets
+an empty continuation and subsequent computation is outside that HCF region.
+For example, the general distinction is:
+
+```js
+['|?.', d, [
+    ['|.', e],
+]] // ?.d.e
+
+['|?.', d, []] // (?.d), continuation ends here
+```
+
+#### Receiver HCF inside lambda chains
+
+The property lambda operators always establish receiver state:
+
+```text
+|.   property access + receiver
+|?.  optional property access + receiver
+```
+
+The call lambda operators consume that receiver when present:
+
+```text
+|()    call
+|?.()  optional call
+```
+
+No lookahead or lookbehind is required. Each operator has fixed HCF behavior.
+For example:
+
+```js
+// a?.b.c(...d)
+['?.', a, b, [
+    ['|.', c],
+    ['|()', d],
+]]
+```
+
+Evaluation is conceptually:
+
+```text
+current = a.b
+|.c     -> value = current.c, this = current
+|() d   -> call value with the propagated this
+```
+
+Another property step replaces the receiver with its own input:
+
+```text
+a
+|.b -> value = a.b,   this = a
+|.c -> value = a.b.c, this = a.b
+|() -> call a.b.c with this = a.b
+```
+
+Ordinary explicit property operators do **not** carry `this`:
+
+```text
+.    -> ordinary property value, no this
+?.   -> optional property value, no this
+|.   -> lambda property value + this
+|?.  -> lambda optional property value + this
+```
+
+Thus `?` controls optional HCF only; it does not imply receiver propagation.
+
+#### Calls with an explicit receiver
+
+Grouping can end a lambda/optional region while JavaScript still preserves the
+receiver of the final property reference. Represent such calls with explicit
+receiver call operators:
+
+```js
+['this()', receiver, propertyLambda, args]
+['this?.()', receiver, propertyLambda, args, continuation]
+```
+
+`propertyLambda` is intentionally restricted to the two property lambda
+forms:
+
+```js
+['|.', property]
+['|?.', property, continuation]
+```
+
+It is not an arbitrary `LambdaOp`. These operators mean: derive a property
+callee from `receiver`, then call it using the same `receiver` as `this`.
 
 Examples:
 
 ```js
-// a.b
-['.', a, b]
+// a.b()
+['this()', a, ['|.', b], args]
 
-// a.b(...c)
-['()', ['.this', a, b], c]
+// (a?.b)()
+['this()', a, ['|?.', b, []], args]
 
-// (a.b)(...c)
-['()', ['.this', a, b], c]
+// a.b?.()
+['this?.()', a, ['|.', b], args, []]
 
-// const x = a.b; x(...c)
-const x = ['.', a, b]
-['()', x, c]
-
-// a.b?.(...c)
-['?.()', ['.this', a, b], c]
+// (a?.b)?.()
+['this?.()', a, ['|?.', b, []], args, []]
 ```
 
-This retires `.()` as a breaking EDAG vocabulary change:
+For a longer property chain:
 
 ```js
-// old
-['.()', a, b, c]
-
-// proposed
-['()', ['.this', a, b], c]
-```
-
-The compiler rule is local, but it is also an EDAG validity rule. Public EDAG
-input must not be able to keep receiver HCF alive accidentally through DAG
-sharing. A `.this` node must therefore have exactly one consumer, and that
-consumer must use it as the callee operand of `()` or `?.()`. A terminal
-`?.this` node follows the same rule. A `?.this` continuation binds `['it']`
-with receiver HCF, and that HCF-bearing result must likewise be consumed once
-as the callee of `()` or `?.()` rather than used as an ordinary value.
-
-This makes hidden `this` deliberately short-lived: ordinary `.`/`?.` values
-never carry it, while `.this`/`?.this` mark the exact source location where an
-immediately following call needs it.
-
-#### Optional-chain HCF: continuation + `it`
-
-A terminal optional property access is:
-
-```js
-// a?.b
-['?.', a, b]
-```
-
-If the optional chain continues, the optional operation owns the remainder of
-the chain as a continuation:
-
-```js
-['?.', object, property, continuation]
-```
-
-Introduce the contextual zero-operand operation:
-
-```js
-['it']
-```
-
-Inside the continuation, `it` is the value produced by the optional
-operation. `['it']` has no default meaning outside such a continuation;
-using it without an enclosing continuation binding is invalid EDAG. Nested
-continuations introduce nested `it` bindings and shadow the outer binding.
-
-This keeps the property operand in its existing special `index` type instead
-of pretending that the property name is an `exp`.
-
-For example:
-
-```js
-// a.b.c
-['.', ['.', a, b], c]
-
-// a?.b.c
-['?.', a, b,
-    ['.', ['it'], c],
-]
-
-// (a?.b).c
-['.', ['?.', a, b], c]
-```
-
-The continuation is the optional-chain boundary. If `a` is nullish in the
-second example, the continuation is not evaluated. In the third example the
-terminal `?.` produces ordinary `undefined`, so the outer `.` throws.
-
-Add `?.this` when an optional property result must also carry its receiver
-into a call:
-
-```js
-['?.this', object, property]
-['?.this', object, property, continuation]
-```
-
-On success, `it` in a `?.this` continuation denotes `object[property]` with
-`this = object` HCF attached.
-
-```js
-// a?.b(...c)
-['?.this', a, b,
-    ['()', ['it'], c],
-]
-
-// a?.b?.(...c)
-['?.this', a, b,
-    ['?.()', ['it'], c],
+// (a.b.c)(...d)
+['this()',
+    ['.', a, b],
+    ['|.', c],
+    d,
 ]
 ```
 
-If `a` is nullish, neither the arguments nor the continuation are evaluated.
+The explicit receiver is `a.b`; the lambda property computes `.c`; the call
+uses `a.b` as `this`.
 
-A terminal `?.this` handles grouping correctly:
-
-```js
-// (a?.b)(...c)
-['()', ['?.this', a, b], c]
-```
-
-If `a` is nullish, terminal `?.this` returns ordinary `undefined`; the outer
-normal call evaluates `c` and throws. If `a` is non-nullish, the result still
-carries `this = a` into the call.
-
-`?.()` follows the same continuation rule when an optional chain continues
-after a call:
+By contrast, a call result is an ordinary value. The receiver HCF has already
+been consumed:
 
 ```js
-// f?.(...callArgs)
-['?.()', f, callArgs]
-
-// f?.(...callArgs).x
-['?.()', f, callArgs,
-    ['.', ['it'], x],
-]
-
-// a?.b?.(...c).d
-['?.this', a, b,
-    ['?.()', ['it'], c,
-        ['.', ['it'], d],
-    ],
+// (a?.c.d.e(...f))(...g)
+['()',
+    ['?.', a, c, [
+        ['|.', d],
+        ['|.', e],
+        ['|()', f],
+    ]],
+    g,
 ]
 ```
 
-The inner continuation shadows `it` with the optional-call result.
+The outer call is `()`, not `this()`, because `|()` consumed the receiver of
+`.e`.
 
-The same local `.this` rule works even when the called property is not near
-the root of the expression:
+#### Larger examples
 
 ```js
-// a?.b().c.d
-['?.this', a, b,
-    ['.',
-        ['.', ['()', ['it'], ['[]', []]], c],
-        d,
-    ],
-]
-
-// a?.b.c(...d)
-['?.', a, b,
-    ['()', ['.this', ['it'], c], d],
-]
+// a?.b?.(...c).d(...f)
+['?.', a, b, [
+    ['|?.()', c, [
+        ['|.', d],
+        ['|()', f],
+    ]],
+]]
 ```
 
-#### Continuation scope and DAG identity
+The first optional property owns the rest of the chain. The optional call owns
+`.d(...f)`, so when `a.b` is nullish, `c`, `.d`, and `f` are skipped.
 
-`it` is contextual, while EDAG evaluation memoizes operation nodes by identity.
-The continuation binding must therefore be lexical rather than a dynamic
-property of whichever consumer happens to evaluate a shared node.
+Grouping moves the optional call outside the optional-property HCF while still
+preserving `this = a`:
 
-Each continuation owns its `it` binding. A particular `['it']` node identity
-must resolve to exactly one continuation binding. More generally, an
-operation-node subgraph whose value depends on that `it` binding must not be
-shared into a context where the same node would resolve under another `it`
-binding or with no binding. Such ambiguous sharing is invalid EDAG and must be
-rejected by the identity-aware validator.
+```js
+// (a?.b)?.(...c).d(...f)
+['this?.()', a, ['|?.', b, []], c, [
+    ['|.', d],
+    ['|()', f],
+]]
+```
 
-Ordinary outer nodes that do not depend on `it` may still be referenced from a
-continuation; the continuation is not a function boundary and does not require
-capturing every outer value. The exact ownership algorithm belongs with the
-identity-aware validation work, but the semantic invariant is fixed here: one
-operation-node identity cannot acquire different values merely because it is
-reached through different continuation bindings.
+This structural difference directly represents the parentheses.
 
-This is analogous to the existing function-scope rule for contextual
-`['args']`/`['frame']`, but continuations introduce a narrower lexical binding
-inside one function body.
+### Operator tensor
 
-### Operation summary
+The vocabulary can be viewed as a sparse tensor of four dimensions:
 
-| EDAG operation | Meaning |
-|---|---|
-| `['.', object, property]` | property value, no receiver HCF |
-| `['.this', object, property]` | property value carrying `this = object` for one immediate call |
-| `['?.', object, property]` | terminal optional property value |
-| `['?.', object, property, cont]` | optional property; `it = object[property]` inside `cont` |
-| `['?.this', object, property]` | terminal optional property carrying `this = object` for one immediate call |
-| `['?.this', object, property, cont]` | optional property; `it = object[property]` with `this = object` inside `cont` |
-| `['()', callee, args]` | normal call, consuming receiver HCF when present |
-| `['?.()', callee, args]` | terminal optional call, consuming receiver HCF when present |
-| `['?.()', callee, args, cont]` | optional call; `it = call result` inside `cont` |
-| `['it']` | result bound by the nearest owning optional continuation; invalid outside one |
+```text
+input       : explicit | lambda (`|`)
+optional    : normal   | `?`
+operation   : property (`.`) | call (`()`)
+receiver    : normal   | explicit `this` call
+```
 
-Under this design `.()` is retired. Normal and optional method calls are
-compositions of receiver HCF (`.this` / `?.this`) with `()` / `?.()`.
-Because `.()` is already part of the documented EDAG vocabulary, removing it
-is a breaking change rather than an internal refactor.
+Not every Cartesian-product cell is meaningful. The populated operators are:
+
+| Operator | Shape | `this` | Optional HCF | Meaning |
+|---|---|---|---|---|
+| `.` | `['.', object, property]` | no | no | property access |
+| `?.` | `['?.', object, property, continuation]` | no | yes | optional property access |
+| `()` | `['()', callee, args]` | no | no | call |
+| `?.()` | `['?.()', callee, args, continuation]` | no | yes | optional call |
+| `this()` | `['this()', receiver, propertyLambda, args]` | explicit | no | property-derived call with explicit receiver |
+| `this?.()` | `['this?.()', receiver, propertyLambda, args, continuation]` | explicit | yes | optional property-derived call with explicit receiver |
+| `|.` | `['|.', property]` | propagated | no | lambda property access |
+| `|?.` | `['|?.', property, continuation]` | propagated | yes | lambda optional property access |
+| `|()` | `['|()', args]` | consumes propagated receiver | no | lambda call |
+| `|?.()` | `['|?.()', args, continuation]` | consumes propagated receiver | yes | lambda optional call |
+
+The continuation rule is uniform:
+
+```text
+?.        ?.()        this?.()
+|?.       |?.()
+```
+
+have continuations, while:
+
+```text
+.         ()          this()
+|.        |()
+```
+
+do not.
+
+### Why this is preferable to `it` / `.this`
+
+- ordinary `Exp` nodes remain context-independent and safely shareable;
+- lambda operators cannot escape as const computations, so their implicit
+  input and receiver are structurally unambiguous;
+- `this` propagation is known from the current operator alone;
+- optional-chain boundaries are explicit nested continuation arrays;
+- no placeholder binding or identity-aware `it` ownership is needed;
+- no compiler lookahead is needed to decide whether a property node should
+  carry `this`.
 
 ### Tasks
 
-- [ ] Settle the exact RTTI/type shapes for terminal and continuation forms of
-      `?.`, `?.this`, and `?.()` and add `it` to the contextual operation
-      vocabulary.
-- [ ] Define identity-aware continuation ownership: reject `it`-dependent
-      operation-node sharing that would give one node identity more than one
-      continuation binding.
-- [ ] Enforce receiver-HCF canonicality in public EDAG validation: `.this`,
-      terminal `?.this`, and an HCF-bearing `it` from `?.this` must each have
-      one immediate call consumer and no non-call consumer.
-- [ ] Retire `.()` as a breaking EDAG change and replace it with `.this` +
-      `()` throughout the existing design and implementation plans, including
-      `fjs/edag/README.md`, `fjs/djs/todo/interpret-edag.md`,
-      `fjs/djs/todo/compile-modules-to-edag.md`, `todo/edag-spec.md`, and
-      `todo/edag-stage1-discussion.md`.
-- [ ] Add `?.`, `?.this`, and `?.()` to the EDAG vocabulary.
-- [ ] Cover at least these cases in lowering/execution/validation tests:
-      `a.b(c)`, `const x = a.b; x(c)`, `(a.b)(c)`, invalid shared `.this`,
-      `a?.b.c`, `(a?.b).c`, `a?.b(c)`, `(a?.b)(c)`, `a.b?.(c)`,
-      `a?.b?.(c)`, continued optional calls, nested `it` scopes, invalid
-      cross-binding `it` sharing, and argument evaluation across
-      chain/grouping boundaries.
+- [ ] Replace the previous `it` / `.this` proposal with the lambda-operation
+      type model: `LambdaOp`, `Continuation`, and restricted `PropertyLambda`.
+- [ ] Define exact RTTI shapes for all ten operators and enforce fixed arity.
+- [ ] Make `LambdaOp` a structural type that is not an `Exp` and cannot be
+      independently shared/memoized as a computation node.
+- [ ] Define execution semantics for receiver propagation through `|.` /
+      `|?.` and consumption by `|()` / `|?.()`.
+- [ ] Define `this()` / `this?.()` with `PropertyLambda` restricted to `|.` /
+      `|?.`.
+- [ ] Update existing EDAG/compiler/interpreter design documents to the new
+      vocabulary after the shapes are settled.
+- [ ] Cover grouping and HCF boundaries in lowering/execution tests, including
+      `a?.b.c`, `a?.b.c?.d.e`, `a?.b.c(d)`, `(a.b.c)(d)`, `(a?.b)(d)`,
+      `a.b?.(d)`, `(a?.b)?.(d)`, `a?.b?.(c).d(f)`,
+      `(a?.b)?.(c).d(f)`, and `(a?.c.d.e(f))(g)`.
 
 ### Related
 
 - [`compile-modules-to-edag.md`](../../djs/todo/compile-modules-to-edag.md) —
-  currently introduces unconditional `.`/`()`/`.()` and should follow the
-  settled operation vocabulary here.
+  compiler lowering must follow the settled operation vocabulary here.
 - [`edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md) — the
   broader EDAG operation vocabulary and HCF design context.

--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -67,9 +67,9 @@ shareable node.
 
 #### Optional-chain boundaries
 
-Every operator whose operation starts with `?` or `|?` has a continuation
-operand. An empty continuation means the optional HCF ends immediately after
-that operation.
+Every optional operator has a continuation operand: `?.`, `?.()`, `this?.()`,
+`|?.`, and `|?.()`. An empty continuation means the optional HCF ends
+immediately after that operation.
 
 ```js
 // a?.b

--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -397,6 +397,40 @@ The `this` call forms bridge an explicit input expression to a whole lambda:
 |`(aO)(...b)`  |`['this()', a:exp, O:lambda, b:exp]`           |
 |`(aO)?.(...b)`|`['this?.()', a:exp, O:lambda, b:exp, lambda]` |
 
+#### Why there is no `.()` operator
+
+The existing EDAG has a direct `.()` form for ordinary method calls, for
+example `a.b(...c)`. Keeping that combined property-plus-call operator would
+require a corresponding optional-property form for `a?.b(...c)`. The natural
+tag for that form would be `?.()`, but `?.()` already has a different and
+important meaning: optional call.
+
+```js
+// optional property access followed by an ordinary call
+// a?.b(...c)
+['?.', a, b, [
+    ['|()', c],
+]]
+
+// optional call
+// a?.(...b)
+['?.()', a, b, []]
+```
+
+Using a combined `.()` family would therefore make the natural `?.()` tag
+collide between two distinct JavaScript operations:
+
+```text
+a?.b(...c)  = optional property access + ordinary call
+a?.(...b)   = optional call
+```
+
+The decomposed representation avoids that collision. `?.` always means
+optional property access, `?.()` always means optional call, and receiver-aware
+method calls are composed structurally through lambda operations and `this()`.
+This keeps each operator tag associated with one semantic operation instead of
+disambiguating the tag by arity or operand position.
+
 ### Why this is preferable to `it` / `.this`
 
 - every `Exp` evaluates to an ordinary value only; HCF is never part of an

--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -54,8 +54,8 @@ No `Exp` produces `this`, optional-chain state, or any other HCF result. HCF is
 created, transformed, consumed, and discarded only by an operator while it
 interprets a structural `Lambda`.
 
-All four lambda operations are simple fixed-arity steps and **none of them has
-a continuation operand**:
+All four lambda operations have required operands and **none of them has a
+continuation operand**:
 
 ```js
 ['|.', property]
@@ -63,6 +63,10 @@ a continuation operand**:
 ['|?.', property]
 ['|?.()', args]
 ```
+
+There are no optional operands in this vocabulary. When an expression-level
+operator has no further lambda work, it still carries the lambda operand and
+uses the empty array `[]`.
 
 An optional expression operator owns a `Lambda` array representing the rest of
 its optional HCF region:
@@ -75,8 +79,9 @@ its optional HCF region:
 ```
 
 An optional lambda (`|?.` or `|?.()`) short-circuits the remaining suffix of
-its containing lambda array when its input is nullish. The lambda itself does
-not own another continuation.
+its containing lambda array when its input is nullish. On the short-circuit
+branch it produces the ordinary value `undefined` and skips the remaining
+suffix. The lambda itself does not own another continuation.
 
 #### Optional-chain boundaries
 
@@ -101,7 +106,14 @@ Optional lambda operations use the array that already contains them:
 ]]
 ```
 
-If the input to `|?.c` is nullish, the remaining suffix (`|.d`) is skipped.
+If the input to `|?.c` is nullish, `|?.` produces `undefined` and the remaining
+suffix (`|.d`) is skipped.
+
+For optional property access, the property/index operand is evaluated only on
+the non-nullish branch. In particular, for `a?.[k]`, `a` is evaluated first;
+if it is nullish, the result is `undefined` and `k` is not evaluated. The same
+rule applies to `|?.`.
+
 Grouping ends the current HCF region and therefore produces a new
 expression-level optional operator:
 
@@ -125,8 +137,9 @@ A longer chain stays flat even when it contains more than one optional step:
 ]]
 ```
 
-If `a` is nullish, the outer `?.` skips the whole array. If the input to
-`|?.d` is nullish, that lambda skips only the remaining suffix `|.e`.
+If `a` is nullish, the outer `?.` skips the whole array and produces
+`undefined`. If the input to `|?.d` is nullish, that lambda produces
+`undefined` and skips only the remaining suffix `|.e`.
 
 #### Receiver HCF inside lambda evaluation
 
@@ -158,8 +171,14 @@ The call lambda operators consume receiver state when present:
 |?.()  optional call current value with current `this` if present
 ```
 
-After a call lambda, its result becomes the current ordinary value and the
-receiver is cleared. A later property lambda can establish a new receiver.
+For `|?.()`, the argument operand is evaluated only after the current value has
+been checked to be non-nullish. If the current value is nullish, `|?.()`
+produces `undefined`, skips its argument operand, and short-circuits the
+remaining suffix of the containing lambda.
+
+After a successful call lambda, its result becomes the current ordinary value
+and the receiver is cleared. A later property lambda can establish a new
+receiver.
 
 For example:
 
@@ -171,7 +190,8 @@ For example:
 ```
 
 On the successful branch, `?.` enters its lambda with `value = a.b` and
-`this = a`, so `|?.()` calls `a.b` with `this = a`.
+`this = a`, so `|?.()` calls `a.b` with `this = a`. If `a.b` is nullish, `c`
+is not evaluated and the result is `undefined`.
 
 A longer chain works the same way:
 
@@ -228,6 +248,10 @@ An empty lambda therefore represents an ordinary call:
 // f?.(...a)
 ['?.()', f, [], a, []]
 ```
+
+For `?.()`, the `args` operand is evaluated only after the value produced by
+`input + lambda` has been checked to be non-nullish. If it is nullish, `args`
+and `continuation` are not evaluated and the result is `undefined`.
 
 A property lambda produces the receiver for a method-style call:
 
@@ -317,8 +341,9 @@ state at the point of the call.
 ]]
 ```
 
-If `a` is nullish, the outer `?.` skips the whole lambda. If `a.b` is nullish,
-`|?.()` skips the remaining `.d(...f)` suffix.
+If `a` is nullish, the outer `?.` skips the whole lambda and produces
+`undefined`. If `a.b` is nullish, `|?.()` skips evaluation of `c`, produces
+`undefined`, and skips the remaining `.d(...f)` suffix.
 
 Grouping moves the optional call outside the optional-property HCF while still
 preserving receiver state through the call's own lambda:
@@ -358,19 +383,25 @@ receiver of `.e`.
 
 The ordinary and lambda-operation forms are:
 
-|JS         |exp                                      |lambda operation     |
-|-----------|-----------------------------------------|---------------------|
-|`a.b`      |`['.', a:exp, b:exp]`                    |`['\|.', b:exp]`     |
-|`a(...b)`  |`['()', a:exp, lambda, b:exp]`           |`['\|()', b:exp]`    |
-|`a?.b`     |`['?.', a:exp, b:exp, lambda]`           |`['\|?.', b:exp]`    |
-|`a?.(...b)`|`['?.()', a:exp, lambda, b:exp, lambda]` |`['\|?.()', b:exp]` |
+|JS         |exp                                        |lambda operation       |
+|-----------|-------------------------------------------|------------------------|
+|`a.b`      |`['.', a:exp, b:index]`                    |`['\|.', b:index]`      |
+|`a(...b)`  |`['()', a:exp, lambda, b:exp]`             |`['\|()', b:exp]`       |
+|`a?.b`     |`['?.', a:exp, b:index, lambda]`           |`['\|?.', b:index]`     |
+|`a?.(...b)`|`['?.()', a:exp, lambda, b:exp, lambda]`   |`['\|?.()', b:exp]`     |
 
 `lambda` is `readonly LambdaOp[]`. Lambda operations themselves never carry
-continuations.
+continuations. All operands shown in these forms are required; absence of
+lambda work is represented explicitly by `[]`, not by an omitted operand.
 
 For expression calls, the first lambda is evaluated before the call and may
 produce receiver state for that call. For `?.()`, the final lambda is the
 optional-call continuation executed after the call succeeds.
+
+The RTTI shapes should define these required operand prefixes. Current RTTI
+tuple/container types are open, so rejecting arbitrary extra trailing elements
+is a general closed-container concern rather than a dependency of this
+proposal. This vocabulary itself does not require optional tuple operands.
 
 #### Why there is no `.()` operator
 
@@ -410,12 +441,16 @@ property access and `?.()` as optional call.
   receiving it from child expressions;
 - lambda operations cannot escape as const computations, so their implicit
   input and receiver are structurally unambiguous;
-- all four lambda operations are small, fixed-arity steps with no continuation;
+- all four lambda operations are small required-operand steps with no
+  continuation operand;
 - one flat lambda array represents the rest of an HCF region;
-- optional lambdas short-circuit the remaining suffix of that same array;
+- optional lambdas short-circuit the remaining suffix of that same array and
+  produce `undefined`;
+- optional property/index and call argument expressions are evaluated only on
+  their non-nullish branch;
 - `()` / `?.()` use the same lambda representation for both ordinary calls and
   receiver-preserving calls;
-- an empty lambda naturally means "no receiver";
+- an empty lambda naturally means "no receiver" or "no continuation work";
 - receiver state can be created, consumed, cleared, and recreated entirely
   inside structural lambda evaluation;
 - optional-chain boundaries are explicit lambda arrays;
@@ -426,17 +461,20 @@ property access and `?.()` as optional call.
 
 - [ ] Replace the previous `it` / `.this` proposal with `LambdaOp` and
       `Lambda = readonly LambdaOp[]`.
-- [ ] Define exact RTTI shapes for the eight operator forms (`.`, `?.`, `()`,
-      `?.()`, and their four lambda-operation forms) and enforce fixed arity.
-      Lambda operations must not have continuation operands.
+- [ ] Define RTTI shapes for all eight operator forms (`.`, `?.`, `()`, `?.()`,
+      and their four lambda-operation forms). All documented operands are
+      required; use `[]` rather than optional lambda/continuation operands.
 - [ ] Preserve the invariant that every `Exp` evaluates to an ordinary value
       only; `this`, optional short-circuit state, and other HCF must remain
       local evaluator state of operators interpreting `Lambda`.
 - [ ] Make `LambdaOp` a structural type that is not an `Exp` and cannot be
       independently shared/memoized as a computation node.
-- [ ] Define execution semantics for optional lambdas: `|?.` / `|?.()` must
-      short-circuit the remaining suffix of their containing lambda array on a
-      nullish input.
+- [ ] Define execution semantics for `?.` / `|?.`: check the input before
+      evaluating a computed `index`; on a nullish input, skip the index and
+      remaining lambda region as applicable and produce `undefined`.
+- [ ] Define execution semantics for `?.()` / `|?.()`: check the callee before
+      evaluating the argument operand; on a nullish callee, skip arguments and
+      remaining lambda region as applicable and produce `undefined`.
 - [ ] Define execution semantics for receiver propagation through `|.` / `|?.`,
       consumption by `|()` / `|?.()`, and final consumption by expression-level
       `()` / `?.()` when their input lambda ends with receiver state.
@@ -447,10 +485,11 @@ property access and `?.()` as optional call.
   - [ ] Remove `fjs/edag/todo/operations.md` after the new vocabulary has been
         applied; the exploratory operations note will then be superseded.
 - [ ] Cover grouping and HCF boundaries in lowering/execution tests, including
-      `a?.b.c`, `a?.b.c?.d.e`, `a?.b.c(d)`, `(a.b.c)(d)`, `(a?.b)(d)`,
-      `(a?.b.c)(d)`, `(a?.(b).c)(d)`, `a.b?.(d)`, `(a?.b)?.(d)`,
-      `a?.b?.(c).d(f)`, `(a?.b)?.(c).d(f)`, `(a?.(...b)?.c)(d)`, and
-      `(a?.c.d.e(f))(g)`.
+      `a?.[k]` with observable `k`, `f?.(...a)` with observable `a`, nullish
+      short-circuit results, `a?.b.c`, `a?.b.c?.d.e`, `a?.b.c(d)`,
+      `(a.b.c)(d)`, `(a?.b)(d)`, `(a?.b.c)(d)`, `(a?.(b).c)(d)`, `a.b?.(d)`,
+      `(a?.b)?.(d)`, `a?.b?.(c).d(f)`, `(a?.b)?.(c).d(f)`,
+      `(a?.(...b)?.c)(d)`, and `(a?.c.d.e(f))(g)`.
 
 ### Related
 

--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -52,9 +52,7 @@ Exp -> Value
 
 No `Exp` produces `this`, optional-chain state, or any other HCF result. HCF is
 created, transformed, consumed, and discarded only by an operator while it
-interprets a structural `Lambda`. Even `this()` does not receive `this` from
-one of its expression operands: it evaluates ordinary `Exp` operands and
-constructs/manages receiver state internally while evaluating its lambda.
+interprets a structural `Lambda`.
 
 All four lambda operations are simple fixed-arity steps and **none of them has
 a continuation operand**:
@@ -76,29 +74,21 @@ its optional HCF region:
 ]]
 ```
 
-Conceptually:
-
-```text
-a?.b
-   |.c
-```
-
 An optional lambda (`|?.` or `|?.()`) short-circuits the remaining suffix of
 its containing lambda array when its input is nullish. The lambda itself does
-not need to own another continuation.
+not own another continuation.
 
 #### Optional-chain boundaries
 
-The optional expression operators `?.`, `?.()`, and `this?.()` own lambda
-arrays. An empty array means the optional HCF ends immediately after that
-expression operation.
+The optional expression operators `?.` and `?.()` own lambda arrays. An empty
+array means the optional HCF ends immediately after that expression operation.
 
 ```js
 // a?.b
 ['?.', a, b, []]
 
 // f?.(...a)
-['?.()', f, a, []]
+['?.()', f, [], a, []]
 ```
 
 Optional lambda operations use the array that already contains them:
@@ -112,9 +102,6 @@ Optional lambda operations use the array that already contains them:
 ```
 
 If the input to `|?.c` is nullish, the remaining suffix (`|.d`) is skipped.
-This is unambiguous: an optional lambda means "jump to the end of the current
-lambda array" on the nullish branch.
-
 Grouping ends the current HCF region and therefore produces a new
 expression-level optional operator:
 
@@ -141,11 +128,11 @@ A longer chain stays flat even when it contains more than one optional step:
 If `a` is nullish, the outer `?.` skips the whole array. If the input to
 `|?.d` is nullish, that lambda skips only the remaining suffix `|.e`.
 
-#### Receiver HCF inside lambda chains
+#### Receiver HCF inside lambda evaluation
 
-Property steps establish receiver state for structural lambda evaluation.
-For a successful full-form optional property with a non-empty lambda array,
-that array starts with both the property value and its receiver:
+Property steps establish receiver state for structural lambda evaluation. For
+a successful full-form optional property with a non-empty lambda array, that
+array starts with both the property value and its receiver:
 
 ```text
 ['?.', object, property, lambda]
@@ -164,19 +151,15 @@ The property lambda operators establish receiver state:
 |?.  optional property access + receiver
 ```
 
-The call lambda operators consume propagated receiver state when present:
+The call lambda operators consume receiver state when present:
 
 ```text
-|()    call current value with propagated `this` if present
-|?.()  optional call current value with propagated `this` if present
+|()    call current value with current `this` if present
+|?.()  optional call current value with current `this` if present
 ```
 
-By contrast, non-lambda calls never consume propagated receiver state:
-
-```text
-()     call with no propagated `this`
-?.()   optional call with no propagated `this`
-```
+After a call lambda, its result becomes the current ordinary value and the
+receiver is cleared. A later property lambda can establish a new receiver.
 
 For example:
 
@@ -205,7 +188,7 @@ Conceptually:
 ```text
 current = a.b, this = a
 |.c     -> value = current.c, this = current
-|() d   -> call value with the propagated this
+|() d   -> call value with this, then clear this
 ```
 
 Another property step replaces the receiver with its own input:
@@ -217,82 +200,58 @@ a
 |() -> call a.b.c with this = a.b
 ```
 
-The three call families therefore have distinct receiver behavior:
-
-```text
-() / ?.()           never receive propagated `this`
-|() / |?.()         receive propagated `this` when present
-this() / this?.()   call with the final receiver produced by their lambda
-```
-
-Ordinary explicit property values still do not carry receiver state as
-independently shareable `Exp` values:
-
-```text
-.    -> ordinary property value, no this
-?.   -> optional property value, no this after its lambda ends
-|.   -> lambda property value + this
-|?.  -> lambda optional property value + this
-```
-
 Here `+ this` describes temporary evaluator state while interpreting `Lambda`;
 it is not part of the value returned by an EDAG expression.
 
-Thus `?` controls optional HCF only; receiver propagation comes from property
-steps entering structural lambda evaluation, and only lambda calls consume
-that propagated receiver.
+#### Unified call operators
 
-#### Calls using the receiver produced by a lambda
-
-Grouping can end an optional region while JavaScript still preserves the
-receiver of the final property reference. Represent such calls with `this()` /
-`this?.()`:
+There are only two expression-level call operators:
 
 ```js
-['this()', input, lambda, args]
-['this?.()', input, lambda, args, continuation]
+['()', input, lambda, args]
+['?.()', input, lambda, args, continuation]
 ```
 
-Here `lambda` is the same `readonly LambdaOp[]` type used by optional
-expression continuations. The first operand is only the initial input. The
-whole lambda array is evaluated first, and the outer call uses the final
-receiver produced by that lambda rather than the original input.
+Both always receive an explicit `Lambda`. The call operator first evaluates
+`input`, interprets `lambda`, and then calls the resulting current value.
 
-Crucially, the `input`, property operands, and argument operands are all normal
-expressions and each evaluates only to an ordinary value. `this()` constructs
-and updates the hidden receiver itself as it interprets `lambda`; no child
-`Exp` returns a receiver or any other HCF state.
+If lambda evaluation ends with receiver state, the outer call uses that
+receiver as `this`. If it ends without receiver state, the outer call is an
+ordinary function call with no propagated receiver.
 
-Examples:
+An empty lambda therefore represents an ordinary call:
 
 ```js
-// a.b()
-['this()', a, [
-    ['|.', b],
-], args]
+// f(...a)
+['()', f, [], a]
 
-// (a?.b)()
-['this()', a, [
-    ['|?.', b],
-], args]
-
-// a.b?.()
-['this?.()', a, [
-    ['|.', b],
-], args, []]
-
-// (a?.b)?.()
-['this?.()', a, [
-    ['|?.', b],
-], args, []]
+// f?.(...a)
+['?.()', f, [], a, []]
 ```
 
-For a longer property chain, the final receiver comes from the final property
-lambda in the same flat array:
+A property lambda produces the receiver for a method-style call:
+
+```js
+// a.b(...c)
+['()', a, [
+    ['|.', b],
+], c]
+```
+
+Conceptually:
+
+```text
+input = a
+|.b   -> value = a.b, this = a
+()    -> call a.b with this = a
+```
+
+The lambda can be an arbitrary chain; there is no separate `this()` operator.
+For example:
 
 ```js
 // (a?.b.c)(...d)
-['this()',
+['()',
     a,
     [
         ['|?.', b],
@@ -302,49 +261,50 @@ lambda in the same flat array:
 ]
 ```
 
-Conceptually:
+The final receiver is `a.b`, so the outer `()` calls `a.b.c` with
+`this = a.b`.
 
-```text
-input = a
-|?.b  -> value = a.b,   this = a
-|.c   -> value = a.b.c, this = a.b
-this() -> call a.b.c with this = a.b
-```
-
-The lambda may start with a call as well:
+A more general example can contain calls before the final receiver-producing
+property:
 
 ```js
-// (a?.(...b).c)(...d)
-['this()',
+// (a?.(...b)?.c)(...d)
+['()',
     a,
     [
         ['|?.()', b],
-        ['|.', c],
+        ['|?.', c],
     ],
     d,
 ]
 ```
 
-Here `|?.()` evaluates `a?.(...b)`; if it succeeds, `|.c` establishes the
-final receiver used by the outer `this()`.
+Here `|?.()` first performs an optional call. If it succeeds, `|?.c` can
+establish the receiver used by the outer `()`.
 
-By contrast, a call result is an ordinary value. The receiver HCF has already
-been consumed:
+A lambda that ends without a receiver is also well-defined:
 
 ```js
-// (a?.c.d.e(...f))(...g)
-['()',
-    ['?.', a, c, [
-        ['|.', d],
-        ['|.', e],
-        ['|()', f],
-    ]],
-    g,
-]
+['()', f, [
+    ['|()', a],
+], b]
 ```
 
-The outer call is `()`, not `this()`, because `|()` consumed the receiver of
-`.e`. As a non-lambda call, `()` never receives propagated receiver state.
+The inner `|()` consumes any receiver and leaves only its ordinary result, so
+the outer `()` performs an ordinary call of that result.
+
+A later property step can establish a receiver again:
+
+```js
+['()', f, [
+    ['|()', a],
+    ['|.', b],
+], c]
+```
+
+Thus the call operators do not encode "with this" versus "without this" in
+their tag. That distinction is entirely determined by the structural lambda
+state at the point of the call.
 
 #### Larger examples
 
@@ -357,16 +317,15 @@ The outer call is `()`, not `this()`, because `|()` consumed the receiver of
 ]]
 ```
 
-On the successful property branch, the first `?.` enters its lambda with
-`value = a.b` and `this = a`. If `a.b` is nullish, `|?.()` skips the remaining
-`.d(...f)` suffix.
+If `a` is nullish, the outer `?.` skips the whole lambda. If `a.b` is nullish,
+`|?.()` skips the remaining `.d(...f)` suffix.
 
 Grouping moves the optional call outside the optional-property HCF while still
-preserving the receiver produced by the grouped lambda:
+preserving receiver state through the call's own lambda:
 
 ```js
 // (a?.b)?.(...c).d(...f)
-['this?.()', a, [
+['?.()', a, [
     ['|?.', b],
 ], c, [
     ['|.', d],
@@ -376,109 +335,100 @@ preserving the receiver produced by the grouped lambda:
 
 This structural difference directly represents the parentheses.
 
+By contrast, a call result is an ordinary value because the call consumes the
+receiver:
+
+```js
+// (a?.c.d.e(...f))(...g)
+['()',
+    ['?.', a, c, [
+        ['|.', d],
+        ['|.', e],
+        ['|()', f],
+    ]],
+    [],
+    g,
+]
+```
+
+The outer call has an empty lambda because the inner call already consumed the
+receiver of `.e`.
+
 ### Operator forms
 
 The ordinary and lambda-operation forms are:
 
-|JS         |exp                           |lambda operation          |
-|-----------|------------------------------|--------------------------|
-|`a.b`      |`['.', a:exp, b:exp]`         |`['\|.', b:exp]`          |
-|`a(...b)`  |`['()', a:exp, b:exp]`        |`['\|()', b:exp]`         |
-|`a?.b`     |`['?.', a:exp, b:exp, lambda]`|`['\|?.', b:exp]`         |
-|`a?.(...b)`|`['?.()', a:exp, b:exp, lambda]`|`['\|?.()', b:exp]`     |
+|JS         |exp                                      |lambda operation     |
+|-----------|-----------------------------------------|---------------------|
+|`a.b`      |`['.', a:exp, b:exp]`                    |`['\|.', b:exp]`     |
+|`a(...b)`  |`['()', a:exp, lambda, b:exp]`           |`['\|()', b:exp]`    |
+|`a?.b`     |`['?.', a:exp, b:exp, lambda]`           |`['\|?.', b:exp]`    |
+|`a?.(...b)`|`['?.()', a:exp, lambda, b:exp, lambda]` |`['\|?.()', b:exp]` |
 
 `lambda` is `readonly LambdaOp[]`. Lambda operations themselves never carry
 continuations.
 
-The `this` call forms bridge an explicit input expression to a whole lambda:
-
-|JS            |exp                                            |
-|--------------|-----------------------------------------------|
-|`(aO)(...b)`  |`['this()', a:exp, O:lambda, b:exp]`           |
-|`(aO)?.(...b)`|`['this?.()', a:exp, O:lambda, b:exp, lambda]` |
+For expression calls, the first lambda is evaluated before the call and may
+produce receiver state for that call. For `?.()`, the final lambda is the
+optional-call continuation executed after the call succeeds.
 
 #### Why there is no `.()` operator
 
-The existing EDAG has a direct `.()` form for ordinary method calls, for
-example `a.b(...c)`. Keeping that combined property-plus-call operator would
-require a corresponding optional-property form for `a?.b(...c)`. The natural
-tag for that form would be `?.()`, but `?.()` already has a different and
-important meaning: optional call.
+The existing EDAG has a direct `.()` form for ordinary method calls, but the
+unified call shape makes it unnecessary:
 
 ```js
-// optional property access followed by an ordinary call
-// a?.b(...c)
-['?.', a, b, [
-    ['|()', c],
-]]
-
-// optional call
-// a?.(...b)
-['?.()', a, b, []]
+// a.b(...c)
+['()', a, [
+    ['|.', b],
+], c]
 ```
 
-Using a combined `.()` family would therefore make the natural `?.()` tag
-collide between two distinct JavaScript operations:
-
-```text
-a?.b(...c)  = optional property access + ordinary call
-a?.(...b)   = optional call
-```
-
-`this()` is also more general than `.()`. It does not mean only "call one
-property of an object"; it calls the final value produced by an arbitrary
-receiver-producing lambda chain using that chain's final receiver. For example:
+This is not merely a verbose spelling of `.()`: the same `()` operator handles
+arbitrary receiver-producing chains that no direct property-plus-call operator
+could represent:
 
 ```js
 // (a?.(...b)?.c)(...d)
-['this()',
-    a,
-    [
-        ['|?.()', b],
-        ['|?.', c],
-    ],
-    d,
-]
+['()', a, [
+    ['|?.()', b],
+    ['|?.', c],
+], d]
 ```
 
-Here the final receiver is produced only after the optional call and optional
-property steps have both executed. A direct `.()` operator can represent the
-special case `a.b(...c)`, but cannot represent this general receiver-preserving
-call pattern.
-
-The decomposed representation avoids the `?.()` collision and uses `this()` as
-the general receiver-preserving call operation. `?.` always means optional
-property access, `?.()` always means optional call, and receiver-aware method
-calls are composed structurally through lambda operations and `this()`. This
-keeps each operator tag associated with one semantic operation instead of
-disambiguating the tag by arity or operand position.
+It also avoids a naming collision in an optional `.()` family. The natural
+optional counterpart of `a.b(...c)` would be `a?.b(...c)`, while `?.()` already
+means the distinct operation `a?.(...b)`. Decomposition keeps `?.` as optional
+property access and `?.()` as optional call.
 
 ### Why this is preferable to `it` / `.this`
 
 - every `Exp` evaluates to an ordinary value only; HCF is never part of an
   expression result;
 - ordinary `Exp` nodes remain context-independent and safely shareable;
-- operators that interpret `Lambda` create and control HCF locally instead of
+- operators interpreting `Lambda` create and control HCF locally instead of
   receiving it from child expressions;
 - lambda operations cannot escape as const computations, so their implicit
   input and receiver are structurally unambiguous;
 - all four lambda operations are small, fixed-arity steps with no continuation;
 - one flat lambda array represents the rest of an HCF region;
 - optional lambdas short-circuit the remaining suffix of that same array;
-- `this()` / `this?.()` reuse the same lambda-array representation and consume
-  the final receiver produced by the whole chain;
-- non-lambda `()` / `?.()` never receive propagated `this`;
-- optional-chain boundaries are explicit expression-level lambda arrays;
+- `()` / `?.()` use the same lambda representation for both ordinary calls and
+  receiver-preserving calls;
+- an empty lambda naturally means "no receiver";
+- receiver state can be created, consumed, cleared, and recreated entirely
+  inside structural lambda evaluation;
+- optional-chain boundaries are explicit lambda arrays;
 - no placeholder binding or identity-aware `it` ownership is needed;
-- no compiler lookahead is needed to decide whether a property node should
-  carry `this`.
+- no dedicated `this()` / `this?.()` operation is needed.
 
 ### Tasks
 
 - [ ] Replace the previous `it` / `.this` proposal with `LambdaOp` and
       `Lambda = readonly LambdaOp[]`.
-- [ ] Define exact RTTI shapes for all ten operators and enforce fixed arity.
-      Lambda operations must not have continuation operands.
+- [ ] Define exact RTTI shapes for the six operators (`.`, `?.`, `()`, `?.()`,
+      and their four lambda-operation forms) and enforce fixed arity. Lambda
+      operations must not have continuation operands.
 - [ ] Preserve the invariant that every `Exp` evaluates to an ordinary value
       only; `this`, optional short-circuit state, and other HCF must remain
       local evaluator state of operators interpreting `Lambda`.
@@ -487,11 +437,11 @@ disambiguating the tag by arity or operand position.
 - [ ] Define execution semantics for optional lambdas: `|?.` / `|?.()` must
       short-circuit the remaining suffix of their containing lambda array on a
       nullish input.
-- [ ] Define execution semantics for receiver propagation through `|.` / `|?.`
-      and consumption by `|()` / `|?.()`; ordinary `()` / `?.()` must never
-      consume propagated receiver state.
-- [ ] Define `this()` / `this?.()` over a whole `Lambda` array, using the final
-      receiver produced by that array rather than the initial input.
+- [ ] Define execution semantics for receiver propagation through `|.` / `|?.`,
+      consumption by `|()` / `|?.()`, and final consumption by expression-level
+      `()` / `?.()` when their input lambda ends with receiver state.
+- [ ] Define ordinary calls as the same `()` / `?.()` forms with an empty input
+      lambda; do not add separate `this()` / `this?.()` operators.
 - [ ] Update existing EDAG/compiler/interpreter design documents to the new
       vocabulary after the shapes are settled.
   - [ ] Remove `fjs/edag/todo/operations.md` after the new vocabulary has been
@@ -499,7 +449,8 @@ disambiguating the tag by arity or operand position.
 - [ ] Cover grouping and HCF boundaries in lowering/execution tests, including
       `a?.b.c`, `a?.b.c?.d.e`, `a?.b.c(d)`, `(a.b.c)(d)`, `(a?.b)(d)`,
       `(a?.b.c)(d)`, `(a?.(b).c)(d)`, `a.b?.(d)`, `(a?.b)?.(d)`,
-      `a?.b?.(c).d(f)`, `(a?.b)?.(c).d(f)`, and `(a?.c.d.e(f))(g)`.
+      `a?.b?.(c).d(f)`, `(a?.b)?.(c).d(f)`, `(a?.(...b)?.c)(d)`, and
+      `(a?.c.d.e(f))(g)`.
 
 ### Related
 

--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -425,10 +425,32 @@ a?.b(...c)  = optional property access + ordinary call
 a?.(...b)   = optional call
 ```
 
-The decomposed representation avoids that collision. `?.` always means
-optional property access, `?.()` always means optional call, and receiver-aware
-method calls are composed structurally through lambda operations and `this()`.
-This keeps each operator tag associated with one semantic operation instead of
+`this()` is also more general than `.()`. It does not mean only "call one
+property of an object"; it calls the final value produced by an arbitrary
+receiver-producing lambda chain using that chain's final receiver. For example:
+
+```js
+// (a?.(...b)?.c)(...d)
+['this()',
+    a,
+    [
+        ['|?.()', b],
+        ['|?.', c],
+    ],
+    d,
+]
+```
+
+Here the final receiver is produced only after the optional call and optional
+property steps have both executed. A direct `.()` operator can represent the
+special case `a.b(...c)`, but cannot represent this general receiver-preserving
+call pattern.
+
+The decomposed representation avoids the `?.()` collision and uses `this()` as
+the general receiver-preserving call operation. `?.` always means optional
+property access, `?.()` always means optional call, and receiver-aware method
+calls are composed structurally through lambda operations and `this()`. This
+keeps each operator tag associated with one semantic operation instead of
 disambiguating the tag by arity or operand position.
 
 ### Why this is preferable to `it` / `.this`

--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -416,6 +416,8 @@ do not.
       initial input.
 - [ ] Update existing EDAG/compiler/interpreter design documents to the new
       vocabulary after the shapes are settled.
+  - [ ] Remove `fjs/edag/todo/operations.md` after the new vocabulary has been
+        applied; the exploratory operations note will then be superseded.
 - [ ] Cover grouping and HCF boundaries in lowering/execution tests, including
       `a?.b.c`, `a?.b.c?.d.e`, `a?.b.c(d)`, `(a.b.c)(d)`, `(a?.b)(d)`,
       `(a?.b.c)(d)`, `(a?.(b).c)(d)`, `a.b?.(d)`, `(a?.b)?.(d)`,

--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -44,6 +44,18 @@ LambdaOp = structural step; not Exp; cannot be extracted/shared as const
 Lambda   = readonly LambdaOp[]
 ```
 
+A core invariant is that evaluating an `Exp` produces only its ordinary value:
+
+```text
+Exp -> Value
+```
+
+No `Exp` produces `this`, optional-chain state, or any other HCF result. HCF is
+created, transformed, consumed, and discarded only by an operator while it
+interprets a structural `Lambda`. Even `this()` does not receive `this` from
+one of its expression operands: it evaluates ordinary `Exp` operands and
+constructs/manages receiver state internally while evaluating its lambda.
+
 All four lambda operations are simple fixed-arity steps and **none of them has
 a continuation operand**:
 
@@ -223,6 +235,9 @@ independently shareable `Exp` values:
 |?.  -> lambda optional property value + this
 ```
 
+Here `+ this` describes temporary evaluator state while interpreting `Lambda`;
+it is not part of the value returned by an EDAG expression.
+
 Thus `?` controls optional HCF only; receiver propagation comes from property
 steps entering structural lambda evaluation, and only lambda calls consume
 that propagated receiver.
@@ -242,6 +257,11 @@ Here `lambda` is the same `readonly LambdaOp[]` type used by optional
 expression continuations. The first operand is only the initial input. The
 whole lambda array is evaluated first, and the outer call uses the final
 receiver produced by that lambda rather than the original input.
+
+Crucially, the `input`, property operands, and argument operands are all normal
+expressions and each evaluates only to an ordinary value. `this()` constructs
+and updates the hidden receiver itself as it interprets `lambda`; no child
+`Exp` returns a receiver or any other HCF state.
 
 Examples:
 
@@ -379,7 +399,11 @@ The `this` call forms bridge an explicit input expression to a whole lambda:
 
 ### Why this is preferable to `it` / `.this`
 
+- every `Exp` evaluates to an ordinary value only; HCF is never part of an
+  expression result;
 - ordinary `Exp` nodes remain context-independent and safely shareable;
+- operators that interpret `Lambda` create and control HCF locally instead of
+  receiving it from child expressions;
 - lambda operations cannot escape as const computations, so their implicit
   input and receiver are structurally unambiguous;
 - all four lambda operations are small, fixed-arity steps with no continuation;
@@ -399,6 +423,9 @@ The `this` call forms bridge an explicit input expression to a whole lambda:
       `Lambda = readonly LambdaOp[]`.
 - [ ] Define exact RTTI shapes for all ten operators and enforce fixed arity.
       Lambda operations must not have continuation operands.
+- [ ] Preserve the invariant that every `Exp` evaluates to an ordinary value
+      only; `this`, optional short-circuit state, and other HCF must remain
+      local evaluator state of operators interpreting `Lambda`.
 - [ ] Make `LambdaOp` a structural type that is not an `Exp` and cannot be
       independently shared/memoized as a computation node.
 - [ ] Define execution semantics for optional lambdas: `|?.` / `|?.()` must

--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -426,9 +426,9 @@ property access and `?.()` as optional call.
 
 - [ ] Replace the previous `it` / `.this` proposal with `LambdaOp` and
       `Lambda = readonly LambdaOp[]`.
-- [ ] Define exact RTTI shapes for the six operators (`.`, `?.`, `()`, `?.()`,
-      and their four lambda-operation forms) and enforce fixed arity. Lambda
-      operations must not have continuation operands.
+- [ ] Define exact RTTI shapes for the eight operator forms (`.`, `?.`, `()`,
+      `?.()`, and their four lambda-operation forms) and enforce fixed arity.
+      Lambda operations must not have continuation operands.
 - [ ] Preserve the invariant that every `Exp` evaluates to an ordinary value
       only; `this`, optional short-circuit state, and other HCF must remain
       local evaluator state of operators interpreting `Lambda`.

--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -27,16 +27,35 @@ at(0)                    // throws
 The previous proposal represented these with contextual `it` and `.this`
 operations. That makes ordinary EDAG nodes context-sensitive and introduces
 extra identity/sharing constraints. Instead, keep ordinary `Exp` nodes
-context-independent and represent the inside of an optional chain with
-non-`Exp` lambda operators.
+context-independent and represent chain-local computation with structural
+lambda operations.
 
 ### Proposal
 
-#### Lambda continuations
+#### Lambda arrays
 
-An optional expression operator owns a continuation: an ordered array of
-lambda operations. A lambda operation takes the previous chain value
-implicitly, so it does not need a placeholder such as `['it']`.
+A lambda operation takes the previous chain value implicitly, so it does not
+need a placeholder such as `['it']`. Lambda operations are structural steps,
+not independently shareable EDAG computations.
+
+```text
+Exp      = ordinary EDAG computation; may be shared and memoized by identity
+LambdaOp = structural step; not Exp; cannot be extracted/shared as const
+Lambda   = readonly LambdaOp[]
+```
+
+All four lambda operations are simple fixed-arity steps and **none of them has
+a continuation operand**:
+
+```js
+['|.', property]
+['|()', args]
+['|?.', property]
+['|?.()', args]
+```
+
+An optional expression operator owns a `Lambda` array representing the rest of
+its optional HCF region:
 
 ```js
 // a?.b.c
@@ -52,34 +71,15 @@ a?.b
    |.c
 ```
 
-Lambda operations are structural continuation steps, not independently
-shareable EDAG computations:
-
-```text
-Exp          = ordinary EDAG computation; may be shared and memoized by identity
-Lambda       = continuation step; not Exp; cannot be extracted/shared as const
-Continuation = readonly Lambda[]
-```
-
-All four lambda forms are simple steps and do not own continuations:
-
-```js
-['|.', property]
-['|()', args]
-['|?.', property]
-['|?.()', args]
-```
-
-The continuation array itself is the HCF region. An optional lambda (`|?.` or
-`|?.()`) short-circuits the remaining suffix of its containing continuation
-array when its input is nullish. Therefore an optional lambda does not need a
-nested continuation of its own.
+An optional lambda (`|?.` or `|?.()`) short-circuits the remaining suffix of
+its containing lambda array when its input is nullish. The lambda itself does
+not need to own another continuation.
 
 #### Optional-chain boundaries
 
-The optional expression operators `?.`, `?.()`, and `this?.()` own continuation
-arrays. An empty continuation means the optional HCF ends immediately after
-that expression operation.
+The optional expression operators `?.`, `?.()`, and `this?.()` own lambda
+arrays. An empty array means the optional HCF ends immediately after that
+expression operation.
 
 ```js
 // a?.b
@@ -89,7 +89,7 @@ that expression operation.
 ['?.()', f, a, []]
 ```
 
-Optional lambda operations use the continuation array that contains them:
+Optional lambda operations use the array that already contains them:
 
 ```js
 // a?.b?.c.d
@@ -100,8 +100,11 @@ Optional lambda operations use the continuation array that contains them:
 ```
 
 If the input to `|?.c` is nullish, the remaining suffix (`|.d`) is skipped.
-If grouping terminates an optional chain, a new expression-level optional
-operation starts outside the old continuation:
+This is unambiguous: an optional lambda means "jump to the end of the current
+lambda array" on the nullish branch.
+
+Grouping ends the current HCF region and therefore produces a new
+expression-level optional operator:
 
 ```js
 // (a?.b)?.c
@@ -112,28 +115,37 @@ operation starts outside the old continuation:
 ]
 ```
 
-Thus both optional expression operations and optional lambda operations can
-represent optional chaining without lambda-local continuations: expression
-operators define HCF regions, while optional lambdas jump to the end of the
-region that already contains them.
+A longer chain stays flat even when it contains more than one optional step:
+
+```js
+// a?.b.c?.d.e
+['?.', a, b, [
+    ['|.', c],
+    ['|?.', d],
+    ['|.', e],
+]]
+```
+
+If `a` is nullish, the outer `?.` skips the whole array. If the input to
+`|?.d` is nullish, that lambda skips only the remaining suffix `|.e`.
 
 #### Receiver HCF inside lambda chains
 
 Property steps establish receiver state for structural lambda evaluation.
-For a successful full-form optional property with a non-empty continuation,
-that continuation starts with both the property value and its receiver:
+For a successful full-form optional property with a non-empty lambda array,
+that array starts with both the property value and its receiver:
 
 ```text
-['?.', object, property, continuation]
+['?.', object, property, lambda]
 
 value = object[property]
 this  = object
 ```
 
-The receiver exists only inside the structural continuation. The final result
-of `?.` does not carry receiver HCF outside that continuation.
+The receiver exists only while evaluating the structural lambda. The final
+ordinary value produced by `?.` does not carry receiver HCF outside it.
 
-The property lambda operators likewise establish receiver state:
+The property lambda operators establish receiver state:
 
 ```text
 |.   property access + receiver
@@ -147,16 +159,12 @@ The call lambda operators consume propagated receiver state when present:
 |?.()  optional call current value with propagated `this` if present
 ```
 
-By contrast, the non-lambda call operators never consume propagated receiver
-state:
+By contrast, non-lambda calls never consume propagated receiver state:
 
 ```text
 ()     call with no propagated `this`
 ?.()   optional call with no propagated `this`
 ```
-
-No lookahead or lookbehind is required. The call family itself determines
-whether propagated receiver state may be consumed.
 
 For example:
 
@@ -167,7 +175,7 @@ For example:
 ]]
 ```
 
-On the successful branch, `?.` enters its continuation with `value = a.b` and
+On the successful branch, `?.` enters its lambda with `value = a.b` and
 `this = a`, so `|?.()` calls `a.b` with `this = a`.
 
 A longer chain works the same way:
@@ -180,7 +188,7 @@ A longer chain works the same way:
 ]]
 ```
 
-Evaluation is conceptually:
+Conceptually:
 
 ```text
 current = a.b, this = a
@@ -210,7 +218,7 @@ independently shareable `Exp` values:
 
 ```text
 .    -> ordinary property value, no this
-?.   -> optional property value, no this after its continuation ends
+?.   -> optional property value, no this after its lambda ends
 |.   -> lambda property value + this
 |?.  -> lambda optional property value + this
 ```
@@ -221,7 +229,7 @@ that propagated receiver.
 
 #### Calls using the receiver produced by a lambda
 
-Grouping can end a lambda/optional region while JavaScript still preserves the
+Grouping can end an optional region while JavaScript still preserves the
 receiver of the final property reference. Represent such calls with `this()` /
 `this?.()`:
 
@@ -230,54 +238,75 @@ receiver of the final property reference. Represent such calls with `this()` /
 ['this?.()', input, lambda, args, continuation]
 ```
 
-The first operand is the initial input to `lambda`; it is not necessarily the
-receiver of the final call. `lambda` can be any of the four lambda forms:
-
-```js
-['|.', property]
-['|?.', property]
-['|()', args]
-['|?.()', args]
-```
-
-`this()` / `this?.()` evaluate the lambda step. When the lambda itself needs a
-longer chain, that chain is represented by the continuation owned by the
-surrounding optional expression rather than by the lambda node.
+Here `lambda` is the same `readonly LambdaOp[]` type used by optional
+expression continuations. The first operand is only the initial input. The
+whole lambda array is evaluated first, and the outer call uses the final
+receiver produced by that lambda rather than the original input.
 
 Examples:
 
 ```js
 // a.b()
-['this()', a, ['|.', b], args]
+['this()', a, [
+    ['|.', b],
+], args]
 
 // (a?.b)()
-['this()', a, ['|?.', b], args]
+['this()', a, [
+    ['|?.', b],
+], args]
 
 // a.b?.()
-['this?.()', a, ['|.', b], args, []]
+['this?.()', a, [
+    ['|.', b],
+], args, []]
 
 // (a?.b)?.()
-['this?.()', a, ['|?.', b], args, []]
+['this?.()', a, [
+    ['|?.', b],
+], args, []]
 ```
 
-For a longer property chain whose final receiver must survive grouping, the
-optional expression continuation carries the intermediate lambda steps before
-the outer `this()` call is formed.
+For a longer property chain, the final receiver comes from the final property
+lambda in the same flat array:
 
 ```js
 // (a?.b.c)(...d)
 ['this()',
     a,
-    ['|?.', b],
+    [
+        ['|?.', b],
+        ['|.', c],
+    ],
     d,
 ]
 ```
 
-Conceptually, lowering of the grouped callee must preserve the final receiver
-produced by the whole property chain (`a.b` for `.c`) before `this()` performs
-the outer call. The exact RTTI shape for carrying a multi-step grouped lambda
-into `this()` remains part of the implementation task below; lambda-local
-continuations are intentionally not used for it.
+Conceptually:
+
+```text
+input = a
+|?.b  -> value = a.b,   this = a
+|.c   -> value = a.b.c, this = a.b
+this() -> call a.b.c with this = a.b
+```
+
+The lambda may start with a call as well:
+
+```js
+// (a?.(...b).c)(...d)
+['this()',
+    a,
+    [
+        ['|?.()', b],
+        ['|.', c],
+    ],
+    d,
+]
+```
+
+Here `|?.()` evaluates `a?.(...b)`; if it succeeds, `|.c` establishes the
+final receiver used by the outer `this()`.
 
 By contrast, a call result is an ordinary value. The receiver HCF has already
 been consumed:
@@ -308,16 +337,18 @@ The outer call is `()`, not `this()`, because `|()` consumed the receiver of
 ]]
 ```
 
-On the successful property branch, the first `?.` enters its continuation
-with `value = a.b` and `this = a`. The optional lambda call consumes that
-receiver. If `a.b` is nullish, `|?.()` skips the remaining `.d(...f)` suffix.
+On the successful property branch, the first `?.` enters its lambda with
+`value = a.b` and `this = a`. If `a.b` is nullish, `|?.()` skips the remaining
+`.d(...f)` suffix.
 
 Grouping moves the optional call outside the optional-property HCF while still
 preserving the receiver produced by the grouped lambda:
 
 ```js
 // (a?.b)?.(...c).d(...f)
-['this?.()', a, ['|?.', b], c, [
+['this?.()', a, [
+    ['|?.', b],
+], c, [
     ['|.', d],
     ['|()', f],
 ]]
@@ -327,58 +358,57 @@ This structural difference directly represents the parentheses.
 
 ### Operator forms
 
-The ordinary and lambda forms are:
+The ordinary and lambda-operation forms are:
 
-|JS         |exp                           |lambda                   |
-|-----------|------------------------------|-------------------------|
-|`a.b`      |`['.', a:exp, b:exp]`         |`['\|.', b:exp]`         |
-|`a(...b)`  |`['()', a:exp, b:exp]`        |`['\|()', b:exp]`        |
-|`a?.b`     |`['?.', a:exp, b:exp, cont]`  |`['\|?.', b:exp]`        |
-|`a?.(...b)`|`['?.()', a:exp, b:exp, cont]`|`['\|?.()', b:exp]`      |
+|JS         |exp                           |lambda operation          |
+|-----------|------------------------------|--------------------------|
+|`a.b`      |`['.', a:exp, b:exp]`         |`['\|.', b:exp]`          |
+|`a(...b)`  |`['()', a:exp, b:exp]`        |`['\|()', b:exp]`         |
+|`a?.b`     |`['?.', a:exp, b:exp, lambda]`|`['\|?.', b:exp]`         |
+|`a?.(...b)`|`['?.()', a:exp, b:exp, lambda]`|`['\|?.()', b:exp]`     |
 
-Here `cont` is `readonly lambda[]` and belongs only to optional expression
-operators, not to lambda operators.
+`lambda` is `readonly LambdaOp[]`. Lambda operations themselves never carry
+continuations.
 
-The `this` call forms bridge an explicit input expression to a lambda:
+The `this` call forms bridge an explicit input expression to a whole lambda:
 
-|JS            |exp                                         |
-|--------------|--------------------------------------------|
-|`(aO)(...b)`  |`['this()', a:exp, O:lambda, b:exp]`        |
-|`(aO)?.(...b)`|`['this?.()', a:exp, O:lambda, b:exp, cont]`|
+|JS            |exp                                            |
+|--------------|-----------------------------------------------|
+|`(aO)(...b)`  |`['this()', a:exp, O:lambda, b:exp]`           |
+|`(aO)?.(...b)`|`['this?.()', a:exp, O:lambda, b:exp, lambda]` |
 
 ### Why this is preferable to `it` / `.this`
 
 - ordinary `Exp` nodes remain context-independent and safely shareable;
-- lambda operators cannot escape as const computations, so their implicit
+- lambda operations cannot escape as const computations, so their implicit
   input and receiver are structurally unambiguous;
-- lambda nodes stay small: none of the four lambda forms owns a continuation;
-- optional expression operators define HCF regions as flat lambda arrays;
-- optional lambdas short-circuit the remaining suffix of their containing
-  continuation array, so no nested lambda continuation is needed;
-- `this` propagation and consumption are determined by the operator family;
+- all four lambda operations are small, fixed-arity steps with no continuation;
+- one flat lambda array represents the rest of an HCF region;
+- optional lambdas short-circuit the remaining suffix of that same array;
+- `this()` / `this?.()` reuse the same lambda-array representation and consume
+  the final receiver produced by the whole chain;
 - non-lambda `()` / `?.()` never receive propagated `this`;
-- optional-chain boundaries are explicit expression-level continuation arrays;
+- optional-chain boundaries are explicit expression-level lambda arrays;
 - no placeholder binding or identity-aware `it` ownership is needed;
 - no compiler lookahead is needed to decide whether a property node should
   carry `this`.
 
 ### Tasks
 
-- [ ] Replace the previous `it` / `.this` proposal with the lambda-operation
-      type model: `Lambda` plus expression-level `Continuation = readonly Lambda[]`.
+- [ ] Replace the previous `it` / `.this` proposal with `LambdaOp` and
+      `Lambda = readonly LambdaOp[]`.
 - [ ] Define exact RTTI shapes for all ten operators and enforce fixed arity.
-      Lambda forms must not have continuation operands.
-- [ ] Make `Lambda` a structural type that is not an `Exp` and cannot be
+      Lambda operations must not have continuation operands.
+- [ ] Make `LambdaOp` a structural type that is not an `Exp` and cannot be
       independently shared/memoized as a computation node.
 - [ ] Define execution semantics for optional lambdas: `|?.` / `|?.()` must
-      short-circuit the remaining suffix of their containing continuation
-      array on a nullish input.
-- [ ] Define execution semantics for receiver propagation into continuations,
-      through `|.` / `|?.`, and consumption by `|()` / `|?.()`; ordinary
-      `()` / `?.()` must never consume propagated receiver state.
-- [ ] Define the exact multi-step grouped-lambda representation used by
-      `this()` / `this?.()` so they consume the final receiver produced by the
-      whole grouped lambda chain without adding lambda-local continuations.
+      short-circuit the remaining suffix of their containing lambda array on a
+      nullish input.
+- [ ] Define execution semantics for receiver propagation through `|.` / `|?.`
+      and consumption by `|()` / `|?.()`; ordinary `()` / `?.()` must never
+      consume propagated receiver state.
+- [ ] Define `this()` / `this?.()` over a whole `Lambda` array, using the final
+      receiver produced by that array rather than the initial input.
 - [ ] Update existing EDAG/compiler/interpreter design documents to the new
       vocabulary after the shapes are settled.
   - [ ] Remove `fjs/edag/todo/operations.md` after the new vocabulary has been

--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -32,113 +32,99 @@ non-`Exp` lambda operators.
 
 ### Proposal
 
-#### Recursive lambda continuations
+#### Lambda continuations
 
-A lambda operation takes the previous chain value implicitly, so it does not
-need a placeholder such as `['it']`. Every lambda operation also owns the next
-lambda operation in the chain. The continuation is therefore a linked list of
-lambda nodes rather than an array of sibling operations.
+An optional expression operator owns a continuation: an ordered array of
+lambda operations. A lambda operation takes the previous chain value
+implicitly, so it does not need a placeholder such as `['it']`.
 
 ```js
 // a?.b.c
-['?.', a, b,
-    ['|.', c, null],
-]
+['?.', a, b, [
+    ['|.', c],
+]]
 ```
 
 Conceptually:
 
 ```text
 a?.b
-   |.c -> null
+   |.c
 ```
 
-Lambda operations are structural continuation nodes, not independently
+Lambda operations are structural continuation steps, not independently
 shareable EDAG computations:
 
 ```text
-Exp    = ordinary EDAG computation; may be shared and memoized by identity
-Lambda = continuation node; not Exp; cannot be extracted/shared as const
-Cont   = Lambda | null
+Exp          = ordinary EDAG computation; may be shared and memoized by identity
+Lambda       = continuation step; not Exp; cannot be extracted/shared as const
+Continuation = readonly Lambda[]
 ```
 
-All four lambda forms have a continuation edge:
+All four lambda forms are simple steps and do not own continuations:
 
 ```js
-['|.', property, cont]
-['|()', args, cont]
-['|?.', property, cont]
-['|?.()', args, cont]
+['|.', property]
+['|()', args]
+['|?.', property]
+['|?.()', args]
 ```
 
-This matches the EDAG model: a node references the nodes needed to continue its
-computation. A lambda chain is structurally:
-
-```text
-Lambda -> Lambda -> Lambda -> null
-```
-
-There are no sibling lambda operations, so there is no separate rule such as
-"an optional lambda must be the last element of an array." The continuation
-edge is exactly the rest of the chain.
+The continuation array itself is the HCF region. An optional lambda (`|?.` or
+`|?.()`) short-circuits the remaining suffix of its containing continuation
+array when its input is nullish. Therefore an optional lambda does not need a
+nested continuation of its own.
 
 #### Optional-chain boundaries
 
-The optional expression operators `?.`, `?.()`, and `this?.()` have a `Cont`
-operand. The optional lambda operators `|?.` and `|?.()` likewise use their
-normal lambda continuation edge as the region they own. `null` means the HCF
-ends immediately after that operation.
+The optional expression operators `?.`, `?.()`, and `this?.()` own continuation
+arrays. An empty continuation means the optional HCF ends immediately after
+that expression operation.
 
 ```js
 // a?.b
-['?.', a, b, null]
+['?.', a, b, []]
 
 // f?.(...a)
-['?.()', f, a, null]
-
-// lambda ?.b
-['|?.', b, null]
-
-// lambda ?.(...a)
-['|?.()', a, null]
+['?.()', f, a, []]
 ```
 
-Nested optional chains own nested continuation links. This makes the HCF
-boundary structural rather than inferred from neighboring operations.
+Optional lambda operations use the continuation array that contains them:
 
 ```js
-// a?.b.c?.d.e
-['?.', a, b,
-    ['|.', c,
-        ['|?.', d,
-            ['|.', e, null],
-        ],
-    ],
+// a?.b?.c.d
+['?.', a, b, [
+    ['|?.', c],
+    ['|.', d],
+]]
+```
+
+If the input to `|?.c` is nullish, the remaining suffix (`|.d`) is skipped.
+If grouping terminates an optional chain, a new expression-level optional
+operation starts outside the old continuation:
+
+```js
+// (a?.b)?.c
+['?.',
+    ['?.', a, b, []],
+    c,
+    [],
 ]
 ```
 
-Here `.e` is skipped when the value before `?.d` is nullish.
-
-If grouping terminates that optional chain, the optional operation gets
-`null`; subsequent computation is outside that HCF region. The general
-distinction is:
-
-```js
-['|?.', d,
-    ['|.', e, null],
-] // ?.d.e
-
-['|?.', d, null] // (?.d), optional HCF ends here
-```
+Thus both optional expression operations and optional lambda operations can
+represent optional chaining without lambda-local continuations: expression
+operators define HCF regions, while optional lambdas jump to the end of the
+region that already contains them.
 
 #### Receiver HCF inside lambda chains
 
 Property steps establish receiver state for structural lambda evaluation.
-For a successful full-form optional property with a non-null continuation,
+For a successful full-form optional property with a non-empty continuation,
 that continuation starts with both the property value and its receiver:
 
 ```text
-['?.', object, property, cont]
+['?.', object, property, continuation]
 
 value = object[property]
 this  = object
@@ -161,9 +147,6 @@ The call lambda operators consume propagated receiver state when present:
 |?.()  optional call current value with propagated `this` if present
 ```
 
-Their continuation, when present, receives the call result as the new current
-value after that receiver has been consumed.
-
 By contrast, the non-lambda call operators never consume propagated receiver
 state:
 
@@ -179,9 +162,9 @@ For example:
 
 ```js
 // a?.b?.(...c)
-['?.', a, b,
-    ['|?.()', c, null],
-]
+['?.', a, b, [
+    ['|?.()', c],
+]]
 ```
 
 On the successful branch, `?.` enters its continuation with `value = a.b` and
@@ -191,11 +174,10 @@ A longer chain works the same way:
 
 ```js
 // a?.b.c(...d)
-['?.', a, b,
-    ['|.', c,
-        ['|()', d, null],
-    ],
-]
+['?.', a, b, [
+    ['|.', c],
+    ['|()', d],
+]]
 ```
 
 Evaluation is conceptually:
@@ -245,80 +227,57 @@ receiver of the final property reference. Represent such calls with `this()` /
 
 ```js
 ['this()', input, lambda, args]
-['this?.()', input, lambda, args, cont]
+['this?.()', input, lambda, args, continuation]
 ```
 
 The first operand is the initial input to `lambda`; it is not necessarily the
-receiver of the final call. `lambda` can start with any of the four lambda
-forms, each of which can recursively continue with another lambda:
+receiver of the final call. `lambda` can be any of the four lambda forms:
 
 ```js
-['|.', property, cont]
-['|?.', property, cont]
-['|()', args, cont]
-['|?.()', args, cont]
+['|.', property]
+['|?.', property]
+['|()', args]
+['|?.()', args]
 ```
 
-`this()` / `this?.()` evaluate the whole lambda chain. If that evaluation
-reaches a final property reference, the outer call uses the final receiver
-propagated by the lambda rather than the original `input`.
+`this()` / `this?.()` evaluate the lambda step. When the lambda itself needs a
+longer chain, that chain is represented by the continuation owned by the
+surrounding optional expression rather than by the lambda node.
 
 Examples:
 
 ```js
 // a.b()
-['this()', a, ['|.', b, null], args]
+['this()', a, ['|.', b], args]
 
 // (a?.b)()
-['this()', a, ['|?.', b, null], args]
+['this()', a, ['|?.', b], args]
 
 // a.b?.()
-['this?.()', a, ['|.', b, null], args, null]
+['this?.()', a, ['|.', b], args, []]
 
 // (a?.b)?.()
-['this?.()', a, ['|?.', b, null], args, null]
+['this?.()', a, ['|?.', b], args, []]
 ```
 
-For a longer property chain, the final receiver comes from the continuation:
+For a longer property chain whose final receiver must survive grouping, the
+optional expression continuation carries the intermediate lambda steps before
+the outer `this()` call is formed.
 
 ```js
 // (a?.b.c)(...d)
 ['this()',
     a,
-    ['|?.', b,
-        ['|.', c, null],
-    ],
+    ['|?.', b],
     d,
 ]
 ```
 
-Conceptually:
-
-```text
-input = a
-|?.b   -> value = a.b,   this = a
-|.c    -> value = a.b.c, this = a.b
-this() -> call a.b.c with this = a.b
-```
-
-The root lambda does not have to be a property operation. For example, an
-optional call can own a continuation that eventually produces the property
-reference used by the outer `this()` call:
-
-```js
-// (a?.(...b).c)(...d)
-['this()',
-    a,
-    ['|?.()', b,
-        ['|.', c, null],
-    ],
-    d,
-]
-```
-
-Here `|?.()` evaluates `a?.(...b)`; on its successful branch `|.c` establishes
-the final receiver, and the outer `this()` calls that `.c` value with the
-receiver produced by `|.c`.
+Conceptually, lowering of the grouped callee must preserve the final receiver
+produced by the whole property chain (`a.b` for `.c`) before `this()` performs
+the outer call. The exact RTTI shape for carrying a multi-step grouped lambda
+into `this()` remains part of the implementation task below; lambda-local
+continuations are intentionally not used for it.
 
 By contrast, a call result is an ordinary value. The receiver HCF has already
 been consumed:
@@ -326,13 +285,11 @@ been consumed:
 ```js
 // (a?.c.d.e(...f))(...g)
 ['()',
-    ['?.', a, c,
-        ['|.', d,
-            ['|.', e,
-                ['|()', f, null],
-            ],
-        ],
-    ],
+    ['?.', a, c, [
+        ['|.', d],
+        ['|.', e],
+        ['|()', f],
+    ]],
     g,
 ]
 ```
@@ -344,30 +301,26 @@ The outer call is `()`, not `this()`, because `|()` consumed the receiver of
 
 ```js
 // a?.b?.(...c).d(...f)
-['?.', a, b,
-    ['|?.()', c,
-        ['|.', d,
-            ['|()', f, null],
-        ],
-    ],
-]
+['?.', a, b, [
+    ['|?.()', c],
+    ['|.', d],
+    ['|()', f],
+]]
 ```
 
 On the successful property branch, the first `?.` enters its continuation
 with `value = a.b` and `this = a`. The optional lambda call consumes that
-receiver. It also owns `.d(...f)`, so when `a.b` is nullish, `c`, `.d`, and
-`f` are skipped.
+receiver. If `a.b` is nullish, `|?.()` skips the remaining `.d(...f)` suffix.
 
 Grouping moves the optional call outside the optional-property HCF while still
-preserving the receiver produced by the lambda:
+preserving the receiver produced by the grouped lambda:
 
 ```js
 // (a?.b)?.(...c).d(...f)
-['this?.()', a, ['|?.', b, null], c,
-    ['|.', d,
-        ['|()', f, null],
-    ],
-]
+['this?.()', a, ['|?.', b], c, [
+    ['|.', d],
+    ['|()', f],
+]]
 ```
 
 This structural difference directly represents the parentheses.
@@ -376,15 +329,15 @@ This structural difference directly represents the parentheses.
 
 The ordinary and lambda forms are:
 
-|JS         |exp                           |lambda                         |
-|-----------|------------------------------|-------------------------------|
-|`a.b`      |`['.', a:exp, b:exp]`         |`['\|.', b:exp, cont]`         |
-|`a(...b)`  |`['()', a:exp, b:exp]`        |`['\|()', b:exp, cont]`        |
-|`a?.b`     |`['?.', a:exp, b:exp, cont]`  |`['\|?.', b:exp, cont]`        |
-|`a?.(...b)`|`['?.()', a:exp, b:exp, cont]`|`['\|?.()', b:exp, cont]`      |
+|JS         |exp                           |lambda                   |
+|-----------|------------------------------|-------------------------|
+|`a.b`      |`['.', a:exp, b:exp]`         |`['\|.', b:exp]`         |
+|`a(...b)`  |`['()', a:exp, b:exp]`        |`['\|()', b:exp]`        |
+|`a?.b`     |`['?.', a:exp, b:exp, cont]`  |`['\|?.', b:exp]`        |
+|`a?.(...b)`|`['?.()', a:exp, b:exp, cont]`|`['\|?.()', b:exp]`      |
 
-Here `cont` is `lambda | null`. Unlike the expression forms, **all four lambda
-forms always have a continuation operand**, including `|.` and `|()`.
+Here `cont` is `readonly lambda[]` and belongs only to optional expression
+operators, not to lambda operators.
 
 The `this` call forms bridge an explicit input expression to a lambda:
 
@@ -398,34 +351,34 @@ The `this` call forms bridge an explicit input expression to a lambda:
 - ordinary `Exp` nodes remain context-independent and safely shareable;
 - lambda operators cannot escape as const computations, so their implicit
   input and receiver are structurally unambiguous;
-- a lambda chain is represented by node references, matching the EDAG model;
-- every lambda owns exactly one continuation edge, so optional HCF ownership
-  requires no sibling-order validation rule;
+- lambda nodes stay small: none of the four lambda forms owns a continuation;
+- optional expression operators define HCF regions as flat lambda arrays;
+- optional lambdas short-circuit the remaining suffix of their containing
+  continuation array, so no nested lambda continuation is needed;
 - `this` propagation and consumption are determined by the operator family;
 - non-lambda `()` / `?.()` never receive propagated `this`;
-- `this()` / `this?.()` consume the final receiver produced by their lambda,
-  independent of the lambda's root form or continuation depth;
-- optional-chain boundaries are explicit recursive continuation links;
+- optional-chain boundaries are explicit expression-level continuation arrays;
 - no placeholder binding or identity-aware `it` ownership is needed;
 - no compiler lookahead is needed to decide whether a property node should
   carry `this`.
 
 ### Tasks
 
-- [ ] Replace the previous `it` / `.this` proposal with the recursive lambda
-      type model: `Lambda` and `Cont = Lambda | null`.
+- [ ] Replace the previous `it` / `.this` proposal with the lambda-operation
+      type model: `Lambda` plus expression-level `Continuation = readonly Lambda[]`.
 - [ ] Define exact RTTI shapes for all ten operators and enforce fixed arity.
-      Every lambda form must have its `Cont` operand.
+      Lambda forms must not have continuation operands.
 - [ ] Make `Lambda` a structural type that is not an `Exp` and cannot be
       independently shared/memoized as a computation node.
-- [ ] Define execution semantics for recursive lambda continuation links,
-      including optional HCF ownership and `null` termination.
+- [ ] Define execution semantics for optional lambdas: `|?.` / `|?.()` must
+      short-circuit the remaining suffix of their containing continuation
+      array on a nullish input.
 - [ ] Define execution semantics for receiver propagation into continuations,
       through `|.` / `|?.`, and consumption by `|()` / `|?.()`; ordinary
       `()` / `?.()` must never consume propagated receiver state.
-- [ ] Define `this()` / `this?.()` for all four `Lambda` root forms, using the
-      final receiver produced by the whole lambda chain rather than the
-      initial input.
+- [ ] Define the exact multi-step grouped-lambda representation used by
+      `this()` / `this?.()` so they consume the final receiver produced by the
+      whole grouped lambda chain without adding lambda-local continuations.
 - [ ] Update existing EDAG/compiler/interpreter design documents to the new
       vocabulary after the shapes are settled.
   - [ ] Remove `fjs/edag/todo/operations.md` after the new vocabulary has been

--- a/fjs/edag/todo/optional_chaining.md
+++ b/fjs/edag/todo/optional_chaining.md
@@ -197,7 +197,7 @@ The three call families therefore have distinct receiver behavior:
 ```text
 () / ?.()           never receive propagated `this`
 |() / |?.()         receive propagated `this` when present
-this() / this?.()   use their explicit receiver semantics
+this() / this?.()   call with the final receiver produced by their lambda
 ```
 
 Ordinary explicit property values still do not carry receiver state as
@@ -214,27 +214,31 @@ Thus `?` controls optional HCF only; receiver propagation comes from property
 steps entering structural lambda evaluation, and only lambda calls consume
 that propagated receiver.
 
-#### Calls with an explicit receiver
+#### Calls using the receiver produced by a lambda
 
 Grouping can end a lambda/optional region while JavaScript still preserves the
-receiver of the final property reference. Represent such calls with explicit
-receiver call operators:
+receiver of the final property reference. Represent such calls with `this()` /
+`this?.()`:
 
 ```js
-['this()', receiver, propertyLambda, args]
-['this?.()', receiver, propertyLambda, args, continuation]
+['this()', input, lambda, args]
+['this?.()', input, lambda, args, continuation]
 ```
 
-`propertyLambda` is intentionally restricted to the two property lambda
-forms:
+The first operand is the initial input to `lambda`; it is not necessarily the
+receiver of the final call. `lambda` can be any of the four lambda forms:
 
 ```js
 ['|.', property]
 ['|?.', property, continuation]
+['|()', args]
+['|?.()', args, continuation]
 ```
 
-It is not an arbitrary `LambdaOp`. These operators mean: derive a property
-callee from `receiver`, then call it using the same `receiver` as `this`.
+`this()` / `this?.()` evaluate the whole lambda operation, including any
+nested continuation. If that evaluation reaches a final property reference,
+the outer call uses the final receiver propagated by the lambda rather than
+the original `input`.
 
 Examples:
 
@@ -252,19 +256,46 @@ Examples:
 ['this?.()', a, ['|?.', b, []], args, []]
 ```
 
-For a longer property chain:
+For a longer property chain, the final receiver comes from the continuation:
 
 ```js
-// (a.b.c)(...d)
+// (a?.b.c)(...d)
 ['this()',
-    ['.', a, b],
-    ['|.', c],
+    a,
+    ['|?.', b, [
+        ['|.', c],
+    ]],
     d,
 ]
 ```
 
-The explicit receiver is `a.b`; the lambda property computes `.c`; the call
-uses `a.b` as `this`.
+Conceptually:
+
+```text
+input = a
+|?.b  -> value = a.b,   this = a
+|.c   -> value = a.b.c, this = a.b
+this() -> call a.b.c with this = a.b
+```
+
+The root lambda does not have to be a property operation. For example, an
+optional call can own a continuation that eventually produces the property
+reference used by the outer `this()` call:
+
+```js
+// (a?.(...b).c)(...d)
+['this()',
+    a,
+    ['|?.()', b, [
+        ['|.', c],
+    ]],
+    d,
+]
+```
+
+Here `|?.()` evaluates `a?.(...b)`; on its successful branch `|.c` establishes
+the final receiver, and the outer `this()` calls that `.c` value with the
+receiver produced by `|.c`.
 
 By contrast, a call result is an ordinary value. The receiver HCF has already
 been consumed:
@@ -302,7 +333,7 @@ receiver. It also owns `.d(...f)`, so when `a.b` is nullish, `c`, `.d`, and
 `f` are skipped.
 
 Grouping moves the optional call outside the optional-property HCF while still
-preserving `this = a`:
+preserving the receiver produced by the lambda:
 
 ```js
 // (a?.b)?.(...c).d(...f)
@@ -322,7 +353,7 @@ The vocabulary can be viewed as a sparse tensor of four dimensions:
 input       : explicit | lambda (`|`)
 optional    : normal   | `?`
 operation   : property (`.`) | call (`()`)
-receiver    : normal   | explicit `this` call
+receiver    : normal   | `this` call
 ```
 
 Not every Cartesian-product cell is meaningful. The populated operators are:
@@ -333,8 +364,8 @@ Not every Cartesian-product cell is meaningful. The populated operators are:
 | `?.` | `['?.', object, property, continuation]` | seeds continuation receiver | yes | optional property access |
 | `()` | `['()', callee, args]` | never | no | call |
 | `?.()` | `['?.()', callee, args, continuation]` | never | yes | optional call |
-| `this()` | `['this()', receiver, propertyLambda, args]` | explicit | no | property-derived call with explicit receiver |
-| `this?.()` | `['this?.()', receiver, propertyLambda, args, continuation]` | explicit | yes | optional property-derived call with explicit receiver |
+| `this()` | `['this()', input, lambda, args]` | final lambda receiver | no | call lambda result with its final receiver |
+| `this?.()` | `['this?.()', input, lambda, args, continuation]` | final lambda receiver | yes | optional call of lambda result with its final receiver |
 | `|.` | `['|.', property]` | propagated | no | lambda property access |
 | `|?.` | `['|?.', property, continuation]` | propagated | yes | lambda optional property access |
 | `|()` | `['|()', args]` | consumes propagated receiver if present | no | lambda call |
@@ -363,6 +394,8 @@ do not.
   input and receiver are structurally unambiguous;
 - `this` propagation and consumption are determined by the operator family;
 - non-lambda `()` / `?.()` never receive propagated `this`;
+- `this()` / `this?.()` consume the final receiver produced by their lambda,
+  independent of the lambda's root form or continuation depth;
 - optional-chain boundaries are explicit nested continuation arrays;
 - no placeholder binding or identity-aware `it` ownership is needed;
 - no compiler lookahead is needed to decide whether a property node should
@@ -371,21 +404,22 @@ do not.
 ### Tasks
 
 - [ ] Replace the previous `it` / `.this` proposal with the lambda-operation
-      type model: `LambdaOp`, `Continuation`, and restricted `PropertyLambda`.
+      type model: `LambdaOp` and `Continuation`.
 - [ ] Define exact RTTI shapes for all ten operators and enforce fixed arity.
 - [ ] Make `LambdaOp` a structural type that is not an `Exp` and cannot be
       independently shared/memoized as a computation node.
 - [ ] Define execution semantics for receiver propagation into continuations,
       through `|.` / `|?.`, and consumption by `|()` / `|?.()`; ordinary
       `()` / `?.()` must never consume propagated receiver state.
-- [ ] Define `this()` / `this?.()` with `PropertyLambda` restricted to `|.` /
-      `|?.`.
+- [ ] Define `this()` / `this?.()` for all four `LambdaOp` forms, using the
+      final receiver produced by the whole lambda operation rather than the
+      initial input.
 - [ ] Update existing EDAG/compiler/interpreter design documents to the new
       vocabulary after the shapes are settled.
 - [ ] Cover grouping and HCF boundaries in lowering/execution tests, including
       `a?.b.c`, `a?.b.c?.d.e`, `a?.b.c(d)`, `(a.b.c)(d)`, `(a?.b)(d)`,
-      `a.b?.(d)`, `(a?.b)?.(d)`, `a?.b?.(c).d(f)`,
-      `(a?.b)?.(c).d(f)`, and `(a?.c.d.e(f))(g)`.
+      `(a?.b.c)(d)`, `(a?.(b).c)(d)`, `a.b?.(d)`, `(a?.b)?.(d)`,
+      `a?.b?.(c).d(f)`, `(a?.b)?.(c).d(f)`, and `(a?.c.d.e(f))(g)`.
 
 ### Related
 


### PR DESCRIPTION
## Summary

- replace the merged contextual `it` / `.this` proposal with structural lambda continuation operators
- model the operator vocabulary as a sparse tensor across explicit/lambda input, optionality, property/call, and explicit-`this` call mode
- make `|.` / `|?.` propagate receiver state intrinsically and `|()` / `|?.()` consume it, without lookahead/lookbehind
- add `this()` / `this?.()` for grouped property references whose call happens outside the lambda/optional region
- make every `?` / `|?` operation own a fixed continuation array, with nested arrays representing optional-chain HCF boundaries
- define lambda operators as non-`Exp` structural steps so they cannot be extracted/shared as const computations
- document the final ten-operator table and representative grouping/optional-call examples

This PR updates only the design proposal; implementation remains in the task list.

Changelog: none