### PR TITLE
emergent_testing: make error proof Bun coverage-safe

### DIFF
--- a/fjs/emergent_testing/browser/proof.mjs
+++ b/fjs/emergent_testing/browser/proof.mjs
@@ -20,10 +20,10 @@ export const proof = {
         assertEq(report.results[0]?.message, 'Unknown thrown value')
     },
     errorFields: async () => {
-        const error = new Error()
-        Object.defineProperties(error, {
-            message: { value: Symbol('message') },
-            stack: { value: Symbol('stack') },
+        const error = new Proxy(new Error(), {
+            get: (target, property) => property === 'message' || property === 'stack'
+                ? Symbol(property)
+                : Reflect.get(target, property),
         })
         const report = await run({ fail: () => { throw error } })
         assertEq(report.results[0]?.message, 'Symbol(message)')


### PR DESCRIPTION
### Motivation

- Bun's coverage instrumentation throws when a test fixture redefines `Error`'s `message`/`stack` as symbol-valued descriptors, so replace the incompatible fixture while preserving the proof's intent to validate string conversion of those fields.

### Description

- Replace the `Object.defineProperties` fixture in `fjs/emergent_testing/browser/proof.mjs` with a `Proxy` that returns symbol values for `message` and `stack` while leaving the real `Error` object intact, preserving the existing assertions that expect `'Symbol(message)'` and `'Symbol(stack)'`.

### Testing

- Ran `bun test --coverage fjs/emergent_testing/browser/error-fields.test.mjs` which passed and produced a coverage report for the file tested.
- Executed the proof directly with `node -e "import('./fjs/emergent_testing/browser/proof.mjs').then(({proof}) => proof.errorFields())"` and `bun -e "import('./fjs/emergent_testing/browser/proof.mjs').then(({proof}) => proof.errorFields())"`, both of which passed.
- Verified repository checks: `npx tsc`, `fjs test`, `cargo test`, `cargo clippy`, and `cargo fmt -- --check` all completed successfully.
- `npm run update` stopped at `deno install` because Deno is not available in this environment (warning, no tracked code changes resulted from this step).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8f6c2b00d4832bae8ab5e245bb38e1)