### PR TITLE
fjs: document file-type naming conventions

### DIFF
--- a/fjs/todo/document-file-type-naming-conventions.md
+++ b/fjs/todo/document-file-type-naming-conventions.md
@@ -21,8 +21,9 @@ and `main`-export conventions:
   spelling authors use today.
 - `module.mjs` — vanilla JavaScript host integration. It may use capabilities
   outside FunctionalScript and may run effects at import time.
-- `types.ts` — authored, type-only TypeScript companion. It has no runtime
-  representation and is imported only with `import type` or JSDoc `@import`.
+- `types.ts` — authored, type-only TypeScript module. It may stand alone when a
+  declaration has no runtime representation, or accompany a runtime module,
+  and is imported only with `import type` or JSDoc `@import`.
 
 ### `proof.*` — a module that proves other modules
 

--- a/fjs/todo/document-file-type-naming-conventions.md
+++ b/fjs/todo/document-file-type-naming-conventions.md
@@ -13,17 +13,26 @@ the file types or points to the other.
 Document the file-type conventions in `fjs/README.md`, next to the existing CLI
 and `main`-export conventions:
 
-### `module.*` — a module
+### `module.*` — a package entry point
 
-- `module.f.mjs` — authored FunctionalScript module: pure by construction and
-  safe to bulk-load. `.f.js` is the planned spelling for parser-compatible,
-  dependency-closed groups once authored-`.f.js` package support exists, not a
-  spelling authors use today.
-- `module.mjs` — vanilla JavaScript host integration. It may use capabilities
-  outside FunctionalScript and may run effects at import time.
-- `types.ts` — authored, type-only TypeScript module. It may stand alone when a
-  declaration has no runtime representation, or accompany a runtime module,
-  and is imported only with `import type` or JSDoc `@import`.
+- `module.f.mjs` — a package entry point authored in FunctionalScript: pure by
+  construction and safe to bulk-load.
+- `module.mjs` — a package entry point authored as vanilla JavaScript host
+  integration. It may use capabilities outside FunctionalScript and may run
+  effects at import time.
+
+The `module` basename marks the package entry point, not every module. Other
+authored FunctionalScript sources use a descriptive basename with the same
+`.f.mjs` marker, such as `bnf.f.mjs` and `json.f.mjs`; other host JavaScript
+sources similarly use `.mjs`. `.f.js` is the planned FunctionalScript spelling
+for parser-compatible, dependency-closed groups once authored-`.f.js` package
+support exists, not a spelling authors use today.
+
+### `types.ts` — a type-only module
+
+An authored, type-only TypeScript module. It may stand alone when a declaration
+has no runtime representation, or accompany a runtime module, and is imported
+only with `import type` or JSDoc `@import`.
 
 ### `proof.*` — a module that proves other modules
 

--- a/fjs/todo/document-file-type-naming-conventions.md
+++ b/fjs/todo/document-file-type-naming-conventions.md
@@ -3,7 +3,12 @@
 **Priority:** P3
 **Status:** open
 
