### PR TITLE
todo: separate private types into private.ts

### DIFF
--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -45,7 +45,7 @@ of basename or whether the file is FunctionalScript. This includes
 `testlib.f.mjs`, and other descriptive companions. Function-local typedefs remain
 allowed as described below.
 
-Private type names continue to start with `_`.
+Private type and runtime constant names continue to start with `_`.
 
 #### Public declaration closure
 
@@ -149,22 +149,30 @@ and normal runtime tables whose type is asserted:
 
 ```js
 // meta.f.mjs
-export const framingKeywords =
+export const _framingKeywords =
     /** @type {const} */ (['import', 'const', 'export', 'default', 'from'])
 ```
 
 ```ts
 // private.ts
-import type { framingKeywords } from './meta.f.mjs'
+import type { _framingKeywords } from './meta.f.mjs'
 
 type _KeywordsAreComplete =
-    Assert<Equal<(typeof framingKeywords)[number], _FramingKeyword>>
+    Assert<Equal<(typeof _framingKeywords)[number], _FramingKeyword>>
 ```
 
 ```js
 // module.f.mjs
-import { framingKeywords } from './meta.f.mjs'
+import { _framingKeywords } from './meta.f.mjs'
 ```
+
+Private constants in `meta.f.mjs` use the same leading-`_` API convention as
+private types. They may need to be exported so sibling runtime or TypeScript
+modules can name them, but that export is module linkage rather than public API:
+consumers must not depend on `_`-prefixed constants directly. Renaming or removing
+such a name is not a breaking change solely because it was exported. As with
+private types, changes that alter an actual public runtime/type contract still
+follow the normal breaking-change rules.
 
 The trigger is an actual TypeScript type dependency (`typeof`, `Ts<typeof ...>`,
 indexed access, a type proof, etc.), not merely that a runtime value *could* be
@@ -289,7 +297,8 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
 - [ ] Prohibit file-scope JSDoc `@typedef` in every authored `.mjs`, including
       `.f.mjs`, host `module.mjs` / `proof.mjs`, and descriptive companions;
       allow function-local `@typedef` everywhere.
-- [ ] Keep the leading `_` convention for every private type name.
+- [ ] Keep the leading `_` convention for every private type and private runtime
+      metadata constant name.
 - [ ] Move public file-scope named types from authored `.mjs` JSDoc into
       `types.ts` as a breaking migration; update importers and changelog.
 - [ ] Keep or inline every private `_` helper required transitively by any
@@ -301,7 +310,8 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
 - [ ] Keep lexical type-proof typedefs inside their functions.
 - [ ] Move runtime constants actually referenced by TypeScript type
       definitions/proofs into `meta.f.mjs`, including RTTI values, non-RTTI
-      literal constants, and runtime-used tables.
+      literal constants, and runtime-used tables; prefix private ones with `_`
+      even when they must be exported for sibling-module access.
 - [ ] Move file-scope private proofs over those constants to `private.ts` (or
       `types.ts` when part of the public declaration closure) and use
       `import type { ... }`.
@@ -328,7 +338,7 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
         former file-scope typedef is moved to the appropriate TypeScript file;
       - a non-FunctionalScript authored `.mjs` file whose former file-scope
         typedef is moved to the appropriate TypeScript file;
-      - `meta.f.mjs` with RTTI, literal, and runtime-used constants.
+      - `meta.f.mjs` with RTTI, literal, runtime-used, and private `_` constants.
 - [ ] Include a retained JSDoc `@import ... './private.ts'` comment in an emitted
       declaration fixture and verify the clean consumer succeeds without
       `private.ts`; this proves comments do not create package dependencies.
@@ -352,9 +362,11 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
 - `types.ts` and every packed public declaration are independent of `private.ts`.
 - Every import in `types.ts` and `private.ts` uses named `import type { ... }`.
 - Runtime constants referenced by TypeScript definitions/proofs live in
-  `meta.f.mjs`, whether RTTI or not. Emergent testing loads `meta.f.mjs`, Node and
-  Deno coverage filters include it, and the existing coverage thresholds apply;
-  this convention does not prescribe how developers satisfy those thresholds.
+  `meta.f.mjs`, whether RTTI or not. Private constants use leading `_` even when
+  exported for sibling-module access; `_` marks them private by contract.
+  Emergent testing loads `meta.f.mjs`, Node and Deno coverage filters include it,
+  and the existing coverage thresholds apply; this convention does not prescribe
+  how developers satisfy those thresholds.
 - Moving public types to `types.ts` and public runtime metadata to `meta.f.mjs`
   are breaking migrations: importers and changelog are updated and no
   compatibility re-exports preserve old entry points.

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -5,7 +5,8 @@
 
 ### Problem
 
-FunctionalScript currently mixes named types with implementation/proof source:
+FunctionalScript currently mixes named types with runtime/proof source. Common
+examples are:
 
 ```text
 module.f.mjs  # implementation + file-scope JSDoc typedefs
@@ -13,11 +14,13 @@ proof.f.mjs   # proofs + file-scope JSDoc typedefs
 types.ts      # public types + private helpers
 ```
 
-TypeScript declaration emit turns file-scope JSDoc `@typedef`s into exported
-aliases, so implementation-private names leak into generated `.d.mts` files.
-The existing leading-`_` convention marks those names private by contract, but
-the declarations still contain noise and make the source/package boundary less
-clear.
+Other authored FunctionalScript companions, such as `testlib.f.mjs`, can contain
+the same file-scope typedefs and are subject to the same declaration emit.
+TypeScript turns file-scope JSDoc `@typedef`s in authored `.f.mjs` files into
+exported aliases, so implementation-private names leak into generated `.d.mts`
+files. The existing leading-`_` convention marks those names private by contract,
+but the declarations still contain noise and make the source/package boundary
+less clear.
 
 The goal is to give every file-scope named type a deliberate home while keeping
 public declarations self-contained.
@@ -27,12 +30,17 @@ public declarations self-contained.
 Use this directory convention where needed:
 
 ```text
-module.f.mjs  # implementation; no file-scope @typedef
-proof.f.mjs   # proofs; no file-scope @typedef
+module.f.mjs  # implementation
+proof.f.mjs   # proofs
 meta.f.mjs    # runtime constants referenced by TypeScript types/proofs
 types.ts      # public declaration closure
 private.ts    # other implementation-private file-scope types
 ```
+
+No authored `.f.mjs` file may declare a **file-scope** JSDoc `@typedef`,
+regardless of basename or role. This includes `module.f.mjs`, `proof.f.mjs`,
+`meta.f.mjs`, `testlib.f.mjs`, and other descriptive FunctionalScript
+companions. Function-local typedefs remain allowed as described below.
 
 Private type names continue to start with `_`.
 
@@ -86,8 +94,9 @@ closure, not a mechanical destination for every `_` name.
 
 #### Function-local typedefs
 
-Function-local JSDoc `@typedef` declarations are allowed everywhere. They may
-refer to lexical values that cannot be named from a sibling TypeScript file.
+Function-local JSDoc `@typedef` declarations are allowed in any authored source
+file. They may refer to lexical values that cannot be named from a sibling
+TypeScript file.
 
 For example:
 
@@ -175,9 +184,9 @@ include it under the same expectations as `module.f.mjs`.
 
 #### Breaking migration; no compatibility re-exports
 
-Moving a public file-scope type from `module.f.mjs` / `proof.f.mjs` to
-`types.ts` changes its public type import path. Moving a public runtime constant
-from `module.f.mjs` to `meta.f.mjs` changes its runtime import path.
+Moving a public file-scope type from any authored `.f.mjs` file to `types.ts`
+changes its public type import path. Moving a public runtime constant from
+`module.f.mjs` to `meta.f.mjs` changes its runtime import path.
 
 Treat both as intentional breaking API changes:
 
@@ -241,22 +250,26 @@ types.ts    # public declaration closure
 private.ts  # implementation-private file-scope types outside that closure
 ```
 
-Both remain type-only modules and use named `import type { ... }` imports.
+Both remain type-only modules and use named `import type { ... }` imports. The
+same policy must also state that file-scope JSDoc `@typedef` is prohibited in
+**all** authored `.f.mjs` files, not just `module.*` and `proof.*` entry points.
 
 ### Tasks
 
 - [ ] Document `types.ts`, `private.ts`, and `meta.f.mjs` beside the existing
-      `module.*` / `proof.*` file conventions.
+      FunctionalScript file conventions, including descriptive `.f.mjs`
+      companions.
 - [ ] Update `fjs/AGENTS.md` to allow `types.ts` and `private.ts` as the authored
-      TypeScript type-module roles and document the public-declaration-closure
-      rule.
+      TypeScript type-module roles, document the public-declaration-closure rule,
+      and prohibit file-scope `@typedef` in every authored `.f.mjs` file.
 - [ ] Update `fjs/fsc/README.md` and delete or narrow
       `todo/blocked/jsdoc-typedef-strip-internal.md` so they no longer prescribe
       a conflicting private-JSDoc strategy.
-- [ ] Prohibit file-scope JSDoc `@typedef` in `module.f.mjs` and `proof.f.mjs`;
-      allow function-local `@typedef` everywhere.
+- [ ] Prohibit file-scope JSDoc `@typedef` in every authored `.f.mjs`, including
+      `module.f.mjs`, `proof.f.mjs`, `meta.f.mjs`, `testlib.f.mjs`, and other
+      descriptive companions; allow function-local `@typedef` everywhere.
 - [ ] Keep the leading `_` convention for every private type name.
-- [ ] Move public file-scope named types from implementation/proof JSDoc into
+- [ ] Move public file-scope named types from authored `.f.mjs` JSDoc into
       `types.ts` as a breaking migration; update importers and changelog.
 - [ ] Keep or inline every private `_` helper required transitively by any
       shipped public declaration in `types.ts`, including helpers appearing in
@@ -287,13 +300,16 @@ Both remain type-only modules and use named `import type { ... }` imports.
         declaration (the `_SortedArray`/`find` shape);
       - an implementation-private type in `private.ts`;
       - a function-local typedef depending on a lexical value;
+      - a descriptive companion such as `testlib.f.mjs` whose former file-scope
+        typedef is moved to the appropriate TypeScript file;
       - `meta.f.mjs` with RTTI, literal, and runtime-used constants.
 - [ ] Verify source checking, declaration emit/cleanup, Node+Deno coverage,
       packing, and clean-consumer type checking.
 
 ### Acceptance criteria
 
-- `module.f.mjs` and `proof.f.mjs` contain no file-scope JSDoc `@typedef`.
+- No authored `.f.mjs` file contains a file-scope JSDoc `@typedef`, regardless
+  of basename or role.
 - Function-local JSDoc `@typedef` is allowed everywhere; private names keep `_`
   and do not escape as exported declaration aliases.
 - `types.ts` is the public declaration closure: public types plus any private
@@ -319,7 +335,8 @@ Both remain type-only modules and use named `import type { ... }` imports.
   resolvable from shipped declarations, including helpers used by exported
   runtime-value/function signatures.
 - `fjs/AGENTS.md` no longer says `types.ts` is the only authored TypeScript and
-  documents both `types.ts` and `private.ts` with the declaration-closure rule.
+  documents both `types.ts` and `private.ts`, the declaration-closure rule, and
+  the all-authored-`.f.mjs` file-scope typedef prohibition.
 - `fjs/fsc/README.md` and the blocked `@internal`/`stripInternal` TODO no longer
   prescribe a conflicting private-JSDoc strategy.
 - A clean TypeScript consumer type-checks successfully against the packed

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -1,4 +1,4 @@
-## Separate private types into `private.ts`
+## Keep private types out of public declarations
 
 **Priority:** P2
 **Status:** open
@@ -24,22 +24,33 @@ implementation-private names leak into generated `.d.mts` files. The existing
 leading-`_` convention marks those names private by contract, but the declarations
 still contain noise and make the source/package boundary less clear.
 
-The goal is to give every file-scope named type a deliberate home while keeping
-public declarations self-contained.
+The requirement is to keep the public declaration/API surface clean and
+self-contained. `private.ts` and `meta.f.mjs` are **optional tools** for reaching
+that result; they are not file roles that every module must introduce.
 
 ### Proposal
 
-Use this directory convention where needed:
+Use these file roles when they improve the concrete design:
 
 ```text
 module.f.mjs  # FunctionalScript implementation
 module.mjs    # host integration, when needed
 proof.f.mjs   # FunctionalScript proofs
 proof.mjs     # host proofs, when needed
-meta.f.mjs    # runtime metadata constants used to define/derive types
+meta.f.mjs    # optional runtime metadata/data extracted to support type structure
 types.ts      # public declaration closure
-private.ts    # other implementation-private file-scope types
+private.ts    # optional implementation-private file-scope TypeScript
 ```
+
+The design target is the public boundary, not the presence of particular files:
+
+- `types.ts` describes the public declaration closure;
+- use `private.ts` when moving implementation-private file-scope types out of the
+  public declaration surface makes the structure cleaner;
+- use `meta.f.mjs` when extracting runtime metadata/data lets TypeScript types or
+  proofs depend on it without reversing the dependency order;
+- do not create either file mechanically when a simpler organization already
+  keeps the public surface clean.
 
 No authored `.mjs` file anywhere in the repository may declare a **file-scope**
 JSDoc `@typedef`, regardless of directory, basename, or whether the file is
@@ -52,7 +63,7 @@ Private type and runtime constant names continue to start with `_`.
 
 #### Dependency order
 
-Keep the source dependency order:
+When these roles are present, keep the source dependency order:
 
 ```text
 meta.f.mjs <- types.ts <- private.ts <- module.f.mjs <- proof.f.mjs <- module.mjs <- proof.mjs
@@ -61,21 +72,21 @@ meta.f.mjs <- types.ts <- private.ts <- module.f.mjs <- proof.f.mjs <- module.mj
 The arrow points from a dependency to a dependent: a file may depend on files to
 its left, but moving a type proof must not introduce a reverse edge merely to
 keep the proof near the declaration it checks. The order is a layering rule, not
-a requirement that every file directly import its immediate neighbor.
+a requirement that every file or edge exists.
 
 The file-placement conventions below are defaults, not a mechanical classifier.
 Analyze concrete cases and prefer the simplest organization that preserves this
-dependency order. In particular, do not force a recursive RTTI constant into
-`meta.f.mjs` when expressing its recursion requires a named annotation from
-`types.ts`; keeping that constant downstream can be cleaner than creating a
-`meta.f.mjs -> types.ts` reverse edge.
+dependency order and the clean public boundary. In particular, do not force a
+recursive RTTI constant into `meta.f.mjs` when expressing its recursion requires
+a named annotation from `types.ts`; keeping that constant downstream can be
+cleaner than creating a `meta.f.mjs -> types.ts` reverse edge.
 
 Place assertions in the earliest layer that can legitimately see everything they
 assert without reversing this order:
 
 - invariants entirely inside the public type model belong in `types.ts`;
-- implementation-private type invariants belong in `private.ts` when they do not
-  need downstream implementation values;
+- implementation-private type invariants may use `private.ts` when that is the
+  cleanest place and they do not need downstream implementation values;
 - assertions about `module.f.mjs` implementations, including function signatures,
   belong downstream in `proof.f.mjs`, normally as function-local typedef proofs;
 - host-specific implementation assertions belong downstream in `proof.mjs`.
@@ -116,9 +127,10 @@ illustrate the intended approach:
   reversing the dependency order.
 
 These examples do not establish a special rule for every recursive type. They
-show the process: inspect the cycle, preserve the dependency direction, and move
-verification downstream when that produces a clearer structure. Narrow
-exceptions may still be needed after the concrete case has been analyzed.
+show the process: inspect the cycle, preserve the dependency direction, move
+verification downstream when useful, and introduce `private.ts` / `meta.f.mjs`
+only when they simplify the result. Narrow exceptions may still be needed after
+the concrete case has been analyzed.
 
 #### Public declaration closure
 
@@ -132,9 +144,9 @@ The default placement guide is:
 ```text
 public type                                         -> types.ts
 private `_` helper used by any public declaration   -> types.ts
-other file-scope private `_` type                   -> private.ts
+other file-scope private `_` type                   -> private.ts, when useful
 function-local typedef                              -> allowed in place
-runtime metadata constant used to define types      -> meta.f.mjs, when layering permits
+runtime metadata/data extracted for type structure  -> meta.f.mjs, when useful
 ```
 
 For example, a helper used by a public type stays in `types.ts`:
@@ -155,18 +167,19 @@ export const find: <T>(cmp: Cmp<T>) =>
 ```
 
 then `_SortedArray` is part of the public declaration closure and must remain in
-`types.ts` (or be inlined into the public declaration). Moving it to `private.ts`
-would make a shipped declaration depend on a declaration module that packaging
-removes.
+`types.ts` (or be inlined into the public declaration). Moving it to
+`private.ts` would make a shipped declaration depend on a declaration module
+that packaging removes.
 
 `types.ts` must never import `private.ts`. If moving a private helper to
 `private.ts` would create a `types.ts -> private.ts` edge or cause any generated
 public declaration to reference `private.ts`, keep or inline that helper in
 `types.ts` instead.
 
-This should keep `private.ts` uncommon in `types.ts`-heavy modules: it is for
+`private.ts` therefore should be uncommon. It is a tool for separating
 implementation-private file-scope types that are outside the public declaration
-closure, not a mechanical destination for every `_` name.
+closure; it is not a required companion and not a mechanical destination for
+every `_` name.
 
 #### Function-local typedefs
 
@@ -198,26 +211,20 @@ exported aliases in generated `.d.ts` / `.d.mts` files.
 
 #### `meta.f.mjs`
 
-`meta.f.mjs` is the preferred home for runtime metadata constants whose
-literal/inferred values are part of the type-level model when they can live there
-without reversing the dependency order. They do not need to be RTTI, and normal
-runtime code may also consume them. Typical cases are RTTI descriptors,
+`meta.f.mjs` is an optional tool for extracting runtime metadata/data when doing
+so improves the type/declaration boundary. Typical cases are RTTI descriptors,
 `as const`-style data, and lookup tables whose literal shape is used to define or
 derive TypeScript types.
 
-This is a convention, not an absolute rule. A recursive metadata constant that
-needs a named annotation from `types.ts` may remain in `module.f.mjs` rather than
-creating a reverse dependency. In such a case, move consistency assertions to a
-downstream proof function when that removes the reverse edge or file-scope typedef
-leak. The `media/revision` and `edag` examples above are the current models for
-this analysis.
+Do not create `meta.f.mjs` merely because a runtime value participates in a type
+proof. A recursive metadata constant that needs a named annotation from
+`types.ts` may remain in `module.f.mjs`; ordinary implementation functions stay
+in `module.f.mjs` even when a proof inspects their signature with `typeof`,
+`ReturnType`, or `Parameters`. Move verification downstream when that is the
+cleaner solution. The `media/revision`, `edag`, and `effects` examples above are
+the current models for this analysis.
 
-`meta.f.mjs` is **not** a destination for ordinary implementation functions just
-because a type proof inspects their signature with `typeof`, `ReturnType`, or
-`Parameters`. Such functions stay in `module.f.mjs`; place their signature proofs
-downstream according to the dependency-order rule above.
-
-Examples of metadata include RTTI values:
+When `meta.f.mjs` is useful, examples include RTTI values:
 
 ```ts
 import type { type } from './meta.f.mjs'
@@ -273,12 +280,13 @@ import type { metadataValue } from './meta.f.mjs'
 Do not use runtime `import { ... }`, namespace imports, or side-effect imports in
 `types.ts` or `private.ts`.
 
-`meta.f.mjs` is executable FunctionalScript source. Emergent testing already
-loads every `*.f.mjs` during normal test discovery, including modules without a
-`proof` export. Add `meta.f.mjs` to the Node and Deno coverage filters so the
-existing coverage thresholds apply to it. How a particular metadata module
-satisfies those thresholds is left to its developer; this convention does not
-prescribe proof imports, calls, or other coverage-specific implementation choices.
+When present, `meta.f.mjs` is executable FunctionalScript source. Emergent
+testing already loads every `*.f.mjs` during normal test discovery, including
+modules without a `proof` export. Add `meta.f.mjs` to the Node and Deno coverage
+filters so the existing coverage thresholds apply to it. How a particular
+metadata module satisfies those thresholds is left to its developer; this
+convention does not prescribe proof imports, calls, or other coverage-specific
+implementation choices.
 
 #### Breaking migration; no compatibility re-exports
 
@@ -286,7 +294,7 @@ Moving a public file-scope type from any authored `.mjs` file to `types.ts`
 changes its public type import path. Moving a public runtime constant from
 `module.f.mjs` to `meta.f.mjs` changes its runtime import path.
 
-Treat both as intentional breaking API changes:
+Treat either move as an intentional breaking API change when it occurs:
 
 ```text
 public type:     ./<source>.mjs  -> ./types.ts
@@ -298,16 +306,16 @@ points with compatibility typedefs, exports, or re-exports.
 
 #### Declaration emission and packaging
 
-`private.ts` remains in the normal TypeScript program so its declarations and all
-JSDoc `@import` users are checked. Therefore normal declaration emit may produce
-an intermediate `private.d.ts`.
+If `private.ts` is used, it remains in the normal TypeScript program so its
+declarations and all JSDoc `@import` users are checked. Normal declaration emit
+may therefore produce an intermediate `private.d.ts`.
 
-Do not try to exclude `private.ts` from the TypeScript program. Instead make
-private-declaration cleanup the final `prepack` step:
+Do not try to exclude `private.ts` from the TypeScript program. Instead, when
+such files exist, make private-declaration cleanup the final `prepack` step:
 
 1. emit declarations;
 2. run the existing declaration round-trip type-check;
-3. delete every generated `private.d.ts` as the final `prepack` command;
+3. delete generated `private.d.ts` files as the final `prepack` command;
 4. let `npm pack` select files after `prepack` completes;
 5. inspect the actual tarball;
 6. install the tarball in a clean TypeScript consumer and type-check it.
@@ -331,9 +339,10 @@ not a TypeScript import or module dependency, so it may remain after
 
 Validation of the packed artifact must prove:
 
-- neither authored `private.ts` nor generated `private.d.ts` is shipped;
+- authored `private.ts` and generated `private.d.ts` are not shipped when those
+  files are used during source checking;
 - no packed `.d.ts` / `.d.mts` has a **semantic TypeScript dependency** on a
-  directory's private type module.
+  private type module that is not shipped.
 
 A raw text search for `private.ts` / `@import` is therefore incorrect because it
 would reject harmless retained comments. If a structural scan is used, it must
@@ -358,39 +367,36 @@ The `.mjs` typedef prohibition is repository-wide, so the implementation must
 also update the root [`../../AGENTS.md`](../../AGENTS.md). The root policy should
 state that no authored `.mjs` anywhere in the repository may contain a file-scope
 JSDoc `@typedef`. `fjs/AGENTS.md` should then document the additional `fjs/`-specific
-file roles and dependency order:
+file roles and dependency order, making clear that `private.ts` and `meta.f.mjs`
+are optional tools rather than required companions.
 
-```text
-types.ts    # public declaration closure
-private.ts  # implementation-private file-scope types outside that closure
-```
-
-Both remain type-only modules and use named `import type { ... }` imports. Do not
-leave a rule that only governs `fjs/` while root-level authored `.mjs` files such
-as `todo/proof.f.mjs` remain outside the convention.
+Authored TypeScript type modules remain type-only and use named
+`import type { ... }` imports. Do not leave a rule that only governs `fjs/` while
+root-level authored `.mjs` files such as `todo/proof.f.mjs` remain outside the
+convention.
 
 ### Tasks
 
-- [ ] Document `types.ts`, `private.ts`, and `meta.f.mjs` beside the existing
-      JavaScript/FunctionalScript file conventions, including host `.mjs` and
-      descriptive companions.
+- [ ] Document `private.ts` and `meta.f.mjs` as optional tools for cleaning the
+      public declaration/API surface, not required companion files.
 - [ ] Document and preserve the dependency order
-      `meta.f.mjs <- types.ts <- private.ts <- module.f.mjs <- proof.f.mjs <- module.mjs <- proof.mjs`.
-- [ ] Treat the placement table as a default design guide, not a mechanical rule;
-      analyze recursive or otherwise constrained metadata case by case before
-      introducing exceptions or reverse dependencies.
+      `meta.f.mjs <- types.ts <- private.ts <- module.f.mjs <- proof.f.mjs <- module.mjs <- proof.mjs`
+      for the roles that are present.
+- [ ] Treat file placement as a design guide, not a mechanical rule; analyze
+      recursive or otherwise constrained cases before introducing files,
+      exceptions, or reverse dependencies.
 - [ ] Update root `AGENTS.md` to prohibit file-scope JSDoc `@typedef` in every
       authored `.mjs` file anywhere in the repository.
-- [ ] Update `fjs/AGENTS.md` to allow `types.ts` and `private.ts` as the authored
-      TypeScript type-module roles and document the public-declaration-closure and
-      dependency-order rules for `fjs/`.
+- [ ] Update `fjs/AGENTS.md` to document `types.ts`, optional `private.ts`, the
+      optional `meta.f.mjs` role, the public-declaration-closure rule, and the
+      dependency-order rule for `fjs/`.
 - [ ] Update `fjs/fsc/README.md` and delete or narrow
       `todo/blocked/jsdoc-typedef-strip-internal.md` so they no longer prescribe
       a conflicting private-JSDoc strategy.
-- [ ] Prohibit file-scope JSDoc `@typedef` in every authored `.mjs` repository-wide;
-      allow function-local `@typedef` everywhere.
+- [ ] Prohibit file-scope JSDoc `@typedef` in every authored `.mjs`
+      repository-wide; allow function-local `@typedef` everywhere.
 - [ ] Migrate existing authored `.mjs` violations outside `fjs/`, including
-      `todo/proof.f.mjs`, using the same placement rules.
+      `todo/proof.f.mjs`, using the same public-boundary and layering principles.
 - [ ] Keep the leading `_` convention for every private type and private runtime
       metadata constant name.
 - [ ] Move public file-scope named types from authored `.mjs` JSDoc into
@@ -398,9 +404,9 @@ as `todo/proof.f.mjs` remain outside the convention.
 - [ ] Keep or inline every private `_` helper required transitively by any
       shipped public declaration in `types.ts`, including helpers appearing in
       exported runtime-value/function signatures.
-- [ ] Move only other implementation-private file-scope types to `private.ts`;
-      do not create reverse dependency edges or public-declaration -> `private.ts`
-      dependencies.
+- [ ] Use `private.ts` only when separating implementation-private file-scope
+      types from the public declaration closure is the cleanest solution; do not
+      create it mechanically or create reverse/public-declaration dependencies.
 - [ ] Review type assertions that currently reverse the dependency order. Move
       implementation-signature assertions downstream into proof files where
       possible; specifically, move the `fjs/effects/types.ts` assertions over
@@ -415,45 +421,42 @@ as `todo/proof.f.mjs` remain outside the convention.
       preserve layering and move file-scope consistency asserts into proof
       functions.
 - [ ] Keep lexical type-proof typedefs inside their functions.
-- [ ] Prefer `meta.f.mjs` for runtime metadata constants used to define/derive
-      TypeScript types when that placement preserves the dependency order,
-      including RTTI values, non-RTTI literal constants, and runtime-used tables;
-      prefix private ones with `_` even when they must be exported for
-      sibling-module access. Do not move ordinary implementation functions, or
-      recursively annotated metadata that would reverse the dependency order,
-      merely because a proof inspects their type.
-- [ ] Move file-scope private proofs over metadata constants to `private.ts`,
+- [ ] Use `meta.f.mjs` only when extracting runtime metadata/data improves the
+      public/type structure while preserving dependency order; private extracted
+      constants use `_`. Do not move ordinary implementation functions or
+      recursively annotated metadata merely because a proof inspects their type.
+- [ ] Move file-scope private proofs over metadata/constants to `private.ts`,
       `types.ts`, or a downstream proof function according to the concrete
       dependency graph; do not force one placement mechanically.
 - [ ] Treat moves of public runtime constants to `meta.f.mjs` as breaking API
-      changes; update runtime importers and changelog, with no compatibility
-      re-exports.
-- [ ] Require every import in `types.ts` and `private.ts` to use named
-      `import type { ... }`.
+      changes when such moves are chosen; update runtime importers and changelog,
+      with no compatibility re-exports.
+- [ ] Require every import in authored TypeScript type modules (`types.ts` and
+      `private.ts` when present) to use named `import type { ... }`.
 - [ ] Update Node and Deno coverage filters to include `meta.f.mjs`; emergent
       testing already loads it, and the existing coverage thresholds apply.
-- [ ] Keep `private.ts` in normal TypeScript checking without runtime JS emit.
-- [ ] Make deletion of generated `private.d.ts` the final `prepack` step.
+- [ ] When `private.ts` is used, keep it in normal TypeScript checking without
+      runtime JS emit and delete generated `private.d.ts` files as the final
+      `prepack` step.
 - [ ] Do not rewrite/post-process emitted declarations to remove retained JSDoc
       `@import` comments; they are non-semantic in `.d.ts` / `.d.mts`.
-- [ ] Inspect the `npm pack` artifact for private files and **semantic** private
-      declaration dependencies, ignoring retained comments.
-- [ ] Add a fixture covering:
+- [ ] Inspect the `npm pack` artifact for unshipped private declaration
+      dependencies, ignoring retained comments.
+- [ ] Add fixtures covering both optional tools and cases that do not need them:
       - a private helper required by a public type alias;
       - a private helper required by an exported runtime value/function
         declaration (the `_SortedArray`/`find` shape);
-      - an implementation-private type in `private.ts`;
+      - an implementation-private type separated with `private.ts`;
       - a function-local typedef depending on a lexical value;
       - an implementation-function signature assertion placed downstream in a
-        proof rather than creating a `types.ts -> module.f.mjs` dependency;
+        proof rather than introducing `private.ts`/`meta.f.mjs` unnecessarily;
       - a recursive metadata case whose named type annotation keeps it in
         `module.f.mjs` while its consistency assert moves into a proof function;
       - a FunctionalScript descriptive companion such as `testlib.f.mjs` whose
-        former file-scope typedef is moved to the appropriate TypeScript file;
-      - a non-FunctionalScript authored `.mjs` file whose former file-scope
-        typedef is moved to the appropriate TypeScript file;
+        former file-scope typedef is moved to the appropriate place;
+      - a non-FunctionalScript authored `.mjs` case;
       - a root/outside-`fjs/` authored `.mjs` case;
-      - `meta.f.mjs` with RTTI, literal, runtime-used, and private `_` constants.
+      - a case where `meta.f.mjs` is useful, including a private `_` constant.
 - [ ] Include a retained JSDoc `@import ... './private.ts'` comment in an emitted
       declaration fixture and verify the clean consumer succeeds without
       `private.ts`; this proves comments do not create package dependencies.
@@ -464,14 +467,16 @@ as `todo/proof.f.mjs` remain outside the convention.
 
 ### Acceptance criteria
 
+- The public declaration/API surface is clean and self-contained; `private.ts`
+  and `meta.f.mjs` are optional tools, not required companion files.
 - The dependency order
   `meta.f.mjs <- types.ts <- private.ts <- module.f.mjs <- proof.f.mjs <- module.mjs <- proof.mjs`
-  is preserved; type assertions do not create reverse edges merely for
-  convenience.
-- File placement follows the dependency order and concrete design needs rather
-  than a blanket syntactic rule; recursive metadata may remain in `module.f.mjs`
-  when moving it to `meta.f.mjs` would require a `types.ts` dependency, with
-  consistency assertions moved downstream when appropriate.
+  is preserved for roles that are present; type assertions do not create reverse
+  edges merely for convenience.
+- File placement follows concrete design needs rather than a blanket syntactic
+  rule; recursive metadata may remain in `module.f.mjs` when moving it to
+  `meta.f.mjs` would require a `types.ts` dependency, with consistency assertions
+  moved downstream when appropriate.
 - No authored `.mjs` file anywhere in the repository contains a file-scope JSDoc
   `@typedef`, regardless of directory, basename, FunctionalScript marker, or role.
 - Function-local JSDoc `@typedef` is allowed everywhere; private names keep `_`
@@ -479,37 +484,42 @@ as `todo/proof.f.mjs` remain outside the convention.
 - `types.ts` is the public declaration closure: public types plus any private
   helpers required transitively to express shipped declarations of public types
   or exported runtime values/functions.
-- `private.ts` contains only implementation-private file-scope types outside the
-  public declaration closure and is expected to be used sparingly where
-  `types.ts` already describes most of a module's type surface.
-- `types.ts` and every packed public declaration are independent of `private.ts`.
+- If present, `private.ts` contains only implementation-private file-scope types
+  outside the public declaration closure. It is used only when that separation
+  improves the design.
+- `types.ts` and every packed public declaration are independent of unshipped
+  private type modules.
 - Assertions about ordinary implementation-function signatures live downstream
   of `module.f.mjs` (normally inside proof functions with function-local typedefs
   in `proof.f.mjs`) rather than forcing those functions into `meta.f.mjs` or
   importing implementation functions into `types.ts`.
-- Every import in `types.ts` and `private.ts` uses named `import type { ... }`.
-- Runtime metadata constants used to define/derive TypeScript types normally live
-  in `meta.f.mjs` when the dependency order permits it. Private constants use
-  leading `_` even when exported for sibling-module access; `_` marks them private
-  by contract. Emergent testing loads `meta.f.mjs`, Node and Deno coverage filters
-  include it, and the existing coverage thresholds apply; this convention does
-  not prescribe how developers satisfy those thresholds.
-- Moving public types to `types.ts` and public runtime metadata to `meta.f.mjs`
-  are breaking migrations: importers and changelog are updated and no
-  compatibility re-exports preserve old entry points.
-- Declaration emit may create `private.d.ts`; final-`prepack` cleanup removes it
+- Every import in authored TypeScript type modules uses named
+  `import type { ... }`.
+- When `meta.f.mjs` is used, it contains runtime metadata/data extracted because
+  that improves the type/public structure while preserving dependency order.
+  Private constants use leading `_` even when exported for sibling-module
+  access; `_` marks them private by contract. Emergent testing loads
+  `meta.f.mjs`, Node and Deno coverage filters include it, and the existing
+  coverage thresholds apply; this convention does not prescribe how developers
+  satisfy those thresholds.
+- Moving public types to `types.ts` or public runtime metadata to `meta.f.mjs`
+  are breaking migrations when those moves occur: importers and changelog are
+  updated and no compatibility re-exports preserve old entry points.
+- If declaration emit creates `private.d.ts`, final-`prepack` cleanup removes it
   before package contents are selected.
 - Emitted declarations are not text-postprocessed: retained JSDoc `@import`
   comments may mention `private.ts` and are allowed because they do not create a
   TypeScript module dependency.
-- The packed tarball contains neither `private.ts` nor `private.d.ts`, and no
-  packed declaration has a semantic dependency on the private module.
+- The packed tarball contains no unshipped private type artifacts required by
+  public declarations, and no packed declaration has a semantic dependency on
+  an unshipped private module.
 - Public declaration helpers retained in `types.ts` remain self-contained and
   resolvable from shipped declarations, including helpers used by exported
   runtime-value/function signatures.
 - Root `AGENTS.md` documents the repository-wide all-authored-`.mjs` file-scope
   typedef prohibition, while `fjs/AGENTS.md` documents the `fjs/`-specific
-  `types.ts` / `private.ts` roles, declaration-closure rule, and dependency order.
+  declaration-closure/dependency-order rules and the optional `private.ts` /
+  `meta.f.mjs` tools.
 - `fjs/fsc/README.md` and the blocked `@internal`/`stripInternal` TODO no longer
   prescribe a conflicting private-JSDoc strategy.
 - A clean TypeScript consumer type-checks successfully against the packed

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -37,6 +37,42 @@ program; that generated private declaration must be removed before packaging.
 The leading `_` convention remains useful in both categories: it means the type
 name itself is private even when the helper must live beside public types.
 
+#### Relationship to the current `_` workaround
+
+[`../fsc/README.md`](../fsc/README.md) currently defines a deliberate interim
+policy for private JSDoc typedefs: until TypeScript supports stripping JSDoc
+`@typedef`s with `@internal` plus `stripInternal`, a leading `_` marks an emitted
+alias as private by contract even when declaration emit exposes it. The upstream
+blocker is
+[microsoft/TypeScript#46407](https://github.com/microsoft/TypeScript/issues/46407),
+and the waiting strategy is tracked in
+[`../../todo/blocked/jsdoc-typedef-strip-internal.md`](../../todo/blocked/jsdoc-typedef-strip-internal.md).
+
+That policy remains authoritative **until this migration is implemented**. This
+TODO intentionally proposes replacing the wait-for-upstream workaround for
+file-scope implementation-private types with a structural boundary:
+
+- file-scope implementation-private named types move to `private.ts`;
+- file-scope JSDoc typedefs disappear from implementation/proof modules, so they
+  no longer leak merely because TypeScript emits them;
+- `private.d.ts` is treated as an intermediate package-build artifact and is
+  removed before packing;
+- function-local typedefs remain available for lexical type proofs and do not
+  need the file-level workaround.
+
+Physical separation is preferred here because it solves the declaration leak
+with tools available today, gives private named types the full TypeScript type
+language, and makes the public/private source and package boundaries explicit.
+The leading `_` remains the naming convention for private types; this proposal
+changes where file-scope private types live, not what `_` means.
+
+When this TODO is implemented, update `fjs/fsc/README.md` so it no longer presents
+leaked file-scope JSDoc typedefs as the intended steady-state convention. Also
+revisit `todo/blocked/jsdoc-typedef-strip-internal.md`: delete it if no remaining
+supported case needs file-scope private JSDoc typedef stripping, or narrow it to
+whatever cases remain. Do not leave two live documents prescribing different
+private-type strategies.
+
 ### Proposal
 
 Use this directory convention where named types or runtime metadata used for
@@ -206,41 +242,30 @@ the same coverage expectations as `module.f.mjs`.
 
 #### Breaking public API migration
 
-Moving public definitions to their dedicated files changes their published
-import paths. Treat these relocations as intentional breaking API changes rather
-than preserving the old entry points with compatibility re-exports.
+Moving a public file-scope JSDoc typedef from `module.f.mjs` or `proof.f.mjs` to
+`types.ts` changes its published type import path. Moving a public runtime
+constant from `module.f.mjs` to `meta.f.mjs` changes its published runtime import
+path. Treat **both** relocations as intentional breaking API changes; do not
+preserve the old entry points with compatibility typedefs, exports, or re-exports.
 
-For public types, if consumers previously imported a type from:
-
-```text
-./module.f.mjs
-```
-
-and the type moves to `types.ts`, its new public type entry point is:
+For types:
 
 ```text
