### PR TITLE
website: address browser test review

### DIFF
--- a/fjs/emergent_testing/todo/browser-testing.md
+++ b/fjs/emergent_testing/todo/browser-testing.md
@@ -47,18 +47,19 @@ three independent test frameworks.
 ```text
 browser-test output
 ├── index.html
-├── browser-test-entry.mjs
-├── browser-test-runner.mjs
+├── _browser-test-entry.mjs
+├── fjs/emergent_testing/browser.mjs
 └── authored or copied .f.mjs / .mjs modules
 ```
 
-`index.html` starts the runner; the generated entry module explicitly imports
-every selected module that exports `proof`, and native browser ES-module
-loading evaluates the full transitive graph. The application exposes HTML and
-JavaScript only — it does not serve the repository working tree, declaration
-files, `types.ts` (type-only imports are JSDoc comments and never produce a
-request), or paths outside the application root. The browser runner must not
-import the Node effect runner, `node:test`, Node built-ins, or Playwright.
+`index.html` starts the runner. The website integration currently loads the
+generated list of proof sources with native `import()` from the repository
+working tree; this is not the isolated application root described by this
+section. The eventual application exposes HTML and JavaScript only — it does
+not serve the repository working tree, declaration files, `types.ts` (type-only
+imports are JSDoc comments and never produce a request), or paths outside the
+application root. The browser runner must not import the Node effect runner,
+`node:test`, Node built-ins, or Playwright.
 
 ### Selection
 

--- a/fjs/web/todo/missing-index-message.md
+++ b/fjs/web/todo/missing-index-message.md
@@ -13,7 +13,7 @@ that, so the first reading is that the address is wrong.
 
 It is reachable from a clean checkout. `index.html` is a build artifact and is
 gitignored, so `fjs web` in a fresh tree answers `not found` at `/` until
-`npm run index-html` has run. Nothing in the response points at that.
+`npm run website` has run. Nothing in the response points at that.
 
 The same sentence covers every other refusal:
 

--- a/fjs/website/browser-prepare.mjs
+++ b/fjs/website/browser-prepare.mjs
@@ -26,7 +26,8 @@ const files = async directory => {
 
 /** @type {(source: string) => boolean} */
 const exportsProof = source =>
-    source.includes('export const proof') ||
+    source.split('export const proof').slice(1).some(part =>
+        part.startsWith(' ') || part.startsWith('\n') || part.startsWith('=')) ||
     source.split('export {').slice(1).some(part => part.split('}')[0].split(',')
         .some(name => (name.split(' as ')[1] ?? name).trim() === 'proof'))
 

--- a/fjs/website/module.f.mjs
+++ b/fjs/website/module.f.mjs
@@ -37,7 +37,7 @@ pre { white-space: pre-wrap }
         ['p',
             'FunctionalScript derives this browser-native unit-test suite from exported proofs. ',
             ['a',
-                { href: 'https://medium.com/javascript-in-plain-english/emergent-testing-in-javascript-e44760d71688?sk=42381f0d5cdff049acecb64c6f9d9531' },
+                { href: 'https://medium.com/javascript-in-plain-english/emergent-testing-in-javascript-e44760d71688' },
                 'Read “Emergent Testing in JavaScript”'
             ],
             '.'

--- a/fjs/website/proof.f.mjs
+++ b/fjs/website/proof.f.mjs
@@ -1,11 +1,13 @@
 /**
  * @import { Dir } from '../effects/node/virtual/types.ts'
+ * @import { Vec } from '../types/bit_vec/types.ts'
  */
 
 import { exitCode } from '../effects/node/module.f.mjs'
 import { main } from './module.f.mjs'
 import { emptyState, virtual } from '../effects/node/virtual/module.f.mjs'
-import { assertEq, assertNotNullish } from '../asserts/module.f.mjs'
+import { assert, assertEq, assertNotNullish } from '../asserts/module.f.mjs'
+import { utf8ToString } from '../text/module.f.mjs'
 
 export const proof = {
     main: () => {
@@ -17,7 +19,12 @@ export const proof = {
         const state = { ...emptyState, root }
         const [generated, result] = virtual(state)(main())
         assertEq(exitCode(result), 0)
-        assertNotNullish(generated.root['index.html'], 'expected generated HTML')
+        const page = assertNotNullish(generated.root['index.html'], 'expected generated HTML')
         assertNotNullish(generated.root['_browser-test-entry.mjs'], 'expected generated entry module')
+        assert(Array.isArray(page), 'expected the generated HTML to be a file')
+        const source = page.map(value => utf8ToString(/** @type {Vec} */ (value))).join('')
+        assert(source.includes('<h1>Emergent Testing in the Browser</h1>'))
+        assert(source.includes('emergent-testing-in-javascript-e44760d71688'))
+        assert(!source.includes('?sk='))
     },
 }


### PR DESCRIPTION
### Motivation

- Address review feedback about the generated browser test page and its documentation so the repo description matches the shipped implementation. 
- Avoid false-positive proof discovery by preventing identifiers like `proofOfWork` from being detected as the `proof` export. 
- Ensure the generated site content is provably correct (heading and link) and does not leak a friend-token query parameter. 

### Description

- Tighten the `proof`-export heuristic in `fjs/website/browser-prepare.mjs` to avoid substring collisions and aliasing errors. 
- Update the website generator and copy in `fjs/website/module.f.mjs` to remove the tokenized Medium URL and use the actual article URL. 
- Add a runtime proof `fjs/website/proof.f.mjs` that asserts the generated `index.html` contains the expected `<h1>`, the article link, and that no `?sk=` token remains. 
- Correct documentation and TODOs to name the real generated modules (`_browser-test-entry.mjs`, `fjs/emergent_testing/browser.mjs`) and replace references to the removed `npm run index-html` with `npm run website`. 

### Testing

- Ran `npx tsc` and it succeeded. 
- Ran the FunctionalScript test runner via `npm test` and `npm start test` and observed the full suite pass: `3406` tests passed, `0` failed. 
- Ran Rust checks `cargo clippy` and `cargo fmt -- --check` and both completed without errors. 
- Ran `git diff --check` and resolved whitespace/format issues; `npm run update` executed but could not run Deno/Bun installation in this environment (note: environment limitation only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8f66dded44832bb89e7aed4e76d356)