### PR TITLE
website: finish browser test review fixes

### DIFF
--- a/changelog/unreleased/1726.md
+++ b/changelog/unreleased/1726.md
@@ -1,2 +1,1 @@
-- `website`: the generated page now loads and runs FunctionalScript proofs in
-  the browser, showing live progress and a serializable pass/fail report.
+- Changelog: browser testing is now available from the generated website.

--- a/fjs/emergent_testing/todo/browser-testing.md
+++ b/fjs/emergent_testing/todo/browser-testing.md
@@ -45,7 +45,7 @@ three independent test frameworks.
 ### Shared browser test application
 
 ```text
-browser-test output
+eventual isolated browser-test application root
 ├── index.html
 ├── _browser-test-entry.mjs
 ├── fjs/emergent_testing/browser.mjs

--- a/fjs/website/browser-prepare.mjs
+++ b/fjs/website/browser-prepare.mjs
@@ -8,7 +8,7 @@ import { run } from '../effects/node/module.mjs'
 import { toPosix } from '../path/module.f.mjs'
 import { main } from './module.f.mjs'
 
-const sourceRoot = new URL('../', import.meta.url)
+const sourceRoot = new URL('../../', import.meta.url)
 const output = new URL('../emergent_testing/_browser-suite.mjs', import.meta.url)
 
 /** @type {(name: string) => boolean} */
@@ -18,7 +18,7 @@ const authored = name => name.endsWith('.f.mjs')
 const files = async directory => {
     const entries = await readdir(directory, { withFileTypes: true })
     return (await Promise.all(entries.map(entry => {
-        if (entry.name.startsWith('.')) { return [] }
+        if (entry.name.startsWith('.') || entry.name === 'node_modules' || entry.name === 'target') { return [] }
         const url = new URL(entry.isDirectory() ? `${entry.name}/` : entry.name, directory)
         return entry.isDirectory() ? files(url) : authored(entry.name) ? [url] : []
     }))).flat()
@@ -39,7 +39,7 @@ const selected = (await Promise.all(candidates.map(async url =>
 const sourcePath = fileURLToPath(sourceRoot)
 const entries = selected.map(url => {
     const path = toPosix(relative(sourcePath, fileURLToPath(url)))
-    return `    './fjs/${path}',`
+    return `    './${path}',`
 })
 const manifest = [
     '/** Generated browser proof source map. Modules are loaded after the page renders. */',


### PR DESCRIPTION
### Motivation

- Make browser proof discovery and the generated manifest correct for the repository layout so root-level authored proofs are discovered and browser imports resolve correctly. 
- Avoid scanning large/generated folders during manifest generation to prevent accidental inclusion of build artifacts. 
- Align documentation and changelog wording with the behavior and the PR body so reviewers and release tooling see a consistent description.

### Description

- Expand the discovery root in `fjs/website/browser-prepare.mjs` from the `fjs/` subtree to the repository root and skip `node_modules` and `target` directories during recursive file collection. 
- Emit repository-relative manifest entries in `fjs/emergent_testing/_browser-suite.mjs` as `./<path>` instead of `./fjs/<path>` so the generated browser entry imports valid paths. 
- Update `fjs/emergent_testing/todo/browser-testing.md` text to clarify that the listed tree describes the eventual isolated browser-test application root. 
- Replace the changelog entry text in `changelog/unreleased/1726.md` so it matches the `Changelog:` line used in the PR body.

### Testing

- Ran `npm run website` to regenerate the browser manifest and site entry and observed successful generation. 
- Ran `npx tsc` and confirmed successful type-checking. 
- Ran `npm test` (the FunctionalScript test suite) and observed the suite pass (3,406 tests passed). 
- Ran Rust checks `cargo clippy` and `cargo fmt -- --check` and observed they completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8f6e79dff4832b9d4a8ba6d1069a10)