-./types.ts
+./module.f.mjs -> ./types.ts
 ```
 
-For public runtime constants, if consumers previously imported a value from:
+For runtime metadata:
 
 ```text
-./module.f.mjs
+./module.f.mjs -> ./meta.f.mjs
 ```
 
-and the value moves to `meta.f.mjs`, its new runtime entry point is:
+The migration must update every repository importer to the new path and record
+the breaking change in the changelog. Keeping compatibility aliases or
+re-exports in `module.f.mjs` would preserve exactly the mixed responsibilities
+this convention is intended to remove.
 
-```text
-./meta.f.mjs
-```
-
-In both cases, update every repository importer to the new path and record the
-breaking change in the changelog. Do **not** leave compatibility typedefs,
-exports, or re-exports in `module.f.mjs` to preserve the old entry point. The
-point of the migration is to make the source/API boundaries explicit rather than
-carry aliases from the old layout indefinitely.
-
-#### Declaration emission and packaging
+### Declaration emission and packaging
 
 `private.ts` is source-only and remains in the normal TypeScript program so its
 types and all `@import` users are checked. Consequently, the existing
@@ -287,6 +312,11 @@ References to packaged `meta.f.mjs` are allowed.
 
 - [ ] Document `private.ts` and `meta.f.mjs` beside the existing `types.ts`,
       `module.*`, and `proof.*` conventions.
+- [ ] Reconcile the implemented convention with the current private-JSDoc policy:
+      update `fjs/fsc/README.md` to replace the leaked-file-scope-typedef
+      workaround, and delete or narrow
+      `todo/blocked/jsdoc-typedef-strip-internal.md` so the repository has one
+      authoritative strategy.
 - [ ] Prohibit file-scope JSDoc `@typedef` declarations in `module.f.mjs` and
       `proof.f.mjs`; allow function-local `@typedef` declarations everywhere.
 - [ ] Keep the leading `_` convention for every private type name, including
@@ -305,14 +335,12 @@ References to packaged `meta.f.mjs` are allowed.
 - [ ] Move runtime constants referenced by TypeScript type definitions/proofs
       into `meta.f.mjs`, including RTTI definitions, non-RTTI literal constants,
       and ordinary runtime tables whose literal/inferred types are asserted.
-- [ ] Treat moves of public runtime constants to `meta.f.mjs` as breaking API
-      changes: update every repository runtime importer to the new path and
-      record the break in the changelog.
-- [ ] Do not add compatibility exports or re-exports in `module.f.mjs` for
-      runtime constants moved to `meta.f.mjs`.
 - [ ] Move file-scope private type proofs over those constants to `private.ts`
       (or keep helpers in `types.ts` when required by a public declaration), and
       use `import type { ... }` to reference the `meta.f.mjs` values.
+- [ ] Treat moves of public runtime constants to `meta.f.mjs` as breaking API
+      changes: update every repository runtime importer and the changelog; do not
+      leave compatibility exports or re-exports in `module.f.mjs`.
 - [ ] Require every import in `types.ts` and `private.ts` to use named
       `import type { ... }`.
 - [ ] Update Node coverage selection to include both `module.f.mjs` and
@@ -341,6 +369,9 @@ References to packaged `meta.f.mjs` are allowed.
 
 ### Acceptance criteria
 
+- The current `_` leak-tolerance policy is explicitly superseded when this
+  migration is implemented; `fjs/fsc/README.md` and the blocked `@internal` /
+  `stripInternal` TODO no longer prescribe a conflicting strategy.
 - `module.f.mjs` and `proof.f.mjs` contain no file-scope JSDoc `@typedef`.
 - Function-local JSDoc `@typedef` declarations are allowed everywhere; private
   ones keep `_` and do not escape as exported declaration aliases.
@@ -349,10 +380,10 @@ References to packaged `meta.f.mjs` are allowed.
   intentional breaking API change: repository importers use the new path, the
   changelog records the break, and no compatibility typedef/re-export preserves
   the old type entry point.
-- Moving a public runtime constant from `module.f.mjs` to `meta.f.mjs` is an
-  intentional breaking API change: repository runtime importers use the new
-  path, the changelog records the break, and no compatibility export/re-export
-  preserves the old runtime entry point.
+- Moving a public runtime constant from `module.f.mjs` to `meta.f.mjs` is also an
+  intentional breaking API change: repository importers use the new path, the
+  changelog records the break, and no compatibility export/re-export preserves
+  the old runtime entry point.
 - Private `_` helpers required to express public types also remain in `types.ts`
   and are not source exports merely because they are declaration helpers.
 - Other private file-scope types live in `private.ts` and keep `_`.
@@ -377,6 +408,14 @@ References to packaged `meta.f.mjs` are allowed.
 
 ### Related
 
+- [`../fsc/README.md`](../fsc/README.md) — current `_` leak-tolerance policy that
+  this migration supersedes once implemented.
+- [`../../todo/blocked/jsdoc-typedef-strip-internal.md`](../../todo/blocked/jsdoc-typedef-strip-internal.md)
+  — current wait-for-`@internal`/`stripInternal` strategy; delete or narrow when
+  this migration lands.
+- [microsoft/TypeScript#46407](https://github.com/microsoft/TypeScript/issues/46407)
+  — upstream JSDoc `@typedef` stripping limitation that motivated the current
+  workaround.
 - [`detect-unexported-types-referenced-by-exported-types.md`](./detect-unexported-types-referenced-by-exported-types.md) — detect private type names that leak through exported types.
 - [`document-file-type-naming-conventions.md`](./document-file-type-naming-conventions.md) — document the repository's source-file roles.
 - [`../../todo/migrate-typescript-to-mjs.md`](../../todo/migrate-typescript-to-mjs.md) — current JavaScript/JSDoc implementation migration and `_` private-type convention.

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -151,19 +151,40 @@ types and all `@import` users are checked. Consequently, the existing
 cannot suppress that output once another program input imports `private.ts`.
 
 Do not require TypeScript to avoid generating that intermediate file. Instead,
-make private declaration cleanup an explicit packaging step:
+make private declaration cleanup the **final step of `prepack`**. `npm pack`
+runs `prepack` itself, so an external emit/check/cleanup sequence followed by
+`npm pack` would be wrong: `npm pack` would rerun declaration emission and
+recreate the deleted `private.d.ts` before selecting package contents.
 
-1. run normal declaration emission and the existing declaration round-trip
-   type-check;
-2. delete every generated `private.d.ts` before `npm pack` selects package
-   contents;
-3. run `npm pack`;
-4. validate the actual packed artifact:
+The packaging lifecycle should therefore be:
+
+1. `prepack` runs normal declaration emission;
+2. `prepack` runs the existing declaration round-trip type-check;
+3. as the final `prepack` command, delete every generated `private.d.ts`;
+4. `npm pack` selects package contents after `prepack` completes;
+5. validate the actual packed artifact:
    - it contains neither authored `private.ts` nor generated `private.d.ts`;
    - every shipped `.d.ts` / `.d.mts` is scanned and must not contain a module
      reference to the directory's `private` type module;
-5. install the tarball in the existing clean TypeScript consumer and type-check
+6. install the tarball in the existing clean TypeScript consumer and type-check
    it as an independent semantic validation.
+
+Conceptually, the current `prepack`:
+
+```text
+tsc --noEmit false --emitDeclarationOnly && tsc
+```
+
+becomes:
+
+```text
+tsc --noEmit false --emitDeclarationOnly && tsc && <delete generated private.d.ts files>
+```
+
+The cleanup command should be implemented with repository-portable tooling; the
+exact command is part of implementation, not this source-layout convention.
+Tests should invoke `npm pack` normally so they exercise the real lifecycle,
+rather than reproducing `prepack` steps externally.
 
 The declaration scan should reject the private module rather than only one
 particular emitted spelling. For example, `./private.ts`, `./private.d.ts`, or a
@@ -206,8 +227,10 @@ rather than retaining `private.d.ts` to make such a leak resolve.
       `Ts<typeof ...>`, `typeof ...`, or equivalent type queries.
 - [ ] Keep `private.ts` in normal TypeScript type-checking without generating a
       runtime JavaScript file for it.
-- [ ] Add a post-declaration-emit packaging step that deletes generated
-      `private.d.ts` files before `npm pack`.
+- [ ] Make deletion of generated `private.d.ts` files the final `prepack` step,
+      after declaration emission and the declaration round-trip check.
+- [ ] Exercise cleanup through a normal `npm pack`; do not run cleanup externally
+      before `npm pack`, because `npm pack` reruns `prepack`.
 - [ ] Inspect the `npm pack` artifact and reject any packed `private.ts` or
       `private.d.ts` file.
 - [ ] Scan every packed `.d.ts` / `.d.mts` and reject any module reference to a
@@ -216,10 +239,10 @@ rather than retaining `private.d.ts` to make such a leak resolve.
       from `private.ts` without declaring any file-scope `@typedef`; also include
       a function-local typedef that depends on a lexical value and verify it does
       not escape into generated declarations. Verify declaration emit creates the
-      intermediate `private.d.ts`, cleanup removes it, generated public
-      declarations contain no implementation-local file-scope typedef exports,
-      and packed-artifact validation finds no private type file or declaration
-      edge.
+      intermediate `private.d.ts`, final-`prepack` cleanup removes it, generated
+      public declarations contain no implementation-local file-scope typedef
+      exports, and packed-artifact validation finds no private type file or
+      declaration edge.
 - [ ] Extend the fixture with `meta.f.mjs` containing both an RTTI value and a
       non-RTTI literal constant used to derive TypeScript types in `types.ts` or
       `private.ts`; verify the source tree and packed consumer resolve both
@@ -243,8 +266,8 @@ rather than retaining `private.d.ts` to make such a leak resolve.
   type queries.
 - Generated public declarations do not expose private file-scope named typedefs
   merely as a consequence of declaration emission.
-- Declaration emission may create `private.d.ts`, but the packaging cleanup
-  removes it before package contents are selected.
+- Declaration emission may create `private.d.ts`; the final `prepack` step
+  removes it, and `npm pack` selects contents only after that cleanup completes.
 - The packed tarball contains neither `private.ts` nor `private.d.ts`.
 - No packed `.d.ts` / `.d.mts` file depends on a directory's private type module,
   regardless of the exact emitted module-specifier suffix.

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -181,8 +181,17 @@ import type { metadataValue } from './meta.f.mjs'
 Do not use runtime `import { ... }`, namespace imports, or side-effect imports in
 `types.ts` or `private.ts`.
 
-`meta.f.mjs` is executable FunctionalScript source. Node and Deno coverage must
-include it under the same expectations as `module.f.mjs`.
+`meta.f.mjs` is executable FunctionalScript source. Node and Deno coverage
+filters should include it so metadata that is actually loaded is measured under
+the same coverage expectations as `module.f.mjs`. Coverage inclusion does not
+load modules by itself, and the convention does not require an otherwise-unused
+`meta.f.mjs` to be imported solely to make it appear in a coverage report.
+
+When a directory has a `meta.f.mjs`, it is recommended for the corresponding
+proof to import and exercise the metadata when that produces a meaningful runtime
+check. This is a recommendation, not a requirement: a metadata module that is
+used only through erased TypeScript `import type` references need not gain an
+artificial runtime import just for coverage.
 
 #### Breaking migration; no compatibility re-exports
 
@@ -291,7 +300,12 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
       re-exports.
 - [ ] Require every import in `types.ts` and `private.ts` to use named
       `import type { ... }`.
-- [ ] Update Node and Deno coverage filters to include `meta.f.mjs`.
+- [ ] Update Node and Deno coverage filters to include `meta.f.mjs`; when a
+      metadata module is loaded, it must be subject to the same coverage
+      thresholds as other executable FunctionalScript source.
+- [ ] Recommend importing and exercising `meta.f.mjs` from the corresponding
+      proof when that gives a meaningful runtime check; do not require artificial
+      proof imports solely to make otherwise-unused metadata appear in coverage.
 - [ ] Keep `private.ts` in normal TypeScript checking without runtime JS emit.
 - [ ] Make deletion of generated `private.d.ts` the final `prepack` step.
 - [ ] Inspect the `npm pack` artifact for private files and private declaration
@@ -307,6 +321,10 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
       - a non-FunctionalScript authored `.mjs` file whose former file-scope
         typedef is moved to the appropriate TypeScript file;
       - `meta.f.mjs` with RTTI, literal, and runtime-used constants.
+- [ ] In the fixture, runtime-load at least one metadata path to prove that the
+      Node/Deno coverage filters include loaded `meta.f.mjs`; do not use the
+      fixture to impose a requirement that every metadata module/export in the
+      repository be runtime-loaded by a proof.
 - [ ] Verify source checking, declaration emit/cleanup, Node+Deno coverage,
       packing, and clean-consumer type checking.
 
@@ -325,8 +343,9 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
 - `types.ts` and every packed public declaration are independent of `private.ts`.
 - Every import in `types.ts` and `private.ts` uses named `import type { ... }`.
 - Runtime constants referenced by TypeScript definitions/proofs live in
-  `meta.f.mjs`, whether RTTI or not; executable metadata is covered by Node and
-  Deno coverage.
+  `meta.f.mjs`, whether RTTI or not. Node and Deno coverage filters include
+  `meta.f.mjs`, but proofs are not required to runtime-import metadata solely for
+  coverage; importing/exercising metadata from proofs is recommended when useful.
 - Moving public types to `types.ts` and public runtime metadata to `meta.f.mjs`
   are breaking migrations: importers and changelog are updated and no
   compatibility re-exports preserve old entry points.

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -16,9 +16,11 @@ types.ts      # public types + private helpers
 ```
 
 Other authored JavaScript companions, such as `testlib.f.mjs`, can contain the
-same file-scope typedefs and are subject to the same declaration emit. TypeScript
-turns file-scope JSDoc `@typedef`s in authored `.mjs` files into exported aliases,
-so implementation-private names leak into generated `.d.mts` files. The existing
+same file-scope typedefs and are subject to the same declaration emit. The same
+problem also exists outside `fjs/`; for example, `todo/proof.f.mjs` is an authored
+`.mjs` file with a file-scope typedef. TypeScript turns file-scope JSDoc
+`@typedef`s in authored `.mjs` files into exported aliases, so
+implementation-private names leak into generated `.d.mts` files. The existing
 leading-`_` convention marks those names private by contract, but the declarations
 still contain noise and make the source/package boundary less clear.
 
@@ -39,11 +41,12 @@ types.ts      # public declaration closure
 private.ts    # other implementation-private file-scope types
 ```
 
-No authored `.mjs` file may declare a **file-scope** JSDoc `@typedef`, regardless
-of basename or whether the file is FunctionalScript. This includes
-`module.f.mjs`, `module.mjs`, `proof.f.mjs`, `proof.mjs`, `meta.f.mjs`,
-`testlib.f.mjs`, and other descriptive companions. Function-local typedefs remain
-allowed as described below.
+No authored `.mjs` file anywhere in the repository may declare a **file-scope**
+JSDoc `@typedef`, regardless of directory, basename, or whether the file is
+FunctionalScript. This includes `module.f.mjs`, `module.mjs`, `proof.f.mjs`,
+`proof.mjs`, `meta.f.mjs`, `testlib.f.mjs`, root-level or `todo/` `.mjs` files,
+and other descriptive companions. Function-local typedefs remain allowed as
+described below.
 
 Private type and runtime constant names continue to start with `_`.
 
@@ -75,16 +78,19 @@ For example, `fjs/effects/types.ts` currently imports `step`, `catchStep`,
 only to assert their inferred signatures with `ReturnType<typeof ...>`. Those
 assertions verify the implementation layer, so the migration should move them to
 `proof.f.mjs` rather than move the implementation functions into `meta.f.mjs`.
-A representative proof can stay lexical:
+A representative group of compile-time-only checks can live inside one proof
+function so every typedef remains lexical:
 
 ```js
