### PR TITLE
nanvm/todo: plan the corpus reuse of canonical EDAG operators

### DIFF
--- a/fjs/nanvm/todo/corpus-eliminators.md
+++ b/fjs/nanvm/todo/corpus-eliminators.md
@@ -55,7 +55,10 @@ get one owner each.
 
 ### Related
 
-- `nanvm-lib/todo/operator-test-operation-model.md` — rewrites the corpus
-  model (semantic operations + arity) across the same three files and keeps
-  the `Swapped` disambiguation; if it lands first, `orders`/`isThrows` should
-  be extracted as part of that rewrite rather than separately.
+- [`reuse-edag-operators.md`](./reuse-edag-operators.md) — rewrites the corpus
+  model (canonical EDAG operations, arity from the `op1`/`op2` grouping)
+  across the same three files and keeps the `Swapped` disambiguation; if it
+  lands first, `orders`/`isThrows` should be extracted as part of that rewrite
+  rather than separately — its step 3 single dispatch path subsumes this task.
+- `nanvm-lib/todo/operator-test-operation-model.md` — the earlier corpus
+  rewrite this section previously pointed at; superseded by the above.

--- a/fjs/nanvm/todo/corpus-eliminators.md
+++ b/fjs/nanvm/todo/corpus-eliminators.md
@@ -59,6 +59,6 @@ get one owner each.
   model (canonical EDAG operations, arity from the `op1`/`op2` grouping)
   across the same three files and keeps the `Swapped` disambiguation; if it
   lands first, `orders`/`isThrows` should be extracted as part of that rewrite
-  rather than separately — its step 3 single dispatch path subsumes this task.
+  rather than separately — its step 3 tasks carry this extraction explicitly.
 - `nanvm-lib/todo/operator-test-operation-model.md` — the earlier corpus
   rewrite this section previously pointed at; superseded by the above.

--- a/fjs/nanvm/todo/reuse-edag-operators.md
+++ b/fjs/nanvm/todo/reuse-edag-operators.md
@@ -279,6 +279,10 @@ Step 3 — execution:
       now; the `interpret-edag` interpreter when it lands).
 - [ ] Print the Rust tests from the derived expression rather than from a
       parallel reading of the case.
