### PR TITLE
djs/transpiler: use mapStep for context projection

### DIFF
--- a/fjs/djs/transpiler/module.f.mjs
+++ b/fjs/djs/transpiler/module.f.mjs
@@ -23,8 +23,7 @@ import { concat as pathConcat } from '../../path/module.f.mjs'
 import { parseFromTokens } from '../parser/module.f.mjs'
 import { parse as jsonParse } from '../../media/json/module.f.mjs'
 import { run } from '../ast/module.f.mjs'
-import { pure } from '../../effects/module.f.mjs'
-import { catchStep, foldStep, mapStep, pureError, pureOk, step } from '../../effects/module.f.mjs'
+import { catchStep, foldStep, mapStep, pure, pureError, pureOk, step } from '../../effects/module.f.mjs'
 import { readUtf8File } from '../../effects/node/module.f.mjs'
 
 /**
@@ -65,16 +64,16 @@ const transpileWithImports = path => module => context => {
     const pathsArray = toArray(pathsCombine)
     const contextWithStack = { ...context, stack: { first: path, tail: context.stack } }
     const x0 = foldStep(pureOk(pathsArray), contextWithStack, foldNextModuleOp)
-    return step(
+    return mapStep(
         x0,
         contextWithImports => {
             const args = toArray(listMap(mapDjs(contextWithImports))(pathsCombine))
             const djs = { djs: run(module[1])(args) }
-            return pureOk({
+            return {
                 ...contextWithImports,
                 stack: drop(1)(contextWithImports.stack),
                 complete: setReplace(path)(djs)(contextWithImports.complete),
-            })
+            }
         })
 }
 

--- a/fjs/effects/todo/map-step-combinator.md
+++ b/fjs/effects/todo/map-step-combinator.md
@@ -32,7 +32,9 @@ Two shapes, both the same thing:
 
 Also `fjs/dev/module.f.mjs`, `fjs/cas/evo/module.f.mjs`,
 `fjs/mcp/evo/module.f.mjs`, `fjs/cas/module.f.mjs`, `fjs/mcp/cas/module.f.mjs`,
-`fjs/protocol/mcp/module.f.mjs`, `fjs/emergent_testing/module.f.mjs`.
+`fjs/protocol/mcp/module.f.mjs`, `fjs/emergent_testing/module.f.mjs`. The plain
+context projection in `fjs/djs/transpiler/module.f.mjs` has also been converted;
+its two `pure(Result)` sites are channel constructors, not `mapStep` candidates.
 
 *Constant projection* (`() => pure(v)`), overwhelmingly the "do the work, then
 yield an exit code" shape of a `NodeProgram`:


### PR DESCRIPTION
### Motivation

- Make an explicit pure projection where the transpiler maps a folded context into the updated `ParseContext` so the effect shape is clear and does not widen the operation set.  
- Avoid the `step(..., x => pureOk(...))` pattern that looks like an effectful continuation but is actually a pure projection, and record the conversion in the outstanding `map-step-combinator` TODO.  

### Description

- Replace the `step(..., context => pureOk(...))` pattern with `mapStep(...)` in `fjs/djs/transpiler/module.f.mjs` for the import-context projection and the module-to-context projection, preserving semantics while keeping the operation set unchanged.  
- Adjusted imports in `fjs/djs/transpiler/module.f.mjs` to use the consolidated `effects` export (`mapStep`, `pure`, `step`, etc.).  
- Return a plain `ParseContext` value from the projection continuation instead of wrapping it in `pureOk(...)`, since `mapStep` expects a projection that yields the pure value.  
- Update `fjs/effects/todo/map-step-combinator.md` to record that the `djs/transpiler` projection was converted and to clarify that nearby `pure(Result)` continuations remain channel constructors and must not be converted.  

### Testing

- Ran `npx tsc` (TypeScript check) and it succeeded.  
- Ran the FunctionalScript test suite via `node fjs/module.mjs test` and all tests passed (3313 passed, 0 failed).  
- Ran Rust checks: `cargo clippy` and `cargo fmt -- --check`, both succeeded.  
- Ran `npm run update`, which completed repository update steps but stopped partway where `deno` is required in this environment; the change itself was exercised by the TypeScript check and the full test suite above.  

Changelog: none

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8e6fe30288832b842ea56a1544f964)