-signature: () => {
+signatures: () => {
     /**
      * @typedef {Assert<Equal<
      *   ReturnType<typeof step<_AddOp, number, NotImplemented, _MulOp, string, string>>,
      *   Effect<_AddOp | _MulOp, string, NotImplemented | string>
      * >>} _StepSig
      */
+
+    /** @typedef {Assert<Equal<ReturnType<typeof catchStep<...>>, Effect<...>>>} _CatchStepSig */
 }
 ```
 
@@ -320,19 +326,20 @@ That policy remains authoritative until this migration is implemented. When this
 TODO lands, update `fjs/fsc/README.md` and delete or narrow the blocked TODO so
 the repository has one private-type strategy.
 
-The migration also changes [`../AGENTS.md`](../AGENTS.md), which currently says
-`types.ts` is the only authored TypeScript under `fjs/`. Update it so the allowed
-authored TypeScript type-module roles are:
+The `.mjs` typedef prohibition is repository-wide, so the implementation must
+also update the root [`../../AGENTS.md`](../../AGENTS.md). The root policy should
+state that no authored `.mjs` anywhere in the repository may contain a file-scope
+JSDoc `@typedef`. `fjs/AGENTS.md` should then document the additional `fjs/`-specific
+file roles and dependency order:
 
 ```text
 types.ts    # public declaration closure
 private.ts  # implementation-private file-scope types outside that closure
 ```
 
-Both remain type-only modules and use named `import type { ... }` imports. The
-same policy must also state that file-scope JSDoc `@typedef` is prohibited in
-**all authored `.mjs` files**, including non-FunctionalScript host JavaScript,
-and document the dependency order above.
+Both remain type-only modules and use named `import type { ... }` imports. Do not
+leave a rule that only governs `fjs/` while root-level authored `.mjs` files such
+as `todo/proof.f.mjs` remain outside the convention.
 
 ### Tasks
 
@@ -341,16 +348,18 @@ and document the dependency order above.
       descriptive companions.
 - [ ] Document and preserve the dependency order
       `meta.f.mjs <- types.ts <- private.ts <- module.f.mjs <- proof.f.mjs <- module.mjs <- proof.mjs`.
+- [ ] Update root `AGENTS.md` to prohibit file-scope JSDoc `@typedef` in every
+      authored `.mjs` file anywhere in the repository.
 - [ ] Update `fjs/AGENTS.md` to allow `types.ts` and `private.ts` as the authored
-      TypeScript type-module roles, document the public-declaration-closure and
-      dependency-order rules, and prohibit file-scope `@typedef` in every
-      authored `.mjs` file.
+      TypeScript type-module roles and document the public-declaration-closure and
+      dependency-order rules for `fjs/`.
 - [ ] Update `fjs/fsc/README.md` and delete or narrow
       `todo/blocked/jsdoc-typedef-strip-internal.md` so they no longer prescribe
       a conflicting private-JSDoc strategy.
-- [ ] Prohibit file-scope JSDoc `@typedef` in every authored `.mjs`, including
-      `.f.mjs`, host `module.mjs` / `proof.mjs`, and descriptive companions;
+- [ ] Prohibit file-scope JSDoc `@typedef` in every authored `.mjs` repository-wide;
       allow function-local `@typedef` everywhere.
+- [ ] Migrate existing authored `.mjs` violations outside `fjs/`, including
+      `todo/proof.f.mjs`, using the same placement rules.
 - [ ] Keep the leading `_` convention for every private type and private runtime
       metadata constant name.
 - [ ] Move public file-scope named types from authored `.mjs` JSDoc into
@@ -365,7 +374,8 @@ and document the dependency order above.
       implementation-signature assertions downstream into proof files where
       possible; specifically, move the `fjs/effects/types.ts` assertions over
       `step` / `catchStep` / `resultStep` / `mapStep` / `resultMapStep` /
-      `unwrapStep` to function-local proofs in `fjs/effects/proof.f.mjs`.
+      `unwrapStep` into one or more proof functions with function-local typedefs
+      in `fjs/effects/proof.f.mjs`.
 - [ ] Keep lexical type-proof typedefs inside their functions.
 - [ ] Move runtime metadata constants used to define/derive TypeScript types into
       `meta.f.mjs`, including RTTI values, non-RTTI literal constants, and
@@ -400,6 +410,7 @@ and document the dependency order above.
         former file-scope typedef is moved to the appropriate TypeScript file;
       - a non-FunctionalScript authored `.mjs` file whose former file-scope
         typedef is moved to the appropriate TypeScript file;
+      - a root/outside-`fjs/` authored `.mjs` case;
       - `meta.f.mjs` with RTTI, literal, runtime-used, and private `_` constants.
 - [ ] Include a retained JSDoc `@import ... './private.ts'` comment in an emitted
       declaration fixture and verify the clean consumer succeeds without
@@ -415,8 +426,8 @@ and document the dependency order above.
   `meta.f.mjs <- types.ts <- private.ts <- module.f.mjs <- proof.f.mjs <- module.mjs <- proof.mjs`
   is preserved; type assertions do not create reverse edges merely for
   convenience.
-- No authored `.mjs` file contains a file-scope JSDoc `@typedef`, regardless of
-  basename, FunctionalScript marker, or role.
+- No authored `.mjs` file anywhere in the repository contains a file-scope JSDoc
+  `@typedef`, regardless of directory, basename, FunctionalScript marker, or role.
 - Function-local JSDoc `@typedef` is allowed everywhere; private names keep `_`
   and do not escape as exported declaration aliases.
 - `types.ts` is the public declaration closure: public types plus any private
@@ -427,9 +438,9 @@ and document the dependency order above.
   `types.ts` already describes most of a module's type surface.
 - `types.ts` and every packed public declaration are independent of `private.ts`.
 - Assertions about ordinary implementation-function signatures live downstream
-  of `module.f.mjs` (normally in function-local `proof.f.mjs` typedefs) rather
-  than forcing those functions into `meta.f.mjs` or importing implementation
-  functions into `types.ts`.
+  of `module.f.mjs` (normally inside proof functions with function-local typedefs
+  in `proof.f.mjs`) rather than forcing those functions into `meta.f.mjs` or
+  importing implementation functions into `types.ts`.
 - Every import in `types.ts` and `private.ts` uses named `import type { ... }`.
 - Runtime metadata constants used to define/derive TypeScript types live in
   `meta.f.mjs`, whether RTTI or not. Private constants use leading `_` even when
@@ -450,10 +461,9 @@ and document the dependency order above.
 - Public declaration helpers retained in `types.ts` remain self-contained and
   resolvable from shipped declarations, including helpers used by exported
   runtime-value/function signatures.
-- `fjs/AGENTS.md` no longer says `types.ts` is the only authored TypeScript and
-  documents both `types.ts` and `private.ts`, the declaration-closure and
-  dependency-order rules, and the all-authored-`.mjs` file-scope typedef
-  prohibition.
+- Root `AGENTS.md` documents the repository-wide all-authored-`.mjs` file-scope
+  typedef prohibition, while `fjs/AGENTS.md` documents the `fjs/`-specific
+  `types.ts` / `private.ts` roles, declaration-closure rule, and dependency order.
 - `fjs/fsc/README.md` and the blocked `@internal`/`stripInternal` TODO no longer
   prescribe a conflicting private-JSDoc strategy.
 - A clean TypeScript consumer type-checks successfully against the packed
@@ -463,7 +473,10 @@ and document the dependency order above.
 ### Related
 
 - [`../fsc/README.md`](../fsc/README.md) — current `_` leak-tolerance policy.
-- [`../AGENTS.md`](../AGENTS.md) — authored-TypeScript policy to update.
+- [`../../AGENTS.md`](../../AGENTS.md) — root repository policy to update with the
+  all-authored-`.mjs` rule.
+- [`../AGENTS.md`](../AGENTS.md) — `fjs/`-specific authored-TypeScript and file-role
+  policy to update.
 - [`../../todo/blocked/jsdoc-typedef-strip-internal.md`](../../todo/blocked/jsdoc-typedef-strip-internal.md)
   — current wait-for-`@internal`/`stripInternal` strategy.
 - [microsoft/TypeScript#46407](https://github.com/microsoft/TypeScript/issues/46407)

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -5,22 +5,22 @@
 
 ### Problem
 
-FunctionalScript currently mixes named types with runtime/proof source. Common
-examples are:
+FunctionalScript currently mixes named types with authored JavaScript source.
+Common examples are:
 
 ```text
-module.f.mjs  # implementation + file-scope JSDoc typedefs
+module.f.mjs  # FunctionalScript implementation + file-scope JSDoc typedefs
+module.mjs    # host integration + file-scope JSDoc typedefs
 proof.f.mjs   # proofs + file-scope JSDoc typedefs
 types.ts      # public types + private helpers
 ```
 
-Other authored FunctionalScript companions, such as `testlib.f.mjs`, can contain
-the same file-scope typedefs and are subject to the same declaration emit.
-TypeScript turns file-scope JSDoc `@typedef`s in authored `.f.mjs` files into
-exported aliases, so implementation-private names leak into generated `.d.mts`
-files. The existing leading-`_` convention marks those names private by contract,
-but the declarations still contain noise and make the source/package boundary
-less clear.
+Other authored JavaScript companions, such as `testlib.f.mjs`, can contain the
+same file-scope typedefs and are subject to the same declaration emit. TypeScript
+turns file-scope JSDoc `@typedef`s in authored `.mjs` files into exported aliases,
+so implementation-private names leak into generated `.d.mts` files. The existing
+leading-`_` convention marks those names private by contract, but the declarations
+still contain noise and make the source/package boundary less clear.
 
 The goal is to give every file-scope named type a deliberate home while keeping
 public declarations self-contained.
@@ -30,17 +30,20 @@ public declarations self-contained.
 Use this directory convention where needed:
 
 ```text
-module.f.mjs  # implementation
-proof.f.mjs   # proofs
+module.f.mjs  # FunctionalScript implementation
+module.mjs    # host integration, when needed
+proof.f.mjs   # FunctionalScript proofs
+proof.mjs     # host proofs, when needed
 meta.f.mjs    # runtime constants referenced by TypeScript types/proofs
 types.ts      # public declaration closure
 private.ts    # other implementation-private file-scope types
 ```
 
-No authored `.f.mjs` file may declare a **file-scope** JSDoc `@typedef`,
-regardless of basename or role. This includes `module.f.mjs`, `proof.f.mjs`,
-`meta.f.mjs`, `testlib.f.mjs`, and other descriptive FunctionalScript
-companions. Function-local typedefs remain allowed as described below.
+No authored `.mjs` file may declare a **file-scope** JSDoc `@typedef`, regardless
+of basename or whether the file is FunctionalScript. This includes
+`module.f.mjs`, `module.mjs`, `proof.f.mjs`, `proof.mjs`, `meta.f.mjs`,
+`testlib.f.mjs`, and other descriptive companions. Function-local typedefs remain
+allowed as described below.
 
 Private type names continue to start with `_`.
 
@@ -79,9 +82,9 @@ export const find: <T>(cmp: Cmp<T>) =>
 ```
 
 then `_SortedArray` is part of the public declaration closure and must remain in
-`types.ts` (or be inlined into the public declaration). Moving it to
-`private.ts` would make a shipped declaration depend on a declaration module
-that packaging removes.
+`types.ts` (or be inlined into the public declaration). Moving it to `private.ts`
+would make a shipped declaration depend on a declaration module that packaging
+removes.
 
 `types.ts` must never import `private.ts`. If moving a private helper to
 `private.ts` would create a `types.ts -> private.ts` edge or cause any generated
@@ -122,10 +125,9 @@ exported aliases in generated `.d.ts` / `.d.mts` files.
 
 #### `meta.f.mjs`
 
-`meta.f.mjs` contains runtime constants whose literal/inferred types are
-actually referenced by TypeScript type definitions or file-scope type proofs.
-They do not need to be RTTI and do not need to exist primarily for type-system
-purposes.
+`meta.f.mjs` contains runtime constants whose literal/inferred types are actually
+referenced by TypeScript type definitions or file-scope type proofs. They do not
+need to be RTTI and do not need to exist primarily for type-system purposes.
 
 Examples include RTTI values:
 
@@ -164,9 +166,9 @@ type _KeywordsAreComplete =
 import { framingKeywords } from './meta.f.mjs'
 ```
 
-The trigger is an actual TypeScript type dependency (`typeof`,
-`Ts<typeof ...>`, indexed access, a type proof, etc.), not merely that a runtime
-value *could* be queried.
+The trigger is an actual TypeScript type dependency (`typeof`, `Ts<typeof ...>`,
+indexed access, a type proof, etc.), not merely that a runtime value *could* be
+queried.
 
 Runtime code imports values from `meta.f.mjs` normally. Authored TypeScript type
 modules use only named type-only imports:
@@ -184,14 +186,14 @@ include it under the same expectations as `module.f.mjs`.
 
 #### Breaking migration; no compatibility re-exports
 
-Moving a public file-scope type from any authored `.f.mjs` file to `types.ts`
+Moving a public file-scope type from any authored `.mjs` file to `types.ts`
 changes its public type import path. Moving a public runtime constant from
 `module.f.mjs` to `meta.f.mjs` changes its runtime import path.
 
 Treat both as intentional breaking API changes:
 
 ```text
-public type:     ./module.f.mjs -> ./types.ts
+public type:     ./<source>.mjs  -> ./types.ts
 public metadata: ./module.f.mjs -> ./meta.f.mjs
 ```
 
@@ -200,9 +202,9 @@ points with compatibility typedefs, exports, or re-exports.
 
 #### Declaration emission and packaging
 
-`private.ts` remains in the normal TypeScript program so its declarations and
-all JSDoc `@import` users are checked. Therefore normal declaration emit may
-produce an intermediate `private.d.ts`.
+`private.ts` remains in the normal TypeScript program so its declarations and all
+JSDoc `@import` users are checked. Therefore normal declaration emit may produce
+an intermediate `private.d.ts`.
 
 Do not try to exclude `private.ts` from the TypeScript program. Instead make
 private-declaration cleanup the final `prepack` step:
@@ -231,8 +233,8 @@ References to packaged `meta.f.mjs` are allowed.
 #### Repository-policy reconciliation
 
 [`../fsc/README.md`](../fsc/README.md) currently documents the leading `_` as an
-interim API contract for private JSDoc typedefs that TypeScript leaks into
-emitted declarations. The upstream blocker is
+interim API contract for private JSDoc typedefs that TypeScript leaks into emitted
+declarations. The upstream blocker is
 [microsoft/TypeScript#46407](https://github.com/microsoft/TypeScript/issues/46407),
 and the wait-for-`@internal`/`stripInternal` strategy is tracked in
 [`../../todo/blocked/jsdoc-typedef-strip-internal.md`](../../todo/blocked/jsdoc-typedef-strip-internal.md).
@@ -252,24 +254,24 @@ private.ts  # implementation-private file-scope types outside that closure
 
 Both remain type-only modules and use named `import type { ... }` imports. The
 same policy must also state that file-scope JSDoc `@typedef` is prohibited in
-**all** authored `.f.mjs` files, not just `module.*` and `proof.*` entry points.
+**all authored `.mjs` files**, including non-FunctionalScript host JavaScript.
 
 ### Tasks
 
 - [ ] Document `types.ts`, `private.ts`, and `meta.f.mjs` beside the existing
-      FunctionalScript file conventions, including descriptive `.f.mjs`
-      companions.
+      JavaScript/FunctionalScript file conventions, including host `.mjs` and
+      descriptive companions.
 - [ ] Update `fjs/AGENTS.md` to allow `types.ts` and `private.ts` as the authored
       TypeScript type-module roles, document the public-declaration-closure rule,
-      and prohibit file-scope `@typedef` in every authored `.f.mjs` file.
+      and prohibit file-scope `@typedef` in every authored `.mjs` file.
 - [ ] Update `fjs/fsc/README.md` and delete or narrow
       `todo/blocked/jsdoc-typedef-strip-internal.md` so they no longer prescribe
       a conflicting private-JSDoc strategy.
-- [ ] Prohibit file-scope JSDoc `@typedef` in every authored `.f.mjs`, including
-      `module.f.mjs`, `proof.f.mjs`, `meta.f.mjs`, `testlib.f.mjs`, and other
-      descriptive companions; allow function-local `@typedef` everywhere.
+- [ ] Prohibit file-scope JSDoc `@typedef` in every authored `.mjs`, including
+      `.f.mjs`, host `module.mjs` / `proof.mjs`, and descriptive companions;
+      allow function-local `@typedef` everywhere.
 - [ ] Keep the leading `_` convention for every private type name.
-- [ ] Move public file-scope named types from authored `.f.mjs` JSDoc into
+- [ ] Move public file-scope named types from authored `.mjs` JSDoc into
       `types.ts` as a breaking migration; update importers and changelog.
 - [ ] Keep or inline every private `_` helper required transitively by any
       shipped public declaration in `types.ts`, including helpers appearing in
@@ -300,7 +302,9 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
         declaration (the `_SortedArray`/`find` shape);
       - an implementation-private type in `private.ts`;
       - a function-local typedef depending on a lexical value;
-      - a descriptive companion such as `testlib.f.mjs` whose former file-scope
+      - a FunctionalScript descriptive companion such as `testlib.f.mjs` whose
+        former file-scope typedef is moved to the appropriate TypeScript file;
+      - a non-FunctionalScript authored `.mjs` file whose former file-scope
         typedef is moved to the appropriate TypeScript file;
       - `meta.f.mjs` with RTTI, literal, and runtime-used constants.
 - [ ] Verify source checking, declaration emit/cleanup, Node+Deno coverage,
@@ -308,8 +312,8 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
 
 ### Acceptance criteria
 
-- No authored `.f.mjs` file contains a file-scope JSDoc `@typedef`, regardless
-  of basename or role.
+- No authored `.mjs` file contains a file-scope JSDoc `@typedef`, regardless of
+  basename, FunctionalScript marker, or role.
 - Function-local JSDoc `@typedef` is allowed everywhere; private names keep `_`
   and do not escape as exported declaration aliases.
 - `types.ts` is the public declaration closure: public types plus any private
@@ -318,8 +322,7 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
 - `private.ts` contains only implementation-private file-scope types outside the
   public declaration closure and is expected to be used sparingly where
   `types.ts` already describes most of a module's type surface.
-- `types.ts` and every packed public declaration are independent of
-  `private.ts`.
+- `types.ts` and every packed public declaration are independent of `private.ts`.
 - Every import in `types.ts` and `private.ts` uses named `import type { ... }`.
 - Runtime constants referenced by TypeScript definitions/proofs live in
   `meta.f.mjs`, whether RTTI or not; executable metadata is covered by Node and
@@ -336,7 +339,7 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
   runtime-value/function signatures.
 - `fjs/AGENTS.md` no longer says `types.ts` is the only authored TypeScript and
   documents both `types.ts` and `private.ts`, the declaration-closure rule, and
-  the all-authored-`.f.mjs` file-scope typedef prohibition.
+  the all-authored-`.mjs` file-scope typedef prohibition.
 - `fjs/fsc/README.md` and the blocked `@internal`/`stripInternal` TODO no longer
   prescribe a conflicting private-JSDoc strategy.
 - A clean TypeScript consumer type-checks successfully against the packed

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -168,6 +168,35 @@ the same coverage expectations as `module.f.mjs`.
   imports and must not create runtime dependencies.
 - a public declaration must never depend on the removable `private.ts` module.
 
+#### Breaking public type migration
+
+Moving a public file-scope JSDoc typedef from `module.f.mjs` or `proof.f.mjs` to
+`types.ts` changes its published import path. Treat that relocation as an
+intentional breaking API change rather than preserving the old type entry point
+with compatibility re-exports.
+
+For example, if consumers previously imported a type from:
+
+```text
+./module.f.mjs
+```
+
+and the type moves to `types.ts`, its new public type entry point is:
+
+```text
+./types.ts
+```
+
+The migration must update every repository importer to the new path and record
+the breaking change in the changelog. Do not leave compatibility typedefs or
+re-exports in `module.f.mjs` merely to preserve the old type-only subpath: that
+would reintroduce the file-scope typedef/declaration noise this convention is
+intended to remove.
+
+This breaking rule applies to type entry points, not runtime exports. Moving
+runtime values to `meta.f.mjs` requires its own API decision if those values are
+publicly imported at runtime.
+
 #### Declaration emission and packaging
 
 `private.ts` is source-only and remains in the normal TypeScript program so its
@@ -220,7 +249,10 @@ References to packaged `meta.f.mjs` are allowed.
 - [ ] Keep the leading `_` convention for every private type name, including
       private helpers in `types.ts` and function-local private typedefs.
 - [ ] Move public file-scope named types from implementation/proof JSDoc into
-      `types.ts`.
+      `types.ts` as a breaking type-API migration; update every repository
+      importer to the new `types.ts` path and record the break in the changelog.
+- [ ] Do not add compatibility typedefs or re-exports to preserve old
+      `module.f.mjs` type entry points.
 - [ ] Keep `_` helpers required to express public declarations in `types.ts`;
       do not create `types.ts -> private.ts` dependencies.
 - [ ] Move other private file-scope named types out of `types.ts`,
@@ -260,6 +292,10 @@ References to packaged `meta.f.mjs` are allowed.
 - Function-local JSDoc `@typedef` declarations are allowed everywhere; private
   ones keep `_` and do not escape as exported declaration aliases.
 - Public file-scope types live in `types.ts`.
+- Moving a public type from `module.f.mjs` / `proof.f.mjs` to `types.ts` is an
+  intentional breaking API change: repository importers use the new path, the
+  changelog records the break, and no compatibility typedef/re-export preserves
+  the old type entry point.
 - Private `_` helpers required to express public types also remain in `types.ts`
   and are not source exports merely because they are declaration helpers.
 - Other private file-scope types live in `private.ts` and keep `_`.

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -11,24 +11,31 @@ public type declarations:
 ```text
 module.f.mjs  # implementation + private JSDoc types
 proof.f.mjs   # proofs + private JSDoc types
-types.ts      # public + private TypeScript types
+types.ts      # public type API + private helper types
 ```
 
 Private types already use a leading `_` by convention, but their location still
 creates declaration and package noise. In particular, file-scope JSDoc
 `@typedef`s in `module.f.mjs` and `proof.f.mjs` escape into generated `.d.mts`
 files: TypeScript emits them as exported type aliases even when they were
-intended to be private. Private declarations in `types.ts` likewise appear in
-the shipped `types.d.ts`.
+intended to be private.
 
-Moving file-scope named types out of implementation/proof files and splitting
-public from private TypeScript types removes the JSDoc typedef leakage
-structurally. TypeScript will still emit a declaration for an imported
-`private.ts`, because that source file is part of the declaration program; that
-generated private declaration must be removed before packaging.
+There are two different kinds of private file-scope type, and the convention must
+not confuse them:
 
-The leading `_` convention should remain: file placement and name visibility are
-complementary signals.
+1. **public-type helpers** such as `_Tuple` that are required to express an
+   exported type such as `Tuple`; these must stay with the public declaration
+   graph in `types.ts`;
+2. **implementation-private types** used only by implementation/proofs; these
+   belong in `private.ts`.
+
+Moving the second category out of implementation/proof files removes the JSDoc
+typedef leakage structurally. TypeScript will still emit a declaration for an
+imported `private.ts`, because that source file is part of the declaration
+program; that generated private declaration must be removed before packaging.
+
+The leading `_` convention remains useful in both categories: it means the type
+name itself is private even when the helper must live beside public types.
 
 ### Proposal
 
@@ -39,56 +46,77 @@ type derivation are needed:
 module.f.mjs  # implementation; no file-scope @typedef
 proof.f.mjs   # proofs; no file-scope @typedef
 meta.f.mjs    # runtime metadata used to define/derive types
-types.ts      # public named TypeScript types
-private.ts    # private named TypeScript types
+types.ts      # public types + `_` helpers required to express them
+private.ts    # implementation-private `_` types
 ```
 
 `module.f.mjs` and `proof.f.mjs` may use JSDoc annotations and `@import`, but
-must not declare file-scope named types with `@typedef`. File-scope named
-TypeScript types have exactly two homes:
+must not declare file-scope named types with `@typedef`.
 
-- `types.ts` for public types;
-- `private.ts` for implementation-only types.
+The placement rule is based on the type dependency graph, not only visibility:
 
-`private.ts` contains implementation-only TypeScript types used by either the
-module or its proofs. Every private file-scope type continues to start with `_`.
+```text
+public type                                      -> types.ts
+private `_` helper required by a public type     -> types.ts
+other file-scope private `_` type                -> private.ts
+function-local typedef                           -> allowed in place
+```
 
-#### Lexically scoped typedefs
+A `_` helper required to define a public type is still private by name and need
+not be exported from `types.ts`. Keeping it there allows TypeScript to emit a
+self-contained public declaration module. Moving it to `private.ts` would make a
+shipped declaration depend on a module that packaging deliberately removes.
+
+For example:
+
+```ts
+type _Tuple<N extends number, T, R extends readonly T[]> =
+    N extends R['length'] ? R : _Tuple<N, T, readonly [...R, T]>
+
+export type Tuple<N extends number, T> = _Tuple<N, T, readonly []>
+```
+
+`_Tuple` stays in `types.ts`: it is private, but it is part of the implementation
+of the public `Tuple` declaration. By contrast, a `_State` used only to annotate
+`module.f.mjs` belongs in `private.ts`.
+
+`types.ts` must never import `private.ts`. If moving a private alias out of
+`types.ts` would create such an edge, that is evidence that the alias is a
+public-type helper and should remain in `types.ts`.
+
+#### Function-local typedefs
 
 Function-local JSDoc `@typedef` declarations are allowed everywhere. They are
 useful for compile-time proofs that depend on values available only in lexical
-scope and therefore cannot be moved to `private.ts` without exposing or
-restructuring implementation locals.
+scope and therefore cannot be moved to `private.ts`.
 
 For example:
 
 ```js
 const proof = () => {
-    const value = f(42)
-    /** @typedef {Assert<Equal<typeof value, 42>>} _Value */
+    const orConst = or(42, string)
+    /** @typedef {Assert<Equal<typeof orConst, Or<readonly [42, typeof string]>>>} _OrConst */
 }
 ```
 
-Such a typedef is a local type assertion, not a file-level API declaration. Keep
-it inside the narrowest function scope that provides the values it needs; do not
-move it to `private.ts` merely to satisfy the file convention. Private local
-typedef names should keep the leading `_` convention.
+A callback-local proof is also valid:
 
-The distinction is therefore scope-based:
-
-```text
-file-scope public named type  -> types.ts
-file-scope private named type -> private.ts
-function-local typedef        -> allowed in place
+```js
+({ kind }) => {
+    /** @typedef {Assert<Equal<typeof kind, 'add'>>} _Kind */
+    return kind
+}
 ```
 
-Declaration validation must verify that function-local typedefs remain lexical
-and do not appear as exported aliases in generated `.d.ts` / `.d.mts` files.
+These typedefs stay inside the narrowest function scope that provides the values
+they need. Private function-local typedef names keep the leading `_` convention.
+Declaration validation must verify that they remain lexical and do not appear as
+exported aliases in generated `.d.ts` / `.d.mts` files.
 
 #### Type metadata
 
 Some TypeScript types are derived from runtime values rather than declared
-independently. These values include RTTI definitions, for example:
+independently. These values include RTTI definitions:
 
 ```ts
 import type { type } from './meta.f.mjs'
@@ -96,7 +124,7 @@ import type { type } from './meta.f.mjs'
 export type Value = Ts<typeof type>
 ```
 
-and ordinary constants whose literal value is used by a type query, for example:
+and ordinary constants whose literal value is used by a type query:
 
 ```ts
 import type { statuses } from './meta.f.mjs'
@@ -105,66 +133,40 @@ export type Status = typeof statuses[number]
 ```
 
 Put runtime values whose primary purpose is to define, describe, or derive
-type-level information in `meta.f.mjs`. This keeps type metadata distinct from
-normal implementation code and from its compile-time TypeScript views:
-
-```text
-meta.f.mjs  # runtime metadata used by types
-types.ts    # public compile-time types
-private.ts  # private compile-time types
-```
+type-level information in `meta.f.mjs`. Values whose primary purpose is normal
+program behavior remain in `module.f.mjs` even if their types are reused
+incidentally.
 
 Both `types.ts` and `private.ts` may depend on `meta.f.mjs` for
-`Ts<typeof ...>`, `typeof ...`, indexed access over `as const`-style values, and
-similar type derivation. These dependencies are still type-only from TypeScript's
-point of view: the imported value is mentioned only through a type query, so the
-import must be erased.
-
-All imports in authored TypeScript type files use the named type-only form:
+`Ts<typeof ...>`, `typeof ...`, indexed access over literal values, and similar
+type derivation. All imports in authored TypeScript type files use the named
+type-only form:
 
 ```ts
 import type { PublicType } from './types.ts'
 import type { metadataValue } from './meta.f.mjs'
 ```
 
-Do not use a runtime `import { ... }`, `import * as ...`, or side-effect import in
-`types.ts` or `private.ts`. This matches the repository rule that authored
-TypeScript is type-only source and prevents a type module from acquiring runtime
-behavior merely because `typeof` refers to an exported `.f.mjs` value.
+Do not use runtime `import { ... }`, namespace imports, or side-effect imports in
+`types.ts` or `private.ts`.
 
-`meta.f.mjs` itself is ordinary runtime FunctionalScript source and is packaged
-like other required `.f.mjs` modules; it is not a private type artifact merely
-because `private.ts` may use it.
+`meta.f.mjs` is executable FunctionalScript source and is packaged like other
+required `.f.mjs` modules. Node and Deno coverage filters must include it under
+the same coverage expectations as `module.f.mjs`.
 
-Do not move a runtime value into `types.ts` or `private.ts` merely to avoid this
-dependency: runtime values belong in `.f.mjs`. Values whose primary purpose is
-normal program behavior remain in `module.f.mjs` even if their types are reused
-incidentally; `meta.f.mjs` is for values whose primary role is type-level
-metadata.
+#### Dependency rules
 
-`meta.f.mjs` is executable FunctionalScript source, not a declaration-only
-companion. Coverage must therefore treat it like `module.f.mjs`: the Node and
-Deno coverage filters must include `meta.f.mjs`, and proofs must execute the
-metadata code sufficiently for the repository's existing coverage thresholds to
-apply. Moving executable values from `module.f.mjs` to `meta.f.mjs` must not make
-them disappear from coverage.
-
-Dependency rules:
-
-- `module.f.mjs` and `proof.f.mjs` may use both `types.ts` and `private.ts`
-  through JSDoc `@import`.
+- `module.f.mjs` and `proof.f.mjs` may use `types.ts` and `private.ts` through
+  JSDoc `@import`.
 - `private.ts` may `import type { ... }` public types from `types.ts`.
-- `types.ts` and `private.ts` may `import type { ... }` runtime type metadata from
-  `meta.f.mjs` for `Ts<typeof ...>`, `typeof ...`, and similar derivation.
-- all imports in `types.ts` and `private.ts` are named `import type { ... }`
-  imports; they must not create runtime dependencies.
 - `types.ts` must not depend on `private.ts`.
-- A public exported API must not require a `private.ts` type by name.
-
-This leaves generated declarations free to describe the public API, including
-structural types inferred from exported values/functions, without also exporting
-implementation-local file-scope typedef names simply because they were declared
-in JSDoc.
+- `_` helpers required to express public aliases remain in `types.ts` rather
+  than creating a `types.ts -> private.ts` edge.
+- `types.ts` and `private.ts` may `import type { ... }` runtime metadata from
+  `meta.f.mjs`.
+- all imports in `types.ts` and `private.ts` are named `import type { ... }`
+  imports and must not create runtime dependencies.
+- a public declaration must never depend on the removable `private.ts` module.
 
 #### Declaration emission and packaging
 
@@ -173,24 +175,22 @@ types and all `@import` users are checked. Consequently, the existing
 `tsc --emitDeclarationOnly` pass will also generate `private.d.ts`; `exclude`
 cannot suppress that output once another program input imports `private.ts`.
 
-Do not require TypeScript to avoid generating that intermediate file. Instead,
-make private declaration cleanup the **final step of `prepack`**. `npm pack`
-runs `prepack` itself, so an external emit/check/cleanup sequence followed by
-`npm pack` would be wrong: `npm pack` would rerun declaration emission and
-recreate the deleted `private.d.ts` before selecting package contents.
+Do not require TypeScript to avoid generating that intermediate file. Make
+private declaration cleanup the **final step of `prepack`**. `npm pack` runs
+`prepack` itself, so an external emit/check/cleanup sequence followed by
+`npm pack` would recreate the deleted declarations.
 
-The packaging lifecycle should therefore be:
+The packaging lifecycle is:
 
 1. `prepack` runs normal declaration emission;
 2. `prepack` runs the existing declaration round-trip type-check;
 3. as the final `prepack` command, delete every generated `private.d.ts`;
-4. `npm pack` selects package contents after `prepack` completes;
+4. `npm pack` selects package contents;
 5. validate the actual packed artifact:
    - it contains neither authored `private.ts` nor generated `private.d.ts`;
-   - every shipped `.d.ts` / `.d.mts` is scanned and must not contain a module
-     reference to the directory's `private` type module;
-6. install the tarball in the existing clean TypeScript consumer and type-check
-   it as an independent semantic validation.
+   - every shipped `.d.ts` / `.d.mts` is scanned and must not reference a
+     directory's `private` type module;
+6. install the tarball in the clean TypeScript consumer and type-check it.
 
 Conceptually, the current `prepack`:
 
@@ -204,111 +204,77 @@ becomes:
 tsc --noEmit false --emitDeclarationOnly && tsc && <delete generated private.d.ts files>
 ```
 
-The cleanup command should be implemented with repository-portable tooling; the
-exact command is part of implementation, not this source-layout convention.
-Tests should invoke `npm pack` normally so they exercise the real lifecycle,
-rather than reproducing `prepack` steps externally.
+The cleanup command should use repository-portable tooling. Tests should invoke
+`npm pack` normally so they exercise the real lifecycle.
 
-The declaration scan should reject the private module rather than only one
-particular emitted spelling. For example, `./private.ts`, `./private.d.ts`, or a
-future equivalent spelling must all be treated as the same forbidden public
-dependency. This is a structural package check over the packed file set and the
-contents of all packed declarations, not a check limited to whichever public
-entry points the clean consumer happens to import.
-
-References from shipped declarations to a packaged `meta.f.mjs` are allowed:
-unlike `private.ts`, metadata is an intentionally packaged runtime module and
-may be required to express public types derived from its exported values.
-
-The cleanup must operate on generated artifacts only; authored `private.ts`
-remains available for source-tree type-checking. Neither `private.ts` nor the
-intermediate generated `private.d.ts` is shipped.
-
-Generated declarations such as `module.f.d.mts` may be produced from source that
-uses `private.ts`, but no shipped declaration may depend on the private type
-module. If an exported declaration needs a private type, either that type is
-actually public and belongs in `types.ts`, or the public declaration must be
-expressible without exposing the private type name. The package check must fail
-rather than retaining `private.d.ts` to make such a leak resolve.
+The declaration scan should reject the private module rather than one particular
+specifier spelling (`./private.ts`, `./private.d.ts`, or a future equivalent).
+References to packaged `meta.f.mjs` are allowed.
 
 ### Tasks
 
 - [ ] Document `private.ts` and `meta.f.mjs` beside the existing `types.ts`,
-      `module.*`, and `proof.*` file conventions.
+      `module.*`, and `proof.*` conventions.
 - [ ] Prohibit file-scope JSDoc `@typedef` declarations in `module.f.mjs` and
       `proof.f.mjs`; allow function-local `@typedef` declarations everywhere.
-- [ ] Keep the leading `_` convention for private types, including function-local
-      private typedefs.
+- [ ] Keep the leading `_` convention for every private type name, including
+      private helpers in `types.ts` and function-local private typedefs.
 - [ ] Move public file-scope named types from implementation/proof JSDoc into
       `types.ts`.
-- [ ] Move private file-scope named types out of `types.ts`, `module.f.mjs`, and
-      `proof.f.mjs` into each directory's `private.ts` where applicable.
+- [ ] Keep `_` helpers required to express public declarations in `types.ts`;
+      do not create `types.ts -> private.ts` dependencies.
+- [ ] Move other private file-scope named types out of `types.ts`,
+      `module.f.mjs`, and `proof.f.mjs` into each directory's `private.ts`.
 - [ ] Keep lexical type-proof typedefs inside the functions whose local values
-      they inspect; do not force them into `private.ts`.
+      they inspect.
 - [ ] Move runtime values whose primary purpose is type derivation into
-      `meta.f.mjs`; include both RTTI definitions and non-RTTI constants used by
-      `Ts<typeof ...>`, `typeof ...`, or equivalent type queries.
-- [ ] Require every import in authored TypeScript type files (`types.ts` and
-      `private.ts`) to use named `import type { ... }`, including imports from
-      `meta.f.mjs` used only through `typeof`.
+      `meta.f.mjs`, including RTTI definitions and non-RTTI literal constants.
+- [ ] Require every import in `types.ts` and `private.ts` to use named
+      `import type { ... }`.
 - [ ] Update Node coverage selection to include both `module.f.mjs` and
-      `meta.f.mjs` under the existing 100% thresholds.
-- [ ] Update Deno `cov` and `cov-html` include filters to include both
-      `module.f.mjs` and `meta.f.mjs`.
-- [ ] Keep `private.ts` in normal TypeScript type-checking without generating a
-      runtime JavaScript file for it.
-- [ ] Make deletion of generated `private.d.ts` files the final `prepack` step,
-      after declaration emission and the declaration round-trip check.
-- [ ] Exercise cleanup through a normal `npm pack`; do not run cleanup externally
-      before `npm pack`, because `npm pack` reruns `prepack`.
-- [ ] Inspect the `npm pack` artifact and reject any packed `private.ts` or
-      `private.d.ts` file.
-- [ ] Scan every packed `.d.ts` / `.d.mts` and reject any module reference to a
-      directory's private type module, independent of the exact emitted suffix.
-- [ ] Add a fixture where `module.f.mjs` and `proof.f.mjs` use `_`-prefixed types
-      from `private.ts` without declaring any file-scope `@typedef`; also include
-      a function-local typedef that depends on a lexical value and verify it does
-      not escape into generated declarations. Verify declaration emit creates the
-      intermediate `private.d.ts`, final-`prepack` cleanup removes it, generated
-      public declarations contain no implementation-local file-scope typedef
-      exports, and packed-artifact validation finds no private type file or
-      declaration edge.
+      `meta.f.mjs` under the existing thresholds.
+- [ ] Update Deno `cov` and `cov-html` filters to include both `module.f.mjs` and
+      `meta.f.mjs`.
+- [ ] Keep `private.ts` in normal TypeScript checking without generating runtime
+      JavaScript for it.
+- [ ] Make deletion of generated `private.d.ts` files the final `prepack` step.
+- [ ] Exercise cleanup through normal `npm pack`.
+- [ ] Inspect the packed artifact and reject any `private.ts` or `private.d.ts`.
+- [ ] Scan every packed `.d.ts` / `.d.mts` and reject any dependency on a
+      directory's private type module.
+- [ ] Add a fixture covering all three private-type cases:
+      - a `_` helper in `types.ts` required by an exported public alias;
+      - an implementation-private `_` type in `private.ts`;
+      - a function-local `_` typedef depending on a lexical value.
+      Verify the first remains self-contained in `types.d.ts`, the second's
+      intermediate `private.d.ts` is removed, and the third does not escape.
 - [ ] Extend the fixture with `meta.f.mjs` containing both an RTTI value and a
-      non-RTTI literal constant used to derive TypeScript types in `types.ts` or
-      `private.ts`; import both with `import type { ... }`, verify the source tree
-      and packed consumer resolve both metadata dependencies correctly, and that
-      executable `meta.f.mjs` code is included in both Node and Deno coverage.
+      non-RTTI literal constant used through `import type { ... }`, and verify
+      source checking, packing, clean-consumer resolution, and Node/Deno coverage.
 - [ ] Verify a clean TypeScript consumer can install the packed tarball and use
       the public API without any private artifact present.
 
 ### Acceptance criteria
 
-- `module.f.mjs` and `proof.f.mjs` contain no file-scope JSDoc `@typedef`
-  declarations.
-- Function-local JSDoc `@typedef` declarations are allowed in any source file and
-  may depend on lexical values; they do not escape as exported declaration
-  aliases.
-- All public file-scope named TypeScript types live in `types.ts`.
-- All private file-scope named TypeScript types live in `private.ts` and keep
-  their leading `_`; private function-local typedefs also keep `_`.
-- Every import in `types.ts` and `private.ts` uses named `import type { ... }`;
-  these files have no runtime imports, including for `.f.mjs` values referenced
-  only through `typeof`.
-- Runtime values whose primary purpose is to define, describe, or derive
-  type-level information live in `meta.f.mjs`; this includes RTTI definitions
-  and non-RTTI constants used by `Ts<typeof ...>`, `typeof ...`, and similar
-  type queries.
-- Node and Deno coverage include executable `meta.f.mjs` files under the same
-  coverage expectations as `module.f.mjs`.
-- Generated public declarations do not expose private file-scope named typedefs
-  merely as a consequence of declaration emission.
+- `module.f.mjs` and `proof.f.mjs` contain no file-scope JSDoc `@typedef`.
+- Function-local JSDoc `@typedef` declarations are allowed everywhere; private
+  ones keep `_` and do not escape as exported declaration aliases.
+- Public file-scope types live in `types.ts`.
+- Private `_` helpers required to express public types also remain in `types.ts`
+  and are not source exports merely because they are declaration helpers.
+- Other private file-scope types live in `private.ts` and keep `_`.
+- `types.ts` never depends on `private.ts`.
+- Every import in `types.ts` and `private.ts` uses named `import type { ... }`.
+- Runtime values primarily used for type derivation live in `meta.f.mjs`.
+- Node and Deno coverage include executable `meta.f.mjs` files.
 - Declaration emission may create `private.d.ts`; the final `prepack` step
-  removes it, and `npm pack` selects contents only after that cleanup completes.
+  removes it before package contents are selected.
 - The packed tarball contains neither `private.ts` nor `private.d.ts`.
-- No packed `.d.ts` / `.d.mts` file depends on a directory's private type module,
-  regardless of the exact emitted module-specifier suffix.
-- Required references to packaged `meta.f.mjs` modules remain valid in the
-  packed artifact and clean consumer.
+- No packed declaration depends on a directory's private type module.
+- Public declaration helpers retained in `types.ts` remain resolvable from the
+  shipped `types.d.ts` without any private artifact.
+- Required references to packaged `meta.f.mjs` remain valid in the packed
+  artifact and clean consumer.
 - A clean TypeScript consumer type-checks successfully against the packed
   tarball after all private artifacts have been removed.
 

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -5,115 +5,55 @@
 
 ### Problem
 
-FunctionalScript directories currently mix private types with implementation and
-public type declarations:
+FunctionalScript currently mixes named types with implementation/proof source:
 
 ```text
-module.f.mjs  # implementation + private JSDoc types
-proof.f.mjs   # proofs + private JSDoc types
-types.ts      # public type API + private helper types
+module.f.mjs  # implementation + file-scope JSDoc typedefs
+proof.f.mjs   # proofs + file-scope JSDoc typedefs
+types.ts      # public types + private helpers
 ```
 
-Private types already use a leading `_` by convention, but their location still
-creates declaration and package noise. In particular, file-scope JSDoc
-`@typedef`s in `module.f.mjs` and `proof.f.mjs` escape into generated `.d.mts`
-files: TypeScript emits them as exported type aliases even when they were
-intended to be private.
+TypeScript declaration emit turns file-scope JSDoc `@typedef`s into exported
+aliases, so implementation-private names leak into generated `.d.mts` files.
+The existing leading-`_` convention marks those names private by contract, but
+the declarations still contain noise and make the source/package boundary less
+clear.
 
-There are two different kinds of private file-scope type, and the convention must
-not confuse them:
-
-1. **public-type helpers** such as `_Tuple` that are required to express an
-   exported type such as `Tuple`; these must stay with the public declaration
-   graph in `types.ts`;
-2. **implementation-private types** used only by implementation/proofs; these
-   belong in `private.ts`.
-
-Moving the second category out of implementation/proof files removes the JSDoc
-typedef leakage structurally. TypeScript will still emit a declaration for an
-imported `private.ts`, because that source file is part of the declaration
-program; that generated private declaration must be removed before packaging.
-
-The leading `_` convention remains useful in both categories: it means the type
-name itself is private even when the helper must live beside public types.
-
-#### Relationship to the current `_` workaround
-
-[`../fsc/README.md`](../fsc/README.md) currently defines a deliberate interim
-policy for private JSDoc typedefs: until TypeScript supports stripping JSDoc
-`@typedef`s with `@internal` plus `stripInternal`, a leading `_` marks an emitted
-alias as private by contract even when declaration emit exposes it. The upstream
-blocker is
-[microsoft/TypeScript#46407](https://github.com/microsoft/TypeScript/issues/46407),
-and the waiting strategy is tracked in
-[`../../todo/blocked/jsdoc-typedef-strip-internal.md`](../../todo/blocked/jsdoc-typedef-strip-internal.md).
-
-That policy remains authoritative **until this migration is implemented**. This
-TODO intentionally proposes replacing the wait-for-upstream workaround for
-file-scope implementation-private types with a structural boundary:
-
-- file-scope implementation-private named types move to `private.ts`;
-- file-scope JSDoc typedefs disappear from implementation/proof modules, so they
-  no longer leak merely because TypeScript emits them;
-- `private.d.ts` is treated as an intermediate package-build artifact and is
-  removed before packing;
-- function-local typedefs remain available for lexical type proofs and do not
-  need the file-level workaround.
-
-Physical separation is preferred here because it solves the declaration leak
-with tools available today, gives private named types the full TypeScript type
-language, and makes the public/private source and package boundaries explicit.
-The leading `_` remains the naming convention for private types; this proposal
-changes where file-scope private types live, not what `_` means.
-
-When this TODO is implemented, update `fjs/fsc/README.md` so it no longer presents
-leaked file-scope JSDoc typedefs as the intended steady-state convention. Also
-revisit `todo/blocked/jsdoc-typedef-strip-internal.md`: delete it if no remaining
-supported case needs file-scope private JSDoc typedef stripping, or narrow it to
-whatever cases remain. Do not leave two live documents prescribing different
-private-type strategies.
-
-The migration also changes the repository's authored-TypeScript policy.
-[`../AGENTS.md`](../AGENTS.md) currently says that `types.ts` is the only authored
-TypeScript in `fjs/`. Once `private.ts` is introduced, update that rule so
-`types.ts` and `private.ts` are the only authored TypeScript type-module roles:
-`types.ts` owns the public type API and the few `_` helpers required to express
-it, while `private.ts` owns implementation-private file-scope types. Both remain
-type-only modules whose imports use named `import type { ... }`. Do not leave the
-implemented convention contradicting the contributor policy.
+The goal is to give every file-scope named type a deliberate home while keeping
+public declarations self-contained.
 
 ### Proposal
 
-Use this directory convention where named types or runtime metadata used for
-type derivation are needed:
+Use this directory convention where needed:
 
 ```text
 module.f.mjs  # implementation; no file-scope @typedef
 proof.f.mjs   # proofs; no file-scope @typedef
-meta.f.mjs    # runtime constants used by TypeScript type definitions/proofs
-types.ts      # public types + `_` helpers required to express them
-private.ts    # implementation-private `_` types
+meta.f.mjs    # runtime constants referenced by TypeScript types/proofs
+types.ts      # public declaration closure
+private.ts    # other implementation-private file-scope types
 ```
 
-`module.f.mjs` and `proof.f.mjs` may use JSDoc annotations and `@import`, but
-must not declare file-scope named types with `@typedef`.
+Private type names continue to start with `_`.
 
-The placement rule is based on the type dependency graph, not only visibility:
+#### Public declaration closure
+
+`types.ts` is primarily the public type API, but it may contain private `_`
+helpers when they are required to express any shipped public declaration.
+"Public declaration" includes both exported type aliases and declarations of
+exported runtime values/functions.
+
+The placement rule is:
 
 ```text
-public type                                      -> types.ts
-private `_` helper required by a public type     -> types.ts
-other file-scope private `_` type                -> private.ts
-function-local typedef                           -> allowed in place
-runtime constant used by TypeScript types/proofs -> meta.f.mjs
+public type                                         -> types.ts
+private `_` helper used by any public declaration   -> types.ts
+other file-scope private `_` type                   -> private.ts
+function-local typedef                              -> allowed in place
+runtime constant referenced by TS types/proofs      -> meta.f.mjs
 ```
 
-A `_` helper required to define a public type is still private by name and need
-not be exported from `types.ts`. Keeping it there allows TypeScript to emit a
-self-contained public declaration module. Moving it to `private.ts` would make a
-shipped declaration depend on a module that packaging deliberately removes.
-
-For example:
+For example, a helper used by a public type stays in `types.ts`:
 
 ```ts
 type _Tuple<N extends number, T, R extends readonly T[]> =
@@ -122,19 +62,32 @@ type _Tuple<N extends number, T, R extends readonly T[]> =
 export type Tuple<N extends number, T> = _Tuple<N, T, readonly []>
 ```
 
-`_Tuple` stays in `types.ts`: it is private, but it is part of the implementation
-of the public `Tuple` declaration. By contrast, a `_State` used only to annotate
-`module.f.mjs` belongs in `private.ts`.
+The same rule applies when a helper appears in an exported value declaration.
+For example, if declaration emit for an exported `find` contains:
 
-`types.ts` must never import `private.ts`. If moving a private alias out of
-`types.ts` would create such an edge, that is evidence that the alias is a
-public-type helper and should remain in `types.ts`.
+```ts
+export const find: <T>(cmp: Cmp<T>) =>
+    (value: T) => (array: _SortedArray<T>) => T | null
+```
+
+then `_SortedArray` is part of the public declaration closure and must remain in
+`types.ts` (or be inlined into the public declaration). Moving it to
+`private.ts` would make a shipped declaration depend on a declaration module
+that packaging removes.
+
+`types.ts` must never import `private.ts`. If moving a private helper to
+`private.ts` would create a `types.ts -> private.ts` edge or cause any generated
+public declaration to reference `private.ts`, keep or inline that helper in
+`types.ts` instead.
+
+This should keep `private.ts` uncommon in `types.ts`-heavy modules: it is for
+implementation-private file-scope types that are outside the public declaration
+closure, not a mechanical destination for every `_` name.
 
 #### Function-local typedefs
 
-Function-local JSDoc `@typedef` declarations are allowed everywhere. They are
-useful for compile-time proofs that depend on values available only in lexical
-scope and therefore cannot be moved to `private.ts`.
+Function-local JSDoc `@typedef` declarations are allowed everywhere. They may
+refer to lexical values that cannot be named from a sibling TypeScript file.
 
 For example:
 
@@ -145,7 +98,7 @@ const proof = () => {
 }
 ```
 
-A callback-local proof is also valid:
+Callback-local type proofs are also valid:
 
 ```js
 ({ kind }) => {
@@ -154,20 +107,18 @@ A callback-local proof is also valid:
 }
 ```
 
-These typedefs stay inside the narrowest function scope that provides the values
-they need. Private function-local typedef names keep the leading `_` convention.
-Declaration validation must verify that they remain lexical and do not appear as
+Private function-local typedefs keep the leading `_`. Declaration validation
+must verify that function-local typedefs remain lexical and do not escape as
 exported aliases in generated `.d.ts` / `.d.mts` files.
 
-#### Type metadata
+#### `meta.f.mjs`
 
-`meta.f.mjs` contains runtime constants that TypeScript type definitions or
-file-scope type proofs refer to. The values do **not** need to be RTTI, and they
-do not need to exist primarily for type-system purposes. A normal runtime
-constant belongs in `meta.f.mjs` when its literal value or inferred type is part
-of a TypeScript type definition/proof.
+`meta.f.mjs` contains runtime constants whose literal/inferred types are
+actually referenced by TypeScript type definitions or file-scope type proofs.
+They do not need to be RTTI and do not need to exist primarily for type-system
+purposes.
 
-This includes RTTI definitions:
+Examples include RTTI values:
 
 ```ts
 import type { type } from './meta.f.mjs'
@@ -183,7 +134,7 @@ import type { statuses } from './meta.f.mjs'
 export type Status = typeof statuses[number]
 ```
 
-and runtime tables that are also used by normal implementation code:
+and normal runtime tables whose type is asserted:
 
 ```js
 // meta.f.mjs
@@ -204,21 +155,12 @@ type _KeywordsAreComplete =
 import { framingKeywords } from './meta.f.mjs'
 ```
 
-This is the intended solution for file-scope type proofs over module constants:
-move the referenced constant to `meta.f.mjs`, keep its runtime consumers using a
-normal JavaScript import, and move the file-scope private proof/type to
-`private.ts` (or `types.ts` when it is required by a public declaration). The
-constant does not become RTTI merely because it lives in `meta.f.mjs`; `meta`
-means that its value participates in the type-level model.
+The trigger is an actual TypeScript type dependency (`typeof`,
+`Ts<typeof ...>`, indexed access, a type proof, etc.), not merely that a runtime
+value *could* be queried.
 
-Do not move arbitrary runtime values to `meta.f.mjs` merely because their type
-could theoretically be queried. The trigger is an actual TypeScript type
-reference/proof (`typeof`, `Ts<typeof ...>`, indexed access, etc.).
-
-Both `types.ts` and `private.ts` may depend on `meta.f.mjs` for
-`Ts<typeof ...>`, `typeof ...`, indexed access over literal values, and similar
-type derivation. All imports in authored TypeScript type files use the named
-type-only form:
+Runtime code imports values from `meta.f.mjs` normally. Authored TypeScript type
+modules use only named type-only imports:
 
 ```ts
 import type { PublicType } from './types.ts'
@@ -228,214 +170,174 @@ import type { metadataValue } from './meta.f.mjs'
 Do not use runtime `import { ... }`, namespace imports, or side-effect imports in
 `types.ts` or `private.ts`.
 
-`meta.f.mjs` is executable FunctionalScript source and is packaged like other
-required `.f.mjs` modules. Node and Deno coverage filters must include it under
-the same coverage expectations as `module.f.mjs`.
+`meta.f.mjs` is executable FunctionalScript source. Node and Deno coverage must
+include it under the same expectations as `module.f.mjs`.
 
-#### Dependency rules
+#### Breaking migration; no compatibility re-exports
 
-- `module.f.mjs` and `proof.f.mjs` may use `types.ts` and `private.ts` through
-  JSDoc `@import`.
-- `module.f.mjs` and other runtime modules may import runtime constants normally
-  from `meta.f.mjs`.
-- `private.ts` may `import type { ... }` public types from `types.ts`.
-- `types.ts` must not depend on `private.ts`.
-- `_` helpers required to express public aliases remain in `types.ts` rather
-  than creating a `types.ts -> private.ts` edge.
-- `types.ts` and `private.ts` may `import type { ... }` constants from
-  `meta.f.mjs` when those values participate in TypeScript type definitions or
-  proofs.
-- all imports in `types.ts` and `private.ts` are named `import type { ... }`
-  imports and must not create runtime dependencies.
-- a public declaration must never depend on the removable `private.ts` module.
+Moving a public file-scope type from `module.f.mjs` / `proof.f.mjs` to
+`types.ts` changes its public type import path. Moving a public runtime constant
+from `module.f.mjs` to `meta.f.mjs` changes its runtime import path.
 
-#### Breaking public API migration
-
-Moving a public file-scope JSDoc typedef from `module.f.mjs` or `proof.f.mjs` to
-`types.ts` changes its published type import path. Moving a public runtime
-constant from `module.f.mjs` to `meta.f.mjs` changes its published runtime import
-path. Treat **both** relocations as intentional breaking API changes; do not
-preserve the old entry points with compatibility typedefs, exports, or re-exports.
-
-For types:
+Treat both as intentional breaking API changes:
 
 ```text
-./module.f.mjs -> ./types.ts
+public type:     ./module.f.mjs -> ./types.ts
+public metadata: ./module.f.mjs -> ./meta.f.mjs
 ```
 
-For runtime metadata:
+Update every repository importer and the changelog. Do not preserve old entry
+points with compatibility typedefs, exports, or re-exports.
 
-```text
-./module.f.mjs -> ./meta.f.mjs
-```
+#### Declaration emission and packaging
 
-The migration must update every repository importer to the new path and record
-the breaking change in the changelog. Keeping compatibility aliases or
-re-exports in `module.f.mjs` would preserve exactly the mixed responsibilities
-this convention is intended to remove.
+`private.ts` remains in the normal TypeScript program so its declarations and
+all JSDoc `@import` users are checked. Therefore normal declaration emit may
+produce an intermediate `private.d.ts`.
 
-### Declaration emission and packaging
+Do not try to exclude `private.ts` from the TypeScript program. Instead make
+private-declaration cleanup the final `prepack` step:
 
-`private.ts` is source-only and remains in the normal TypeScript program so its
-types and all `@import` users are checked. Consequently, the existing
-`tsc --emitDeclarationOnly` pass will also generate `private.d.ts`; `exclude`
-cannot suppress that output once another program input imports `private.ts`.
+1. emit declarations;
+2. run the existing declaration round-trip type-check;
+3. delete every generated `private.d.ts` as the final `prepack` command;
+4. let `npm pack` select files after `prepack` completes;
+5. inspect the actual tarball;
+6. install the tarball in a clean TypeScript consumer and type-check it.
 
-Do not require TypeScript to avoid generating that intermediate file. Make
-private declaration cleanup the **final step of `prepack`**. `npm pack` runs
-`prepack` itself, so an external emit/check/cleanup sequence followed by
-`npm pack` would recreate the deleted declarations.
-
-The packaging lifecycle is:
-
-1. `prepack` runs normal declaration emission;
-2. `prepack` runs the existing declaration round-trip type-check;
-3. as the final `prepack` command, delete every generated `private.d.ts`;
-4. `npm pack` selects package contents;
-5. validate the actual packed artifact:
-   - it contains neither authored `private.ts` nor generated `private.d.ts`;
-   - every shipped `.d.ts` / `.d.mts` is scanned and must not reference a
-     directory's `private` type module;
-6. install the tarball in the clean TypeScript consumer and type-check it.
-
-Conceptually, the current `prepack`:
-
-```text
-tsc --noEmit false --emitDeclarationOnly && tsc
-```
-
-becomes:
+Conceptually:
 
 ```text
 tsc --noEmit false --emitDeclarationOnly && tsc && <delete generated private.d.ts files>
 ```
 
-The cleanup command should use repository-portable tooling. Tests should invoke
-`npm pack` normally so they exercise the real lifecycle.
+Validation of the packed artifact must prove both:
 
-The declaration scan should reject the private module rather than one particular
-specifier spelling (`./private.ts`, `./private.d.ts`, or a future equivalent).
+- neither authored `private.ts` nor generated `private.d.ts` is shipped;
+- no packed `.d.ts` / `.d.mts` references a directory's private type module,
+  regardless of the exact emitted suffix.
+
 References to packaged `meta.f.mjs` are allowed.
+
+#### Repository-policy reconciliation
+
+[`../fsc/README.md`](../fsc/README.md) currently documents the leading `_` as an
+interim API contract for private JSDoc typedefs that TypeScript leaks into
+emitted declarations. The upstream blocker is
+[microsoft/TypeScript#46407](https://github.com/microsoft/TypeScript/issues/46407),
+and the wait-for-`@internal`/`stripInternal` strategy is tracked in
+[`../../todo/blocked/jsdoc-typedef-strip-internal.md`](../../todo/blocked/jsdoc-typedef-strip-internal.md).
+
+That policy remains authoritative until this migration is implemented. When this
+TODO lands, update `fjs/fsc/README.md` and delete or narrow the blocked TODO so
+the repository has one private-type strategy.
+
+The migration also changes [`../AGENTS.md`](../AGENTS.md), which currently says
+`types.ts` is the only authored TypeScript under `fjs/`. Update it so the allowed
+authored TypeScript type-module roles are:
+
+```text
+types.ts    # public declaration closure
+private.ts  # implementation-private file-scope types outside that closure
+```
+
+Both remain type-only modules and use named `import type { ... }` imports.
 
 ### Tasks
 
-- [ ] Document `private.ts` and `meta.f.mjs` beside the existing `types.ts`,
-      `module.*`, and `proof.*` conventions.
-- [ ] Reconcile the implemented convention with the current private-JSDoc policy:
-      update `fjs/fsc/README.md` to replace the leaked-file-scope-typedef
-      workaround, and delete or narrow
-      `todo/blocked/jsdoc-typedef-strip-internal.md` so the repository has one
-      authoritative strategy.
-- [ ] Update `fjs/AGENTS.md` so the authored-TypeScript policy allows exactly the
-      intended type-module roles: `types.ts` for public types/public-type helpers
-      and `private.ts` for implementation-private file-scope types. Preserve the
-      rule that all imports in those files are named `import type { ... }`.
-- [ ] Prohibit file-scope JSDoc `@typedef` declarations in `module.f.mjs` and
-      `proof.f.mjs`; allow function-local `@typedef` declarations everywhere.
-- [ ] Keep the leading `_` convention for every private type name, including
-      private helpers in `types.ts` and function-local private typedefs.
+- [ ] Document `types.ts`, `private.ts`, and `meta.f.mjs` beside the existing
+      `module.*` / `proof.*` file conventions.
+- [ ] Update `fjs/AGENTS.md` to allow `types.ts` and `private.ts` as the authored
+      TypeScript type-module roles and document the public-declaration-closure
+      rule.
+- [ ] Update `fjs/fsc/README.md` and delete or narrow
+      `todo/blocked/jsdoc-typedef-strip-internal.md` so they no longer prescribe
+      a conflicting private-JSDoc strategy.
+- [ ] Prohibit file-scope JSDoc `@typedef` in `module.f.mjs` and `proof.f.mjs`;
+      allow function-local `@typedef` everywhere.
+- [ ] Keep the leading `_` convention for every private type name.
 - [ ] Move public file-scope named types from implementation/proof JSDoc into
-      `types.ts` as a breaking type-API migration; update every repository
-      importer to the new `types.ts` path and record the break in the changelog.
-- [ ] Do not add compatibility typedefs or re-exports to preserve old
-      `module.f.mjs` type entry points.
-- [ ] Keep `_` helpers required to express public declarations in `types.ts`;
-      do not create `types.ts -> private.ts` dependencies.
-- [ ] Move other private file-scope named types out of `types.ts`,
-      `module.f.mjs`, and `proof.f.mjs` into each directory's `private.ts`.
-- [ ] Keep lexical type-proof typedefs inside the functions whose local values
-      they inspect.
-- [ ] Move runtime constants referenced by TypeScript type definitions/proofs
-      into `meta.f.mjs`, including RTTI definitions, non-RTTI literal constants,
-      and ordinary runtime tables whose literal/inferred types are asserted.
-- [ ] Move file-scope private type proofs over those constants to `private.ts`
-      (or keep helpers in `types.ts` when required by a public declaration), and
-      use `import type { ... }` to reference the `meta.f.mjs` values.
+      `types.ts` as a breaking migration; update importers and changelog.
+- [ ] Keep or inline every private `_` helper required transitively by any
+      shipped public declaration in `types.ts`, including helpers appearing in
+      exported runtime-value/function signatures.
+- [ ] Move only other implementation-private file-scope types to `private.ts`;
+      do not create `types.ts -> private.ts` or public-declaration -> `private.ts`
+      dependencies.
+- [ ] Keep lexical type-proof typedefs inside their functions.
+- [ ] Move runtime constants actually referenced by TypeScript type
+      definitions/proofs into `meta.f.mjs`, including RTTI values, non-RTTI
+      literal constants, and runtime-used tables.
+- [ ] Move file-scope private proofs over those constants to `private.ts` (or
+      `types.ts` when part of the public declaration closure) and use
+      `import type { ... }`.
 - [ ] Treat moves of public runtime constants to `meta.f.mjs` as breaking API
-      changes: update every repository runtime importer and the changelog; do not
-      leave compatibility exports or re-exports in `module.f.mjs`.
+      changes; update runtime importers and changelog, with no compatibility
+      re-exports.
 - [ ] Require every import in `types.ts` and `private.ts` to use named
       `import type { ... }`.
-- [ ] Update Node coverage selection to include both `module.f.mjs` and
-      `meta.f.mjs` under the existing thresholds.
-- [ ] Update Deno `cov` and `cov-html` filters to include both `module.f.mjs` and
-      `meta.f.mjs`.
-- [ ] Keep `private.ts` in normal TypeScript checking without generating runtime
-      JavaScript for it.
-- [ ] Make deletion of generated `private.d.ts` files the final `prepack` step.
-- [ ] Exercise cleanup through normal `npm pack`.
-- [ ] Inspect the packed artifact and reject any `private.ts` or `private.d.ts`.
-- [ ] Scan every packed `.d.ts` / `.d.mts` and reject any dependency on a
-      directory's private type module.
-- [ ] Add a fixture covering all three private-type cases:
-      - a `_` helper in `types.ts` required by an exported public alias;
-      - an implementation-private `_` type in `private.ts`;
-      - a function-local `_` typedef depending on a lexical value.
-      Verify the first remains self-contained in `types.d.ts`, the second's
-      intermediate `private.d.ts` is removed, and the third does not escape.
-- [ ] Extend the fixture with `meta.f.mjs` containing an RTTI value, a non-RTTI
-      literal constant, and a runtime-used constant whose type is asserted from
-      `private.ts`; verify runtime imports, type-only imports, source checking,
-      packing, clean-consumer resolution, and Node/Deno coverage.
-- [ ] Verify a clean TypeScript consumer can install the packed tarball and use
-      the public API without any private artifact present.
+- [ ] Update Node and Deno coverage filters to include `meta.f.mjs`.
+- [ ] Keep `private.ts` in normal TypeScript checking without runtime JS emit.
+- [ ] Make deletion of generated `private.d.ts` the final `prepack` step.
+- [ ] Inspect the `npm pack` artifact for private files and private declaration
+      dependencies.
+- [ ] Add a fixture covering:
+      - a private helper required by a public type alias;
+      - a private helper required by an exported runtime value/function
+        declaration (the `_SortedArray`/`find` shape);
+      - an implementation-private type in `private.ts`;
+      - a function-local typedef depending on a lexical value;
+      - `meta.f.mjs` with RTTI, literal, and runtime-used constants.
+- [ ] Verify source checking, declaration emit/cleanup, Node+Deno coverage,
+      packing, and clean-consumer type checking.
 
 ### Acceptance criteria
 
-- The current `_` leak-tolerance policy is explicitly superseded when this
-  migration is implemented; `fjs/fsc/README.md` and the blocked `@internal` /
-  `stripInternal` TODO no longer prescribe a conflicting strategy.
-- `fjs/AGENTS.md` no longer says `types.ts` is the only authored TypeScript;
-  it documents `types.ts` and `private.ts` as the allowed authored TypeScript
-  type-module roles, with their public/private responsibilities and named
-  `import type { ... }` import rule.
 - `module.f.mjs` and `proof.f.mjs` contain no file-scope JSDoc `@typedef`.
-- Function-local JSDoc `@typedef` declarations are allowed everywhere; private
-  ones keep `_` and do not escape as exported declaration aliases.
-- Public file-scope types live in `types.ts`.
-- Moving a public type from `module.f.mjs` / `proof.f.mjs` to `types.ts` is an
-  intentional breaking API change: repository importers use the new path, the
-  changelog records the break, and no compatibility typedef/re-export preserves
-  the old type entry point.
-- Moving a public runtime constant from `module.f.mjs` to `meta.f.mjs` is also an
-  intentional breaking API change: repository importers use the new path, the
-  changelog records the break, and no compatibility export/re-export preserves
-  the old runtime entry point.
-- Private `_` helpers required to express public types also remain in `types.ts`
-  and are not source exports merely because they are declaration helpers.
-- Other private file-scope types live in `private.ts` and keep `_`.
-- `types.ts` never depends on `private.ts`.
+- Function-local JSDoc `@typedef` is allowed everywhere; private names keep `_`
+  and do not escape as exported declaration aliases.
+- `types.ts` is the public declaration closure: public types plus any private
+  helpers required transitively to express shipped declarations of public types
+  or exported runtime values/functions.
+- `private.ts` contains only implementation-private file-scope types outside the
+  public declaration closure and is expected to be used sparingly where
+  `types.ts` already describes most of a module's type surface.
+- `types.ts` and every packed public declaration are independent of
+  `private.ts`.
 - Every import in `types.ts` and `private.ts` uses named `import type { ... }`.
-- Runtime constants referenced by TypeScript type definitions/proofs live in
-  `meta.f.mjs`, whether they are RTTI, literal metadata, or ordinary runtime
-  tables also consumed by implementation code.
-- File-scope private proofs over such constants can live in `private.ts` without
-  exporting implementation locals from `module.f.mjs`.
-- Node and Deno coverage include executable `meta.f.mjs` files.
-- Declaration emission may create `private.d.ts`; the final `prepack` step
-  removes it before package contents are selected.
-- The packed tarball contains neither `private.ts` nor `private.d.ts`.
-- No packed declaration depends on a directory's private type module.
-- Public declaration helpers retained in `types.ts` remain resolvable from the
-  shipped `types.d.ts` without any private artifact.
-- Required references to packaged `meta.f.mjs` remain valid in the packed
-  artifact and clean consumer.
+- Runtime constants referenced by TypeScript definitions/proofs live in
+  `meta.f.mjs`, whether RTTI or not; executable metadata is covered by Node and
+  Deno coverage.
+- Moving public types to `types.ts` and public runtime metadata to `meta.f.mjs`
+  are breaking migrations: importers and changelog are updated and no
+  compatibility re-exports preserve old entry points.
+- Declaration emit may create `private.d.ts`; final-`prepack` cleanup removes it
+  before package contents are selected.
+- The packed tarball contains neither `private.ts` nor `private.d.ts`, and no
+  packed declaration depends on the private module.
+- Public declaration helpers retained in `types.ts` remain self-contained and
+  resolvable from shipped declarations, including helpers used by exported
+  runtime-value/function signatures.
+- `fjs/AGENTS.md` no longer says `types.ts` is the only authored TypeScript and
+  documents both `types.ts` and `private.ts` with the declaration-closure rule.
+- `fjs/fsc/README.md` and the blocked `@internal`/`stripInternal` TODO no longer
+  prescribe a conflicting private-JSDoc strategy.
 - A clean TypeScript consumer type-checks successfully against the packed
-  tarball after all private artifacts have been removed.
+  tarball after private artifacts are removed.
 
 ### Related
 
-- [`../fsc/README.md`](../fsc/README.md) — current `_` leak-tolerance policy that
-  this migration supersedes once implemented.
-- [`../AGENTS.md`](../AGENTS.md) — current authored-TypeScript policy that must be
-  updated when `private.ts` becomes an allowed authored type module.
+- [`../fsc/README.md`](../fsc/README.md) — current `_` leak-tolerance policy.
+- [`../AGENTS.md`](../AGENTS.md) — authored-TypeScript policy to update.
 - [`../../todo/blocked/jsdoc-typedef-strip-internal.md`](../../todo/blocked/jsdoc-typedef-strip-internal.md)
-  — current wait-for-`@internal`/`stripInternal` strategy; delete or narrow when
-  this migration lands.
+  — current wait-for-`@internal`/`stripInternal` strategy.
 - [microsoft/TypeScript#46407](https://github.com/microsoft/TypeScript/issues/46407)
-  — upstream JSDoc `@typedef` stripping limitation that motivated the current
-  workaround.
-- [`detect-unexported-types-referenced-by-exported-types.md`](./detect-unexported-types-referenced-by-exported-types.md) — detect private type names that leak through exported types.
-- [`document-file-type-naming-conventions.md`](./document-file-type-naming-conventions.md) — document the repository's source-file roles.
-- [`../../todo/migrate-typescript-to-mjs.md`](../../todo/migrate-typescript-to-mjs.md) — current JavaScript/JSDoc implementation migration and `_` private-type convention.
-- [`../ci/todo/f-mjs-package-support.md`](../ci/todo/f-mjs-package-support.md) — declaration emission and clean packed-package validation.
+  — upstream JSDoc typedef stripping limitation.
+- [`detect-unexported-types-referenced-by-exported-types.md`](./detect-unexported-types-referenced-by-exported-types.md)
+  — related declaration-leak detection.
+- [`document-file-type-naming-conventions.md`](./document-file-type-naming-conventions.md)
+  — repository source-file roles.
+- [`../../todo/migrate-typescript-to-mjs.md`](../../todo/migrate-typescript-to-mjs.md)
+  — current JavaScript/JSDoc migration and `_` convention.
+- [`../ci/todo/f-mjs-package-support.md`](../ci/todo/f-mjs-package-support.md)
+  — declaration emission and clean package validation.

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -73,6 +73,15 @@ supported case needs file-scope private JSDoc typedef stripping, or narrow it to
 whatever cases remain. Do not leave two live documents prescribing different
 private-type strategies.
 
+The migration also changes the repository's authored-TypeScript policy.
+[`../AGENTS.md`](../AGENTS.md) currently says that `types.ts` is the only authored
+TypeScript in `fjs/`. Once `private.ts` is introduced, update that rule so
+`types.ts` and `private.ts` are the only authored TypeScript type-module roles:
+`types.ts` owns the public type API and the few `_` helpers required to express
+it, while `private.ts` owns implementation-private file-scope types. Both remain
+type-only modules whose imports use named `import type { ... }`. Do not leave the
+implemented convention contradicting the contributor policy.
+
 ### Proposal
 
 Use this directory convention where named types or runtime metadata used for
@@ -317,6 +326,10 @@ References to packaged `meta.f.mjs` are allowed.
       workaround, and delete or narrow
       `todo/blocked/jsdoc-typedef-strip-internal.md` so the repository has one
       authoritative strategy.
+- [ ] Update `fjs/AGENTS.md` so the authored-TypeScript policy allows exactly the
+      intended type-module roles: `types.ts` for public types/public-type helpers
+      and `private.ts` for implementation-private file-scope types. Preserve the
+      rule that all imports in those files are named `import type { ... }`.
 - [ ] Prohibit file-scope JSDoc `@typedef` declarations in `module.f.mjs` and
       `proof.f.mjs`; allow function-local `@typedef` declarations everywhere.
 - [ ] Keep the leading `_` convention for every private type name, including
@@ -372,6 +385,10 @@ References to packaged `meta.f.mjs` are allowed.
 - The current `_` leak-tolerance policy is explicitly superseded when this
   migration is implemented; `fjs/fsc/README.md` and the blocked `@internal` /
   `stripInternal` TODO no longer prescribe a conflicting strategy.
+- `fjs/AGENTS.md` no longer says `types.ts` is the only authored TypeScript;
+  it documents `types.ts` and `private.ts` as the allowed authored TypeScript
+  type-module roles, with their public/private responsibilities and named
+  `import type { ... }` import rule.
 - `module.f.mjs` and `proof.f.mjs` contain no file-scope JSDoc `@typedef`.
 - Function-local JSDoc `@typedef` declarations are allowed everywhere; private
   ones keep `_` and do not escape as exported declaration aliases.
@@ -410,6 +427,8 @@ References to packaged `meta.f.mjs` are allowed.
 
 - [`../fsc/README.md`](../fsc/README.md) — current `_` leak-tolerance policy that
   this migration supersedes once implemented.
+- [`../AGENTS.md`](../AGENTS.md) — current authored-TypeScript policy that must be
+  updated when `private.ts` becomes an allowed authored type module.
 - [`../../todo/blocked/jsdoc-typedef-strip-internal.md`](../../todo/blocked/jsdoc-typedef-strip-internal.md)
   — current wait-for-`@internal`/`stripInternal` strategy; delete or narrow when
   this migration lands.

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -128,6 +128,13 @@ normal program behavior remain in `module.f.mjs` even if their types are reused
 incidentally; `meta.f.mjs` is for values whose primary role is type-level
 metadata.
 
+`meta.f.mjs` is executable FunctionalScript source, not a declaration-only
+companion. Coverage must therefore treat it like `module.f.mjs`: the Node and
+Deno coverage filters must include `meta.f.mjs`, and proofs must execute the
+metadata code sufficiently for the repository's existing coverage thresholds to
+apply. Moving executable values from `module.f.mjs` to `meta.f.mjs` must not make
+them disappear from coverage.
+
 Dependency rules:
 
 - `module.f.mjs` and `proof.f.mjs` may use both `types.ts` and `private.ts`
@@ -225,6 +232,10 @@ rather than retaining `private.d.ts` to make such a leak resolve.
 - [ ] Move runtime values whose primary purpose is type derivation into
       `meta.f.mjs`; include both RTTI definitions and non-RTTI constants used by
       `Ts<typeof ...>`, `typeof ...`, or equivalent type queries.
+- [ ] Update Node coverage selection to include both `module.f.mjs` and
+      `meta.f.mjs` under the existing 100% thresholds.
+- [ ] Update Deno `cov` and `cov-html` include filters to include both
+      `module.f.mjs` and `meta.f.mjs`.
 - [ ] Keep `private.ts` in normal TypeScript type-checking without generating a
       runtime JavaScript file for it.
 - [ ] Make deletion of generated `private.d.ts` files the final `prepack` step,
@@ -246,7 +257,8 @@ rather than retaining `private.d.ts` to make such a leak resolve.
 - [ ] Extend the fixture with `meta.f.mjs` containing both an RTTI value and a
       non-RTTI literal constant used to derive TypeScript types in `types.ts` or
       `private.ts`; verify the source tree and packed consumer resolve both
-      metadata dependencies correctly.
+      metadata dependencies correctly, and that executable `meta.f.mjs` code is
+      included in both Node and Deno coverage.
 - [ ] Verify a clean TypeScript consumer can install the packed tarball and use
       the public API without any private artifact present.
 
@@ -264,6 +276,8 @@ rather than retaining `private.d.ts` to make such a leak resolve.
   type-level information live in `meta.f.mjs`; this includes RTTI definitions
   and non-RTTI constants used by `Ts<typeof ...>`, `typeof ...`, and similar
   type queries.
+- Node and Deno coverage include executable `meta.f.mjs` files under the same
+  coverage expectations as `module.f.mjs`.
 - Generated public declarations do not expose private file-scope named typedefs
   merely as a consequence of declaration emission.
 - Declaration emission may create `private.d.ts`; the final `prepack` step

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -31,17 +31,20 @@ complementary signals.
 
 ### Proposal
 
-Use this directory convention where named types are needed:
+Use this directory convention where named types or RTTI type definitions are
+needed:
 
 ```text
 module.f.mjs  # implementation; no @typedef
 proof.f.mjs   # proofs; no @typedef
-types.ts      # public named types
-private.ts    # private named types
+rtti.f.mjs    # runtime type definitions used by RTTI
+types.ts      # public named TypeScript types
+private.ts    # private named TypeScript types
 ```
 
 `module.f.mjs` and `proof.f.mjs` may use JSDoc annotations and `@import`, but
-must not declare named types with `@typedef`. Named types have exactly two homes:
+must not declare named types with `@typedef`. Named TypeScript types have exactly
+two homes:
 
 - `types.ts` for public types;
 - `private.ts` for implementation-only types.
@@ -49,18 +52,45 @@ must not declare named types with `@typedef`. Named types have exactly two homes
 `private.ts` contains implementation-only TypeScript types used by either the
 module or its proofs. Every private type continues to start with `_`.
 
-Dependency direction:
+#### RTTI type definitions
+
+Some TypeScript types are derived from runtime RTTI definitions, for example:
+
+```ts
+import { type } from './rtti.f.mjs'
+
+export type Value = Ts<typeof type>
+```
+
+Put runtime values whose primary purpose is to represent types in `rtti.f.mjs`.
+This keeps runtime type definitions distinct from normal implementation code and
+from their compile-time TypeScript views:
 
 ```text
-              types.ts
-              ^      ^
-              |      |
-private.ts <- module.f.mjs / proof.f.mjs
+rtti.f.mjs  # runtime representation of types
+types.ts    # public compile-time types
+private.ts  # private compile-time types
 ```
+
+Both `types.ts` and `private.ts` may depend on `rtti.f.mjs` when defining types
+such as `Ts<typeof type>`. This is an intentional dependency on a runtime value,
+not a violation of the public/private type boundary. `rtti.f.mjs` is ordinary
+runtime FunctionalScript source and is packaged like other required `.f.mjs`
+modules; it is not a private type artifact merely because `private.ts` may use
+it.
+
+Do not move an RTTI value into `types.ts` or `private.ts` merely to avoid this
+dependency: the RTTI definition is a runtime value and belongs in `.f.mjs`.
+Normal runtime values whose primary purpose is not type representation remain in
+`module.f.mjs` rather than being moved mechanically to `rtti.f.mjs`.
+
+Dependency rules:
 
 - `module.f.mjs` and `proof.f.mjs` may use both `types.ts` and `private.ts`
   through JSDoc `@import`.
 - `private.ts` may import public types from `types.ts`.
+- `types.ts` and `private.ts` may depend on runtime type definitions from
+  `rtti.f.mjs` for `Ts<typeof ...>` and similar type derivation.
 - `types.ts` must not depend on `private.ts`.
 - A public exported API must not require a `private.ts` type by name.
 
@@ -97,6 +127,10 @@ dependency. This is a structural package check over the packed file set and the
 contents of all packed declarations, not a check limited to whichever public
 entry points the clean consumer happens to import.
 
+References from shipped declarations to a packaged `rtti.f.mjs` are allowed:
+unlike `private.ts`, RTTI is a runtime module intentionally available to the
+package and may be required to express public types derived with `Ts<typeof ...>`.
+
 The cleanup must operate on generated artifacts only; authored `private.ts`
 remains available for source-tree type-checking. Neither `private.ts` nor the
 intermediate generated `private.d.ts` is shipped.
@@ -110,13 +144,16 @@ rather than retaining `private.d.ts` to make such a leak resolve.
 
 ### Tasks
 
-- [ ] Document `private.ts` beside the existing `types.ts`, `module.*`, and
-      `proof.*` file conventions.
+- [ ] Document `private.ts` and `rtti.f.mjs` beside the existing `types.ts`,
+      `module.*`, and `proof.*` file conventions.
 - [ ] Prohibit JSDoc `@typedef` declarations in `module.f.mjs` and `proof.f.mjs`.
 - [ ] Keep the leading `_` convention for every type declared in `private.ts`.
 - [ ] Move public named types from implementation/proof JSDoc into `types.ts`.
 - [ ] Move private named types out of `types.ts`, `module.f.mjs`, and
       `proof.f.mjs` into each directory's `private.ts` where applicable.
+- [ ] Move runtime RTTI definitions whose primary purpose is type representation
+      into `rtti.f.mjs` when `types.ts` or `private.ts` derives TypeScript types
+      from them with `Ts<typeof ...>` or an equivalent type query.
 - [ ] Keep `private.ts` in normal TypeScript type-checking without generating a
       runtime JavaScript file for it.
 - [ ] Add a post-declaration-emit packaging step that deletes generated
@@ -130,14 +167,21 @@ rather than retaining `private.d.ts` to make such a leak resolve.
       creates the intermediate `private.d.ts`, cleanup removes it, generated
       public declarations contain no implementation-local typedef exports, and
       packed-artifact validation finds no private type file or declaration edge.
+- [ ] Extend the fixture with `rtti.f.mjs` plus a `Ts<typeof ...>`-derived type in
+      `types.ts` or `private.ts`; verify the source tree and packed consumer both
+      resolve the RTTI dependency correctly.
 - [ ] Verify a clean TypeScript consumer can install the packed tarball and use
       the public API without any private artifact present.
 
 ### Acceptance criteria
 
 - `module.f.mjs` and `proof.f.mjs` contain no JSDoc `@typedef` declarations.
-- All public named types live in `types.ts`.
-- All private named types live in `private.ts` and keep their leading `_`.
+- All public named TypeScript types live in `types.ts`.
+- All private named TypeScript types live in `private.ts` and keep their leading
+  `_`.
+- Runtime values whose primary purpose is RTTI type representation live in
+  `rtti.f.mjs`; `types.ts` and `private.ts` may depend on them for
+  `Ts<typeof ...>`-style type derivation.
 - Generated public declarations do not expose private named typedefs merely as a
   consequence of declaration emission.
 - Declaration emission may create `private.d.ts`, but the packaging cleanup
@@ -145,6 +189,8 @@ rather than retaining `private.d.ts` to make such a leak resolve.
 - The packed tarball contains neither `private.ts` nor `private.d.ts`.
 - No packed `.d.ts` / `.d.mts` file depends on a directory's private type module,
   regardless of the exact emitted module-specifier suffix.
+- Required references to packaged `rtti.f.mjs` modules remain valid in the
+  packed artifact and clean consumer.
 - A clean TypeScript consumer type-checks successfully against the packed
   tarball after all private artifacts have been removed.
 

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -45,7 +45,7 @@ type derivation are needed:
 ```text
 module.f.mjs  # implementation; no file-scope @typedef
 proof.f.mjs   # proofs; no file-scope @typedef
-meta.f.mjs    # runtime metadata used to define/derive types
+meta.f.mjs    # runtime constants used by TypeScript type definitions/proofs
 types.ts      # public types + `_` helpers required to express them
 private.ts    # implementation-private `_` types
 ```
@@ -60,6 +60,7 @@ public type                                      -> types.ts
 private `_` helper required by a public type     -> types.ts
 other file-scope private `_` type                -> private.ts
 function-local typedef                           -> allowed in place
+runtime constant used by TypeScript types/proofs -> meta.f.mjs
 ```
 
 A `_` helper required to define a public type is still private by name and need
@@ -115,8 +116,13 @@ exported aliases in generated `.d.ts` / `.d.mts` files.
 
 #### Type metadata
 
-Some TypeScript types are derived from runtime values rather than declared
-independently. These values include RTTI definitions:
+`meta.f.mjs` contains runtime constants that TypeScript type definitions or
+file-scope type proofs refer to. The values do **not** need to be RTTI, and they
+do not need to exist primarily for type-system purposes. A normal runtime
+constant belongs in `meta.f.mjs` when its literal value or inferred type is part
+of a TypeScript type definition/proof.
+
+This includes RTTI definitions:
 
 ```ts
 import type { type } from './meta.f.mjs'
@@ -124,7 +130,7 @@ import type { type } from './meta.f.mjs'
 export type Value = Ts<typeof type>
 ```
 
-and ordinary constants whose literal value is used by a type query:
+ordinary literal constants:
 
 ```ts
 import type { statuses } from './meta.f.mjs'
@@ -132,10 +138,37 @@ import type { statuses } from './meta.f.mjs'
 export type Status = typeof statuses[number]
 ```
 
-Put runtime values whose primary purpose is to define, describe, or derive
-type-level information in `meta.f.mjs`. Values whose primary purpose is normal
-program behavior remain in `module.f.mjs` even if their types are reused
-incidentally.
+and runtime tables that are also used by normal implementation code:
+
+```js
+// meta.f.mjs
+export const framingKeywords =
+    /** @type {const} */ (['import', 'const', 'export', 'default', 'from'])
+```
+
+```ts
+// private.ts
+import type { framingKeywords } from './meta.f.mjs'
+
+type _KeywordsAreComplete =
+    Assert<Equal<(typeof framingKeywords)[number], _FramingKeyword>>
+```
+
+```js
+// module.f.mjs
+import { framingKeywords } from './meta.f.mjs'
+```
+
+This is the intended solution for file-scope type proofs over module constants:
+move the referenced constant to `meta.f.mjs`, keep its runtime consumers using a
+normal JavaScript import, and move the file-scope private proof/type to
+`private.ts` (or `types.ts` when it is required by a public declaration). The
+constant does not become RTTI merely because it lives in `meta.f.mjs`; `meta`
+means that its value participates in the type-level model.
+
+Do not move arbitrary runtime values to `meta.f.mjs` merely because their type
+could theoretically be queried. The trigger is an actual TypeScript type
+reference/proof (`typeof`, `Ts<typeof ...>`, indexed access, etc.).
 
 Both `types.ts` and `private.ts` may depend on `meta.f.mjs` for
 `Ts<typeof ...>`, `typeof ...`, indexed access over literal values, and similar
@@ -158,12 +191,15 @@ the same coverage expectations as `module.f.mjs`.
 
 - `module.f.mjs` and `proof.f.mjs` may use `types.ts` and `private.ts` through
   JSDoc `@import`.
+- `module.f.mjs` and other runtime modules may import runtime constants normally
+  from `meta.f.mjs`.
 - `private.ts` may `import type { ... }` public types from `types.ts`.
 - `types.ts` must not depend on `private.ts`.
 - `_` helpers required to express public aliases remain in `types.ts` rather
   than creating a `types.ts -> private.ts` edge.
-- `types.ts` and `private.ts` may `import type { ... }` runtime metadata from
-  `meta.f.mjs`.
+- `types.ts` and `private.ts` may `import type { ... }` constants from
+  `meta.f.mjs` when those values participate in TypeScript type definitions or
+  proofs.
 - all imports in `types.ts` and `private.ts` are named `import type { ... }`
   imports and must not create runtime dependencies.
 - a public declaration must never depend on the removable `private.ts` module.
@@ -193,9 +229,10 @@ re-exports in `module.f.mjs` merely to preserve the old type-only subpath: that
 would reintroduce the file-scope typedef/declaration noise this convention is
 intended to remove.
 
-This breaking rule applies to type entry points, not runtime exports. Moving
-runtime values to `meta.f.mjs` requires its own API decision if those values are
-publicly imported at runtime.
+This breaking rule applies to type entry points, not runtime exports. Moving a
+public runtime constant from `module.f.mjs` to `meta.f.mjs` requires its own API
+decision: preserve the old runtime entry point with a re-export or make that
+runtime move an explicit breaking change and update importers/changelog.
 
 #### Declaration emission and packaging
 
@@ -259,8 +296,12 @@ References to packaged `meta.f.mjs` are allowed.
       `module.f.mjs`, and `proof.f.mjs` into each directory's `private.ts`.
 - [ ] Keep lexical type-proof typedefs inside the functions whose local values
       they inspect.
-- [ ] Move runtime values whose primary purpose is type derivation into
-      `meta.f.mjs`, including RTTI definitions and non-RTTI literal constants.
+- [ ] Move runtime constants referenced by TypeScript type definitions/proofs
+      into `meta.f.mjs`, including RTTI definitions, non-RTTI literal constants,
+      and ordinary runtime tables whose literal/inferred types are asserted.
+- [ ] Move file-scope private type proofs over those constants to `private.ts`
+      (or keep helpers in `types.ts` when required by a public declaration), and
+      use `import type { ... }` to reference the `meta.f.mjs` values.
 - [ ] Require every import in `types.ts` and `private.ts` to use named
       `import type { ... }`.
 - [ ] Update Node coverage selection to include both `module.f.mjs` and
@@ -280,9 +321,10 @@ References to packaged `meta.f.mjs` are allowed.
       - a function-local `_` typedef depending on a lexical value.
       Verify the first remains self-contained in `types.d.ts`, the second's
       intermediate `private.d.ts` is removed, and the third does not escape.
-- [ ] Extend the fixture with `meta.f.mjs` containing both an RTTI value and a
-      non-RTTI literal constant used through `import type { ... }`, and verify
-      source checking, packing, clean-consumer resolution, and Node/Deno coverage.
+- [ ] Extend the fixture with `meta.f.mjs` containing an RTTI value, a non-RTTI
+      literal constant, and a runtime-used constant whose type is asserted from
+      `private.ts`; verify runtime imports, type-only imports, source checking,
+      packing, clean-consumer resolution, and Node/Deno coverage.
 - [ ] Verify a clean TypeScript consumer can install the packed tarball and use
       the public API without any private artifact present.
 
@@ -301,7 +343,11 @@ References to packaged `meta.f.mjs` are allowed.
 - Other private file-scope types live in `private.ts` and keep `_`.
 - `types.ts` never depends on `private.ts`.
 - Every import in `types.ts` and `private.ts` uses named `import type { ... }`.
-- Runtime values primarily used for type derivation live in `meta.f.mjs`.
+- Runtime constants referenced by TypeScript type definitions/proofs live in
+  `meta.f.mjs`, whether they are RTTI, literal metadata, or ordinary runtime
+  tables also consumed by implementation code.
+- File-scope private proofs over such constants can live in `private.ts` without
+  exporting implementation locals from `module.f.mjs`.
 - Node and Deno coverage include executable `meta.f.mjs` files.
 - Declaration emission may create `private.d.ts`; the final `prepack` step
   removes it before package contents are selected.

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -31,13 +31,13 @@ complementary signals.
 
 ### Proposal
 
-Use this directory convention where named types or RTTI type definitions are
-needed:
+Use this directory convention where named types or runtime metadata used for
+type derivation are needed:
 
 ```text
 module.f.mjs  # implementation; no @typedef
 proof.f.mjs   # proofs; no @typedef
-rtti.f.mjs    # runtime type definitions used by RTTI
+meta.f.mjs    # runtime metadata used to define/derive types
 types.ts      # public named TypeScript types
 private.ts    # private named TypeScript types
 ```
@@ -52,45 +52,56 @@ two homes:
 `private.ts` contains implementation-only TypeScript types used by either the
 module or its proofs. Every private type continues to start with `_`.
 
-#### RTTI type definitions
+#### Type metadata
 
-Some TypeScript types are derived from runtime RTTI definitions, for example:
+Some TypeScript types are derived from runtime values rather than declared
+independently. These values include RTTI definitions, for example:
 
 ```ts
-import { type } from './rtti.f.mjs'
+import { type } from './meta.f.mjs'
 
 export type Value = Ts<typeof type>
 ```
 
-Put runtime values whose primary purpose is to represent types in `rtti.f.mjs`.
-This keeps runtime type definitions distinct from normal implementation code and
-from their compile-time TypeScript views:
+and ordinary constants whose literal value is used by a type query, for example:
+
+```ts
+import { statuses } from './meta.f.mjs'
+
+export type Status = typeof statuses[number]
+```
+
+Put runtime values whose primary purpose is to define, describe, or derive
+type-level information in `meta.f.mjs`. This keeps type metadata distinct from
+normal implementation code and from its compile-time TypeScript views:
 
 ```text
-rtti.f.mjs  # runtime representation of types
+meta.f.mjs  # runtime metadata used by types
 types.ts    # public compile-time types
 private.ts  # private compile-time types
 ```
 
-Both `types.ts` and `private.ts` may depend on `rtti.f.mjs` when defining types
-such as `Ts<typeof type>`. This is an intentional dependency on a runtime value,
-not a violation of the public/private type boundary. `rtti.f.mjs` is ordinary
+Both `types.ts` and `private.ts` may depend on `meta.f.mjs` for
+`Ts<typeof ...>`, `typeof ...`, indexed access over `as const`-style values, and
+similar type derivation. This is an intentional dependency on runtime values,
+not a violation of the public/private type boundary. `meta.f.mjs` is ordinary
 runtime FunctionalScript source and is packaged like other required `.f.mjs`
 modules; it is not a private type artifact merely because `private.ts` may use
 it.
 
-Do not move an RTTI value into `types.ts` or `private.ts` merely to avoid this
-dependency: the RTTI definition is a runtime value and belongs in `.f.mjs`.
-Normal runtime values whose primary purpose is not type representation remain in
-`module.f.mjs` rather than being moved mechanically to `rtti.f.mjs`.
+Do not move a runtime value into `types.ts` or `private.ts` merely to avoid this
+dependency: runtime values belong in `.f.mjs`. Values whose primary purpose is
+normal program behavior remain in `module.f.mjs` even if their types are reused
+incidentally; `meta.f.mjs` is for values whose primary role is type-level
+metadata.
 
 Dependency rules:
 
 - `module.f.mjs` and `proof.f.mjs` may use both `types.ts` and `private.ts`
   through JSDoc `@import`.
 - `private.ts` may import public types from `types.ts`.
-- `types.ts` and `private.ts` may depend on runtime type definitions from
-  `rtti.f.mjs` for `Ts<typeof ...>` and similar type derivation.
+- `types.ts` and `private.ts` may depend on runtime type metadata from
+  `meta.f.mjs` for `Ts<typeof ...>`, `typeof ...`, and similar derivation.
 - `types.ts` must not depend on `private.ts`.
 - A public exported API must not require a `private.ts` type by name.
 
@@ -127,9 +138,9 @@ dependency. This is a structural package check over the packed file set and the
 contents of all packed declarations, not a check limited to whichever public
 entry points the clean consumer happens to import.
 
-References from shipped declarations to a packaged `rtti.f.mjs` are allowed:
-unlike `private.ts`, RTTI is a runtime module intentionally available to the
-package and may be required to express public types derived with `Ts<typeof ...>`.
+References from shipped declarations to a packaged `meta.f.mjs` are allowed:
+unlike `private.ts`, metadata is an intentionally packaged runtime module and
+may be required to express public types derived from its exported values.
 
 The cleanup must operate on generated artifacts only; authored `private.ts`
 remains available for source-tree type-checking. Neither `private.ts` nor the
@@ -144,16 +155,16 @@ rather than retaining `private.d.ts` to make such a leak resolve.
 
 ### Tasks
 
-- [ ] Document `private.ts` and `rtti.f.mjs` beside the existing `types.ts`,
+- [ ] Document `private.ts` and `meta.f.mjs` beside the existing `types.ts`,
       `module.*`, and `proof.*` file conventions.
 - [ ] Prohibit JSDoc `@typedef` declarations in `module.f.mjs` and `proof.f.mjs`.
 - [ ] Keep the leading `_` convention for every type declared in `private.ts`.
 - [ ] Move public named types from implementation/proof JSDoc into `types.ts`.
 - [ ] Move private named types out of `types.ts`, `module.f.mjs`, and
       `proof.f.mjs` into each directory's `private.ts` where applicable.
-- [ ] Move runtime RTTI definitions whose primary purpose is type representation
-      into `rtti.f.mjs` when `types.ts` or `private.ts` derives TypeScript types
-      from them with `Ts<typeof ...>` or an equivalent type query.
+- [ ] Move runtime values whose primary purpose is type derivation into
+      `meta.f.mjs`; include both RTTI definitions and non-RTTI constants used by
+      `Ts<typeof ...>`, `typeof ...`, or equivalent type queries.
 - [ ] Keep `private.ts` in normal TypeScript type-checking without generating a
       runtime JavaScript file for it.
 - [ ] Add a post-declaration-emit packaging step that deletes generated
@@ -167,9 +178,10 @@ rather than retaining `private.d.ts` to make such a leak resolve.
       creates the intermediate `private.d.ts`, cleanup removes it, generated
       public declarations contain no implementation-local typedef exports, and
       packed-artifact validation finds no private type file or declaration edge.
-- [ ] Extend the fixture with `rtti.f.mjs` plus a `Ts<typeof ...>`-derived type in
-      `types.ts` or `private.ts`; verify the source tree and packed consumer both
-      resolve the RTTI dependency correctly.
+- [ ] Extend the fixture with `meta.f.mjs` containing both an RTTI value and a
+      non-RTTI literal constant used to derive TypeScript types in `types.ts` or
+      `private.ts`; verify the source tree and packed consumer resolve both
+      metadata dependencies correctly.
 - [ ] Verify a clean TypeScript consumer can install the packed tarball and use
       the public API without any private artifact present.
 
@@ -179,9 +191,10 @@ rather than retaining `private.d.ts` to make such a leak resolve.
 - All public named TypeScript types live in `types.ts`.
 - All private named TypeScript types live in `private.ts` and keep their leading
   `_`.
-- Runtime values whose primary purpose is RTTI type representation live in
-  `rtti.f.mjs`; `types.ts` and `private.ts` may depend on them for
-  `Ts<typeof ...>`-style type derivation.
+- Runtime values whose primary purpose is to define, describe, or derive
+  type-level information live in `meta.f.mjs`; this includes RTTI definitions
+  and non-RTTI constants used by `Ts<typeof ...>`, `typeof ...`, and similar
+  type queries.
 - Generated public declarations do not expose private named typedefs merely as a
   consequence of declaration emission.
 - Declaration emission may create `private.d.ts`, but the packaging cleanup
@@ -189,7 +202,7 @@ rather than retaining `private.d.ts` to make such a leak resolve.
 - The packed tarball contains neither `private.ts` nor `private.d.ts`.
 - No packed `.d.ts` / `.d.mts` file depends on a directory's private type module,
   regardless of the exact emitted module-specifier suffix.
-- Required references to packaged `rtti.f.mjs` modules remain valid in the
+- Required references to packaged `meta.f.mjs` modules remain valid in the
   packed artifact and clean consumer.
 - A clean TypeScript consumer type-checks successfully against the packed
   tarball after all private artifacts have been removed.

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -181,17 +181,12 @@ import type { metadataValue } from './meta.f.mjs'
 Do not use runtime `import { ... }`, namespace imports, or side-effect imports in
 `types.ts` or `private.ts`.
 
-`meta.f.mjs` is executable FunctionalScript source. Node and Deno coverage
-filters should include it so metadata that is actually loaded is measured under
-the same coverage expectations as `module.f.mjs`. Coverage inclusion does not
-load modules by itself, and the convention does not require an otherwise-unused
-`meta.f.mjs` to be imported solely to make it appear in a coverage report.
-
-When a directory has a `meta.f.mjs`, it is recommended for the corresponding
-proof to import and exercise the metadata when that produces a meaningful runtime
-check. This is a recommendation, not a requirement: a metadata module that is
-used only through erased TypeScript `import type` references need not gain an
-artificial runtime import just for coverage.
+`meta.f.mjs` is executable FunctionalScript source. Emergent testing already
+loads every `*.f.mjs` during normal test discovery, including modules without a
+`proof` export. Add `meta.f.mjs` to the Node and Deno coverage filters so the
+existing coverage thresholds apply to it. How a particular metadata module
+satisfies those thresholds is left to its developer; this convention does not
+prescribe proof imports, calls, or other coverage-specific implementation choices.
 
 #### Breaking migration; no compatibility re-exports
 
@@ -315,12 +310,8 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
       re-exports.
 - [ ] Require every import in `types.ts` and `private.ts` to use named
       `import type { ... }`.
-- [ ] Update Node and Deno coverage filters to include `meta.f.mjs`; when a
-      metadata module is loaded, it must be subject to the same coverage
-      thresholds as other executable FunctionalScript source.
-- [ ] Recommend importing and exercising `meta.f.mjs` from the corresponding
-      proof when that gives a meaningful runtime check; do not require artificial
-      proof imports solely to make otherwise-unused metadata appear in coverage.
+- [ ] Update Node and Deno coverage filters to include `meta.f.mjs`; emergent
+      testing already loads it, and the existing coverage thresholds apply.
 - [ ] Keep `private.ts` in normal TypeScript checking without runtime JS emit.
 - [ ] Make deletion of generated `private.d.ts` the final `prepack` step.
 - [ ] Do not rewrite/post-process emitted declarations to remove retained JSDoc
@@ -341,10 +332,8 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
 - [ ] Include a retained JSDoc `@import ... './private.ts'` comment in an emitted
       declaration fixture and verify the clean consumer succeeds without
       `private.ts`; this proves comments do not create package dependencies.
-- [ ] In the fixture, runtime-load at least one metadata path to prove that the
-      Node/Deno coverage filters include loaded `meta.f.mjs`; do not use the
-      fixture to impose a requirement that every metadata module/export in the
-      repository be runtime-loaded by a proof.
+- [ ] Verify the normal test runner loads fixture `meta.f.mjs` and Node/Deno
+      coverage includes it under the existing thresholds.
 - [ ] Verify source checking, declaration emit/cleanup, Node+Deno coverage,
       packing, and clean-consumer type checking.
 
@@ -363,9 +352,9 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
 - `types.ts` and every packed public declaration are independent of `private.ts`.
 - Every import in `types.ts` and `private.ts` uses named `import type { ... }`.
 - Runtime constants referenced by TypeScript definitions/proofs live in
-  `meta.f.mjs`, whether RTTI or not. Node and Deno coverage filters include
-  `meta.f.mjs`, but proofs are not required to runtime-import metadata solely for
-  coverage; importing/exercising metadata from proofs is recommended when useful.
+  `meta.f.mjs`, whether RTTI or not. Emergent testing loads `meta.f.mjs`, Node and
+  Deno coverage filters include it, and the existing coverage thresholds apply;
+  this convention does not prescribe how developers satisfy those thresholds.
 - Moving public types to `types.ts` and public runtime metadata to `meta.f.mjs`
   are breaking migrations: importers and changelog are updated and no
   compatibility re-exports preserve old entry points.

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -34,7 +34,7 @@ module.f.mjs  # FunctionalScript implementation
 module.mjs    # host integration, when needed
 proof.f.mjs   # FunctionalScript proofs
 proof.mjs     # host proofs, when needed
-meta.f.mjs    # runtime constants referenced by TypeScript types/proofs
+meta.f.mjs    # runtime metadata constants used to define/derive types
 types.ts      # public declaration closure
 private.ts    # other implementation-private file-scope types
 ```
@@ -46,6 +46,53 @@ of basename or whether the file is FunctionalScript. This includes
 allowed as described below.
 
 Private type and runtime constant names continue to start with `_`.
+
+#### Dependency order
+
+Keep the source dependency order:
+
+```text
+meta.f.mjs <- types.ts <- private.ts <- module.f.mjs <- proof.f.mjs <- module.mjs <- proof.mjs
+```
+
+The arrow points from a dependency to a dependent: a file may depend on files to
+its left, but moving a type proof must not introduce a reverse edge merely to
+keep the proof near the declaration it checks. The order is a layering rule, not
+a requirement that every file directly import its immediate neighbor.
+
+Place assertions in the earliest layer that can legitimately see everything they
+assert without reversing this order:
+
+- invariants entirely inside the public type model belong in `types.ts`;
+- implementation-private type invariants belong in `private.ts` when they do not
+  need downstream implementation values;
+- assertions about `module.f.mjs` implementations, including function signatures,
+  belong downstream in `proof.f.mjs`, normally as function-local typedef proofs;
+- host-specific implementation assertions belong downstream in `proof.mjs`.
+
+For example, `fjs/effects/types.ts` currently imports `step`, `catchStep`,
+`resultStep`, `mapStep`, `resultMapStep`, and `unwrapStep` from `module.f.mjs`
+only to assert their inferred signatures with `ReturnType<typeof ...>`. Those
+assertions verify the implementation layer, so the migration should move them to
+`proof.f.mjs` rather than move the implementation functions into `meta.f.mjs`.
+A representative proof can stay lexical:
+
+```js
+signature: () => {
+    /**
+     * @typedef {Assert<Equal<
+     *   ReturnType<typeof step<_AddOp, number, NotImplemented, _MulOp, string, string>>,
+     *   Effect<_AddOp | _MulOp, string, NotImplemented | string>
+     * >>} _StepSig
+     */
+}
+```
+
+Do not create a broad exception merely because a type proof uses `typeof` on a
+runtime function. First check whether the proof can move to a downstream proof
+file while preserving the dependency order. Narrow exceptions may still be
+needed, but they should be justified by a concrete case after the cleaner
+placement has been ruled out.
 
 #### Public declaration closure
 
@@ -61,7 +108,7 @@ public type                                         -> types.ts
 private `_` helper used by any public declaration   -> types.ts
 other file-scope private `_` type                   -> private.ts
 function-local typedef                              -> allowed in place
-runtime constant referenced by TS types/proofs      -> meta.f.mjs
+runtime metadata constant used to define types      -> meta.f.mjs
 ```
 
 For example, a helper used by a public type stays in `types.ts`:
@@ -125,11 +172,18 @@ exported aliases in generated `.d.ts` / `.d.mts` files.
 
 #### `meta.f.mjs`
 
-`meta.f.mjs` contains runtime constants whose literal/inferred types are actually
-referenced by TypeScript type definitions or file-scope type proofs. They do not
-need to be RTTI and do not need to exist primarily for type-system purposes.
+`meta.f.mjs` contains runtime metadata constants whose literal/inferred values are
+part of the type-level model. They do not need to be RTTI, and normal runtime code
+may also consume them. Typical cases are RTTI descriptors, `as const`-style data,
+and lookup tables whose literal shape is used to define or derive TypeScript
+types.
 
-Examples include RTTI values:
+`meta.f.mjs` is **not** a destination for ordinary implementation functions just
+because a type proof inspects their signature with `typeof`, `ReturnType`, or
+`Parameters`. Such functions stay in `module.f.mjs`; place their signature proofs
+downstream according to the dependency-order rule above.
+
+Examples of metadata include RTTI values:
 
 ```ts
 import type { type } from './meta.f.mjs'
@@ -173,10 +227,6 @@ consumers must not depend on `_`-prefixed constants directly. Renaming or removi
 such a name is not a breaking change solely because it was exported. As with
 private types, changes that alter an actual public runtime/type contract still
 follow the normal breaking-change rules.
-
-The trigger is an actual TypeScript type dependency (`typeof`, `Ts<typeof ...>`,
-indexed access, a type proof, etc.), not merely that a runtime value *could* be
-queried.
 
 Runtime code imports values from `meta.f.mjs` normally. Authored TypeScript type
 modules use only named type-only imports:
@@ -281,16 +331,20 @@ private.ts  # implementation-private file-scope types outside that closure
 
 Both remain type-only modules and use named `import type { ... }` imports. The
 same policy must also state that file-scope JSDoc `@typedef` is prohibited in
-**all authored `.mjs` files**, including non-FunctionalScript host JavaScript.
+**all authored `.mjs` files**, including non-FunctionalScript host JavaScript,
+and document the dependency order above.
 
 ### Tasks
 
 - [ ] Document `types.ts`, `private.ts`, and `meta.f.mjs` beside the existing
       JavaScript/FunctionalScript file conventions, including host `.mjs` and
       descriptive companions.
+- [ ] Document and preserve the dependency order
+      `meta.f.mjs <- types.ts <- private.ts <- module.f.mjs <- proof.f.mjs <- module.mjs <- proof.mjs`.
 - [ ] Update `fjs/AGENTS.md` to allow `types.ts` and `private.ts` as the authored
-      TypeScript type-module roles, document the public-declaration-closure rule,
-      and prohibit file-scope `@typedef` in every authored `.mjs` file.
+      TypeScript type-module roles, document the public-declaration-closure and
+      dependency-order rules, and prohibit file-scope `@typedef` in every
+      authored `.mjs` file.
 - [ ] Update `fjs/fsc/README.md` and delete or narrow
       `todo/blocked/jsdoc-typedef-strip-internal.md` so they no longer prescribe
       a conflicting private-JSDoc strategy.
@@ -305,14 +359,20 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
       shipped public declaration in `types.ts`, including helpers appearing in
       exported runtime-value/function signatures.
 - [ ] Move only other implementation-private file-scope types to `private.ts`;
-      do not create `types.ts -> private.ts` or public-declaration -> `private.ts`
+      do not create reverse dependency edges or public-declaration -> `private.ts`
       dependencies.
+- [ ] Review type assertions that currently reverse the dependency order. Move
+      implementation-signature assertions downstream into proof files where
+      possible; specifically, move the `fjs/effects/types.ts` assertions over
+      `step` / `catchStep` / `resultStep` / `mapStep` / `resultMapStep` /
+      `unwrapStep` to function-local proofs in `fjs/effects/proof.f.mjs`.
 - [ ] Keep lexical type-proof typedefs inside their functions.
-- [ ] Move runtime constants actually referenced by TypeScript type
-      definitions/proofs into `meta.f.mjs`, including RTTI values, non-RTTI
-      literal constants, and runtime-used tables; prefix private ones with `_`
-      even when they must be exported for sibling-module access.
-- [ ] Move file-scope private proofs over those constants to `private.ts` (or
+- [ ] Move runtime metadata constants used to define/derive TypeScript types into
+      `meta.f.mjs`, including RTTI values, non-RTTI literal constants, and
+      runtime-used tables; prefix private ones with `_` even when they must be
+      exported for sibling-module access. Do not move ordinary implementation
+      functions merely because a proof inspects their type.
+- [ ] Move file-scope private proofs over metadata constants to `private.ts` (or
       `types.ts` when part of the public declaration closure) and use
       `import type { ... }`.
 - [ ] Treat moves of public runtime constants to `meta.f.mjs` as breaking API
@@ -334,6 +394,8 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
         declaration (the `_SortedArray`/`find` shape);
       - an implementation-private type in `private.ts`;
       - a function-local typedef depending on a lexical value;
+      - an implementation-function signature assertion placed downstream in a
+        proof rather than creating a `types.ts -> module.f.mjs` dependency;
       - a FunctionalScript descriptive companion such as `testlib.f.mjs` whose
         former file-scope typedef is moved to the appropriate TypeScript file;
       - a non-FunctionalScript authored `.mjs` file whose former file-scope
@@ -349,6 +411,10 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
 
 ### Acceptance criteria
 
+- The dependency order
+  `meta.f.mjs <- types.ts <- private.ts <- module.f.mjs <- proof.f.mjs <- module.mjs <- proof.mjs`
+  is preserved; type assertions do not create reverse edges merely for
+  convenience.
 - No authored `.mjs` file contains a file-scope JSDoc `@typedef`, regardless of
   basename, FunctionalScript marker, or role.
 - Function-local JSDoc `@typedef` is allowed everywhere; private names keep `_`
@@ -360,8 +426,12 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
   public declaration closure and is expected to be used sparingly where
   `types.ts` already describes most of a module's type surface.
 - `types.ts` and every packed public declaration are independent of `private.ts`.
+- Assertions about ordinary implementation-function signatures live downstream
+  of `module.f.mjs` (normally in function-local `proof.f.mjs` typedefs) rather
+  than forcing those functions into `meta.f.mjs` or importing implementation
+  functions into `types.ts`.
 - Every import in `types.ts` and `private.ts` uses named `import type { ... }`.
-- Runtime constants referenced by TypeScript definitions/proofs live in
+- Runtime metadata constants used to define/derive TypeScript types live in
   `meta.f.mjs`, whether RTTI or not. Private constants use leading `_` even when
   exported for sibling-module access; `_` marks them private by contract.
   Emergent testing loads `meta.f.mjs`, Node and Deno coverage filters include it,
@@ -381,8 +451,9 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
   resolvable from shipped declarations, including helpers used by exported
   runtime-value/function signatures.
 - `fjs/AGENTS.md` no longer says `types.ts` is the only authored TypeScript and
-  documents both `types.ts` and `private.ts`, the declaration-closure rule, and
-  the all-authored-`.mjs` file-scope typedef prohibition.
+  documents both `types.ts` and `private.ts`, the declaration-closure and
+  dependency-order rules, and the all-authored-`.mjs` file-scope typedef
+  prohibition.
 - `fjs/fsc/README.md` and the blocked `@internal`/`stripInternal` TODO no longer
   prescribe a conflicting private-JSDoc strategy.
 - A clean TypeScript consumer type-checks successfully against the packed

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -5,534 +5,266 @@
 
 ### Problem
 
-FunctionalScript currently mixes named types with authored JavaScript source.
-Common examples are:
+TypeScript declaration emit turns file-scope JSDoc `@typedef`s in authored
+`.mjs` files into declaration aliases. Implementation-private `_` types therefore
+leak into generated `.d.ts` / `.d.mts` files and add noise to the public surface.
 
-```text
-module.f.mjs  # FunctionalScript implementation + file-scope JSDoc typedefs
-module.mjs    # host integration + file-scope JSDoc typedefs
-proof.f.mjs   # proofs + file-scope JSDoc typedefs
-types.ts      # public types + private helpers
-```
+The requirement is a clean, self-contained public declaration/API boundary.
+`private.ts` and subordinate modules such as `meta/module.f.mjs` are **tools** for
+reaching that result, not required companion files.
 
-Other authored JavaScript companions, such as `testlib.f.mjs`, can contain the
-same file-scope typedefs and are subject to the same declaration emit. The same
-problem also exists outside `fjs/`; for example, `todo/proof.f.mjs` is an authored
-`.mjs` file with a file-scope typedef. TypeScript turns file-scope JSDoc
-`@typedef`s in authored `.mjs` files into exported aliases, so
-implementation-private names leak into generated `.d.mts` files. The existing
-leading-`_` convention marks those names private by contract, but the declarations
-still contain noise and make the source/package boundary less clear.
+### Rules
 
-The requirement is to keep the public declaration/API surface clean and
-self-contained. `private.ts` and `meta.f.mjs` are **optional tools** for reaching
-that result; they are not file roles that every module must introduce.
+#### No file-scope typedefs in authored `.mjs`
 
-### Proposal
+No authored `.mjs` anywhere in the repository may contain a **file-scope** JSDoc
+`@typedef`, regardless of directory, basename, or whether the file is
+FunctionalScript. This includes `module.f.mjs`, `proof.f.mjs`, host `.mjs` files,
+descriptive companions such as `testlib.f.mjs`, and root/`todo/` files such as
+`todo/proof.f.mjs`.
 
-Use these file roles when they improve the concrete design:
-
-```text
-module.f.mjs  # FunctionalScript implementation
-module.mjs    # host integration, when needed
-proof.f.mjs   # FunctionalScript proofs
-proof.mjs     # host proofs, when needed
-meta.f.mjs    # optional runtime metadata/data extracted to support type structure
-types.ts      # public declaration closure
-private.ts    # optional implementation-private file-scope TypeScript
-```
-
-The design target is the public boundary, not the presence of particular files:
-
-- `types.ts` describes the public declaration closure;
-- use `private.ts` when moving implementation-private file-scope types out of the
-  public declaration surface makes the structure cleaner;
-- use `meta.f.mjs` when extracting runtime metadata/data lets TypeScript types or
-  proofs depend on it without reversing the dependency order;
-- do not create either file mechanically when a simpler organization already
-  keeps the public surface clean.
-
-No authored `.mjs` file anywhere in the repository may declare a **file-scope**
-JSDoc `@typedef`, regardless of directory, basename, or whether the file is
-FunctionalScript. This includes `module.f.mjs`, `module.mjs`, `proof.f.mjs`,
-`proof.mjs`, `meta.f.mjs`, `testlib.f.mjs`, root-level or `todo/` `.mjs` files,
-and other descriptive companions. Function-local typedefs remain allowed as
-described below.
-
-Private type and runtime constant names continue to start with `_`.
-
-#### Dependency order
-
-When these roles are present, keep the source dependency order:
-
-```text
-meta.f.mjs <- types.ts <- private.ts <- module.f.mjs <- proof.f.mjs <- module.mjs <- proof.mjs
-```
-
-The arrow points from a dependency to a dependent: a file may depend on files to
-its left, but moving a type proof must not introduce a reverse edge merely to
-keep the proof near the declaration it checks. The order is a layering rule, not
-a requirement that every file or edge exists.
-
-The file-placement conventions below are defaults, not a mechanical classifier.
-Analyze concrete cases and prefer the simplest organization that preserves this
-dependency order and the clean public boundary. In particular, do not force a
-recursive RTTI constant into `meta.f.mjs` when expressing its recursion requires
-a named annotation from `types.ts`; keeping that constant downstream can be
-cleaner than creating a `meta.f.mjs -> types.ts` reverse edge.
-
-Place assertions in the earliest layer that can legitimately see everything they
-assert without reversing this order:
-
-- invariants entirely inside the public type model belong in `types.ts`;
-- implementation-private type invariants may use `private.ts` when that is the
-  cleanest place and they do not need downstream implementation values;
-- assertions about `module.f.mjs` implementations, including function signatures,
-  belong downstream in `proof.f.mjs`, normally as function-local typedef proofs;
-- host-specific implementation assertions belong downstream in `proof.mjs`.
-
-For example, `fjs/effects/types.ts` currently imports `step`, `catchStep`,
-`resultStep`, `mapStep`, `resultMapStep`, and `unwrapStep` from `module.f.mjs`
-only to assert their inferred signatures with `ReturnType<typeof ...>`. Those
-assertions verify the implementation layer, so the migration should move them to
-`proof.f.mjs` rather than move the implementation functions into `meta.f.mjs`.
-A representative group of compile-time-only checks can live inside one proof
-function so every typedef remains lexical:
+Function-local typedefs remain allowed. This is especially useful for compile-time
+proofs that need lexical or downstream runtime values:
 
 ```js
-signatures: () => {
-    /**
-     * @typedef {Assert<Equal<
-     *   ReturnType<typeof step<_AddOp, number, NotImplemented, _MulOp, string, string>>,
-     *   Effect<_AddOp | _MulOp, string, NotImplemented | string>
-     * >>} _StepSig
-     */
-
-    /** @typedef {Assert<Equal<ReturnType<typeof catchStep<...>>, Effect<...>>>} _CatchStepSig */
+const signatures = () => {
+    /** @typedef {Assert<Equal<ReturnType<typeof step<...>>, Effect<...>>>} _Step */
+    /** @typedef {Assert<Equal<ReturnType<typeof catchStep<...>>, Effect<...>>>} _CatchStep */
 }
 ```
 
-Recursive metadata needs the same case-by-case treatment. Two current examples
-illustrate the intended approach:
-
-- `fjs/media/revision`: `LockMap` / `LockSchema` stay in `types.ts`; the recursive
-  `lock` RTTI constant may stay in `module.f.mjs` because its initializer needs
-  the named `LockSchema` annotation from `types.ts`; the `Assert<Check<...>>`
-  consistency checks that currently make `types.ts` import `module.f.mjs` move
-  downstream into a function in `proof.f.mjs`.
-- `fjs/edag`: recursive RTTI such as `exp` may stay in `module.f.mjs` when its
-  explicit annotation depends on the public EDAG types; file-scope consistency
-  assertions such as `Assert<Check...>` move into one or more proof functions so
-  the RTTI/type relationship is still pinned without leaking typedefs or
-  reversing the dependency order.
-
-These examples do not establish a special rule for every recursive type. They
-show the process: inspect the cycle, preserve the dependency direction, move
-verification downstream when useful, and introduce `private.ts` / `meta.f.mjs`
-only when they simplify the result. Narrow exceptions may still be needed after
-the concrete case has been analyzed.
+Private type and runtime constant names continue to use a leading `_`.
 
 #### Public declaration closure
 
-`types.ts` is primarily the public type API, but it may contain private `_`
-helpers when they are required to express any shipped public declaration.
-"Public declaration" includes both exported type aliases and declarations of
-exported runtime values/functions.
+`types.ts` describes the public declaration closure:
 
-The default placement guide is:
+- public types;
+- private `_` helpers required transitively by shipped public declarations,
+  including declarations of exported runtime functions/values.
+
+For example, if an exported `find` declaration contains `_SortedArray<T>`, then
+`_SortedArray` is part of the public declaration closure and stays in `types.ts`
+(or is inlined). Moving it to an unshipped private module would make the public
+declaration incomplete.
+
+`types.ts` must not depend on `private.ts`.
+
+`private.ts` is optional. Use it only when separating implementation-private
+file-scope types outside the public declaration closure makes the design cleaner.
+Do not create it mechanically for every `_` name.
+
+#### Dependency order
+
+Preserve the dependency direction for the roles that exist:
 
 ```text
-public type                                         -> types.ts
-private `_` helper used by any public declaration   -> types.ts
-other file-scope private `_` type                   -> private.ts, when useful
-function-local typedef                              -> allowed in place
-runtime metadata/data extracted for type structure  -> meta.f.mjs, when useful
+meta/module.f.mjs <- types.ts <- private.ts <- module.f.mjs <- proof.f.mjs <- module.mjs <- proof.mjs
 ```
 
-For example, a helper used by a public type stays in `types.ts`:
+The arrow points from dependency to dependent. This is a layering guide, not a
+requirement that every file or edge exists.
 
-```ts
-type _Tuple<N extends number, T, R extends readonly T[]> =
-    N extends R['length'] ? R : _Tuple<N, T, readonly [...R, T]>
+Move verification downstream before moving implementation upstream. For example,
+`fjs/effects/types.ts` currently imports implementation functions only to assert
+`ReturnType<typeof ...>` signatures. Those assertions verify `module.f.mjs`, so
+move them into one or more proof functions in `proof.f.mjs`; keep the functions
+in `module.f.mjs`.
 
-export type Tuple<N extends number, T> = _Tuple<N, T, readonly []>
+Analyze constrained and recursive cases individually rather than inventing broad
+exceptions:
+
+- `fjs/media/revision`: `LockMap` / `LockSchema` can remain in `types.ts`; recursive
+  `lock` can remain in `module.f.mjs` when it requires the named `LockSchema`
+  annotation; move `Assert<Check<...>>` consistency checks into a proof function.
+- `fjs/edag`: recursive RTTI such as `exp` can remain in `module.f.mjs` when its
+  annotation depends on public EDAG types; move file-scope consistency asserts
+  into proof functions.
+
+The goal is to preserve the dependency direction and simplify the public surface,
+not to satisfy a mechanical file-placement rule.
+
+### Optional metaprogramming submodule
+
+When declarative runtime constants are shared between TypeScript and runtime code,
+it can be useful to split them into a normal subordinate module, for example:
+
+```text
+meta/
+    module.f.mjs
 ```
 
-The same rule applies when a helper appears in an exported value declaration.
-For example, if declaration emit for an exported `find` contains:
+`meta` here means **metaprogramming**: declarative definitions of types/schema-like
+information that are useful at both compile time (TypeScript through `typeof`,
+RTTI conversion, indexed access, etc.) and runtime.
 
-```ts
-export const find: <T>(cmp: Cmp<T>) =>
-    (value: T) => (array: _SortedArray<T>) => T | null
-```
+Typical examples are:
 
-then `_SortedArray` is part of the public declaration closure and must remain in
-`types.ts` (or be inlined into the public declaration). Moving it to
-`private.ts` would make a shipped declaration depend on a declaration module
-that packaging removes.
+- RTTI/schema constants;
+- `as const`-style literal data;
+- declarative lookup tables whose literal shape defines or constrains types.
 
-`types.ts` must never import `private.ts`. If moving a private helper to
-`private.ts` would create a `types.ts -> private.ts` edge or cause any generated
-public declaration to reference `private.ts`, keep or inline that helper in
-`types.ts` instead.
+This is only a suggestion. Do not create `meta/` merely because a runtime value
+appears in a type proof. Ordinary implementation functions stay in
+`module.f.mjs`; recursively annotated metadata may also stay there when moving it
+would reverse the dependency direction.
 
-`private.ts` therefore should be uncommon. It is a tool for separating
-implementation-private file-scope types that are outside the public declaration
-closure; it is not a required companion and not a mechanical destination for
-every `_` name.
-
-#### Function-local typedefs
-
-Function-local JSDoc `@typedef` declarations are allowed in any authored source
-file. They may refer to lexical values that cannot be named from a sibling
-TypeScript file.
-
-For example:
+A private constant exported from `meta/module.f.mjs` for sibling-module linkage
+uses a leading `_`:
 
 ```js
-const proof = () => {
-    const orConst = or(42, string)
-    /** @typedef {Assert<Equal<typeof orConst, Or<readonly [42, typeof string]>>>} _OrConst */
-}
-```
-
-Callback-local type proofs are also valid:
-
-```js
-({ kind }) => {
-    /** @typedef {Assert<Equal<typeof kind, 'add'>>} _Kind */
-    return kind
-}
-```
-
-Private function-local typedefs keep the leading `_`. Declaration validation
-must verify that function-local typedefs remain lexical and do not escape as
-exported aliases in generated `.d.ts` / `.d.mts` files.
-
-#### `meta.f.mjs`
-
-`meta.f.mjs` is an optional tool for extracting runtime metadata/data when doing
-so improves the type/declaration boundary. Typical cases are RTTI descriptors,
-`as const`-style data, and lookup tables whose literal shape is used to define or
-derive TypeScript types.
-
-Do not create `meta.f.mjs` merely because a runtime value participates in a type
-proof. A recursive metadata constant that needs a named annotation from
-`types.ts` may remain in `module.f.mjs`; ordinary implementation functions stay
-in `module.f.mjs` even when a proof inspects their signature with `typeof`,
-`ReturnType`, or `Parameters`. Move verification downstream when that is the
-cleaner solution. The `media/revision`, `edag`, and `effects` examples above are
-the current models for this analysis.
-
-When `meta.f.mjs` is useful, examples include RTTI values:
-
-```ts
-import type { type } from './meta.f.mjs'
-
-export type Value = Ts<typeof type>
-```
-
-ordinary literal constants:
-
-```ts
-import type { statuses } from './meta.f.mjs'
-
-export type Status = typeof statuses[number]
-```
-
-and normal runtime tables whose type is asserted:
-
-```js
-// meta.f.mjs
+// meta/module.f.mjs
 export const _framingKeywords =
     /** @type {const} */ (['import', 'const', 'export', 'default', 'from'])
 ```
 
 ```ts
-// private.ts
-import type { _framingKeywords } from './meta.f.mjs'
-
-type _KeywordsAreComplete =
-    Assert<Equal<(typeof _framingKeywords)[number], _FramingKeyword>>
+// private.ts or types.ts
+import type { _framingKeywords } from './meta/module.f.mjs'
 ```
 
 ```js
 // module.f.mjs
-import { _framingKeywords } from './meta.f.mjs'
+import { _framingKeywords } from './meta/module.f.mjs'
 ```
 
-Private constants in `meta.f.mjs` use the same leading-`_` API convention as
-private types. They may need to be exported so sibling runtime or TypeScript
-modules can name them, but that export is module linkage rather than public API:
-consumers must not depend on `_`-prefixed constants directly. Renaming or removing
-such a name is not a breaking change solely because it was exported. As with
-private types, changes that alter an actual public runtime/type contract still
-follow the normal breaking-change rules.
+Exportability is linkage, not API status: `_` means consumers must not depend on
+the name. Renaming/removing it is not breaking solely because it is exported.
 
-Runtime code imports values from `meta.f.mjs` normally. Authored TypeScript type
-modules use only named type-only imports:
+Because `meta/module.f.mjs` is just another `module.f.mjs`, existing tooling
+already handles it:
 
-```ts
-import type { PublicType } from './types.ts'
-import type { metadataValue } from './meta.f.mjs'
-```
+- emergent testing loads it as `*.f.mjs`;
+- the existing Node `**/module.f.mjs` coverage filter includes it;
+- the existing Deno `.*module\\.f\\.mjs` filter includes it.
 
-Do not use runtime `import { ... }`, namespace imports, or side-effect imports in
-`types.ts` or `private.ts`.
+No special metadata filename or coverage rule is needed.
 
-When present, `meta.f.mjs` is executable FunctionalScript source. Emergent
-testing already loads every `*.f.mjs` during normal test discovery, including
-modules without a `proof` export. Add `meta.f.mjs` to the Node and Deno coverage
-filters so the existing coverage thresholds apply to it. How a particular
-metadata module satisfies those thresholds is left to its developer; this
-convention does not prescribe proof imports, calls, or other coverage-specific
-implementation choices.
+### Breaking migrations
 
-#### Breaking migration; no compatibility re-exports
+Moving an existing public type from an authored `.mjs` declaration surface to
+`types.ts` changes its public type import path. Moving an existing public runtime
+constant into a subordinate module such as `meta/module.f.mjs` changes its runtime
+import path.
 
-Moving a public file-scope type from any authored `.mjs` file to `types.ts`
-changes its public type import path. Moving a public runtime constant from
-`module.f.mjs` to `meta.f.mjs` changes its runtime import path.
+When such moves are chosen, treat them as intentional breaking changes:
 
-Treat either move as an intentional breaking API change when it occurs:
+- update every repository importer;
+- update the changelog;
+- do **not** add compatibility typedefs, exports, or re-exports to preserve the
+  old entry point.
 
-```text
-public type:     ./<source>.mjs  -> ./types.ts
-public metadata: ./module.f.mjs -> ./meta.f.mjs
-```
+Private `_` names are not public API merely because declaration emit or module
+linkage exposes them.
 
-Update every repository importer and the changelog. Do not preserve old entry
-points with compatibility typedefs, exports, or re-exports.
+### Declaration emission and packaging
 
-#### Declaration emission and packaging
+If `private.ts` is used, keep it in the normal TypeScript program so source users
+are checked. Declaration emit may therefore create an intermediate
+`private.d.ts`.
 
-If `private.ts` is used, it remains in the normal TypeScript program so its
-declarations and all JSDoc `@import` users are checked. Normal declaration emit
-may therefore produce an intermediate `private.d.ts`.
+Do not try to exclude `private.ts` from checking. Instead delete generated
+`private.d.ts` files as the final `prepack` step, after declaration emit and the
+existing declaration round-trip check, before package contents are selected.
 
-Do not try to exclude `private.ts` from the TypeScript program. Instead, when
-such files exist, make private-declaration cleanup the final `prepack` step:
-
-1. emit declarations;
-2. run the existing declaration round-trip type-check;
-3. delete generated `private.d.ts` files as the final `prepack` command;
-4. let `npm pack` select files after `prepack` completes;
-5. inspect the actual tarball;
-6. install the tarball in a clean TypeScript consumer and type-check it.
-
-Conceptually:
-
-```text
-tsc --noEmit false --emitDeclarationOnly && tsc && <delete generated private.d.ts files>
-```
-
-Do **not** rewrite or post-process emitted declaration text. TypeScript may retain
-source JSDoc comments such as:
+Do **not** rewrite/post-process emitted declaration text. TypeScript may retain a
+source comment such as:
 
 ```js
 /** @import { _Private } from './private.ts' */
 ```
 
-inside an emitted `.d.ts` / `.d.mts`. In a declaration file this is a comment,
-not a TypeScript import or module dependency, so it may remain after
-`private.d.ts` is deleted.
+inside an emitted declaration. In `.d.ts` / `.d.mts` this is only a comment, not
+a TypeScript module dependency, so it may remain after the private declaration is
+removed.
 
-Validation of the packed artifact must prove:
+Package validation must check semantic dependencies, not raw text:
 
-- authored `private.ts` and generated `private.d.ts` are not shipped when those
-  files are used during source checking;
-- no packed `.d.ts` / `.d.mts` has a **semantic TypeScript dependency** on a
-  private type module that is not shipped.
+- no authored/generated private type artifact that is intended to be unshipped is
+  present in the tarball;
+- no packed declaration semantically depends on an unshipped private type module;
+- a clean TypeScript consumer installed from the tarball type-checks successfully.
 
-A raw text search for `private.ts` / `@import` is therefore incorrect because it
-would reject harmless retained comments. If a structural scan is used, it must
-ignore comments and reject only actual declaration syntax that creates a module
-dependency. The clean-consumer TypeScript check is the final semantic validation.
-References to packaged `meta.f.mjs` are allowed.
+### Repository policy
 
-#### Repository-policy reconciliation
+When this TODO is implemented:
 
-[`../fsc/README.md`](../fsc/README.md) currently documents the leading `_` as an
-interim API contract for private JSDoc typedefs that TypeScript leaks into emitted
-declarations. The upstream blocker is
-[microsoft/TypeScript#46407](https://github.com/microsoft/TypeScript/issues/46407),
-and the wait-for-`@internal`/`stripInternal` strategy is tracked in
-[`../../todo/blocked/jsdoc-typedef-strip-internal.md`](../../todo/blocked/jsdoc-typedef-strip-internal.md).
+- update root `AGENTS.md` with the repository-wide rule that authored `.mjs` files
+  may not contain file-scope JSDoc `@typedef`;
+- update `fjs/AGENTS.md` with the public-declaration-closure rule, optional
+  `private.ts`, optional subordinate metaprogramming modules such as
+  `meta/module.f.mjs`, and the dependency-order guidance;
+- update `fjs/fsc/README.md` and delete or narrow
+  `todo/blocked/jsdoc-typedef-strip-internal.md` so the repository does not keep
+  two conflicting private-type strategies.
 
-That policy remains authoritative until this migration is implemented. When this
-TODO lands, update `fjs/fsc/README.md` and delete or narrow the blocked TODO so
-the repository has one private-type strategy.
-
-The `.mjs` typedef prohibition is repository-wide, so the implementation must
-also update the root [`../../AGENTS.md`](../../AGENTS.md). The root policy should
-state that no authored `.mjs` anywhere in the repository may contain a file-scope
-JSDoc `@typedef`. `fjs/AGENTS.md` should then document the additional `fjs/`-specific
-file roles and dependency order, making clear that `private.ts` and `meta.f.mjs`
-are optional tools rather than required companions.
-
-Authored TypeScript type modules remain type-only and use named
-`import type { ... }` imports. Do not leave a rule that only governs `fjs/` while
-root-level authored `.mjs` files such as `todo/proof.f.mjs` remain outside the
-convention.
+Authored TypeScript type modules (`types.ts`, and `private.ts` when present) remain
+type-only and use named `import type { ... }` imports.
 
 ### Tasks
 
-- [ ] Document `private.ts` and `meta.f.mjs` as optional tools for cleaning the
-      public declaration/API surface, not required companion files.
-- [ ] Document and preserve the dependency order
-      `meta.f.mjs <- types.ts <- private.ts <- module.f.mjs <- proof.f.mjs <- module.mjs <- proof.mjs`
-      for the roles that are present.
-- [ ] Treat file placement as a design guide, not a mechanical rule; analyze
-      recursive or otherwise constrained cases before introducing files,
-      exceptions, or reverse dependencies.
-- [ ] Update root `AGENTS.md` to prohibit file-scope JSDoc `@typedef` in every
-      authored `.mjs` file anywhere in the repository.
-- [ ] Update `fjs/AGENTS.md` to document `types.ts`, optional `private.ts`, the
-      optional `meta.f.mjs` role, the public-declaration-closure rule, and the
-      dependency-order rule for `fjs/`.
-- [ ] Update `fjs/fsc/README.md` and delete or narrow
-      `todo/blocked/jsdoc-typedef-strip-internal.md` so they no longer prescribe
-      a conflicting private-JSDoc strategy.
-- [ ] Prohibit file-scope JSDoc `@typedef` in every authored `.mjs`
-      repository-wide; allow function-local `@typedef` everywhere.
-- [ ] Migrate existing authored `.mjs` violations outside `fjs/`, including
-      `todo/proof.f.mjs`, using the same public-boundary and layering principles.
-- [ ] Keep the leading `_` convention for every private type and private runtime
-      metadata constant name.
-- [ ] Move public file-scope named types from authored `.mjs` JSDoc into
-      `types.ts` as a breaking migration; update importers and changelog.
-- [ ] Keep or inline every private `_` helper required transitively by any
-      shipped public declaration in `types.ts`, including helpers appearing in
-      exported runtime-value/function signatures.
-- [ ] Use `private.ts` only when separating implementation-private file-scope
-      types from the public declaration closure is the cleanest solution; do not
-      create it mechanically or create reverse/public-declaration dependencies.
-- [ ] Review type assertions that currently reverse the dependency order. Move
-      implementation-signature assertions downstream into proof files where
-      possible; specifically, move the `fjs/effects/types.ts` assertions over
-      `step` / `catchStep` / `resultStep` / `mapStep` / `resultMapStep` /
-      `unwrapStep` into one or more proof functions with function-local typedefs
-      in `fjs/effects/proof.f.mjs`.
-- [ ] Review recursive metadata cases individually. For `fjs/media/revision`,
-      keep the recursive `lock` RTTI in `module.f.mjs` if its `LockSchema`
-      annotation requires `types.ts`, and move the `LockMap` / `LockField`
-      consistency asserts into a proof function. Apply the same analysis to
-      recursive EDAG RTTI such as `exp`: keep it in `module.f.mjs` when needed to
-      preserve layering and move file-scope consistency asserts into proof
-      functions.
-- [ ] Keep lexical type-proof typedefs inside their functions.
-- [ ] Use `meta.f.mjs` only when extracting runtime metadata/data improves the
-      public/type structure while preserving dependency order; private extracted
-      constants use `_`. Do not move ordinary implementation functions or
-      recursively annotated metadata merely because a proof inspects their type.
-- [ ] Move file-scope private proofs over metadata/constants to `private.ts`,
-      `types.ts`, or a downstream proof function according to the concrete
-      dependency graph; do not force one placement mechanically.
-- [ ] Treat moves of public runtime constants to `meta.f.mjs` as breaking API
-      changes when such moves are chosen; update runtime importers and changelog,
-      with no compatibility re-exports.
-- [ ] Require every import in authored TypeScript type modules (`types.ts` and
-      `private.ts` when present) to use named `import type { ... }`.
-- [ ] Update Node and Deno coverage filters to include `meta.f.mjs`; emergent
-      testing already loads it, and the existing coverage thresholds apply.
-- [ ] When `private.ts` is used, keep it in normal TypeScript checking without
-      runtime JS emit and delete generated `private.d.ts` files as the final
+- [ ] Document the repository-wide prohibition on file-scope JSDoc `@typedef` in
+      authored `.mjs`; allow function-local typedefs.
+- [ ] Migrate existing violations, including authored `.mjs` outside `fjs/` such
+      as `todo/proof.f.mjs`.
+- [ ] Keep `types.ts` as the public declaration closure; retain/in-line private
+      helpers required by public declarations.
+- [ ] Use `private.ts` only where separating implementation-private file-scope
+      types improves the design.
+- [ ] Preserve the dependency direction shown above; move verification downstream
+      when that is cleaner.
+- [ ] Move the `fjs/effects/types.ts` implementation-signature asserts into proof
+      functions in `fjs/effects/proof.f.mjs`.
+- [ ] Review recursive cases individually, including `fjs/media/revision` and
+      `fjs/edag`; keep recursive RTTI in `module.f.mjs` when required by layering
+      and move consistency asserts into proof functions.
+- [ ] Where useful, split declarative compile-time/runtime constants into a normal
+      subordinate module such as `meta/module.f.mjs`; do not require it.
+- [ ] Preserve leading `_` for private types and private runtime constants.
+- [ ] Treat chosen public import-path moves as breaking changes with no
+      compatibility re-exports.
+- [ ] If `private.ts` is used, delete generated `private.d.ts` as the final
       `prepack` step.
-- [ ] Do not rewrite/post-process emitted declarations to remove retained JSDoc
-      `@import` comments; they are non-semantic in `.d.ts` / `.d.mts`.
-- [ ] Inspect the `npm pack` artifact for unshipped private declaration
-      dependencies, ignoring retained comments.
-- [ ] Add fixtures covering both optional tools and cases that do not need them:
-      - a private helper required by a public type alias;
-      - a private helper required by an exported runtime value/function
-        declaration (the `_SortedArray`/`find` shape);
-      - an implementation-private type separated with `private.ts`;
-      - a function-local typedef depending on a lexical value;
-      - an implementation-function signature assertion placed downstream in a
-        proof rather than introducing `private.ts`/`meta.f.mjs` unnecessarily;
-      - a recursive metadata case whose named type annotation keeps it in
-        `module.f.mjs` while its consistency assert moves into a proof function;
-      - a FunctionalScript descriptive companion such as `testlib.f.mjs` whose
-        former file-scope typedef is moved to the appropriate place;
-      - a non-FunctionalScript authored `.mjs` case;
-      - a root/outside-`fjs/` authored `.mjs` case;
-      - a case where `meta.f.mjs` is useful, including a private `_` constant.
-- [ ] Include a retained JSDoc `@import ... './private.ts'` comment in an emitted
-      declaration fixture and verify the clean consumer succeeds without
-      `private.ts`; this proves comments do not create package dependencies.
-- [ ] Verify the normal test runner loads fixture `meta.f.mjs` and Node/Deno
-      coverage includes it under the existing thresholds.
-- [ ] Verify source checking, declaration emit/cleanup, Node+Deno coverage,
-      packing, and clean-consumer type checking.
+- [ ] Do not text-postprocess emitted declarations; validate semantic private
+      dependencies and clean-consumer type checking instead.
+- [ ] Add fixtures/examples covering: public-declaration helpers, optional
+      `private.ts`, function-local proof typedefs, recursive RTTI kept in
+      `module.f.mjs`, optional `meta/module.f.mjs`, retained non-semantic JSDoc
+      comments, and authored `.mjs` outside `fjs/`.
+- [ ] Update root/fjs policy documentation and reconcile the old `_` leak policy.
 
 ### Acceptance criteria
 
-- The public declaration/API surface is clean and self-contained; `private.ts`
-  and `meta.f.mjs` are optional tools, not required companion files.
-- The dependency order
-  `meta.f.mjs <- types.ts <- private.ts <- module.f.mjs <- proof.f.mjs <- module.mjs <- proof.mjs`
-  is preserved for roles that are present; type assertions do not create reverse
-  edges merely for convenience.
-- File placement follows concrete design needs rather than a blanket syntactic
-  rule; recursive metadata may remain in `module.f.mjs` when moving it to
-  `meta.f.mjs` would require a `types.ts` dependency, with consistency assertions
-  moved downstream when appropriate.
-- No authored `.mjs` file anywhere in the repository contains a file-scope JSDoc
-  `@typedef`, regardless of directory, basename, FunctionalScript marker, or role.
-- Function-local JSDoc `@typedef` is allowed everywhere; private names keep `_`
-  and do not escape as exported declaration aliases.
-- `types.ts` is the public declaration closure: public types plus any private
-  helpers required transitively to express shipped declarations of public types
-  or exported runtime values/functions.
-- If present, `private.ts` contains only implementation-private file-scope types
-  outside the public declaration closure. It is used only when that separation
-  improves the design.
-- `types.ts` and every packed public declaration are independent of unshipped
-  private type modules.
-- Assertions about ordinary implementation-function signatures live downstream
-  of `module.f.mjs` (normally inside proof functions with function-local typedefs
-  in `proof.f.mjs`) rather than forcing those functions into `meta.f.mjs` or
-  importing implementation functions into `types.ts`.
-- Every import in authored TypeScript type modules uses named
-  `import type { ... }`.
-- When `meta.f.mjs` is used, it contains runtime metadata/data extracted because
-  that improves the type/public structure while preserving dependency order.
-  Private constants use leading `_` even when exported for sibling-module
-  access; `_` marks them private by contract. Emergent testing loads
-  `meta.f.mjs`, Node and Deno coverage filters include it, and the existing
-  coverage thresholds apply; this convention does not prescribe how developers
-  satisfy those thresholds.
-- Moving public types to `types.ts` or public runtime metadata to `meta.f.mjs`
-  are breaking migrations when those moves occur: importers and changelog are
-  updated and no compatibility re-exports preserve old entry points.
+- The public declaration/API surface is clean and self-contained.
+- No authored `.mjs` anywhere in the repository contains a file-scope JSDoc
+  `@typedef`; function-local typedefs are allowed.
+- `types.ts` contains the public declaration closure and does not depend on an
+  unshipped private type module.
+- `private.ts`, when present, is an optional implementation tool rather than a
+  required companion.
+- A subordinate module such as `meta/module.f.mjs`, when present, is an optional
+  metaprogramming/design tool rather than a special file role or requirement.
+- The dependency direction is preserved; assertions do not create reverse edges
+  merely for convenience.
+- Private types/constants use leading `_`, even when linkage requires an export.
+- Existing `module.f.mjs` discovery and coverage rules automatically include
+  `meta/module.f.mjs`; no metadata-specific coverage convention exists.
+- Chosen public import-path moves are breaking migrations with importers/changelog
+  updated and no compatibility re-exports.
 - If declaration emit creates `private.d.ts`, final-`prepack` cleanup removes it
-  before package contents are selected.
-- Emitted declarations are not text-postprocessed: retained JSDoc `@import`
-  comments may mention `private.ts` and are allowed because they do not create a
-  TypeScript module dependency.
-- The packed tarball contains no unshipped private type artifacts required by
-  public declarations, and no packed declaration has a semantic dependency on
-  an unshipped private module.
-- Public declaration helpers retained in `types.ts` remain self-contained and
-  resolvable from shipped declarations, including helpers used by exported
-  runtime-value/function signatures.
-- Root `AGENTS.md` documents the repository-wide all-authored-`.mjs` file-scope
-  typedef prohibition, while `fjs/AGENTS.md` documents the `fjs/`-specific
-  declaration-closure/dependency-order rules and the optional `private.ts` /
-  `meta.f.mjs` tools.
-- `fjs/fsc/README.md` and the blocked `@internal`/`stripInternal` TODO no longer
-  prescribe a conflicting private-JSDoc strategy.
-- A clean TypeScript consumer type-checks successfully against the packed
-  tarball after private artifacts are removed, including when retained comments
-  mention the removed private source path.
+  before packaging.
+- Emitted declarations are not text-postprocessed; retained JSDoc `@import`
+  comments are allowed when they are non-semantic.
+- The packed artifact has no semantic dependency on an unshipped private type
+  module, and a clean TypeScript consumer type-checks successfully.
+- Root `AGENTS.md`, `fjs/AGENTS.md`, `fjs/fsc/README.md`, and the blocked
+  `@internal` TODO no longer prescribe conflicting rules.
 
 ### Related
 
 - [`../fsc/README.md`](../fsc/README.md) — current `_` leak-tolerance policy.
-- [`../../AGENTS.md`](../../AGENTS.md) — root repository policy to update with the
-  all-authored-`.mjs` rule.
-- [`../AGENTS.md`](../AGENTS.md) — `fjs/`-specific authored-TypeScript and file-role
-  policy to update.
+- [`../../AGENTS.md`](../../AGENTS.md) — root repository policy to update.
+- [`../AGENTS.md`](../AGENTS.md) — `fjs/`-specific file/dependency policy.
 - [`../../todo/blocked/jsdoc-typedef-strip-internal.md`](../../todo/blocked/jsdoc-typedef-strip-internal.md)
   — current wait-for-`@internal`/`stripInternal` strategy.
 - [microsoft/TypeScript#46407](https://github.com/microsoft/TypeScript/issues/46407)

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -91,7 +91,7 @@ Some TypeScript types are derived from runtime values rather than declared
 independently. These values include RTTI definitions, for example:
 
 ```ts
-import { type } from './meta.f.mjs'
+import type { type } from './meta.f.mjs'
 
 export type Value = Ts<typeof type>
 ```
@@ -99,7 +99,7 @@ export type Value = Ts<typeof type>
 and ordinary constants whose literal value is used by a type query, for example:
 
 ```ts
-import { statuses } from './meta.f.mjs'
+import type { statuses } from './meta.f.mjs'
 
 export type Status = typeof statuses[number]
 ```
@@ -116,11 +116,25 @@ private.ts  # private compile-time types
 
 Both `types.ts` and `private.ts` may depend on `meta.f.mjs` for
 `Ts<typeof ...>`, `typeof ...`, indexed access over `as const`-style values, and
-similar type derivation. This is an intentional dependency on runtime values,
-not a violation of the public/private type boundary. `meta.f.mjs` is ordinary
-runtime FunctionalScript source and is packaged like other required `.f.mjs`
-modules; it is not a private type artifact merely because `private.ts` may use
-it.
+similar type derivation. These dependencies are still type-only from TypeScript's
+point of view: the imported value is mentioned only through a type query, so the
+import must be erased.
+
+All imports in authored TypeScript type files use the named type-only form:
+
+```ts
+import type { PublicType } from './types.ts'
+import type { metadataValue } from './meta.f.mjs'
+```
+
+Do not use a runtime `import { ... }`, `import * as ...`, or side-effect import in
+`types.ts` or `private.ts`. This matches the repository rule that authored
+TypeScript is type-only source and prevents a type module from acquiring runtime
+behavior merely because `typeof` refers to an exported `.f.mjs` value.
+
+`meta.f.mjs` itself is ordinary runtime FunctionalScript source and is packaged
+like other required `.f.mjs` modules; it is not a private type artifact merely
+because `private.ts` may use it.
 
 Do not move a runtime value into `types.ts` or `private.ts` merely to avoid this
 dependency: runtime values belong in `.f.mjs`. Values whose primary purpose is
@@ -139,9 +153,11 @@ Dependency rules:
 
 - `module.f.mjs` and `proof.f.mjs` may use both `types.ts` and `private.ts`
   through JSDoc `@import`.
-- `private.ts` may import public types from `types.ts`.
-- `types.ts` and `private.ts` may depend on runtime type metadata from
+- `private.ts` may `import type { ... }` public types from `types.ts`.
+- `types.ts` and `private.ts` may `import type { ... }` runtime type metadata from
   `meta.f.mjs` for `Ts<typeof ...>`, `typeof ...`, and similar derivation.
+- all imports in `types.ts` and `private.ts` are named `import type { ... }`
+  imports; they must not create runtime dependencies.
 - `types.ts` must not depend on `private.ts`.
 - A public exported API must not require a `private.ts` type by name.
 
@@ -232,6 +248,9 @@ rather than retaining `private.d.ts` to make such a leak resolve.
 - [ ] Move runtime values whose primary purpose is type derivation into
       `meta.f.mjs`; include both RTTI definitions and non-RTTI constants used by
       `Ts<typeof ...>`, `typeof ...`, or equivalent type queries.
+- [ ] Require every import in authored TypeScript type files (`types.ts` and
+      `private.ts`) to use named `import type { ... }`, including imports from
+      `meta.f.mjs` used only through `typeof`.
 - [ ] Update Node coverage selection to include both `module.f.mjs` and
       `meta.f.mjs` under the existing 100% thresholds.
 - [ ] Update Deno `cov` and `cov-html` include filters to include both
@@ -256,9 +275,9 @@ rather than retaining `private.d.ts` to make such a leak resolve.
       declaration edge.
 - [ ] Extend the fixture with `meta.f.mjs` containing both an RTTI value and a
       non-RTTI literal constant used to derive TypeScript types in `types.ts` or
-      `private.ts`; verify the source tree and packed consumer resolve both
-      metadata dependencies correctly, and that executable `meta.f.mjs` code is
-      included in both Node and Deno coverage.
+      `private.ts`; import both with `import type { ... }`, verify the source tree
+      and packed consumer resolve both metadata dependencies correctly, and that
+      executable `meta.f.mjs` code is included in both Node and Deno coverage.
 - [ ] Verify a clean TypeScript consumer can install the packed tarball and use
       the public API without any private artifact present.
 
@@ -272,6 +291,9 @@ rather than retaining `private.d.ts` to make such a leak resolve.
 - All public file-scope named TypeScript types live in `types.ts`.
 - All private file-scope named TypeScript types live in `private.ts` and keep
   their leading `_`; private function-local typedefs also keep `_`.
+- Every import in `types.ts` and `private.ts` uses named `import type { ... }`;
+  these files have no runtime imports, including for `.f.mjs` values referenced
+  only through `typeof`.
 - Runtime values whose primary purpose is to define, describe, or derive
   type-level information live in `meta.f.mjs`; this includes RTTI definitions
   and non-RTTI constants used by `Ts<typeof ...>`, `typeof ...`, and similar

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -63,6 +63,13 @@ its left, but moving a type proof must not introduce a reverse edge merely to
 keep the proof near the declaration it checks. The order is a layering rule, not
 a requirement that every file directly import its immediate neighbor.
 
+The file-placement conventions below are defaults, not a mechanical classifier.
+Analyze concrete cases and prefer the simplest organization that preserves this
+dependency order. In particular, do not force a recursive RTTI constant into
+`meta.f.mjs` when expressing its recursion requires a named annotation from
+`types.ts`; keeping that constant downstream can be cleaner than creating a
+`meta.f.mjs -> types.ts` reverse edge.
+
 Place assertions in the earliest layer that can legitimately see everything they
 assert without reversing this order:
 
@@ -94,11 +101,24 @@ signatures: () => {
 }
 ```
 
-Do not create a broad exception merely because a type proof uses `typeof` on a
-runtime function. First check whether the proof can move to a downstream proof
-file while preserving the dependency order. Narrow exceptions may still be
-needed, but they should be justified by a concrete case after the cleaner
-placement has been ruled out.
+Recursive metadata needs the same case-by-case treatment. Two current examples
+illustrate the intended approach:
+
+- `fjs/media/revision`: `LockMap` / `LockSchema` stay in `types.ts`; the recursive
+  `lock` RTTI constant may stay in `module.f.mjs` because its initializer needs
+  the named `LockSchema` annotation from `types.ts`; the `Assert<Check<...>>`
+  consistency checks that currently make `types.ts` import `module.f.mjs` move
+  downstream into a function in `proof.f.mjs`.
+- `fjs/edag`: recursive RTTI such as `exp` may stay in `module.f.mjs` when its
+  explicit annotation depends on the public EDAG types; file-scope consistency
+  assertions such as `Assert<Check...>` move into one or more proof functions so
+  the RTTI/type relationship is still pinned without leaking typedefs or
+  reversing the dependency order.
+
+These examples do not establish a special rule for every recursive type. They
+show the process: inspect the cycle, preserve the dependency direction, and move
+verification downstream when that produces a clearer structure. Narrow
+exceptions may still be needed after the concrete case has been analyzed.
 
 #### Public declaration closure
 
@@ -107,14 +127,14 @@ helpers when they are required to express any shipped public declaration.
 "Public declaration" includes both exported type aliases and declarations of
 exported runtime values/functions.
 
-The placement rule is:
+The default placement guide is:
 
 ```text
 public type                                         -> types.ts
 private `_` helper used by any public declaration   -> types.ts
 other file-scope private `_` type                   -> private.ts
 function-local typedef                              -> allowed in place
-runtime metadata constant used to define types      -> meta.f.mjs
+runtime metadata constant used to define types      -> meta.f.mjs, when layering permits
 ```
 
 For example, a helper used by a public type stays in `types.ts`:
@@ -178,11 +198,19 @@ exported aliases in generated `.d.ts` / `.d.mts` files.
 
 #### `meta.f.mjs`
 
-`meta.f.mjs` contains runtime metadata constants whose literal/inferred values are
-part of the type-level model. They do not need to be RTTI, and normal runtime code
-may also consume them. Typical cases are RTTI descriptors, `as const`-style data,
-and lookup tables whose literal shape is used to define or derive TypeScript
-types.
+`meta.f.mjs` is the preferred home for runtime metadata constants whose
+literal/inferred values are part of the type-level model when they can live there
+without reversing the dependency order. They do not need to be RTTI, and normal
+runtime code may also consume them. Typical cases are RTTI descriptors,
+`as const`-style data, and lookup tables whose literal shape is used to define or
+derive TypeScript types.
+
+This is a convention, not an absolute rule. A recursive metadata constant that
+needs a named annotation from `types.ts` may remain in `module.f.mjs` rather than
+creating a reverse dependency. In such a case, move consistency assertions to a
+downstream proof function when that removes the reverse edge or file-scope typedef
+leak. The `media/revision` and `edag` examples above are the current models for
+this analysis.
 
 `meta.f.mjs` is **not** a destination for ordinary implementation functions just
 because a type proof inspects their signature with `typeof`, `ReturnType`, or
@@ -348,6 +376,9 @@ as `todo/proof.f.mjs` remain outside the convention.
       descriptive companions.
 - [ ] Document and preserve the dependency order
       `meta.f.mjs <- types.ts <- private.ts <- module.f.mjs <- proof.f.mjs <- module.mjs <- proof.mjs`.
+- [ ] Treat the placement table as a default design guide, not a mechanical rule;
+      analyze recursive or otherwise constrained metadata case by case before
+      introducing exceptions or reverse dependencies.
 - [ ] Update root `AGENTS.md` to prohibit file-scope JSDoc `@typedef` in every
       authored `.mjs` file anywhere in the repository.
 - [ ] Update `fjs/AGENTS.md` to allow `types.ts` and `private.ts` as the authored
@@ -376,15 +407,24 @@ as `todo/proof.f.mjs` remain outside the convention.
       `step` / `catchStep` / `resultStep` / `mapStep` / `resultMapStep` /
       `unwrapStep` into one or more proof functions with function-local typedefs
       in `fjs/effects/proof.f.mjs`.
+- [ ] Review recursive metadata cases individually. For `fjs/media/revision`,
+      keep the recursive `lock` RTTI in `module.f.mjs` if its `LockSchema`
+      annotation requires `types.ts`, and move the `LockMap` / `LockField`
+      consistency asserts into a proof function. Apply the same analysis to
+      recursive EDAG RTTI such as `exp`: keep it in `module.f.mjs` when needed to
+      preserve layering and move file-scope consistency asserts into proof
+      functions.
 - [ ] Keep lexical type-proof typedefs inside their functions.
-- [ ] Move runtime metadata constants used to define/derive TypeScript types into
-      `meta.f.mjs`, including RTTI values, non-RTTI literal constants, and
-      runtime-used tables; prefix private ones with `_` even when they must be
-      exported for sibling-module access. Do not move ordinary implementation
-      functions merely because a proof inspects their type.
-- [ ] Move file-scope private proofs over metadata constants to `private.ts` (or
-      `types.ts` when part of the public declaration closure) and use
-      `import type { ... }`.
+- [ ] Prefer `meta.f.mjs` for runtime metadata constants used to define/derive
+      TypeScript types when that placement preserves the dependency order,
+      including RTTI values, non-RTTI literal constants, and runtime-used tables;
+      prefix private ones with `_` even when they must be exported for
+      sibling-module access. Do not move ordinary implementation functions, or
+      recursively annotated metadata that would reverse the dependency order,
+      merely because a proof inspects their type.
+- [ ] Move file-scope private proofs over metadata constants to `private.ts`,
+      `types.ts`, or a downstream proof function according to the concrete
+      dependency graph; do not force one placement mechanically.
 - [ ] Treat moves of public runtime constants to `meta.f.mjs` as breaking API
       changes; update runtime importers and changelog, with no compatibility
       re-exports.
@@ -406,6 +446,8 @@ as `todo/proof.f.mjs` remain outside the convention.
       - a function-local typedef depending on a lexical value;
       - an implementation-function signature assertion placed downstream in a
         proof rather than creating a `types.ts -> module.f.mjs` dependency;
+      - a recursive metadata case whose named type annotation keeps it in
+        `module.f.mjs` while its consistency assert moves into a proof function;
       - a FunctionalScript descriptive companion such as `testlib.f.mjs` whose
         former file-scope typedef is moved to the appropriate TypeScript file;
       - a non-FunctionalScript authored `.mjs` file whose former file-scope
@@ -426,6 +468,10 @@ as `todo/proof.f.mjs` remain outside the convention.
   `meta.f.mjs <- types.ts <- private.ts <- module.f.mjs <- proof.f.mjs <- module.mjs <- proof.mjs`
   is preserved; type assertions do not create reverse edges merely for
   convenience.
+- File placement follows the dependency order and concrete design needs rather
+  than a blanket syntactic rule; recursive metadata may remain in `module.f.mjs`
+  when moving it to `meta.f.mjs` would require a `types.ts` dependency, with
+  consistency assertions moved downstream when appropriate.
 - No authored `.mjs` file anywhere in the repository contains a file-scope JSDoc
   `@typedef`, regardless of directory, basename, FunctionalScript marker, or role.
 - Function-local JSDoc `@typedef` is allowed everywhere; private names keep `_`
@@ -442,12 +488,12 @@ as `todo/proof.f.mjs` remain outside the convention.
   in `proof.f.mjs`) rather than forcing those functions into `meta.f.mjs` or
   importing implementation functions into `types.ts`.
 - Every import in `types.ts` and `private.ts` uses named `import type { ... }`.
-- Runtime metadata constants used to define/derive TypeScript types live in
-  `meta.f.mjs`, whether RTTI or not. Private constants use leading `_` even when
-  exported for sibling-module access; `_` marks them private by contract.
-  Emergent testing loads `meta.f.mjs`, Node and Deno coverage filters include it,
-  and the existing coverage thresholds apply; this convention does not prescribe
-  how developers satisfy those thresholds.
+- Runtime metadata constants used to define/derive TypeScript types normally live
+  in `meta.f.mjs` when the dependency order permits it. Private constants use
+  leading `_` even when exported for sibling-module access; `_` marks them private
+  by contract. Emergent testing loads `meta.f.mjs`, Node and Deno coverage filters
+  include it, and the existing coverage thresholds apply; this convention does
+  not prescribe how developers satisfy those thresholds.
 - Moving public types to `types.ts` and public runtime metadata to `meta.f.mjs`
   are breaking migrations: importers and changelog are updated and no
   compatibility re-exports preserve old entry points.

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -21,8 +21,10 @@ emits them as exported type aliases even when they were intended to be private.
 Private declarations in `types.ts` likewise appear in the shipped `types.d.ts`.
 
 Moving all named types out of implementation/proof files and splitting public
-from private TypeScript types removes this leakage structurally instead of
-trying to strip it after declaration generation.
+from private TypeScript types removes the JSDoc typedef leakage structurally.
+TypeScript will still emit a declaration for an imported `private.ts`, because
+that source file is part of the declaration program; that generated private
+declaration must be removed before packaging.
 
 The leading `_` convention should remain: file placement and name visibility are
 complementary signals.
@@ -66,18 +68,33 @@ This leaves generated declarations free to describe the public API, including
 structural types inferred from exported values/functions, without also exporting
 implementation-local typedef names simply because they were declared in JSDoc.
 
-`private.ts` is source-only. It must be type-checked, but package declaration
-emission must not generate or ship `private.d.ts`, and the package must not ship
-`private.ts` itself.
+#### Declaration emission and packaging
+
+`private.ts` is source-only and remains in the normal TypeScript program so its
+types and all `@import` users are checked. Consequently, the existing
+`tsc --emitDeclarationOnly` pass will also generate `private.d.ts`; `exclude`
+cannot suppress that output once another program input imports `private.ts`.
+
+Do not require TypeScript to avoid generating that intermediate file. Instead,
+make private declaration cleanup an explicit packaging step:
+
+1. run normal declaration emission and the existing declaration round-trip
+   type-check;
+2. delete every generated `private.d.ts` before `npm pack` selects package
+   contents;
+3. verify that no declaration which remains in the package references
+   `private.ts` or `private.d.ts`.
+
+The cleanup must operate on generated artifacts only; authored `private.ts`
+remains available for source-tree type-checking. Neither `private.ts` nor the
+intermediate generated `private.d.ts` is shipped.
 
 Generated declarations such as `module.f.d.mts` may be produced from source that
 uses `private.ts`, but no shipped declaration may reference `private.ts` or a
 `private.d.ts` artifact. If an exported declaration needs a private type, either
 that type is actually public and belongs in `types.ts`, or the public declaration
-must be expressible without exposing the private type name.
-
-This should be enforced by the build/package checks rather than relying only on
-review convention.
+must be expressible without exposing the private type name. The package check
+must fail rather than retaining `private.d.ts` to make such a leak resolve.
 
 ### Tasks
 
@@ -90,14 +107,17 @@ review convention.
       `proof.f.mjs` into each directory's `private.ts` where applicable.
 - [ ] Keep `private.ts` in normal TypeScript type-checking without generating a
       runtime JavaScript file for it.
-- [ ] Exclude `private.ts` from declaration/package output: do not generate or
-      ship `private.d.ts` and do not ship `private.ts`.
+- [ ] Add a post-declaration-emit packaging step that deletes generated
+      `private.d.ts` files before `npm pack`.
+- [ ] Do not ship authored `private.ts`.
 - [ ] Reject shipped generated declarations that reference `private.ts` or
-      `private.d.ts`.
+      `private.d.ts`; do not preserve `private.d.ts` merely to satisfy such a
+      reference.
 - [ ] Add a fixture where `module.f.mjs` and `proof.f.mjs` use `_`-prefixed types
-      from `private.ts` without declaring any `@typedef`; verify their generated
-      declarations contain no implementation-local typedef exports and the packed
-      package contains no private type file.
+      from `private.ts` without declaring any `@typedef`; verify declaration emit
+      creates the intermediate `private.d.ts`, cleanup removes it, generated
+      public declarations contain no implementation-local typedef exports, and
+      the packed package contains no private type file.
 - [ ] Verify a clean TypeScript consumer can use the packed public API without
       any private artifact present.
 
@@ -108,6 +128,8 @@ review convention.
 - All private named types live in `private.ts` and keep their leading `_`.
 - Generated public declarations do not expose private named typedefs merely as a
   consequence of declaration emission.
+- Declaration emission may create `private.d.ts`, but the packaging cleanup
+  removes it before package contents are selected.
 - Neither `private.ts` nor `private.d.ts` is shipped.
 - No shipped `.d.ts` / `.d.mts` file references `private.ts` or `private.d.ts`.
 

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -56,14 +56,17 @@ Do not create it mechanically for every `_` name.
 
 #### Dependency order
 
-Preserve the dependency direction for the roles that exist:
+Within one module directory, preserve the dependency direction for the roles that
+exist:
 
 ```text
-meta/module.f.mjs <- types.ts <- private.ts <- module.f.mjs <- proof.f.mjs <- module.mjs <- proof.mjs
+types.ts <- private.ts <- module.f.mjs <- proof.f.mjs <- module.mjs <- proof.mjs
 ```
 
 The arrow points from dependency to dependent. This is a layering guide, not a
-requirement that every file or edge exists.
+requirement that every file or edge exists. A subordinate module such as
+`meta/module.f.mjs` is a separate module and is therefore described separately
+below rather than appearing in this intra-directory diagram.
 
 Move verification downstream before moving implementation upstream. For example,
 `fjs/effects/types.ts` currently imports implementation functions only to assert
@@ -108,6 +111,10 @@ This is only a suggestion. Do not create `meta/` merely because a runtime value
 appears in a type proof. Ordinary implementation functions stay in
 `module.f.mjs`; recursively annotated metadata may also stay there when moving it
 would reverse the dependency direction.
+
+The parent module may depend on `meta/module.f.mjs` like any other lower-level
+module. The `meta/` module itself follows the same normal module conventions and,
+if it grows additional files, its own intra-directory dependency order.
 
 A private constant exported from `meta/module.f.mjs` for sibling-module linkage
 uses a leading `_`:
@@ -211,8 +218,8 @@ type-only and use named `import type { ... }` imports.
       helpers required by public declarations.
 - [ ] Use `private.ts` only where separating implementation-private file-scope
       types improves the design.
-- [ ] Preserve the dependency direction shown above; move verification downstream
-      when that is cleaner.
+- [ ] Preserve the intra-directory dependency direction shown above; move
+      verification downstream when that is cleaner.
 - [ ] Move the `fjs/effects/types.ts` implementation-signature asserts into proof
       functions in `fjs/effects/proof.f.mjs`.
 - [ ] Review recursive cases individually, including `fjs/media/revision` and
@@ -244,8 +251,8 @@ type-only and use named `import type { ... }` imports.
   required companion.
 - A subordinate module such as `meta/module.f.mjs`, when present, is an optional
   metaprogramming/design tool rather than a special file role or requirement.
-- The dependency direction is preserved; assertions do not create reverse edges
-  merely for convenience.
+- The intra-directory dependency direction is preserved; assertions do not create
+  reverse edges merely for convenience.
 - Private types/constants use leading `_`, even when linkage requires an export.
 - Existing `module.f.mjs` discovery and coverage rules automatically include
   `meta/module.f.mjs`; no metadata-specific coverage convention exists.

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -15,16 +15,17 @@ types.ts      # public + private TypeScript types
 ```
 
 Private types already use a leading `_` by convention, but their location still
-creates declaration and package noise. In particular, JSDoc `@typedef`s in
-`module.f.mjs` and `proof.f.mjs` escape into generated `.d.mts` files: TypeScript
-emits them as exported type aliases even when they were intended to be private.
-Private declarations in `types.ts` likewise appear in the shipped `types.d.ts`.
+creates declaration and package noise. In particular, file-scope JSDoc
+`@typedef`s in `module.f.mjs` and `proof.f.mjs` escape into generated `.d.mts`
+files: TypeScript emits them as exported type aliases even when they were
+intended to be private. Private declarations in `types.ts` likewise appear in
+the shipped `types.d.ts`.
 
-Moving all named types out of implementation/proof files and splitting public
-from private TypeScript types removes the JSDoc typedef leakage structurally.
-TypeScript will still emit a declaration for an imported `private.ts`, because
-that source file is part of the declaration program; that generated private
-declaration must be removed before packaging.
+Moving file-scope named types out of implementation/proof files and splitting
+public from private TypeScript types removes the JSDoc typedef leakage
+structurally. TypeScript will still emit a declaration for an imported
+`private.ts`, because that source file is part of the declaration program; that
+generated private declaration must be removed before packaging.
 
 The leading `_` convention should remain: file placement and name visibility are
 complementary signals.
@@ -35,22 +36,54 @@ Use this directory convention where named types or runtime metadata used for
 type derivation are needed:
 
 ```text
-module.f.mjs  # implementation; no @typedef
-proof.f.mjs   # proofs; no @typedef
+module.f.mjs  # implementation; no file-scope @typedef
+proof.f.mjs   # proofs; no file-scope @typedef
 meta.f.mjs    # runtime metadata used to define/derive types
 types.ts      # public named TypeScript types
 private.ts    # private named TypeScript types
 ```
 
 `module.f.mjs` and `proof.f.mjs` may use JSDoc annotations and `@import`, but
-must not declare named types with `@typedef`. Named TypeScript types have exactly
-two homes:
+must not declare file-scope named types with `@typedef`. File-scope named
+TypeScript types have exactly two homes:
 
 - `types.ts` for public types;
 - `private.ts` for implementation-only types.
 
 `private.ts` contains implementation-only TypeScript types used by either the
-module or its proofs. Every private type continues to start with `_`.
+module or its proofs. Every private file-scope type continues to start with `_`.
+
+#### Lexically scoped typedefs
+
+Function-local JSDoc `@typedef` declarations are allowed everywhere. They are
+useful for compile-time proofs that depend on values available only in lexical
+scope and therefore cannot be moved to `private.ts` without exposing or
+restructuring implementation locals.
+
+For example:
+
+```js
+const proof = () => {
+    const value = f(42)
+    /** @typedef {Assert<Equal<typeof value, 42>>} _Value */
+}
+```
+
+Such a typedef is a local type assertion, not a file-level API declaration. Keep
+it inside the narrowest function scope that provides the values it needs; do not
+move it to `private.ts` merely to satisfy the file convention. Private local
+typedef names should keep the leading `_` convention.
+
+The distinction is therefore scope-based:
+
+```text
+file-scope public named type  -> types.ts
+file-scope private named type -> private.ts
+function-local typedef        -> allowed in place
+```
+
+Declaration validation must verify that function-local typedefs remain lexical
+and do not appear as exported aliases in generated `.d.ts` / `.d.mts` files.
 
 #### Type metadata
 
@@ -107,7 +140,8 @@ Dependency rules:
 
 This leaves generated declarations free to describe the public API, including
 structural types inferred from exported values/functions, without also exporting
-implementation-local typedef names simply because they were declared in JSDoc.
+implementation-local file-scope typedef names simply because they were declared
+in JSDoc.
 
 #### Declaration emission and packaging
 
@@ -157,11 +191,16 @@ rather than retaining `private.d.ts` to make such a leak resolve.
 
 - [ ] Document `private.ts` and `meta.f.mjs` beside the existing `types.ts`,
       `module.*`, and `proof.*` file conventions.
-- [ ] Prohibit JSDoc `@typedef` declarations in `module.f.mjs` and `proof.f.mjs`.
-- [ ] Keep the leading `_` convention for every type declared in `private.ts`.
-- [ ] Move public named types from implementation/proof JSDoc into `types.ts`.
-- [ ] Move private named types out of `types.ts`, `module.f.mjs`, and
+- [ ] Prohibit file-scope JSDoc `@typedef` declarations in `module.f.mjs` and
+      `proof.f.mjs`; allow function-local `@typedef` declarations everywhere.
+- [ ] Keep the leading `_` convention for private types, including function-local
+      private typedefs.
+- [ ] Move public file-scope named types from implementation/proof JSDoc into
+      `types.ts`.
+- [ ] Move private file-scope named types out of `types.ts`, `module.f.mjs`, and
       `proof.f.mjs` into each directory's `private.ts` where applicable.
+- [ ] Keep lexical type-proof typedefs inside the functions whose local values
+      they inspect; do not force them into `private.ts`.
 - [ ] Move runtime values whose primary purpose is type derivation into
       `meta.f.mjs`; include both RTTI definitions and non-RTTI constants used by
       `Ts<typeof ...>`, `typeof ...`, or equivalent type queries.
@@ -174,10 +213,13 @@ rather than retaining `private.d.ts` to make such a leak resolve.
 - [ ] Scan every packed `.d.ts` / `.d.mts` and reject any module reference to a
       directory's private type module, independent of the exact emitted suffix.
 - [ ] Add a fixture where `module.f.mjs` and `proof.f.mjs` use `_`-prefixed types
-      from `private.ts` without declaring any `@typedef`; verify declaration emit
-      creates the intermediate `private.d.ts`, cleanup removes it, generated
-      public declarations contain no implementation-local typedef exports, and
-      packed-artifact validation finds no private type file or declaration edge.
+      from `private.ts` without declaring any file-scope `@typedef`; also include
+      a function-local typedef that depends on a lexical value and verify it does
+      not escape into generated declarations. Verify declaration emit creates the
+      intermediate `private.d.ts`, cleanup removes it, generated public
+      declarations contain no implementation-local file-scope typedef exports,
+      and packed-artifact validation finds no private type file or declaration
+      edge.
 - [ ] Extend the fixture with `meta.f.mjs` containing both an RTTI value and a
       non-RTTI literal constant used to derive TypeScript types in `types.ts` or
       `private.ts`; verify the source tree and packed consumer resolve both
@@ -187,16 +229,20 @@ rather than retaining `private.d.ts` to make such a leak resolve.
 
 ### Acceptance criteria
 
-- `module.f.mjs` and `proof.f.mjs` contain no JSDoc `@typedef` declarations.
-- All public named TypeScript types live in `types.ts`.
-- All private named TypeScript types live in `private.ts` and keep their leading
-  `_`.
+- `module.f.mjs` and `proof.f.mjs` contain no file-scope JSDoc `@typedef`
+  declarations.
+- Function-local JSDoc `@typedef` declarations are allowed in any source file and
+  may depend on lexical values; they do not escape as exported declaration
+  aliases.
+- All public file-scope named TypeScript types live in `types.ts`.
+- All private file-scope named TypeScript types live in `private.ts` and keep
+  their leading `_`; private function-local typedefs also keep `_`.
 - Runtime values whose primary purpose is to define, describe, or derive
   type-level information live in `meta.f.mjs`; this includes RTTI definitions
   and non-RTTI constants used by `Ts<typeof ...>`, `typeof ...`, and similar
   type queries.
-- Generated public declarations do not expose private named typedefs merely as a
-  consequence of declaration emission.
+- Generated public declarations do not expose private file-scope named typedefs
+  merely as a consequence of declaration emission.
 - Declaration emission may create `private.d.ts`, but the packaging cleanup
   removes it before package contents are selected.
 - The packed tarball contains neither `private.ts` nor `private.d.ts`.

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -15,25 +15,34 @@ types.ts      # public + private TypeScript types
 ```
 
 Private types already use a leading `_` by convention, but their location still
-creates declaration and package noise. JSDoc private typedefs in `module.f.mjs`
-can be emitted into `module.f.d.mts`, while private declarations in `types.ts`
-are emitted into the shipped `types.d.ts`.
+creates declaration and package noise. In particular, JSDoc `@typedef`s in
+`module.f.mjs` and `proof.f.mjs` escape into generated `.d.mts` files: TypeScript
+emits them as exported type aliases even when they were intended to be private.
+Private declarations in `types.ts` likewise appear in the shipped `types.d.ts`.
 
-Moving private types to a separate TypeScript file should make the source
-boundary explicit and allow package declaration generation to omit private type
-artifacts entirely. The leading `_` convention should remain: file placement and
-name visibility are complementary signals.
+Moving all named types out of implementation/proof files and splitting public
+from private TypeScript types removes this leakage structurally instead of
+trying to strip it after declaration generation.
+
+The leading `_` convention should remain: file placement and name visibility are
+complementary signals.
 
 ### Proposal
 
-Use this directory convention where private named types are needed:
+Use this directory convention where named types are needed:
 
 ```text
-module.f.mjs  # implementation
-proof.f.mjs   # proofs
-types.ts      # public types
-private.ts    # private types
+module.f.mjs  # implementation; no @typedef
+proof.f.mjs   # proofs; no @typedef
+types.ts      # public named types
+private.ts    # private named types
 ```
+
+`module.f.mjs` and `proof.f.mjs` may use JSDoc annotations and `@import`, but
+must not declare named types with `@typedef`. Named types have exactly two homes:
+
+- `types.ts` for public types;
+- `private.ts` for implementation-only types.
 
 `private.ts` contains implementation-only TypeScript types used by either the
 module or its proofs. Every private type continues to start with `_`.
@@ -53,6 +62,10 @@ private.ts <- module.f.mjs / proof.f.mjs
 - `types.ts` must not depend on `private.ts`.
 - A public exported API must not require a `private.ts` type by name.
 
+This leaves generated declarations free to describe the public API, including
+structural types inferred from exported values/functions, without also exporting
+implementation-local typedef names simply because they were declared in JSDoc.
+
 `private.ts` is source-only. It must be type-checked, but package declaration
 emission must not generate or ship `private.d.ts`, and the package must not ship
 `private.ts` itself.
@@ -70,7 +83,9 @@ review convention.
 
 - [ ] Document `private.ts` beside the existing `types.ts`, `module.*`, and
       `proof.*` file conventions.
+- [ ] Prohibit JSDoc `@typedef` declarations in `module.f.mjs` and `proof.f.mjs`.
 - [ ] Keep the leading `_` convention for every type declared in `private.ts`.
+- [ ] Move public named types from implementation/proof JSDoc into `types.ts`.
 - [ ] Move private named types out of `types.ts`, `module.f.mjs`, and
       `proof.f.mjs` into each directory's `private.ts` where applicable.
 - [ ] Keep `private.ts` in normal TypeScript type-checking without generating a
@@ -80,10 +95,21 @@ review convention.
 - [ ] Reject shipped generated declarations that reference `private.ts` or
       `private.d.ts`.
 - [ ] Add a fixture where `module.f.mjs` and `proof.f.mjs` use `_`-prefixed types
-      from `private.ts` while the generated public declarations and packed
-      package contain no private type file.
+      from `private.ts` without declaring any `@typedef`; verify their generated
+      declarations contain no implementation-local typedef exports and the packed
+      package contains no private type file.
 - [ ] Verify a clean TypeScript consumer can use the packed public API without
       any private artifact present.
+
+### Acceptance criteria
+
+- `module.f.mjs` and `proof.f.mjs` contain no JSDoc `@typedef` declarations.
+- All public named types live in `types.ts`.
+- All private named types live in `private.ts` and keep their leading `_`.
+- Generated public declarations do not expose private named typedefs merely as a
+  consequence of declaration emission.
+- Neither `private.ts` nor `private.d.ts` is shipped.
+- No shipped `.d.ts` / `.d.mts` file references `private.ts` or `private.d.ts`.
 
 ### Related
 

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -204,14 +204,13 @@ the same coverage expectations as `module.f.mjs`.
   imports and must not create runtime dependencies.
 - a public declaration must never depend on the removable `private.ts` module.
 
-#### Breaking public type migration
+#### Breaking public API migration
 
-Moving a public file-scope JSDoc typedef from `module.f.mjs` or `proof.f.mjs` to
-`types.ts` changes its published import path. Treat that relocation as an
-intentional breaking API change rather than preserving the old type entry point
-with compatibility re-exports.
+Moving public definitions to their dedicated files changes their published
+import paths. Treat these relocations as intentional breaking API changes rather
+than preserving the old entry points with compatibility re-exports.
 
-For example, if consumers previously imported a type from:
+For public types, if consumers previously imported a type from:
 
 ```text
 ./module.f.mjs
@@ -223,16 +222,23 @@ and the type moves to `types.ts`, its new public type entry point is:
 ./types.ts
 ```
 
-The migration must update every repository importer to the new path and record
-the breaking change in the changelog. Do not leave compatibility typedefs or
-re-exports in `module.f.mjs` merely to preserve the old type-only subpath: that
-would reintroduce the file-scope typedef/declaration noise this convention is
-intended to remove.
+For public runtime constants, if consumers previously imported a value from:
 
-This breaking rule applies to type entry points, not runtime exports. Moving a
-public runtime constant from `module.f.mjs` to `meta.f.mjs` requires its own API
-decision: preserve the old runtime entry point with a re-export or make that
-runtime move an explicit breaking change and update importers/changelog.
+```text
+./module.f.mjs
+```
+
+and the value moves to `meta.f.mjs`, its new runtime entry point is:
+
+```text
+./meta.f.mjs
+```
+
+In both cases, update every repository importer to the new path and record the
+breaking change in the changelog. Do **not** leave compatibility typedefs,
+exports, or re-exports in `module.f.mjs` to preserve the old entry point. The
+point of the migration is to make the source/API boundaries explicit rather than
+carry aliases from the old layout indefinitely.
 
 #### Declaration emission and packaging
 
@@ -299,6 +305,11 @@ References to packaged `meta.f.mjs` are allowed.
 - [ ] Move runtime constants referenced by TypeScript type definitions/proofs
       into `meta.f.mjs`, including RTTI definitions, non-RTTI literal constants,
       and ordinary runtime tables whose literal/inferred types are asserted.
+- [ ] Treat moves of public runtime constants to `meta.f.mjs` as breaking API
+      changes: update every repository runtime importer to the new path and
+      record the break in the changelog.
+- [ ] Do not add compatibility exports or re-exports in `module.f.mjs` for
+      runtime constants moved to `meta.f.mjs`.
 - [ ] Move file-scope private type proofs over those constants to `private.ts`
       (or keep helpers in `types.ts` when required by a public declaration), and
       use `import type { ... }` to reference the `meta.f.mjs` values.
@@ -338,6 +349,10 @@ References to packaged `meta.f.mjs` are allowed.
   intentional breaking API change: repository importers use the new path, the
   changelog records the break, and no compatibility typedef/re-export preserves
   the old type entry point.
+- Moving a public runtime constant from `module.f.mjs` to `meta.f.mjs` is an
+  intentional breaking API change: repository runtime importers use the new
+  path, the changelog records the break, and no compatibility export/re-export
+  preserves the old runtime entry point.
 - Private `_` helpers required to express public types also remain in `types.ts`
   and are not source exports merely because they are declaration helpers.
 - Other private file-scope types live in `private.ts` and keep `_`.

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -1,0 +1,93 @@
+## Separate private types into `private.ts`
+
+**Priority:** P2
+**Status:** open
+
+### Problem
+
+FunctionalScript directories currently mix private types with implementation and
+public type declarations:
+
+```text
+module.f.mjs  # implementation + private JSDoc types
+proof.f.mjs   # proofs + private JSDoc types
+types.ts      # public + private TypeScript types
+```
+
+Private types already use a leading `_` by convention, but their location still
+creates declaration and package noise. JSDoc private typedefs in `module.f.mjs`
+can be emitted into `module.f.d.mts`, while private declarations in `types.ts`
+are emitted into the shipped `types.d.ts`.
+
+Moving private types to a separate TypeScript file should make the source
+boundary explicit and allow package declaration generation to omit private type
+artifacts entirely. The leading `_` convention should remain: file placement and
+name visibility are complementary signals.
+
+### Proposal
+
+Use this directory convention where private named types are needed:
+
+```text
+module.f.mjs  # implementation
+proof.f.mjs   # proofs
+types.ts      # public types
+private.ts    # private types
+```
+
+`private.ts` contains implementation-only TypeScript types used by either the
+module or its proofs. Every private type continues to start with `_`.
+
+Dependency direction:
+
+```text
+              types.ts
+              ^      ^
+              |      |
+private.ts <- module.f.mjs / proof.f.mjs
+```
+
+- `module.f.mjs` and `proof.f.mjs` may use both `types.ts` and `private.ts`
+  through JSDoc `@import`.
+- `private.ts` may import public types from `types.ts`.
+- `types.ts` must not depend on `private.ts`.
+- A public exported API must not require a `private.ts` type by name.
+
+`private.ts` is source-only. It must be type-checked, but package declaration
+emission must not generate or ship `private.d.ts`, and the package must not ship
+`private.ts` itself.
+
+Generated declarations such as `module.f.d.mts` may be produced from source that
+uses `private.ts`, but no shipped declaration may reference `private.ts` or a
+`private.d.ts` artifact. If an exported declaration needs a private type, either
+that type is actually public and belongs in `types.ts`, or the public declaration
+must be expressible without exposing the private type name.
+
+This should be enforced by the build/package checks rather than relying only on
+review convention.
+
+### Tasks
+
+- [ ] Document `private.ts` beside the existing `types.ts`, `module.*`, and
+      `proof.*` file conventions.
+- [ ] Keep the leading `_` convention for every type declared in `private.ts`.
+- [ ] Move private named types out of `types.ts`, `module.f.mjs`, and
+      `proof.f.mjs` into each directory's `private.ts` where applicable.
+- [ ] Keep `private.ts` in normal TypeScript type-checking without generating a
+      runtime JavaScript file for it.
+- [ ] Exclude `private.ts` from declaration/package output: do not generate or
+      ship `private.d.ts` and do not ship `private.ts`.
+- [ ] Reject shipped generated declarations that reference `private.ts` or
+      `private.d.ts`.
+- [ ] Add a fixture where `module.f.mjs` and `proof.f.mjs` use `_`-prefixed types
+      from `private.ts` while the generated public declarations and packed
+      package contain no private type file.
+- [ ] Verify a clean TypeScript consumer can use the packed public API without
+      any private artifact present.
+
+### Related
+
+- [`detect-unexported-types-referenced-by-exported-types.md`](./detect-unexported-types-referenced-by-exported-types.md) — detect private type names that leak through exported types.
+- [`document-file-type-naming-conventions.md`](./document-file-type-naming-conventions.md) — document the repository's source-file roles.
+- [`../../todo/migrate-typescript-to-mjs.md`](../../todo/migrate-typescript-to-mjs.md) — current JavaScript/JSDoc implementation migration and `_` private-type convention.
+- [`../ci/todo/f-mjs-package-support.md`](../ci/todo/f-mjs-package-support.md) — declaration emission and clean packed-package validation.

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -82,19 +82,31 @@ make private declaration cleanup an explicit packaging step:
    type-check;
 2. delete every generated `private.d.ts` before `npm pack` selects package
    contents;
-3. verify that no declaration which remains in the package references
-   `private.ts` or `private.d.ts`.
+3. run `npm pack`;
+4. validate the actual packed artifact:
+   - it contains neither authored `private.ts` nor generated `private.d.ts`;
+   - every shipped `.d.ts` / `.d.mts` is scanned and must not contain a module
+     reference to the directory's `private` type module;
+5. install the tarball in the existing clean TypeScript consumer and type-check
+   it as an independent semantic validation.
+
+The declaration scan should reject the private module rather than only one
+particular emitted spelling. For example, `./private.ts`, `./private.d.ts`, or a
+future equivalent spelling must all be treated as the same forbidden public
+dependency. This is a structural package check over the packed file set and the
+contents of all packed declarations, not a check limited to whichever public
+entry points the clean consumer happens to import.
 
 The cleanup must operate on generated artifacts only; authored `private.ts`
 remains available for source-tree type-checking. Neither `private.ts` nor the
 intermediate generated `private.d.ts` is shipped.
 
 Generated declarations such as `module.f.d.mts` may be produced from source that
-uses `private.ts`, but no shipped declaration may reference `private.ts` or a
-`private.d.ts` artifact. If an exported declaration needs a private type, either
-that type is actually public and belongs in `types.ts`, or the public declaration
-must be expressible without exposing the private type name. The package check
-must fail rather than retaining `private.d.ts` to make such a leak resolve.
+uses `private.ts`, but no shipped declaration may depend on the private type
+module. If an exported declaration needs a private type, either that type is
+actually public and belongs in `types.ts`, or the public declaration must be
+expressible without exposing the private type name. The package check must fail
+rather than retaining `private.d.ts` to make such a leak resolve.
 
 ### Tasks
 
@@ -109,17 +121,17 @@ must fail rather than retaining `private.d.ts` to make such a leak resolve.
       runtime JavaScript file for it.
 - [ ] Add a post-declaration-emit packaging step that deletes generated
       `private.d.ts` files before `npm pack`.
-- [ ] Do not ship authored `private.ts`.
-- [ ] Reject shipped generated declarations that reference `private.ts` or
-      `private.d.ts`; do not preserve `private.d.ts` merely to satisfy such a
-      reference.
+- [ ] Inspect the `npm pack` artifact and reject any packed `private.ts` or
+      `private.d.ts` file.
+- [ ] Scan every packed `.d.ts` / `.d.mts` and reject any module reference to a
+      directory's private type module, independent of the exact emitted suffix.
 - [ ] Add a fixture where `module.f.mjs` and `proof.f.mjs` use `_`-prefixed types
       from `private.ts` without declaring any `@typedef`; verify declaration emit
       creates the intermediate `private.d.ts`, cleanup removes it, generated
       public declarations contain no implementation-local typedef exports, and
-      the packed package contains no private type file.
-- [ ] Verify a clean TypeScript consumer can use the packed public API without
-      any private artifact present.
+      packed-artifact validation finds no private type file or declaration edge.
+- [ ] Verify a clean TypeScript consumer can install the packed tarball and use
+      the public API without any private artifact present.
 
 ### Acceptance criteria
 
@@ -130,8 +142,11 @@ must fail rather than retaining `private.d.ts` to make such a leak resolve.
   consequence of declaration emission.
 - Declaration emission may create `private.d.ts`, but the packaging cleanup
   removes it before package contents are selected.
-- Neither `private.ts` nor `private.d.ts` is shipped.
-- No shipped `.d.ts` / `.d.mts` file references `private.ts` or `private.d.ts`.
+- The packed tarball contains neither `private.ts` nor `private.d.ts`.
+- No packed `.d.ts` / `.d.mts` file depends on a directory's private type module,
+  regardless of the exact emitted module-specifier suffix.
+- A clean TypeScript consumer type-checks successfully against the packed
+  tarball after all private artifacts have been removed.
 
 ### Related
 

--- a/fjs/todo/separate-private-types.md
+++ b/fjs/todo/separate-private-types.md
@@ -231,12 +231,27 @@ Conceptually:
 tsc --noEmit false --emitDeclarationOnly && tsc && <delete generated private.d.ts files>
 ```
 
-Validation of the packed artifact must prove both:
+Do **not** rewrite or post-process emitted declaration text. TypeScript may retain
+source JSDoc comments such as:
+
+```js
+/** @import { _Private } from './private.ts' */
+```
+
+inside an emitted `.d.ts` / `.d.mts`. In a declaration file this is a comment,
+not a TypeScript import or module dependency, so it may remain after
+`private.d.ts` is deleted.
+
+Validation of the packed artifact must prove:
 
 - neither authored `private.ts` nor generated `private.d.ts` is shipped;
-- no packed `.d.ts` / `.d.mts` references a directory's private type module,
-  regardless of the exact emitted suffix.
+- no packed `.d.ts` / `.d.mts` has a **semantic TypeScript dependency** on a
+  directory's private type module.
 
+A raw text search for `private.ts` / `@import` is therefore incorrect because it
+would reject harmless retained comments. If a structural scan is used, it must
+ignore comments and reject only actual declaration syntax that creates a module
+dependency. The clean-consumer TypeScript check is the final semantic validation.
 References to packaged `meta.f.mjs` are allowed.
 
 #### Repository-policy reconciliation
@@ -308,8 +323,10 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
       proof imports solely to make otherwise-unused metadata appear in coverage.
 - [ ] Keep `private.ts` in normal TypeScript checking without runtime JS emit.
 - [ ] Make deletion of generated `private.d.ts` the final `prepack` step.
-- [ ] Inspect the `npm pack` artifact for private files and private declaration
-      dependencies.
+- [ ] Do not rewrite/post-process emitted declarations to remove retained JSDoc
+      `@import` comments; they are non-semantic in `.d.ts` / `.d.mts`.
+- [ ] Inspect the `npm pack` artifact for private files and **semantic** private
+      declaration dependencies, ignoring retained comments.
 - [ ] Add a fixture covering:
       - a private helper required by a public type alias;
       - a private helper required by an exported runtime value/function
@@ -321,6 +338,9 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
       - a non-FunctionalScript authored `.mjs` file whose former file-scope
         typedef is moved to the appropriate TypeScript file;
       - `meta.f.mjs` with RTTI, literal, and runtime-used constants.
+- [ ] Include a retained JSDoc `@import ... './private.ts'` comment in an emitted
+      declaration fixture and verify the clean consumer succeeds without
+      `private.ts`; this proves comments do not create package dependencies.
 - [ ] In the fixture, runtime-load at least one metadata path to prove that the
       Node/Deno coverage filters include loaded `meta.f.mjs`; do not use the
       fixture to impose a requirement that every metadata module/export in the
@@ -351,8 +371,11 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
   compatibility re-exports preserve old entry points.
 - Declaration emit may create `private.d.ts`; final-`prepack` cleanup removes it
   before package contents are selected.
+- Emitted declarations are not text-postprocessed: retained JSDoc `@import`
+  comments may mention `private.ts` and are allowed because they do not create a
+  TypeScript module dependency.
 - The packed tarball contains neither `private.ts` nor `private.d.ts`, and no
-  packed declaration depends on the private module.
+  packed declaration has a semantic dependency on the private module.
 - Public declaration helpers retained in `types.ts` remain self-contained and
   resolvable from shipped declarations, including helpers used by exported
   runtime-value/function signatures.
@@ -362,7 +385,8 @@ same policy must also state that file-scope JSDoc `@typedef` is prohibited in
 - `fjs/fsc/README.md` and the blocked `@internal`/`stripInternal` TODO no longer
   prescribe a conflicting private-JSDoc strategy.
 - A clean TypeScript consumer type-checks successfully against the packed
-  tarball after private artifacts are removed.
+  tarball after private artifacts are removed, including when retained comments
+  mention the removed private source path.
 
 ### Related
 


### PR DESCRIPTION
## Summary

Add a repository-wide TODO for separating private named types into `private.ts` while preserving the leading `_` convention.

The TODO defines the intended source/package boundary:

- `types.ts` contains public types;
- `private.ts` contains `_`-prefixed private types used by implementation/proofs;
- `private.ts` is type-checked but neither `private.ts` nor `private.d.ts` is shipped;
- shipped generated declarations such as `module.f.d.mts` must not reference private artifacts.

It also links the existing declaration-leak detection, file-convention, migration, and package-support TODOs.