### PR TITLE
ci: the job schema can express ordering

### DIFF
--- a/fjs/ci/common/module.f.mjs
+++ b/fjs/ci/common/module.f.mjs
@@ -30,8 +30,14 @@ export const stepSchema = /** @type {const} */ ({
     with: or(option, record(string))
 })
 
+// `needs` is how one job waits for another: a job that consumes an artifact
+// cannot start before the job that uploads it. It is optional because most jobs
+// are independent, and it is named here rather than emitted past the schema —
+// `parseGitHubAction` reads back the workflow this repository generates, so an
+// unmodelled key would fail that round-trip in `fjs/ci/proof.f.mjs`.
 export const jobSchema = /** @type {const} */ ({
     'runs-on': string,
+    needs: or(option, array(string)),
     steps: array(stepSchema)
 })
 

--- a/fjs/ci/proof.f.mjs
+++ b/fjs/ci/proof.f.mjs
@@ -1,6 +1,7 @@
 /**
  * @import { MetaStep, Os, GitHubAction } from './common/types.ts'
  * @import { Dir, State } from '../effects/node/virtual/types.ts'
+ * @import { Unknown } from '../djs/types.ts'
  */
 
 import { exitCode } from '../effects/node/module.f.mjs'
@@ -220,5 +221,40 @@ export const proof = {
         const job = ubuntu([test({ run: 'echo hi' })])
         assert(job['runs-on'] !== undefined, 'expected runs-on')
         assert(job.steps.length > 0, 'expected steps')
+    },
+    jobNeeds: () => {
+        const steps = [{ run: 'echo hi' }]
+        /** @type {(jobs: Unknown) => Unknown} */
+        const action = jobs => ({
+            name: 'test',
+            on: {},
+            permissions: { contents: 'read' },
+            jobs,
+        })
+        // Modelled, so a job that waits for another survives the round-trip.
+        // Without this a consuming job could only reach the workflow by being
+        // emitted past the schema, which `parseGitHubAction` would then reject.
+        const ordered = unwrap(parseGitHubAction(action({
+            pack: { 'runs-on': 'ubuntu-latest', steps },
+            check: { 'runs-on': 'ubuntu-latest', needs: ['pack'], steps },
+        })))
+        assertEq(ordered.jobs.check?.needs?.[0], 'pack')
+        assertEq(ordered.jobs.check?.needs?.length, 1)
+        // Optional: the independent jobs, which is all of them today, still parse.
+        assertEq(unwrap(parseGitHubAction(action({
+            pack: { 'runs-on': 'ubuntu-latest', steps },
+        }))).jobs.pack?.needs, undefined)
+        // Constrained, not merely accepted. GitHub also allows a bare scalar
+        // (`needs: pack`); this generator emits the list form only, so the
+        // scalar is drift rather than an alternative spelling — the same reason
+        // these schemas are closed.
+        assertEq(parseGitHubAction(action({
+            check: { 'runs-on': 'ubuntu-latest', needs: 'pack', steps },
+        }))[0], 'error')
+        // Dormant until something orders itself: the first consumer is the
+        // packed-artifact check in `fjs/ci/todo/f-mjs-package-support.md`.
+        assert(
+            definedValues(run(false).jobs).every(job => job.needs === undefined),
+            'unexpected job ordering in the generated workflow')
     },
 }

--- a/fjs/ci/proof.f.mjs
+++ b/fjs/ci/proof.f.mjs
@@ -223,7 +223,7 @@ export const proof = {
         assert(job.steps.length > 0, 'expected steps')
     },
     jobNeeds: () => {
-        const steps = [{ run: 'echo hi' }]
+        const steps = /** @type {const} */ ([{ run: 'echo hi' }])
         /** @type {(jobs: Unknown) => Unknown} */
         const action = jobs => ({
             name: 'test',


### PR DESCRIPTION
First step of Stage 2's packed-artifact check, recorded in [#1757](https://github.com/functionalscript/functionalscript/pull/1757). It is the prerequisite the design names, and nothing else in the stage can start without it.

## Why this is a prerequisite, not a detail

A job that consumes an artifact must not start before the job that uploads it. The generator could not say so: `jobSchema` named only `runs-on` and `steps`.

Emitting a bare `needs:` key past the schema is not an option, and the reason is specific to this repository: `jobSchema` is deliberately **closed**, and it is the same schema `parseGitHubAction` reads the generated workflow back through in `fjs/ci/proof.f.mjs`. An unmodelled key is generator drift by construction, so the round-trip proof would reject it.

Without this, the packed-artifact check could only fail at `download-artifact` — a required check red for a reason unrelated to what it tests, which is the one failure mode that trains people to hit re-run instead of reading the log.

## The change

`needs: or(option, array(string))` on `jobSchema`, matching the optional-field idiom already used by `stepSchema`. `Job` widens automatically through `Ts<typeof jobSchema>`, so `fjs/ci/common/types.ts` needed no edit.

**The generated workflow is unchanged.** Nothing orders itself yet, so the field stays absent and `npm run ci-update` reproduces `.github/workflows/ci.yml` byte-identically. This lands dormant.

## What the proof covers

Not that the field exists — what it is for:

- an ordered pair round-trips with its dependency intact, which is the property the consuming job depends on;
- independent jobs still parse with the field absent, so optionality is real;
- a bare scalar `needs: pack` is **rejected**. GitHub accepts that spelling, but this generator emits the list form only, so a scalar is drift rather than an alternative — the same reasoning that makes these schemas closed;
- no generated job carries the field today, so the first one to do so is a deliberate change rather than an accident.

## Ownership

Owned by [`fjs/ci/todo/ci-integration-tests.md`](https://github.com/functionalscript/functionalscript/blob/main/fjs/ci/todo/ci-integration-tests.md) rather than by either consumer. That issue's own two-stage build/integration split needs the same edge, so putting it at the artifact hand-off stops whichever consumer lands first from implementing another issue's task.

## Checks

`npx tsc` clean; full suite 3528/3528; coverage 100%; `npm run ci-update` produces no diff.

No changelog entry: behavior is unchanged and `fjs/ci` is this repository's own generator, so this is internal — the entry rules scope release notes to users of the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqeS5t2ZKkSu3chRPMXR7n

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqeS5t2ZKkSu3chRPMXR7n)_