+- [ ] Extract the corpus-format rules both consumers re-implement — the
+      commutative `orders` expansion with its `Swapped` naming, and the
+      `throws`-marker probe — into the shared data module, imported by the
+      proof and the printer ([corpus-eliminators](./corpus-eliminators.md)).
 - [ ] When the `nanvm-lib` interpreter lands, extend the printer to construct
       the same expressions as `Any` values and hand them to it (serialized
       `Any` once the roadmap's post-MVP serialization exists), and register
@@ -314,4 +318,4 @@ Throughout:
   [#1489 r3770797058](https://github.com/functionalscript/functionalscript/pull/1489#discussion_r3770797058).
 - [`./corpus-eliminators.md`](./corpus-eliminators.md) — deduplicates the
   corpus rules (`Swapped` expansion, the `throws` probe) the consumers
-  currently re-implement; step 3's single dispatch path subsumes it.
+  currently re-implement; step 3 carries that extraction as an explicit task.

--- a/fjs/nanvm/todo/reuse-edag-operators.md
+++ b/fjs/nanvm/todo/reuse-edag-operators.md
@@ -3,168 +3,286 @@
 **Priority:** P3
 **Status:** open
 
-**Blocked by:** [`../../djs/todo/compile-modules-to-edag.md`](../../djs/todo/compile-modules-to-edag.md)
-
 ### Problem
 
-`fjs/nanvm/` has a shared operator corpus that is consumed by both the
-JavaScript proof and the Rust test generator. Today it identifies operations with a
-NaNVM-specific vocabulary:
+`fjs/nanvm/` has a shared operator corpus consumed by both the JavaScript proof
+([`proof.f.mjs`](../proof.f.mjs)) and the Rust test generator
+([`rust/module.f.mjs`](../rust/module.f.mjs)). Today it identifies operations
+with a NaNVM-specific vocabulary:
 
 ```ts
 export type Op = 'unaryPlus' | 'unaryMinus' | 'mul' | 'stringCoercion'
 ```
 
-A related TODO, [`operator-test-operation-model.md`](../../../nanvm-lib/todo/operator-test-operation-model.md),
-proposes improving this by introducing another semantic operation descriptor such as:
+and types `Case.args` as `readonly Value[]`, so nothing connects an operation to
+its operand count — a unary operation given two arguments is not a type error.
 
-```ts
-readonly ['+', 1]
-readonly ['-', 1]
-readonly ['*', 2]
-```
+The canonical vocabulary this should reuse now exists. [`fjs/edag/`](../../edag/README.md)
+is the EDAG data model of record: the RTTI schema in
+[`module.f.mjs`](../../edag/module.f.mjs) exports the operation-id vocabularies
+`op1Id` (`String` `Number` `neg` `!` `~`) and
+`op2Id` (`=>` `own` `===` `!==` `>` `>=` `<` `<=` `+` `-` `*` `/` `%` `**`
+`&` `|` `^` `<<` `>>` `>>>` `&&` `||` `??`), and
+[`types.ts`](../../edag/types.ts) carries the same ids at the type level
+(`Op1Id`, `Op2Id`) with the node shapes `Op1 = readonly[Op1Id, Exp]` and
+`Op2 = readonly[Op2Id, Exp, Exp]`, pinned against the schema with
+`Assert<Check<...>>` so the two cannot drift. Operations are grouped by
+`exp`-operand count — `op0`/`op1`/`op2` — so an operation's arity is not an
+annotation: it is which group its tag belongs to. Every tag is unique across
+the groups (negation is the word tag `neg`, never an arity-overloaded `-` —
+see the "Operators" section of
+[`edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)), so
+deriving operand shape from a tag lookup is unambiguous.
 
-That fixes the current implementation-style names and exposes arity, but EDAG is now
-becoming the canonical FunctionalScript computation representation and already needs to
-own exactly this information: the operator spelling and the shape/arity of its operands.
-NaNVM should not define a second semantic operator format that can drift from EDAG.
+An earlier revision of this todo was blocked on that vocabulary existing.
+It does now, and nothing below needs the DJS compiler
+([compile-modules-to-edag](../../djs/todo/compile-modules-to-edag.md)): the
+corpus imports the schema and the types directly, along the same one-way
+dependency every EDAG consumer uses.
 
-For example, EDAG operations have the canonical tagged-array shape itself:
+Every operation the corpus tests today maps onto that vocabulary:
 
-```js
-['neg', a]
-['-', a, b]
-['*', a, b]
-['===', a, b]
-```
+| corpus `Op` today | canonical EDAG operation | group |
+|---|---|---|
+| `unaryMinus` | `['neg', exp]` | `op1` |
+| `mul` | `['*', exp, exp]` | `op2` |
+| `stringCoercion` | `['String', exp]` | `op1` — a canonical id now, no longer a NaNVM-only name |
+| `unaryPlus` | none | the EDAG has no unary `+`; the group becomes `['Number', exp]` via [replace-unary-plus-with-number](../../../nanvm-lib/todo/replace-unary-plus-with-number.md) — a semantic change (`Number(0n)` does not throw where `+0n` does), tracked there, not a rename here |
+| the `eq` section | `['===', exp, exp]` | `op2` — see [`eq` and node sharing](#eq-and-node-sharing) |
 
-If EDAG later changes an operator spelling, operand shape, or validation rule, the
-NaNVM corpus should consume that change through the shared EDAG definition rather than
-requiring a parallel edit to a local `Op`/`Operation` model.
+NaNVM must not keep a second semantic operator format that can drift from this.
+If EDAG changes an operator spelling, operand shape, or validation rule, the
+corpus consumes the change through the shared definition — through a failing
+`npx tsc` or a failing proof, never through a parallel edit staying in sync by
+discipline.
 
 ### Proposal
 
-Make the canonical EDAG operation definitions in `fjs/edag/` the single source of truth
-for operator identity and operand shape, and make `fjs/nanvm/` reuse them.
+Make `fjs/edag/` the single source of truth for operator identity and operand
+contract in the corpus, in three steps: the corpus **types** reuse the EDAG id
+vocabularies; each **case** derives a real EDAG expression, validated against
+the schema; the **consumers** converge on evaluating that expression, until the
+corpus doubles as the shared EDAG conformance vectors.
 
-The exact exported EDAG API should be chosen by the EDAG implementation; this TODO does
-not introduce a second wrapper merely to prescribe names. Conceptually, NaNVM should be
-able to express a group as "cases for this canonical EDAG operation" and derive the
-required argument tuple from that operation's EDAG schema.
-
-For example, instead of locally declaring that multiplication is `['*', 2]`, the corpus
-should refer to the EDAG definition for:
-
-```js
-['*', left, right]
-```
-
-and derive that its case arguments are a two-element tuple. Negation and binary `-`
-(subtraction) don't share a tag — negation is `"neg"`, not an arity-overloaded `"-"` (an
-earlier draft spelled it `['-', a]`, matching JS's own overloading of unary and binary
-`-`, but the design settled on a distinct word tag instead specifically so no `or`
-alternative's position is order-sensitive relative to another; see
-`edag-stage1-discussion.md`'s "Operators" section). NaNVM therefore does not need an
-arity-disambiguation scheme at all: every EDAG tag is unique, so deriving operand shape
-from a tag lookup is unambiguous. (The EDAG also has no unary `+` — same section — so
-NaNVM's own `unaryPlus` op, if kept, has no EDAG operation to derive its shape from.)
-
-This does **not** mean the NaNVM corpus becomes an EDAG program or that all test values
-must be encoded as EDAG nodes. The corpus still owns test-only data such as:
+This does **not** turn the corpus into an EDAG program. The corpus still owns
+everything test-only:
 
 - case names used as stable proof/test diagnostics;
-- concrete input values and expected values;
-- `throws`, `ref`, and other test-only markers;
+- concrete input values and expected values (`expected` describes the test's
+  outcome, not the program under test — it stays a `Value` compared with
+  `Object.is`);
+- `throws`, `ref`, `functionValue`, and other test-only markers;
 - `rust` gap/reason metadata;
-- commutative-case expansion.
+- commutative-case expansion and the `Swapped` name convention.
 
-Only the **semantic operation identity and operand contract** come from EDAG.
+Only the semantic operation identity and operand contract come from EDAG.
 
-The JavaScript proof and Rust generator remain consumers. They map a canonical EDAG
-operation to the corresponding host implementation:
+#### Step 1 — the types reuse the EDAG vocabulary
 
-```text
-EDAG operation
-  -> JavaScript operator/expression used by proof.f.mjs
-  -> Rust operation/function used by rust/module.f.mjs
+Replace the local `Op` union with the imported ids, and split `Group` by the
+same operand-count rule the schema itself uses:
+
+```ts
+import type { Op1Id, Op2Id } from '../edag/types.ts'
+import type { Tuple } from '../types/array/types.ts'
+
+export type Case<N extends number> = {
+    readonly name: string
+    readonly args: Tuple<N, Value>
+    readonly expected: Value
+    readonly rust?: string
+}
+
+export type Group1 = {
+    readonly op: Op1Id
+    readonly cases: readonly Case<1>[]
+}
+
+export type Group2 = {
+    readonly op: Op2Id
+    readonly commutative?: boolean
+    readonly cases: readonly Case<2>[]
+}
+
+export type Group = Group1 | Group2
 ```
 
-Backend names are not EDAG names. In particular, Rust identifiers such as a helper
-function name remain local to the Rust generator rather than leaking back into the
-shared corpus.
+- The arity is derived from which vocabulary the group's `op` belongs to —
+  `Op1Id` groups carry `Case<1>`, `Op2Id` groups `Case<2>` — mirroring
+  `op1`/`op2` instead of annotating an `argsN` next to the tag. Wrong operand
+  counts are rejected statically; add type-level proofs of that.
+- `commutative` exists only on `Group2`, so it is binary-only by construction.
+- The coupling proof comes free: the corpus data spells ids as literals
+  (`op: '*'`), so removing or respelling an id in `fjs/edag/types.ts` fails
+  `npx tsc` in the corpus instead of silently leaving it stale.
+- The group order in `data.groups` and the generated Rust function names are
+  consumer concerns and stay stable: the Rust printer owns an explicit
+  `Op1Id | Op2Id -> Rust identifier` map (`'*'` → `mul`, `'neg'` → `neg`,
+  `'String'` → `string_coercion`, …). It must never derive an identifier by
+  `snakeCase` over a punctuation tag, and Rust names never leak back into the
+  shared data.
 
-### Operations not yet present in EDAG
+#### Step 2 — a case is an EDAG expression
 
-Some current NaNVM corpus operations may not yet have a canonical EDAG operation. For
-example, the current `stringCoercion` group should not cause `fjs/nanvm/` to invent a
-permanent EDAG spelling independently.
+Each case, joined with its group's id, denotes a program: apply the operation
+to constant operands. Say so literally — derive an EDAG `Exp` per case:
 
-When this happens, either:
+```js
+/** @type {(v: Value) => Exp} */
+const constExp = v => {
+    if (v === undefined) { return ['undefined'] }
+    if (Array.isArray(v)) { return ['[]', v.map(constExp)] }
+    if (typeof v === 'object' && v !== null) {
+        return ['{}', entries(v).map(([k, p]) => [':', k, constExp(p)])]
+    }
+    return v // null, boolean, number, string, bigint: a primitive is itself
+}
 
-1. define the operation in the canonical EDAG vocabulary first, if it belongs there; or
-2. keep the NaNVM case explicitly outside the EDAG-backed groups until the EDAG design
-   reaches it.
+// a Group1 case:      [id, constExp(a)]
+// a Group2 case:      [id, constExp(a), constExp(b)]
+// e.g. mulCases[0]:   ['*', null, null]
+```
 
-The temporary exception must be visible in the type/data model. Do not silently mix
-EDAG-backed operations and NaNVM-only semantic names into one supposedly canonical
-operation type.
+- `ref(name)` lowers to the **same node object** for every reference. EDAG
+  sharing is identity — one node referenced from several places, observable
+  (`{} === {}` is `false`) — which is exactly what the corpus `shared`/`ref`
+  machinery exists to express. `a: ref('emptyArray'), b: ref('emptyArray')`
+  is `['===', n, n]` with one shared `n`.
+- `throws` never appears in the derived expression: it describes the case's
+  outcome and stays on the `expected` side. (Once `['throw', exp]` from the
+  stage-1 discussion lands in the schema, it becomes useful the other way
+  around — as an operand proving a lazy operator did not establish it; see
+  step 3.)
+- `functionValue` is the one escape. A constant function is spellable as
+  `['=>', ['[]', []], body]`, but establishing `=>` drags closure construction
+  into both consumers for cases that never inspect the function. Keep such
+  cases visibly outside the EDAG-derived path (an explicit marker in the
+  lowering, not a silent fallthrough) until an executor establishes `=>`
+  anyway.
 
-### Relationship to `operator-test-operation-model.md`
+The proof then validates every derived expression with the schema —
+`validate(exp)` from `fjs/types/rtti/validate` over `exp` from
+`fjs/edag/module.f.mjs` — before running it. That is the runtime half of the
+coupling: a change to an operand shape or validation rule in the schema fails
+the corpus proof. (`validate` is shape-only and not identity-aware — it
+re-walks shared subgraphs — which is fine here: case trees are small, acyclic
+by construction, and identity-dependent canonicality is out of scope for a
+test corpus.)
 
-[`nanvm-lib/todo/operator-test-operation-model.md`](../../../nanvm-lib/todo/operator-test-operation-model.md)
-contains useful requirements that still apply:
+#### Step 3 — one execution path
 
-- semantic operator spellings instead of implementation names;
-- arity-aware case types;
-- wrong argument counts rejected statically;
-- consumer-owned mapping to JavaScript/Rust implementations;
-- stable case names and explicit `Swapped` diagnostics.
+The consumers stop switching on a local op name and dispatch on the derived
+EDAG node:
 
-However, its proposed local `readonly [name, argsN]` operation model should be replaced
-by reuse of the EDAG operation definition once `fjs/edag/` exposes it. There should be
-one semantic operation vocabulary, not an EDAG vocabulary plus a nearly identical
-NaNVM vocabulary.
+- **JavaScript proof** — an inline evaluator for the constant subset the
+  corpus uses (primitives, `['undefined']`, `['[]', …]`, `['{}', …]`, `op1`,
+  `op2`), each id mapped to the JS operator/expression it names. When the
+  EDAG interpreter ([interpret-edag](../../djs/todo/interpret-edag.md)) lands,
+  the inline evaluator is replaced by it and the corpus becomes part of its
+  test suite for free.
+- **Rust generator** — `valueExpr`/`call` walk the same node and print the
+  `nanvm-lib` expression for each id, via the explicit map from step 1.
+- **`nanvm-lib` interpreter** — the roadmap's interpreter executes "the `Any`
+  described by the EDAG spec"
+  ([mvp-roadmap](../../../nanvm-lib/todo/mvp-roadmap.md)); the derived case
+  expressions are exactly such values, so the same corpus feeds it as data
+  with no generation step. That makes the corpus the "conformance examples
+  (test vectors) shared by the FJS and Rust implementations" that
+  [edag-spec](../../../todo/edag-spec.md) asks for, and it is what keeps the
+  interpreter and the generated code in agreement — the point the roadmap's
+  test-generation item makes.
+
+The next operators the roadmap needs — `&&` `||` `??` — are already in
+`op2Id`, with laziness that is positional, not nodal. With constant operands a
+corpus case cannot observe non-establishment; pin their value results now, and
+add non-establishment cases (a `['throw', …]` operand in the lazy position)
+once that node joins the schema.
+
+#### `eq` and node sharing
+
+The `eq` section is `['===', a, b]` with test-only structure on top: `shared`
+plus `ref` is node sharing spelled by name, and `eq: boolean` is `expected`.
+Unifying it into an ordinary `'==='` `Group2` is deliberately **not** part of
+this task — its dual-name cases (`name2`) and symmetric `b === a` check don't
+fit `Case<2>` yet — but the lowering above must treat `ref` as sharing from
+the start, so the later unification is a data move, not a redesign.
+
+### Operations without a canonical EDAG operation
+
+An operation the corpus needs before the EDAG design reaches it must not cause
+`fjs/nanvm/` to invent a permanent EDAG spelling. Either define it in the
+canonical vocabulary first, if it belongs there, or keep the group explicitly
+outside the EDAG-backed types until then — the exception visible in the type
+model, never a NaNVM-only name mixed into a supposedly canonical id union.
+Today the only such case is `unaryPlus`, already scheduled to become `Number`
+by [replace-unary-plus-with-number](../../../nanvm-lib/todo/replace-unary-plus-with-number.md).
 
 ### Tasks
 
-- [ ] Once `fjs/edag/` exposes canonical operation definitions, import/reuse those
-      definitions from `fjs/nanvm/`; do not duplicate EDAG operator spellings or arities.
-- [ ] Remove the local semantic `Op` union from `fjs/nanvm/types.ts` for EDAG-backed
-      operations.
-- [ ] Make NaNVM operator groups reference the canonical EDAG operation definition and
-      derive their case argument tuple/arity from its operand schema.
-- [ ] Preserve NaNVM-only test metadata (`name`, `expected`, `rust`, `commutative`, and
-      special test markers) outside the EDAG model.
-- [ ] Update `fjs/nanvm/module.f.mjs` to use EDAG operator spellings/shapes rather than
-      implementation-style names such as `unaryPlus`, `unaryMinus`, and `mul`.
-- [ ] Update `fjs/nanvm/proof.f.mjs` to dispatch from canonical EDAG operations to the
-      corresponding JavaScript expressions.
-- [ ] Update `fjs/nanvm/rust/module.f.mjs` to map canonical EDAG operations to Rust
-      expressions/function names without putting Rust naming into EDAG or the corpus.
-- [ ] Keep operations that have no canonical EDAG representation explicitly separate;
-      either add them to EDAG first or defer their migration.
-- [ ] Fold the applicable requirements from
-      `nanvm-lib/todo/operator-test-operation-model.md` into this shared-EDAG model rather
-      than implementing its independent `[name, argsN]` format.
-- [ ] Add type-level proofs that invalid operand counts are rejected through the EDAG
-      operation schema.
-- [ ] Add a coupling proof/test so an incompatible change to an EDAG operator shape
-      fails NaNVM type-checking instead of silently leaving the corpus stale.
-- [ ] Regenerate `nanvm-lib/tests/test/generated.rs` and preserve existing test
-      semantics/coverage.
+Step 1 — vocabulary:
+
+- [ ] Replace the local `Op` union in [`types.ts`](../types.ts) with `Op1Id`/
+      `Op2Id` imported from `fjs/edag/types.ts`: `Group1`/`Group2` as above,
+      `Case<N>` with `Tuple<N, Value>` args, `commutative` on `Group2` only.
+- [ ] Add type-level proofs that wrong operand counts are rejected.
+- [ ] Migrate the data in [`module.f.mjs`](../module.f.mjs): `unaryMinus` →
+      `neg`, `mul` → `*`, `stringCoercion` → `String`. Keep `unaryPlus`
+      explicitly outside the EDAG-backed groups until
+      `replace-unary-plus-with-number.md` turns it into `Number`.
+- [ ] Update [`proof.f.mjs`](../proof.f.mjs) to dispatch on the canonical ids,
+      preserving case proof keys and the `Swapped` convention.
+- [ ] Update [`rust/module.f.mjs`](../rust/module.f.mjs): an explicit id →
+      Rust expression/function-name map; no `snakeCase` over punctuation tags;
+      Rust identifiers stay local to the printer.
+- [ ] Regenerate `nanvm-lib/tests/test/generated.rs`, preserving existing test
+      names, semantics, and coverage.
+
+Step 2 — cases as EDAG values:
+
+- [ ] Implement the `Value` → constant-`Exp` lowering (`undefined`, arrays,
+      objects, primitives; `ref` as literal node sharing; `functionValue` as
+      the explicit non-EDAG escape).
+- [ ] Derive an `Exp` per case and `validate` it against the `exp` schema in
+      the proof, so every corpus case is a well-formed EDAG and a schema
+      change fails the proof instead of silently going unnoticed.
+
+Step 3 — execution:
+
+- [ ] Evaluate the derived expression in the proof (constant-subset evaluator
+      now; the `interpret-edag` interpreter when it lands).
+- [ ] Print the Rust tests from the derived expression rather than from a
+      parallel reading of the case.
+- [ ] When the `nanvm-lib` interpreter lands, feed it the same expressions as
+      data and register the corpus as the shared conformance vectors of
+      [edag-spec](../../../todo/edag-spec.md).
+- [ ] Extend the corpus to `&&` `||` `??`; add non-establishment cases once
+      `['throw', exp]` is in the schema.
+
+Throughout:
+
 - [ ] `npx tsc`, `fjs test`, `npm run ci-update`, `cargo test`,
       `cargo clippy -- -D warnings`, and `cargo fmt -- --check`.
 
 ### Related
 
-- [`../../djs/todo/compile-modules-to-edag.md`](../../djs/todo/compile-modules-to-edag.md)
-  — introduces the canonical EDAG model consumed by DJS and this task.
+- [`fjs/edag/`](../../edag/README.md) — the canonical schema and types this
+  reuses: `op1Id`/`op2Id` in `module.f.mjs`, `Op1Id`/`Op2Id` in `types.ts`.
 - [`../../../todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)
-  — canonical EDAG operation vocabulary and semantics.
-- [`../../../todo/edag-spec.md`](../../../todo/edag-spec.md) — eventual distilled EDAG
-  specification.
+  — the operator vocabulary's design of record: word-tag `neg`, no unary `+`,
+  positional laziness, the future `throw`/`?:`.
+- [`../../../todo/edag-spec.md`](../../../todo/edag-spec.md) — the module
+  boundary, the Rust-from-RTTI generation plan, and the shared conformance
+  test vectors the corpus becomes.
+- [`../../../nanvm-lib/todo/mvp-roadmap.md`](../../../nanvm-lib/todo/mvp-roadmap.md)
+  — the interpreter and remaining-operators items this feeds.
+- [`../../../nanvm-lib/todo/replace-unary-plus-with-number.md`](../../../nanvm-lib/todo/replace-unary-plus-with-number.md)
+  — retires `unaryPlus` in favor of the canonical `Number`.
 - [`../../../nanvm-lib/todo/operator-test-operation-model.md`](../../../nanvm-lib/todo/operator-test-operation-model.md)
-  — existing NaNVM operator-corpus redesign whose local operation descriptor should be
-  replaced by EDAG reuse.
-- [`./corpus-eliminators.md`](./corpus-eliminators.md) — deduplicates test-corpus
-  eliminator rules used by the same JavaScript and Rust consumers.
+  — the superseded local `[name, argsN]` model; its still-applicable
+  requirements (stable names and `Swapped`, faithful literals in diagnostics,
+  static arity rejection, consumer-owned mappings) are folded in above.
+  Original reviews: [#1489 r3770780551](https://github.com/functionalscript/functionalscript/pull/1489#discussion_r3770780551),
+  [#1489 r3770797058](https://github.com/functionalscript/functionalscript/pull/1489#discussion_r3770797058).
+- [`./corpus-eliminators.md`](./corpus-eliminators.md) — deduplicates the
+  corpus rules (`Swapped` expansion, the `throws` probe) the consumers
+  currently re-implement; step 3's single dispatch path subsumes it.

--- a/fjs/nanvm/todo/reuse-edag-operators.md
+++ b/fjs/nanvm/todo/reuse-edag-operators.md
@@ -104,7 +104,20 @@ export type Group2 = {
     readonly cases: readonly Case<2>[]
 }
 
-export type Group = Group1 | Group2
+/**
+ * The visible exception: an operation with no canonical EDAG id yet. The
+ * field is deliberately not `op`, so a NaNVM-only name can never mix into
+ * the canonical id unions. Today its one inhabitant is `unaryPlus`; the
+ * type is deleted when
+ * [replace-unary-plus-with-number](../../nanvm-lib/todo/replace-unary-plus-with-number.md)
+ * moves that group to `Number`.
+ */
+export type NonEdagGroup = {
+    readonly nanvmOp: 'unaryPlus'
+    readonly cases: readonly Case<1>[]
+}
+
+export type Group = Group1 | Group2 | NonEdagGroup
 ```
 
 - The arity is derived from which vocabulary the group's `op` belongs to —
@@ -222,11 +235,11 @@ the start, so the later unification is a data move, not a redesign.
 
 An operation the corpus needs before the EDAG design reaches it must not cause
 `fjs/nanvm/` to invent a permanent EDAG spelling. Either define it in the
-canonical vocabulary first, if it belongs there, or keep the group explicitly
-outside the EDAG-backed types until then — the exception visible in the type
-model, never a NaNVM-only name mixed into a supposedly canonical id union.
-Today the only such case is `unaryPlus`, already scheduled to become `Number`
-by [replace-unary-plus-with-number](../../../nanvm-lib/todo/replace-unary-plus-with-number.md).
+canonical vocabulary first, if it belongs there, or keep the group as a
+`NonEdagGroup` (step 1) until then — the exception visible in the type model,
+never a NaNVM-only name mixed into a supposedly canonical id union. Today the
+only such case is `unaryPlus`, already scheduled to become `Number` by
+[replace-unary-plus-with-number](../../../nanvm-lib/todo/replace-unary-plus-with-number.md).
 
 ### Tasks
 
@@ -237,9 +250,10 @@ Step 1 — vocabulary:
       `Case<N>` with `Tuple<N, Value>` args, `commutative` on `Group2` only.
 - [ ] Add type-level proofs that wrong operand counts are rejected.
 - [ ] Migrate the data in [`module.f.mjs`](../module.f.mjs): `unaryMinus` →
-      `neg`, `mul` → `*`, `stringCoercion` → `String`. Keep `unaryPlus`
-      explicitly outside the EDAG-backed groups until
-      `replace-unary-plus-with-number.md` turns it into `Number`.
+      `neg`, `mul` → `*`, `stringCoercion` → `String`. Keep `unaryPlus` as
+      the one `NonEdagGroup` — same cases, same generated output — until
+      `replace-unary-plus-with-number.md` turns it into `Number` and deletes
+      that type.
 - [ ] Update [`proof.f.mjs`](../proof.f.mjs) to dispatch on the canonical ids,
       preserving case proof keys and the `Swapped` convention.
 - [ ] Update [`rust/module.f.mjs`](../rust/module.f.mjs): an explicit id →

--- a/fjs/nanvm/todo/reuse-edag-operators.md
+++ b/fjs/nanvm/todo/reuse-edag-operators.md
@@ -155,10 +155,15 @@ const constExp = v => {
   step 3.)
 - `functionValue` is the one escape. A constant function is spellable as
   `['=>', ['[]', []], body]`, but establishing `=>` drags closure construction
-  into both consumers for cases that never inspect the function. Keep such
-  cases visibly outside the EDAG-derived path (an explicit marker in the
-  lowering, not a silent fallthrough) until an executor establishes `=>`
-  anyway.
+  into both consumers for cases that never inspect the function. So the
+  derivation is per **case**, not per group: a case whose operands all lower
+  derives an `Exp`; a case with a `functionValue` operand stays on the
+  direct-value path, with an explicit marker in the lowering rather than a
+  silent fallthrough — the consumers dispatch on the group's canonical id
+  either way. This is not hypothetical: `numberCoercionCases` contains a
+  `functionValue` case and feeds the EDAG-backed `neg` group, so an
+  EDAG-backed group must be able to carry escaped cases until an executor
+  establishes `=>` anyway.
 
 The proof then validates every derived expression with the schema —
 `validate(exp)` from `fjs/types/rtti/validate` over `exp` from
@@ -185,12 +190,18 @@ EDAG node:
 - **`nanvm-lib` interpreter** — the roadmap's interpreter executes "the `Any`
   described by the EDAG spec"
   ([mvp-roadmap](../../../nanvm-lib/todo/mvp-roadmap.md)); the derived case
-  expressions are exactly such values, so the same corpus feeds it as data
-  with no generation step. That makes the corpus the "conformance examples
-  (test vectors) shared by the FJS and Rust implementations" that
-  [edag-spec](../../../todo/edag-spec.md) asks for, and it is what keeps the
-  interpreter and the generated code in agreement — the point the roadmap's
-  test-generation item makes.
+  expressions are exactly such values. They still need a transport into
+  Rust: the roadmap defers generic `Any` serialization to post-MVP, and the
+  repository's cross-language bridge is generated Rust — so the printer
+  grows a second output that *constructs* each derivable case's expression
+  as an `Any` and hands it to the interpreter, next to the direct-operator
+  tests it prints today. Authoring stays single-source; only the transport
+  is generated. Once the deferred `Any`/CBOR serialization lands, the same
+  expressions can ship as serialized data instead. Either way the corpus is
+  the "conformance examples (test vectors) shared by the FJS and Rust
+  implementations" that [edag-spec](../../../todo/edag-spec.md) asks for,
+  and it is what keeps the interpreter and the generated code in agreement —
+  the point the roadmap's test-generation item makes.
 
 The next operators the roadmap needs — `&&` `||` `??` — are already in
 `op2Id`, with laziness that is positional, not nodal. With constant operands a
@@ -242,9 +253,11 @@ Step 2 — cases as EDAG values:
 - [ ] Implement the `Value` → constant-`Exp` lowering (`undefined`, arrays,
       objects, primitives; `ref` as literal node sharing; `functionValue` as
       the explicit non-EDAG escape).
-- [ ] Derive an `Exp` per case and `validate` it against the `exp` schema in
-      the proof, so every corpus case is a well-formed EDAG and a schema
-      change fails the proof instead of silently going unnoticed.
+- [ ] Derive an `Exp` for every case whose operands lower, and `validate` it
+      against the `exp` schema in the proof, so each derived case is a
+      well-formed EDAG and a schema change fails the proof instead of
+      silently going unnoticed. Cases with a `functionValue` operand keep
+      the direct-value path, visibly marked.
 
 Step 3 — execution:
 
@@ -252,8 +265,10 @@ Step 3 — execution:
       now; the `interpret-edag` interpreter when it lands).
 - [ ] Print the Rust tests from the derived expression rather than from a
       parallel reading of the case.
-- [ ] When the `nanvm-lib` interpreter lands, feed it the same expressions as
-      data and register the corpus as the shared conformance vectors of
+- [ ] When the `nanvm-lib` interpreter lands, extend the printer to construct
+      the same expressions as `Any` values and hand them to it (serialized
+      `Any` once the roadmap's post-MVP serialization exists), and register
+      the corpus as the shared conformance vectors of
       [edag-spec](../../../todo/edag-spec.md).
 - [ ] Extend the corpus to `&&` `||` `??`; add non-establishment cases once
       `['throw', exp]` is in the schema.

--- a/fjs/nanvm/todo/reuse-edag-operators.md
+++ b/fjs/nanvm/todo/reuse-edag-operators.md
@@ -194,12 +194,20 @@ EDAG node:
 
 - **JavaScript proof** — an inline evaluator for the constant subset the
   corpus uses (primitives, `['undefined']`, `['[]', …]`, `['{}', …]`, `op1`,
-  `op2`), each id mapped to the JS operator/expression it names. When the
-  EDAG interpreter ([interpret-edag](../../djs/todo/interpret-edag.md)) lands,
-  the inline evaluator is replaced by it and the corpus becomes part of its
-  test suite for free.
+  `op2`), each id mapped to the JS operator/expression it names. It must
+  memoize nodes by identity within one case, as real EDAG evaluation does
+  ("shared nodes evaluate once" — [`fjs/edag/`](../../edag/README.md)): a
+  naive recursive walk would construct a shared `n` twice and turn
+  `['===', n, n]` into `false`. When the EDAG interpreter
+  ([interpret-edag](../../djs/todo/interpret-edag.md)) lands, the inline
+  evaluator is replaced by it and the corpus becomes part of its test suite
+  for free — the memoization contract is the same one that interpreter
+  already owes.
 - **Rust generator** — `valueExpr`/`call` walk the same node and print the
-  `nanvm-lib` expression for each id, via the explicit map from step 1.
+  `nanvm-lib` expression for each id, via the explicit map from step 1. It
+  needs the identity awareness in printed form: a multiply-referenced node
+  becomes one shared `let` binding reused at every reference — exactly what
+  the current `eqFn` does for `shared` values — never two constructions.
 - **`nanvm-lib` interpreter** — the roadmap's interpreter executes "the `Any`
   described by the EDAG spec"
   ([mvp-roadmap](../../../nanvm-lib/todo/mvp-roadmap.md)); the derived case
@@ -229,7 +237,10 @@ plus `ref` is node sharing spelled by name, and `eq: boolean` is `expected`.
 Unifying it into an ordinary `'==='` `Group2` is deliberately **not** part of
 this task — its dual-name cases (`name2`) and symmetric `b === a` check don't
 fit `Case<2>` yet — but the lowering above must treat `ref` as sharing from
-the start, so the later unification is a data move, not a redesign.
+the start, and step 3's consumers must be identity-aware (the evaluator's
+per-case memo, the printer's shared bindings), so that `arrayByItself` and
+`objectByItself` keep meaning "the same object" and the later unification is
+a data move, not a redesign.
 
 ### Operations without a canonical EDAG operation
 
@@ -276,9 +287,12 @@ Step 2 — cases as EDAG values:
 Step 3 — execution:
 
 - [ ] Evaluate the derived expression in the proof (constant-subset evaluator
-      now; the `interpret-edag` interpreter when it lands).
+      now; the `interpret-edag` interpreter when it lands), memoizing nodes
+      by identity within a case so shared nodes evaluate once and identity
+      cases stay true.
 - [ ] Print the Rust tests from the derived expression rather than from a
-      parallel reading of the case.
+      parallel reading of the case, emitting a shared `let` binding for any
+      multiply-referenced node.
 - [ ] Extract the corpus-format rules both consumers re-implement — the
       commutative `orders` expansion with its `Swapped` naming, and the
       `throws`-marker probe — into the shared data module, imported by the

--- a/nanvm-lib/todo/operator-test-operation-model.md
+++ b/nanvm-lib/todo/operator-test-operation-model.md
@@ -1,129 +1,57 @@
 ## operator-test-operation-model. Describe operations by syntax and arity
 
 **Priority:** P3
-**Status:** open
+**Status:** irrelevant — superseded by
+[reuse-edag-operators](../../fjs/nanvm/todo/reuse-edag-operators.md)
 
 ### Problem
 
-The shared operator corpus in `fjs/nanvm/` currently uses implementation-style
-names such as `unaryPlus`, `unaryMinus`, and `mul`:
-
-```ts
-export type Op = 'unaryPlus' | 'unaryMinus' | 'mul' | 'stringCoercion'
-```
-
-`Case.args` is also just `readonly Value[]`, so the type system does not connect
-an operation with its number of arguments. A unary operation can therefore be
-given two arguments, or a binary operation one argument, without a type error.
-
-The shared corpus should describe the JavaScript operation itself rather than
-the identifier chosen by a particular proof or code generator. Consumer-specific
-names such as Rust function names belong in the consumer.
-
-This follows the post-merge review discussion on #1489:
-
-- use operation spellings such as `+`, `-`, and `*` instead of `unaryPlus`,
-  `unaryMinus`, and `mul`;
-- associate every operation with its arity and use that arity to type its cases.
-
-### Proposal
-
-Represent an operation as a small immutable tuple containing its semantic name
-and argument count:
+The shared operator corpus in `fjs/nanvm/` uses implementation-style names
+(`'unaryPlus' | 'unaryMinus' | 'mul' | 'stringCoercion'`) and types `Case.args`
+as `readonly Value[]`, so an operation is not connected to its operand count.
+This todo, following the post-merge review of #1489, proposed fixing both with
+a local semantic descriptor carrying a name and an arity:
 
 ```ts
 export type Operation<N extends number = number> =
-    readonly [name: string, argsN: N]
+    readonly [name: string, argsN: N]   // ['+', 1], ['*', 2], ['String', 1]
 ```
 
-The corpus can then describe operations along these lines:
+### Why superseded
 
-```ts
-['+', 1]
-['-', 1]
-['*', 2]
-['String', 1]
-```
+[`fjs/edag/`](../../fjs/edag/README.md) now ships the canonical operation
+vocabulary this descriptor would have duplicated: `op1Id`/`op2Id` in
+[`module.f.mjs`](../../fjs/edag/module.f.mjs) and `Op1Id`/`Op2Id` in
+[`types.ts`](../../fjs/edag/types.ts). There, arity is not an annotation but
+the group a tag belongs to (`op1`/`op2`), and every tag is unique — negation is
+`neg`, not an arity-overloaded `-`, and there is no unary `+` at all — so the
+`[name, argsN]` disambiguation scheme has nothing left to disambiguate, and a
+local model would be a second vocabulary able to drift from the canonical one.
 
-The arity disambiguates operations that share syntax, such as unary `+` and a
-future binary `+`. The tuple keeps the shared data compact and makes the arity
-available directly as `O[1]` for types such as `Case<O[1]>`.
+The corpus redesign therefore reuses the EDAG definitions instead;
+[reuse-edag-operators](../../fjs/nanvm/todo/reuse-edag-operators.md) carries
+the plan, including this todo's still-applicable requirements:
 
-Make `Case` generic over the argument count and use the existing fixed-length
-array machinery (`Tuple<N, T>`) so an operation's cases have exactly the right
-number of arguments:
-
-```ts
-export type Case<N extends number> = {
-    readonly name: string
-    readonly args: Tuple<N, Value>
-    readonly expected: Value
-    readonly rust?: string
-}
-```
-
-Keep the case `name`. It is diagnostic metadata and a stable proof key, not part
-of the operation semantics. The arguments and expected result are not sufficient
-as a unique key: for a commutative operation, a case with equal arguments is
-identical to its swapped form, so an expression such as `2 * 2 === 4` cannot
-distinguish the two entries. The current proof uses the case name and derives a
-`Swapped` suffix for the reversed order; preserve that explicit disambiguation
-rather than relying on `fromEntries` to silently collapse duplicate keys.
-
-Semantic expressions may still be generated as supplemental diagnostics. When
-doing so, render operands as faithful source literals so distinct values remain
-distinct (`123` versus `123n`, `0` versus `-0`, quoted strings, and so on), and
-use an explicit `Object.is(...)` form when `===` would describe the comparison
-incorrectly. Throwing cases should likewise use an explicit form such as
-`+0n throws`.
-
-Groups must preserve the operation's literal arity so their cases are typed as
-`Case<O[1]>`, where element `1` is the operation's `argsN`. The exact TypeScript
-shape may use generic groups or separate unary/binary group types; the important
-invariant is that invalid case arity is rejected statically.
-
-`commutative` only makes sense for binary operations. Prefer a type shape where
-it is available only for binary groups rather than a general optional property.
-
-The JavaScript proof and Rust printer should translate the semantic operation
-into their own implementation. In particular, the Rust printer must not derive
-Rust identifiers by applying `snakeCase` to punctuation such as `+`; it should
-own an explicit mapping from an operation plus arity to the Rust expression and,
-when needed, generated function name.
-
-Do not broaden this task into making strict equality (`===`) use the generic
-`Group` representation. `Eq` has shared-reference requirements today; it can be
-unified later if doing so becomes clearly useful. Its existing case representation
-is therefore outside this task as well.
-
-### Tasks
-
-- [ ] Replace the current string-union `Op` model with `readonly [name, argsN]`
-      operations carrying a semantic name and literal argument count.
-- [ ] Make `Case` generic over argument count while keeping its stable `name`,
-      and type `args` as a fixed-length tuple.
-- [ ] Keep case names as FunctionalScript proof keys and Rust assertion
-      diagnostics; keep the explicit `Swapped` disambiguation for reversed
-      commutative cases.
-- [ ] If semantic expressions are generated for diagnostics, render values as
-      faithful source literals and handle `Object.is`-sensitive and throwing
-      cases explicitly.
-- [ ] Make each group's cases derive their argument count from `operation[1]`.
-- [ ] Restrict `commutative` to binary groups.
-- [ ] Update `fjs/nanvm/module.f.mjs` to use semantic operation descriptions.
-- [ ] Update `fjs/nanvm/proof.f.mjs` to dispatch on the semantic operation and
-      arity while preserving unique case proof keys.
-- [ ] Update `fjs/nanvm/rust/module.f.mjs` to map semantic operations to Rust
-      syntax and generated identifiers without leaking those identifiers into
-      the shared data.
-- [ ] Add type-level coverage proving that wrong argument counts are rejected.
-- [ ] Regenerate `nanvm-lib/tests/test/generated.rs` and keep the generated test
-      behavior unchanged.
-- [ ] Run `npx tsc`, `fjs test`, `npm run ci-update`, `cargo test`,
-      `cargo clippy -- -D warnings`, and `cargo fmt -- --check`.
+- semantic operator spellings instead of implementation names — now the
+  canonical `Op1Id`/`Op2Id` spellings;
+- arity-aware case types with wrong argument counts rejected statically — now
+  `Case<1>`/`Case<2>` derived from the id's group;
+- `commutative` restricted to binary groups;
+- stable case names as proof keys, with the explicit `Swapped` disambiguation
+  (equal-argument commutative cases make the name, not the expression, the
+  unique key);
+- diagnostics rendered as faithful source literals (`123` vs `123n`, `0` vs
+  `-0`), with explicit `Object.is`/throw forms where `===` would misdescribe
+  the comparison;
+- consumer-owned mapping to JavaScript/Rust implementations — in particular no
+  `snakeCase` over punctuation tags, and no Rust identifiers leaking into the
+  shared data;
+- `eq` (`===`) kept outside the generic group model for now.
 
 ### Related
 
+- [reuse-edag-operators](../../fjs/nanvm/todo/reuse-edag-operators.md) — the
+  superseding plan.
 - #1489 — introduced the shared operator corpus.
 - #1489 review: https://github.com/functionalscript/functionalscript/pull/1489#discussion_r3770780551
 - #1489 review: https://github.com/functionalscript/functionalscript/pull/1489#discussion_r3770797058

--- a/nanvm-lib/todo/replace-unary-plus-with-number.md
+++ b/nanvm-lib/todo/replace-unary-plus-with-number.md
@@ -69,15 +69,21 @@ emits `Any::unary_plus(...)` when generating `nanvm-lib/tests/test/generated.rs`
   arithmetic/comparison operators, which legitimately reject `BigInt` mixing the same way
   JS does. The two coercions differ only in their `BigInt` arm; keep both, under names
   that say which is which.
-- In `fjs/nanvm/types.ts`, replace `'unaryPlus'` in the `Op` union with a coercion-named
-  member — `'numberCoercion'`, matching the existing `'stringCoercion'` precedent, not an
-  operator-shaped name.
+- In the corpus, the group's new spelling is the **canonical EDAG id `'Number'`**
+  (`op1Id` in [`fjs/edag/module.f.mjs`](../../fjs/edag/module.f.mjs)) — never a new
+  NaNVM-only name such as `numberCoercion`, which would introduce exactly the second
+  vocabulary [`reuse-edag-operators.md`](../../fjs/nanvm/todo/reuse-edag-operators.md)
+  exists to remove (that plan also renames `'stringCoercion'` to the canonical
+  `'String'`). Order-aware: if that task has landed, move the group from its
+  `NonEdagGroup` into an EDAG-backed `Group1` with `op: 'Number'` and delete the
+  `NonEdagGroup` type; if this task lands first, replace `'unaryPlus'` with `'Number'`
+  in the current `Op` union.
 - Update `fjs/nanvm/module.f.mjs`'s case group for the renamed op: the bigint case's
   `expected` changes from `throws` to the converted number, not an error. Its
   `numberCoercionCases(negate)` helper is shared with `unaryMinus` — keep that helper and
   `unaryMinus`'s group untouched; only the `unaryPlus` group and its bigint case move.
-- Update `fjs/nanvm/proof.f.mjs`'s `apply` switch: replace `case 'unaryPlus': { return +a }`
-  with `case 'numberCoercion': { return Number(a) }`.
+- Update `fjs/nanvm/proof.f.mjs`'s dispatch: replace the `unaryPlus` arm (`return +a`)
+  with a `'Number'` arm returning `Number(a)`.
 - Update `fjs/nanvm/rust/module.f.mjs`'s `call` switch to emit the new Rust method instead
   of `Any::unary_plus(...)`, and `fjs/nanvm/rust/proof.f.mjs`'s pinned expected-output
   strings to match.
@@ -92,10 +98,12 @@ emits `Any::unary_plus(...)` when generating `nanvm-lib/tests/test/generated.rs`
 
 - [ ] Remove `Any::unary_plus()`, its README row, and the `any/neg.rs` comment reference.
 - [ ] Implement the real `Number(x)` coercion, including a `BigInt<A> → f64` conversion.
-- [ ] `fjs/nanvm/types.ts`: replace `'unaryPlus'` with `'numberCoercion'` in `Op`.
-- [ ] `fjs/nanvm/module.f.mjs`: move the group under the new op name; bigint case expects
+- [ ] `fjs/nanvm/types.ts`: retire `'unaryPlus'` in favor of the canonical `'Number'`
+      (post-`reuse-edag-operators`: delete `NonEdagGroup`; before it: replace the
+      member in `Op`).
+- [ ] `fjs/nanvm/module.f.mjs`: move the group under `'Number'`; bigint case expects
       a converted number, not `throws`.
-- [ ] `fjs/nanvm/proof.f.mjs`: `case 'numberCoercion': { return Number(a) }`.
+- [ ] `fjs/nanvm/proof.f.mjs`: dispatch `'Number'` to `Number(a)`.
 - [ ] `fjs/nanvm/rust/module.f.mjs` and `fjs/nanvm/rust/proof.f.mjs`: update the emitted
       Rust call and its pinned expected snippets.
 - [ ] `npm run ci-update` to regenerate `nanvm-lib/tests/test/generated.rs`.


### PR DESCRIPTION
The reuse-edag-operators todo predated the `fjs/edag/` module: it was blocked on a canonical operation vocabulary existing and assumed `stringCoercion` had no EDAG spelling. `fjs/edag/` now ships `op1Id`/`op2Id` (with `Op1Id`/`Op2Id` at the type level, arity carried by the `op0`/`op1`/`op2` grouping), so this pull request rewrites the plan against that shipped vocabulary and reconciles the neighboring todos with it.

## `fjs/nanvm/todo/reuse-edag-operators.md`

- Removed the blocking dependency on `compile-modules-to-edag.md` — the EDAG vocabulary now exists and is consumed directly.
- Mapped each current corpus operation to its canonical EDAG id (`unaryMinus` → `neg`, `mul` → `*`, `stringCoercion` → `String`); `unaryPlus` stays the one visible exception as a `NonEdagGroup` until it becomes `Number`.
- Three-step plan:
  1. **Vocabulary** — replace the local `Op` union with imported `Op1Id`/`Op2Id`; split `Group` by operand count so arity comes from group membership, with `NonEdagGroup` as the explicit temporary exception.
  2. **Cases as EDAG values** — lower each case's operands to a constant `Exp`, validated against the schema; `ref` becomes literal node sharing, `functionValue` a per-case escape.
  3. **Execution** — both consumers dispatch on the derived expression, identity-aware (the proof's evaluator memoizes nodes per case, the printer emits shared `let` bindings); the corpus-format rules (`orders`/`isThrows`) get one shared owner; the corpus becomes the shared conformance vectors once the `nanvm-lib` interpreter lands, transported as printer-constructed `Any` values until generic `Any` serialization exists.

## `nanvm-lib/todo/operator-test-operation-model.md`

- Marked superseded: its local `[name, argsN]` descriptor would duplicate the shipped vocabulary, and every EDAG tag is unique so there is nothing left for arity to disambiguate.
- Its surviving requirements (semantic spellings, static arity rejection, `Swapped` disambiguation, faithful diagnostics, consumer-owned mappings) are folded into the plan above.

## `nanvm-lib/todo/replace-unary-plus-with-number.md`

- Retargeted at the canonical id: the corpus spelling becomes `'Number'`, never a new NaNVM-only `numberCoercion` name, and its tasks are order-aware — after the reuse plan lands, the group moves out of `NonEdagGroup` (deleting that type); before it, `'Number'` replaces `'unaryPlus'` in the `Op` union.

## `fjs/nanvm/todo/corpus-eliminators.md`

- Repointed its coordination note at `reuse-edag-operators.md`, whose step 3 now carries the `orders`/`isThrows` extraction as an explicit task.

Changelog: none

https://claude.ai/code/session_01HY2q7Xvkergz1yxhsGGaze