-The repo uses several filename conventions to signal what a file *is* — pure module, proof, application entry point — but the conventions are only implied by usage. There is no single place that defines them.
+The repo uses several filename conventions to signal what a file *is* — pure
+module, proof, application entry point — but their documentation is split.
+[`fjs/AGENTS.md` §3.5](../AGENTS.md#35-functionalscript-module-rules) owns the
+FunctionalScript source and type-only import rules, while `fjs/README.md` owns
+the CLI and `main`-export conventions. Neither gives a reader a short map of
+the file types or points to the other.
 
 Document the file-type conventions in `fjs/README.md`, next to the existing CLI
 and `main`-export conventions:
@@ -11,8 +16,9 @@ and `main`-export conventions:
 ### `module.*` — a module
 
 - `module.f.mjs` — authored FunctionalScript module: pure by construction and
-  safe to bulk-load. `.f.js` is the planned spelling after the compiler's
-  extension migration, not a spelling authors use today.
+  safe to bulk-load. `.f.js` is the planned spelling for parser-compatible,
+  dependency-closed groups once authored-`.f.js` package support exists, not a
+  spelling authors use today.
 - `module.mjs` — vanilla JavaScript host integration. It may use capabilities
   outside FunctionalScript and may run effects at import time.
 - `types.ts` — authored, type-only TypeScript companion. It has no runtime
@@ -22,8 +28,9 @@ and `main`-export conventions:
 
 Tests other modules. Usually exports only `proof` (the proof tree). See [`fjs/emergent_testing/README.md`](../emergent_testing/README.md).
 
-- `proof.f.mjs` — authored FunctionalScript proof. `.f.js` is the planned
-  spelling after the compiler's extension migration.
+- `proof.f.mjs` — authored FunctionalScript proof. Like implementation modules,
+  proofs move to `.f.js` only in parser-compatible, dependency-closed groups
+  once authored-`.f.js` package support exists.
 - `proof.mjs` — vanilla JavaScript proof, used when the proof needs host
   capabilities that FunctionalScript excludes.
 
@@ -45,10 +52,10 @@ The host-side `module.mjs` runner is separate when an application needs one.
 Existing and new applications both follow this convention; no entry-point
 rename is required.
 
-### Proof
+### Tasks
 
-- Add the conventions as a dedicated section in `fjs/README.md` and link to
-  the existing compiler, testing, and `fjs run` documentation instead of
-  duplicating their details.
-- Check every spelling against the files currently authored under `fjs/`.
-- Remove this issue in the same pull request as the documentation.
+- [ ] Add the conventions as a dedicated section in `fjs/README.md`; link to
+      the source rules in `fjs/AGENTS.md` and the existing compiler, testing,
+      and `fjs run` documentation instead of duplicating their details.
+- [ ] Check every spelling against the files currently authored under `fjs/`.
+- [ ] Remove this issue in the same pull request as the documentation.

--- a/fjs/todo/document-file-type-naming-conventions.md
+++ b/fjs/todo/document-file-type-naming-conventions.md
@@ -5,31 +5,50 @@
 
 The repo uses several filename conventions to signal what a file *is* — pure module, proof, application entry point — but the conventions are only implied by usage. There is no single place that defines them.
 
-Document the file-type conventions in `fjs/README.md` (or a dedicated `CONVENTIONS.md`):
+Document the file-type conventions in `fjs/README.md`, next to the existing CLI
+and `main`-export conventions:
 
 ### `module.*` — a module
 
-- `module.f.mjs` / `module.f.js` — FunctionalScript module: pure by construction, safe to bulk-load.
-- `module.mjs` / `module.ts` — vanilla JS/TS: host integration that may run side effects at import time.
+- `module.f.mjs` — authored FunctionalScript module: pure by construction and
+  safe to bulk-load. `.f.js` is the planned spelling after the compiler's
+  extension migration, not a spelling authors use today.
+- `module.mjs` — vanilla JavaScript host integration. It may use capabilities
+  outside FunctionalScript and may run effects at import time.
+- `types.ts` — authored, type-only TypeScript companion. It has no runtime
+  representation and is imported only with `import type` or JSDoc `@import`.
 
 ### `proof.*` — a module that proves other modules
 
 Tests other modules. Usually exports only `proof` (the proof tree). See [`fjs/emergent_testing/README.md`](../emergent_testing/README.md).
 
-- `proof.f.mjs` / `proof.f.js` — FunctionalScript proof.
-- `proof.ts` / `proof.js` / `proof.mts` / `proof.mjs` — vanilla proof.
+- `proof.f.mjs` — authored FunctionalScript proof. `.f.js` is the planned
+  spelling after the compiler's extension migration.
+- `proof.mjs` — vanilla JavaScript proof, used when the proof needs host
+  capabilities that FunctionalScript excludes.
 
-### `node.app.f.mjs` / `node.app.f.js` — a Node application
+### Applications use `main`; they do not get a filename suffix
 
-A module whose `export default` is a `NodeProgram` (`Program<NodeOp>`). The `.f.` infix is kept because the program is a pure effect description:
+A FunctionalScript application is an ordinary module whose named `main` export
+is a `NodeProgram` (`Program<NodeOp>`). Its effect description remains pure, so
+the ordinary `.f.mjs` marker already says everything a `node.app.f.mjs` suffix
+would say. The named export also matches the existing `fjs run` contract; do
+not introduce a competing default-export convention.
 
 ```js
-import app from './node.app.f.mjs'
+import { main } from './module.f.mjs'
 import { run } from '../effects/node/module.mjs'
-await run(app)
+await run(main)
 ```
 
-### Open questions
+The host-side `module.mjs` runner is separate when an application needs one.
+Existing and new applications both follow this convention; no entry-point
+rename is required.
 
-- Should existing entry points (`fjs/module.mjs`) be migrated to the `node.app.f.mjs` convention, or only new entry points?
-- Canonical doc location: top-level `README.md`, `fjs/README.md`, or `CONVENTIONS.md`?
+### Proof
+
+- Add the conventions as a dedicated section in `fjs/README.md` and link to
+  the existing compiler, testing, and `fjs run` documentation instead of
+  duplicating their details.
+- Check every spelling against the files currently authored under `fjs/`.
+- Remove this issue in the same pull request as the documentation.


### PR DESCRIPTION
### Motivation

- The repository lacks a single canonical description of filename conventions for FunctionalScript modules, proofs, host-side modules, and type-only companions, which causes confusion when introducing new conventions. 
- The open todo asked whether to introduce a `node.app.*` application suffix and where the canonical doc should live, so the design needs to be resolved before any implementation work. 

### Description

- Updated `fjs/todo/document-file-type-naming-conventions.md` to clarify current conventions and to recommend documenting them in `fjs/README.md` adjacent to the CLI and `main`-export guidance. 
- The change distinguishes authored FunctionalScript modules (`module.f.mjs`) from host JavaScript modules (`module.mjs`) and explicitly identifies `types.ts` as the type-only companion, and it clarifies proof file spellings and that `.f.js` is a future planned spelling. 
- The file records a decision to not introduce a `node.app.*` filename suffix and to keep the existing named `main` export convention for applications, plus a short checklist for adding the final docs and removing the todo. 
- Changelog: none

### Testing

- Ran `git diff --check` and inspected the resulting diff, which reported no formatting or whitespace errors and shows the intended content changes. 
- Verified repository file patterns with `find` and `rg` to ensure the documented spellings match existing files under `fjs/`. 
- Performed regular VCS operations (`git add` / `git commit`) to create the change; those commands succeeded. 
- The TypeScript build and test suites were not run because this is a documentation/design change only and touches no executable code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8e203eeca4832b96952f450597e168)