### PR TITLE
ci: enter a job's Nix shell through a generated run script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,13 +389,13 @@
           "uses": "actions/checkout@v7.0.1"
         },
         {
-          "run": "test \"$(nix develop --no-write-lock-file ./nix/deno --command deno eval 'console.log(Deno.version.deno)')\" = 2.8.3"
+          "run": "test \"$(./nix/deno/run deno eval 'console.log(Deno.version.deno)')\" = 2.8.3"
         },
         {
-          "run": "nix develop --no-write-lock-file ./nix/deno --command deno install --frozen"
+          "run": "./nix/deno/run deno install --frozen"
         },
         {
-          "run": "nix develop --no-write-lock-file ./nix/deno --command deno task cov"
+          "run": "./nix/deno/run deno task cov"
         }
       ]
     },
@@ -429,13 +429,13 @@
           "uses": "actions/checkout@v7.0.1"
         },
         {
-          "run": "test \"$(nix develop --no-write-lock-file ./nix/node22 --command node --version)\" = v22.23.2"
+          "run": "test \"$(./nix/node22/run node --version)\" = v22.23.2"
         },
         {
-          "run": "nix develop --no-write-lock-file ./nix/node22 --command npm ci"
+          "run": "./nix/node22/run npm ci"
         },
         {
-          "run": "nix develop --no-write-lock-file ./nix/node22 --command node --test"
+          "run": "./nix/node22/run node --test"
         }
       ]
     },
@@ -449,13 +449,13 @@
           "uses": "actions/checkout@v7.0.1"
         },
         {
-          "run": "test \"$(nix develop --no-write-lock-file ./nix/node24 --command node --version)\" = v24.19.0"
+          "run": "test \"$(./nix/node24/run node --version)\" = v24.19.0"
         },
         {
-          "run": "nix develop --no-write-lock-file ./nix/node24 --command npm ci"
+          "run": "./nix/node24/run npm ci"
         },
         {
-          "run": "nix develop --no-write-lock-file ./nix/node24 --command node --test"
+          "run": "./nix/node24/run node --test"
         }
       ]
     },
@@ -469,22 +469,22 @@
           "uses": "actions/checkout@v7.0.1"
         },
         {
-          "run": "test \"$(nix develop --no-write-lock-file ./nix/node26 --command node --version)\" = v26.7.0"
+          "run": "test \"$(./nix/node26/run node --version)\" = v26.7.0"
         },
         {
-          "run": "nix develop --no-write-lock-file ./nix/node26 --command npm ci"
+          "run": "./nix/node26/run npm ci"
         },
         {
-          "run": "nix develop --no-write-lock-file ./nix/node26 --command npx tsc"
+          "run": "./nix/node26/run npx tsc"
         },
         {
-          "run": "nix develop --no-write-lock-file ./nix/node26 --command npm run cov"
+          "run": "./nix/node26/run npm run cov"
         },
         {
-          "run": "nix develop --no-write-lock-file ./nix/node26 --command npm pack"
+          "run": "./nix/node26/run npm pack"
         },
         {
-          "run": "nix develop --no-write-lock-file ./nix/node26 --command npm run ci-update"
+          "run": "./nix/node26/run npm run ci-update"
         },
         {
           "run": "git add -A && git diff --cached --exit-code"

--- a/changelog/unreleased/1787.md
+++ b/changelog/unreleased/1787.md
@@ -1,0 +1,5 @@
+- `ci`: each generated Nix job directory now holds a `run` script, and workflow
+  steps invoke it — `./nix/node26/run npm run cov` — instead of spelling out
+  `nix develop`. The script passes `--quiet`, which drops Nix's substitution
+  chatter from the logs without touching warnings, errors, or the command's own
+  output.

--- a/fjs/ci/README.md
+++ b/fjs/ci/README.md
@@ -86,13 +86,23 @@ feed the flakes' package attributes where the attribute is versioned, as well as
 therefore means moving the Nixpkgs commit first and copying the versions it offers.
 `bun` is not one of these: `setup-bun` installs it, so that pin is a released Bun.
 
+Each job directory also gets a generated `run` script, and a workflow step reads
+as the command it runs — `./nix/node26/run npm run cov` — rather than as a
+`nix develop` invocation repeated fifteen times. The script carries
+`--no-write-lock-file` (leave the checkout untouched) and `--quiet` (drop Nix's
+logging from `info` to `notice`, which removes the `copying N paths`
+substitution chatter without touching warnings, errors, or the command's own
+output). `-q` is not a spelling Nix accepts; see
+[nix/README.md](../../nix/README.md), which also covers why the executable bit
+is committed rather than generated.
+
 No job checks the flakes; the jobs that use them check the runtime they get. Every
 canonical job asserts, as its first command, that its own shell reports the version
 `config/module.f.mjs` records for it:
 
 ```sh
-test "$(nix develop --no-write-lock-file ./nix/node26 --command node --version)" = v26.7.0
-test "$(nix develop --no-write-lock-file ./nix/deno --command deno eval 'console.log(Deno.version.deno)')" = 2.8.3
+test "$(./nix/node26/run node --version)" = v26.7.0
+test "$(./nix/deno/run deno eval 'console.log(Deno.version.deno)')" = 2.8.3
 ```
 
 The runtimes disagree on both halves, which is why the check takes the command and

--- a/fjs/ci/nix/module.f.mjs
+++ b/fjs/ci/nix/module.f.mjs
@@ -94,6 +94,10 @@ export const flakeText = job =>
  * to: the `case` arm is what makes a `$0` with no `/` mean the current
  * directory, which is the one thing stripping a suffix cannot say by itself.
  *
+ * What holds that is the proof pinning this text exactly, not a scan for tool
+ * names — §6 rules out the scan, and the exact text already fails on any change
+ * at all.
+ *
  * `exec` replaces the shell, so the command's exit status is the script's and
  * no wrapper process sits between CI and the failure.
  *

--- a/fjs/ci/nix/module.f.mjs
+++ b/fjs/ci/nix/module.f.mjs
@@ -88,6 +88,12 @@ export const flakeText = job =>
  * `./nix/deno/run deno eval 'console.log(Deno.version.deno)'` arrives as three
  * arguments, not as text to re-parse.
  *
+ * That location comes from `case` and `${0%/*}`, which are shell syntax and
+ * parameter expansion — not `dirname`, and not any other program. A generated
+ * script calls no external tool (root `AGENTS.md` §6), and this one has no need
+ * to: the `case` arm is what makes a `$0` with no `/` mean the current
+ * directory, which is the one thing stripping a suffix cannot say by itself.
+ *
  * `exec` replaces the shell, so the command's exit status is the script's and
  * no wrapper process sits between CI and the failure.
  *
@@ -109,7 +115,8 @@ export const flakeText = job =>
  * inherited, so a job's own output is exactly what it was.
  */
 export const runText = `#!/bin/sh
-exec nix develop --no-write-lock-file --quiet "$(dirname "$0")" --command "$@"
+case $0 in */*) d=\${0%/*} ;; *) d=. ;; esac
+exec nix develop --no-write-lock-file --quiet "$d" --command "$@"
 `
 
 /**
@@ -128,11 +135,12 @@ exec nix develop --no-write-lock-file --quiet "$(dirname "$0")" --command "$@"
 const writeJob = job => {
     const directory = `${generatedDirectory}/${job.id}`
     const created = mkdir(directory, { recursive: true })
-    return step(
+    const flakeWritten = step(
         created,
-        () => step(
-            writeUtf8File(`${directory}/flake.nix`, flakeText(job)),
-            () => writeUtf8File(`${directory}/run`, runText)))
+        () => writeUtf8File(`${directory}/flake.nix`, flakeText(job)))
+    return step(
+        flakeWritten,
+        () => writeUtf8File(`${directory}/run`, runText))
 }
 
 /**

--- a/fjs/ci/nix/module.f.mjs
+++ b/fjs/ci/nix/module.f.mjs
@@ -28,9 +28,9 @@ import { install, test, uses } from '../common/module.f.mjs'
 import { nixpkgs } from '../config/module.f.mjs'
 
 /**
- * Directory holding the generated flakes, one subdirectory per job. The
- * generator owns those subdirectories, not everything here: `nix/README.md` is
- * written by hand.
+ * Directory holding the generated environments, one subdirectory per job, each
+ * with a `flake.nix` and a `run` script. The generator owns those
+ * subdirectories, not everything here: `nix/README.md` is written by hand.
  */
 export const generatedDirectory = /** @type {const} */ ('nix')
 
@@ -77,47 +77,100 @@ const flake = ({ system, packages, shellHook }) => ['set',
 export const flakeText = job =>
     unwrapNullable(fromUndefined(nixToString(flake(job))))
 
-/** @type {(job: NixJob) => Effect<Mkdir | WriteFile, void, IoChannel>} */
-const writeFlake = job => {
+/**
+ * The `run` script generated beside a job's flake. `./nix/node26/run npm run cov`
+ * is what a workflow step says; this is what makes that a command.
+ *
+ * It resolves the flake from its own location rather than from the working
+ * directory, so it behaves the same run from the repository root, from `nix/`,
+ * or by absolute path. `"$@"` passes the caller's argument vector through
+ * unsplit, which is what lets a step keep quoting of its own —
+ * `./nix/deno/run deno eval 'console.log(Deno.version.deno)'` arrives as three
+ * arguments, not as text to re-parse.
+ *
+ * `exec` replaces the shell, so the command's exit status is the script's and
+ * no wrapper process sits between CI and the failure.
+ *
+ * The two flags live here rather than in every step. `--no-write-lock-file`
+ * keeps the invocation read-only against the checkout: Nix otherwise writes a
+ * `flake.lock` beside the flake it enters, and the pin in `flake.nix` already
+ * determines every input, so that lock resolves nothing the flake did not
+ * already say. `--quiet` drops Nix's own logging one level, from `info` to
+ * `notice`, which removes the substitution chatter — `copying N paths`, started
+ * at `lvlInfo` — while leaving warnings and errors, which sit below `notice`.
+ *
+ * `--quiet` is spelled long because Nix has no short form for it: `--verbose`
+ * declares `.shortName = 'v'` and `--quiet` declares none, so `-q` is not an
+ * option the `nix` CLI accepts. The one short flag nearby, `-Q`
+ * (`--no-build-output`), belongs to `LegacyArgs` — `nix-build` and `nix-shell`,
+ * not `nix develop`.
+ *
+ * Neither flag reaches the command being run: `--command` execs it with stdio
+ * inherited, so a job's own output is exactly what it was.
+ */
+export const runText = `#!/bin/sh
+exec nix develop --no-write-lock-file --quiet "$(dirname "$0")" --command "$@"
+`
+
+/**
+ * Writes a job's flake and the `run` script beside it, stopping at the first
+ * failure.
+ *
+ * The script's **content** is generated; its executable bit is not. Nothing in
+ * `fjs/effects/node` can set a file mode, and `fs.writeFile` preserves the mode
+ * of a file that already exists — so a script committed once as `100755` stays
+ * executable through every regeneration, and only a job that has never been
+ * generated needs `git update-index --chmod=+x` by hand. See
+ * `../todo/generated-run-script-mode.md`.
+ *
+ * @type {(job: NixJob) => Effect<Mkdir | WriteFile, void, IoChannel>}
+ */
+const writeJob = job => {
     const directory = `${generatedDirectory}/${job.id}`
     const created = mkdir(directory, { recursive: true })
     return step(
         created,
-        () => writeUtf8File(`${directory}/flake.nix`, flakeText(job)))
+        () => step(
+            writeUtf8File(`${directory}/flake.nix`, flakeText(job)),
+            () => writeUtf8File(`${directory}/run`, runText)))
 }
 
 /**
- * Writes one generated flake per job, stopping at the first failure.
+ * Writes one generated environment per job, stopping at the first failure.
  *
  * @type {(jobs: readonly NixJob[]) => Effect<Mkdir | WriteFile, void, IoChannel>}
  */
 export const nixFlakes = jobs =>
-    forEachStep(pureOk(jobs), writeFlake)
+    forEachStep(pureOk(jobs), writeJob)
 
-/** Path a workflow passes to `nix develop`, for the job of the given id. */
+/** Directory holding the flake and `run` script for the job of the given id. */
 /** @type {(id: string) => string} */
 export const flakePath = id => `./${generatedDirectory}/${id}`
+
+/** The `run` script a workflow step invokes, for the job of the given id. */
+/** @type {(id: string) => string} */
+export const runPath = id => `${flakePath(id)}/run`
 
 /** Installs Nix, with `nix-command` and `flakes` enabled by the action's defaults. */
 export const nixInstall = install(uses('cachix/install-nix-action'))
 
 /**
- * Runs one command inside a job's generated development shell.
+ * Runs one command inside a job's generated development shell, through that
+ * job's `run` script.
  *
- * `--no-write-lock-file` keeps the invocation read-only against the checkout:
- * Nix otherwise writes a `flake.lock` beside the flake it enters. The pin in
- * `flake.nix` already determines every input, so that lock resolves nothing the
- * flake did not already say.
+ * A step reads as the command it runs — `./nix/node26/run npm run cov` — with
+ * the `nix develop` spelling and its flags in one generated place rather than
+ * repeated fifteen times across the workflow. {@link runText} documents what
+ * that spelling is and why.
  *
- * It is not what keeps the Node 26 drift check honest: the root `.gitignore`
- * covers a per-job `flake.lock`, and `git add -A` does not stage an ignored
- * file, so that check never saw one. The ignore rule stays for a hand-run
- * `nix develop` without the flag.
+ * The `.gitignore` rule for a per-job `flake.lock` stays even though the script
+ * passes `--no-write-lock-file`: it is there for a hand-run `nix develop` that
+ * omits the flag, and never for CI, whose drift check could not have seen an
+ * ignored file anyway.
  *
  * @type {(id: string, command: string) => string}
  */
-export const nixDevelop = (id, command) =>
-    `nix develop --no-write-lock-file ${flakePath(id)} --command ${command}`
+export const nixDevelop = (id, command) => `${runPath(id)} ${command}`
 
 /**
  * The Nix system of the runner every job with a flake uses. `ubuntuArm` picks

--- a/fjs/ci/nix/proof.f.mjs
+++ b/fjs/ci/nix/proof.f.mjs
@@ -124,12 +124,21 @@ export const proof = {
             }
         },
         // What that script must say, pinned rather than described. `exec` keeps
-        // the command's exit status; `dirname "$0"` finds the flake from the
-        // script rather than from the working directory; `"$@"` passes the
-        // caller's arguments through unsplit.
+        // the command's exit status; the `case` and `${0%/*}` find the flake
+        // from the script rather than from the working directory; `"$@"` passes
+        // the caller's arguments through unsplit.
         runText: () => assertEq(runText, `#!/bin/sh
-exec nix develop --no-write-lock-file --quiet "$(dirname "$0")" --command "$@"
+case $0 in */*) d=\${0%/*} ;; *) d=. ;; esac
+exec nix develop --no-write-lock-file --quiet "$d" --command "$@"
 `),
+        // A generated script calls no external tool (root `AGENTS.md` §6).
+        // `dirname` is the one this script would otherwise have reached for, so
+        // it is the one worth naming; the rest of the line is shell syntax.
+        runCallsNoExternalTool: () => {
+            for (const tool of ['dirname', 'basename', 'realpath', 'grep', 'sed', 'awk']) {
+                assert(!runText.includes(tool), tool)
+            }
+        },
         // Every declared job runs on the one runner the flakes are generated
         // for. A second system would need its own `devShells.<system>.default`
         // rather than a loop, so a job that quietly declared another would

--- a/fjs/ci/nix/proof.f.mjs
+++ b/fjs/ci/nix/proof.f.mjs
@@ -21,6 +21,8 @@ import {
     nixSteps,
     nixSystem,
     nixVersionStep,
+    runPath,
+    runText,
 } from './module.f.mjs'
 
 const { commit } = nixpkgs
@@ -79,15 +81,18 @@ const shellHookFlake = `{
 }
 `
 
-/** @type {(jobs: readonly NixJob[], id: string) => string} */
-const generated = (jobs, id) => {
+/** @type {(jobs: readonly NixJob[], id: string, file: string) => string} */
+const generatedFile = (jobs, id, file) => {
     const written = ioStep(
         nixFlakes(jobs),
-        () => readUtf8File(`${generatedDirectory}/${id}/flake.nix`))
+        () => readUtf8File(`${generatedDirectory}/${id}/${file}`))
     const [, [tag, result]] = virtual(emptyState)(written)
     assert(tag === 'ok', result)
     return result
 }
+
+/** @type {(jobs: readonly NixJob[], id: string) => string} */
+const generated = (jobs, id) => generatedFile(jobs, id, 'flake.nix')
 
 export const proof = {
     flakeText: {
@@ -110,6 +115,21 @@ export const proof = {
                 assertEq(packages[0], `nodejs_${id.slice('node'.length)}`)
             }
         },
+        // The `run` script is written beside every flake, byte for byte the
+        // same for each job: it resolves its own flake from `$0`, so nothing
+        // in it varies by job.
+        run: () => {
+            for (const job of nixJobs) {
+                assertEq(generatedFile(nixJobs, job.id, 'run'), runText)
+            }
+        },
+        // What that script must say, pinned rather than described. `exec` keeps
+        // the command's exit status; `dirname "$0"` finds the flake from the
+        // script rather than from the working directory; `"$@"` passes the
+        // caller's arguments through unsplit.
+        runText: () => assertEq(runText, `#!/bin/sh
+exec nix develop --no-write-lock-file --quiet "$(dirname "$0")" --command "$@"
+`),
         // Every declared job runs on the one runner the flakes are generated
         // for. A second system would need its own `devShells.<system>.default`
         // rather than a loop, so a job that quietly declared another would
@@ -134,9 +154,13 @@ export const proof = {
         // The path a workflow passes to `nix develop` must be the directory the
         // generator wrote the flake into.
         flakePath: () => assertEq(flakePath(plain.id), `./${generatedDirectory}/node24`),
+        // A step reads as the command it runs. The `nix develop` spelling and
+        // its flags live in the generated script instead, once per job rather
+        // than once per step.
         nixDevelop: () => assertEq(
             nixDevelop(plain.id, 'node --version'),
-            'nix develop --no-write-lock-file ./nix/node24 --command node --version'),
+            './nix/node24/run node --version'),
+        runPath: () => assertEq(runPath(plain.id), './nix/node24/run'),
         // One step per command, each entering the shell itself (root
         // `AGENTS.md` §7) — never one invocation carrying the sequence.
         nixSteps: () => {
@@ -144,10 +168,7 @@ export const proof = {
             assertEq(steps.length, 2)
             assertStructurallySame(
                 steps.map(s => s.type === 'test' ? s.step.run : undefined),
-                [
-                    'nix develop --no-write-lock-file ./nix/node24 --command npm ci',
-                    'nix develop --no-write-lock-file ./nix/node24 --command node --test',
-                ])
+                ['./nix/node24/run npm ci', './nix/node24/run node --test'])
         },
         // The command and the expected string are independent: Node's output
         // carries a leading `v` that the configured version does not.
@@ -156,7 +177,7 @@ export const proof = {
             assertEq(step.type, 'test')
             assertEq(
                 step.type === 'test' ? step.step.run : undefined,
-                'test "$(nix develop --no-write-lock-file ./nix/node24 --command node --version)" = v24.19.0')
+                'test "$(./nix/node24/run node --version)" = v24.19.0')
         },
         nixInstall: () => {
             assertEq(nixInstall.type, 'install')

--- a/fjs/ci/nix/proof.f.mjs
+++ b/fjs/ci/nix/proof.f.mjs
@@ -127,18 +127,18 @@ export const proof = {
         // the command's exit status; the `case` and `${0%/*}` find the flake
         // from the script rather than from the working directory; `"$@"` passes
         // the caller's arguments through unsplit.
+        //
+        // This is also the whole of what holds the script to root `AGENTS.md`
+        // §6, which forbids a generated script from calling an external tool:
+        // the text is fixed, so reintroducing `dirname` — or anything else —
+        // fails here. A separate guard scanning for tool names would add no
+        // coverage this does not already have, and would be the kind of check
+        // §6 describes: blind to any name it does not list, and tripped by one
+        // appearing in a comment.
         runText: () => assertEq(runText, `#!/bin/sh
 case $0 in */*) d=\${0%/*} ;; *) d=. ;; esac
 exec nix develop --no-write-lock-file --quiet "$d" --command "$@"
 `),
-        // A generated script calls no external tool (root `AGENTS.md` §6).
-        // `dirname` is the one this script would otherwise have reached for, so
-        // it is the one worth naming; the rest of the line is shell syntax.
-        runCallsNoExternalTool: () => {
-            for (const tool of ['dirname', 'basename', 'realpath', 'grep', 'sed', 'awk']) {
-                assert(!runText.includes(tool), tool)
-            }
-        },
         // Every declared job runs on the one runner the flakes are generated
         // for. A second system would need its own `devShells.<system>.default`
         // rather than a loop, so a job that quietly declared another would

--- a/fjs/ci/proof.f.mjs
+++ b/fjs/ci/proof.f.mjs
@@ -260,8 +260,8 @@ export const proof = {
             assertStructurallySame(
                 job.steps.flatMap(step => step.run === undefined ? [] : [step.run]),
                 [
-                    `test "$(nix develop --no-write-lock-file ./nix/${id} --command node --version)" = v${version}`,
-                    ...commands.map(command => `nix develop --no-write-lock-file ./nix/${id} --command ${command}`),
+                    `test "$(./nix/${id}/run node --version)" = v${version}`,
+                    ...commands.map(command => `./nix/${id}/run ${command}`),
                     ...(id === `node${major(node.default)}`
                         ? ['git add -A && git diff --cached --exit-code']
                         : []),
@@ -340,7 +340,7 @@ export const proof = {
         const job = gha.jobs[`node${major(node.default)}`]
         assert(job !== undefined, 'expected the canonical Node job')
         const packIndex = job.steps.findIndex(
-            step => step.run === `nix develop --no-write-lock-file ./nix/node${major(node.default)} --command npm pack`)
+            step => step.run === `./nix/node${major(node.default)}/run npm pack`)
         const uploadIndex = job.steps.findIndex(
             step => step.uses === `actions/upload-artifact@${actions['actions/upload-artifact']}`)
         assert(packIndex !== -1, 'expected npm pack')

--- a/fjs/ci/todo/65z-ci-nix.md
+++ b/fjs/ci/todo/65z-ci-nix.md
@@ -211,9 +211,11 @@ Neither flag is written in a workflow step. Each job directory holds a generated
 ./nix/node26/run npm run cov
 ```
 
-The script is the same for every job — `exec nix develop … "$(dirname "$0")"
---command "$@"` — so the spelling and its flags have one home instead of fifteen,
-and a step reads as the command it runs. Its executable bit is committed rather
+The script is the same for every job — it resolves its own directory with shell
+parameter expansion rather than `dirname`, since a generated script calls no
+external tool (§6), and `exec`s `nix develop … --command "$@"` — so the spelling
+and its flags have one home instead of fifteen, and a step reads as the command
+it runs. Its executable bit is committed rather
 than generated, because nothing in `fjs/effects/node` can set a file mode;
 [generated-run-script-mode](generated-run-script-mode.md) owns closing that gap.
 

--- a/fjs/ci/todo/65z-ci-nix.md
+++ b/fjs/ci/todo/65z-ci-nix.md
@@ -196,6 +196,27 @@ tells it not to: every invocation passes `--no-write-lock-file`, so a CI run lea
 checkout exactly as it found it. The pin in `flake.nix` already determines every input,
 so the lock resolves nothing the flake did not already say.
 
+Every invocation also passes `--quiet`, which is about the log rather than the
+checkout: it drops Nix's logging from `info` to `notice`, removing the `copying N
+paths` substitution chatter and leaving warnings and errors. Nix has no short
+spelling — `--quiet` declares no short name, and the `-Q` that exists is
+`--no-build-output` on the legacy commands — so `-q` is not available here.
+
+#### Generated `run` scripts
+
+Neither flag is written in a workflow step. Each job directory holds a generated
+`run` script beside its flake, and a step invokes that:
+
+```sh
+./nix/node26/run npm run cov
+```
+
+The script is the same for every job — `exec nix develop … "$(dirname "$0")"
+--command "$@"` — so the spelling and its flags have one home instead of fifteen,
+and a step reads as the command it runs. Its executable bit is committed rather
+than generated, because nothing in `fjs/effects/node` can set a file mode;
+[generated-run-script-mode](generated-run-script-mode.md) owns closing that gap.
+
 An earlier revision took the opposite trade — ignore the lock rather than add a flag to
 every invocation — and the scoped root `.gitignore` rule it added stays:
 
@@ -216,7 +237,7 @@ Adopt jobs independently. Each migrated workflow uses:
 3. one step per command of that job's existing sequence, each entering the job's shell:
 
 ```sh
-nix develop --no-write-lock-file ./nix/<job> --command <command>
+./nix/<job>/run <command>
 ```
 
 A CI step runs one command (root [`AGENTS.md`](../../../AGENTS.md) §7), so the sequence
@@ -227,7 +248,7 @@ A step enters the shell only when it needs a tool the flake pins. `git` is the
 runner's, so the Node 26 drift check stays a plain step:
 
 ```sh
-nix develop --no-write-lock-file ./nix/node26 --command npm run ci-update
+./nix/node26/run npm run ci-update
 git add -A && git diff --cached --exit-code
 ```
 
@@ -284,6 +305,8 @@ A failure or unresolved design in one follow-up must not block unrelated flakes.
 - [x] Generate one readable self-contained flake per job with
       `devShells.aarch64-linux.default`.
 - [ ] Remove stale generated job directories.
+- [x] Generate a `run` script per job, so a workflow step names a command rather
+      than a `nix develop` invocation.
 - [x] Ignore `/nix/*/flake.lock`.
 - [x] Keep `npm run ci-update` Nix-independent and Windows-compatible.
 - [x] Commit the generated flakes.

--- a/fjs/ci/todo/66b-dockerfile-nix-integration.md
+++ b/fjs/ci/todo/66b-dockerfile-nix-integration.md
@@ -205,7 +205,7 @@ Each migrated Node job checks out the repository, installs Nix through a pinned 
 and then runs one step per command of its existing sequence:
 
 ```sh
-nix develop --no-write-lock-file ./nix/<job> --command <command>
+./nix/<job>/run <command>
 ```
 
 A CI step runs one command (root [`AGENTS.md`](../../../AGENTS.md) §7): a bundled
@@ -229,22 +229,22 @@ Preserve each job's command sequence. This is what the three jobs run, all migra
 
 ```text
 node22 (flake):
-  test "$(nix develop --no-write-lock-file ./nix/node22 --command node --version)" = v<configured>
-  nix develop --no-write-lock-file ./nix/node22 --command npm ci
-  nix develop --no-write-lock-file ./nix/node22 --command node --test
+  test "$(./nix/node22/run node --version)" = v<configured>
+  ./nix/node22/run npm ci
+  ./nix/node22/run node --test
 
 node24 (flake) — the same, one builder emits both:
-  test "$(nix develop --no-write-lock-file ./nix/node24 --command node --version)" = v<configured>
-  nix develop --no-write-lock-file ./nix/node24 --command npm ci
-  nix develop --no-write-lock-file ./nix/node24 --command node --test
+  test "$(./nix/node24/run node --version)" = v<configured>
+  ./nix/node24/run npm ci
+  ./nix/node24/run node --test
 
 node26 (flake):
-  test "$(nix develop --no-write-lock-file ./nix/node26 --command node --version)" = v<configured>
-  nix develop --no-write-lock-file ./nix/node26 --command npm ci
-  nix develop --no-write-lock-file ./nix/node26 --command npx tsc
-  nix develop --no-write-lock-file ./nix/node26 --command npm run cov
-  nix develop --no-write-lock-file ./nix/node26 --command npm pack
-  nix develop --no-write-lock-file ./nix/node26 --command npm run ci-update
+  test "$(./nix/node26/run node --version)" = v<configured>
+  ./nix/node26/run npm ci
+  ./nix/node26/run npx tsc
+  ./nix/node26/run npm run cov
+  ./nix/node26/run npm pack
+  ./nix/node26/run npm run ci-update
   git add -A && git diff --cached --exit-code
 ```
 
@@ -265,7 +265,7 @@ For each Node job:
 3. switch only that job after equivalent behavior is demonstrated.
 
 A migrated job checks its Node version like any other, as its first real step:
-`test "$(nix develop --no-write-lock-file ./nix/<job> --command node --version)" = v<version>`. The
+`test "$(./nix/<job>/run node --version)" = v<version>`. The
 pin decides which Node the flake resolves to, and `fjs/ci/config/module.f.mjs`
 only claims to know which — so the claim is checked where it can be, and the
 migration changes a job's runtime without changing what CI guarantees about it.

--- a/fjs/ci/todo/generated-run-script-mode.md
+++ b/fjs/ci/todo/generated-run-script-mode.md
@@ -1,0 +1,81 @@
+## generated-run-script-mode. Let the generator make its `run` scripts executable
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+`fjs/ci/nix` generates `nix/<job>/run` beside each `nix/<job>/flake.nix`, and CI
+invokes it directly:
+
+```sh
+./nix/node26/run npm run cov
+```
+
+That requires the executable bit, and the generator cannot set it. Nothing in
+[`fjs/effects/node`](../../effects/node/module.f.mjs) takes a file mode:
+`writeFile` is `(path, data)`, there is no `chmod` operation, and the virtual
+filesystem in `../../effects/node/virtual` models no modes at all.
+
+What makes this survivable rather than broken:
+
+- `fs.writeFile` **preserves the mode of a file that already exists** — it
+  truncates rather than recreating. So a script committed once as `100755` stays
+  executable through every regeneration, and `npm run ci-update` never has to
+  care.
+- The repository already tracks one `100755` file, `fjs/module.mjs`, so an
+  executable in Git is not a new thing here.
+
+What is left exposed is exactly one case: **a job generated for the first time.**
+Its `run` lands as `100644`, and the job fails with `Permission denied` at its
+first step. Loud, but avoidable, and it will happen to whoever adds the next
+runtime — the spidermonkey job in
+[spidermonkey-test-runner](../../emergent_testing/todo/spidermonkey-test-runner.md)
+is the likely first victim. The workaround is one command:
+
+```sh
+git update-index --chmod=+x nix/<job>/run
+```
+
+The drift check does not catch it. `git add -A && git diff --cached --exit-code`
+compares a tree the file is *new* in, so there is no recorded mode to differ
+from.
+
+### Proposal
+
+Give the effects layer a way to express "this file is executable", and have
+`writeJob` use it. Two shapes, and the choice is the work:
+
+1. **A `chmod` operation.** Direct, and mirrors `fs.chmod`. It also invites
+   callers to express modes this repository has no other use for, and forces a
+   decision about what a mode means on Windows, where `fjs ci` must keep running
+   (`65Z` requires the generator stay Nix-independent and Windows-compatible).
+2. **An `executable` flag on `writeFile`.** Narrower — the only distinction the
+   generator needs is script-or-not — and it degrades honestly on Windows, where
+   the concept is absent and the flag can be a no-op. It changes an operation's
+   signature, so every implementation and its proofs move together: the real
+   one, the virtual one, `memory`, and the RTTI in `types.ts`.
+
+Prefer 2 unless a second caller appears that wants a real mode.
+
+Either way the virtual filesystem has to start modelling the bit, or the proof
+that the generator sets it cannot exist — and a generator capability with no
+proof is the thing this repository does not ship.
+
+### Tasks
+
+- [ ] Decide between a `chmod` operation and an `executable` flag on `writeFile`
+- [ ] Decide what it does on Windows, and record the answer
+- [ ] Teach `../../effects/node/virtual` to model the bit, so the behaviour is
+      provable without touching a real filesystem
+- [ ] Have `writeJob` in `../nix/module.f.mjs` mark `run` executable
+- [ ] Drop the `git update-index --chmod=+x` note from `writeJob`'s docstring,
+      `nix/README.md` and this file's siblings once it is untrue
+
+### Related
+
+- [65Z-ci-nix](65z-ci-nix.md) — owns the generated directory, and requires the
+  generator stay Windows-compatible
+- [spidermonkey-test-runner](../../emergent_testing/todo/spidermonkey-test-runner.md)
+  — the next job likely to be generated for the first time, and so the next to
+  hit this

--- a/fjs/emergent_testing/todo/spidermonkey-test-runner.md
+++ b/fjs/emergent_testing/todo/spidermonkey-test-runner.md
@@ -96,7 +96,7 @@ commit (`../../ci/config/module.f.mjs`) and generates one flake per job
 CI, at a version the pin decides:
 
 ```sh
-nix develop --no-write-lock-file ./nix/spidermonkey --command js --version
+./nix/spidermonkey/run js --version
 ```
 
 Both halves of that line are read off the pinned commit rather than assumed.

--- a/nix/README.md
+++ b/nix/README.md
@@ -39,15 +39,20 @@ It is the same two lines for every job:
 
 ```sh
 #!/bin/sh
-exec nix develop --no-write-lock-file --quiet "$(dirname "$0")" --command "$@"
+case $0 in */*) d=${0%/*} ;; *) d=. ;; esac
+exec nix develop --no-write-lock-file --quiet "$d" --command "$@"
 ```
 
-`dirname "$0"` resolves the flake from the script's own location, so it behaves
-the same from the repository root, from `nix/`, or by absolute path. `"$@"`
-passes the caller's argument vector through unsplit, which is what lets a step
-keep quoting of its own — `./nix/deno/run deno eval 'console.log(…)'` arrives as
-three arguments rather than as text to re-parse. `exec` replaces the shell, so
-the command's exit status is the script's.
+The `case` line resolves the flake from the script's own location, so it behaves
+the same from the repository root, from `nix/`, or by absolute path. It is shell
+syntax and parameter expansion rather than `dirname`, because a generated script
+calls no external tool ([`AGENTS.md`](../AGENTS.md) §6); the second arm is what
+makes a `$0` with no `/` mean the current directory, which stripping a suffix
+cannot say by itself. `"$@"` passes the caller's argument vector through
+unsplit, which is what lets a step keep quoting of its own —
+`./nix/deno/run deno eval 'console.log(…)'` arrives as three arguments rather
+than as text to re-parse. `exec` replaces the shell, so the command's exit
+status is the script's.
 
 The two flags live there rather than in every step. `--no-write-lock-file` keeps
 the invocation read-only against the checkout: Nix otherwise writes a

--- a/nix/README.md
+++ b/nix/README.md
@@ -11,7 +11,7 @@ Each flake pins the exact Nixpkgs commit from
 development shell for the job's runner:
 
 ```sh
-nix develop --no-write-lock-file ./nix/node24 --command node --version
+./nix/node24/run node --version
 ```
 
 The pinned commit determines the package versions: `pkgs.nodejs_24` at that
@@ -26,10 +26,52 @@ The files stay static and readable on purpose — no job selection, no
 gets a second explicit `devShells.<system>.default` attribute rather than a
 loop.
 
-The pinned commit in `flake.nix` is the lock, so nothing needs a `flake.lock`
-beside it. CI passes `--no-write-lock-file` to every `nix develop`, which is why
-its runs leave the checkout untouched; the root `.gitignore` still ignores those
-files, for a hand-run `nix develop` that omits the flag.
+### `run`
+
+Each job directory also holds a generated `run` script, and that is what CI
+invokes:
+
+```sh
+./nix/node26/run npm run cov
+```
+
+It is the same two lines for every job:
+
+```sh
+#!/bin/sh
+exec nix develop --no-write-lock-file --quiet "$(dirname "$0")" --command "$@"
+```
+
+`dirname "$0"` resolves the flake from the script's own location, so it behaves
+the same from the repository root, from `nix/`, or by absolute path. `"$@"`
+passes the caller's argument vector through unsplit, which is what lets a step
+keep quoting of its own — `./nix/deno/run deno eval 'console.log(…)'` arrives as
+three arguments rather than as text to re-parse. `exec` replaces the shell, so
+the command's exit status is the script's.
+
+The two flags live there rather than in every step. `--no-write-lock-file` keeps
+the invocation read-only against the checkout: Nix otherwise writes a
+`flake.lock` beside the flake it enters, and the pin already determines every
+input, so that lock resolves nothing the flake did not already say. The root
+`.gitignore` still ignores those files, for a hand-run `nix develop` that omits
+the flag.
+
+`--quiet` drops Nix's own logging from `info` to `notice`. That removes the
+substitution chatter — the `copying N paths` lines that are most of what these
+steps print and none of what they check — while leaving warnings and errors,
+which sit below `notice`. Nix has no short spelling for it: `--verbose` declares
+a `v` short name and `--quiet` declares none, so `-q` is not an option the `nix`
+CLI accepts, and the `-Q` that exists is `--no-build-output` on
+`nix-build`/`nix-shell` rather than on this command. Neither flag reaches the
+command being run — `--command` execs it with stdio inherited — so a job's own
+output is unchanged.
+
+The generator writes the script's **content**; its executable bit is committed
+once and preserved by every regeneration, because `fs.writeFile` keeps the mode
+of a file that already exists. A job generated for the first time needs
+`git update-index --chmod=+x nix/<job>/run` by hand —
+[`fjs/ci/todo/generated-run-script-mode.md`](../fjs/ci/todo/generated-run-script-mode.md)
+is about removing that step.
 
 Every canonical job with a flake runs through it — the three Node jobs and
 `deno`. Each installs Nix, checks the runtime its shell provides, and then runs

--- a/nix/deno/run
+++ b/nix/deno/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec nix develop --no-write-lock-file --quiet "$(dirname "$0")" --command "$@"

--- a/nix/deno/run
+++ b/nix/deno/run
@@ -1,2 +1,3 @@
 #!/bin/sh
-exec nix develop --no-write-lock-file --quiet "$(dirname "$0")" --command "$@"
+case $0 in */*) d=${0%/*} ;; *) d=. ;; esac
+exec nix develop --no-write-lock-file --quiet "$d" --command "$@"

--- a/nix/node22/run
+++ b/nix/node22/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec nix develop --no-write-lock-file --quiet "$(dirname "$0")" --command "$@"

--- a/nix/node22/run
+++ b/nix/node22/run
@@ -1,2 +1,3 @@
 #!/bin/sh
-exec nix develop --no-write-lock-file --quiet "$(dirname "$0")" --command "$@"
+case $0 in */*) d=${0%/*} ;; *) d=. ;; esac
+exec nix develop --no-write-lock-file --quiet "$d" --command "$@"

--- a/nix/node24/run
+++ b/nix/node24/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec nix develop --no-write-lock-file --quiet "$(dirname "$0")" --command "$@"

--- a/nix/node24/run
+++ b/nix/node24/run
@@ -1,2 +1,3 @@
 #!/bin/sh
-exec nix develop --no-write-lock-file --quiet "$(dirname "$0")" --command "$@"
+case $0 in */*) d=${0%/*} ;; *) d=. ;; esac
+exec nix develop --no-write-lock-file --quiet "$d" --command "$@"

--- a/nix/node26/run
+++ b/nix/node26/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec nix develop --no-write-lock-file --quiet "$(dirname "$0")" --command "$@"

--- a/nix/node26/run
+++ b/nix/node26/run
@@ -1,2 +1,3 @@
 #!/bin/sh
-exec nix develop --no-write-lock-file --quiet "$(dirname "$0")" --command "$@"
+case $0 in */*) d=${0%/*} ;; *) d=. ;; esac
+exec nix develop --no-write-lock-file --quiet "$d" --command "$@"


### PR DESCRIPTION
A workflow step said this, fifteen times:

```sh
nix develop --no-write-lock-file ./nix/node26 --command npm run cov
```

It now says what it runs:

```sh
./nix/node26/run npm run cov
```

Each job directory gets a generated `run` beside its `flake.nix`, identical for
every job:

```sh
#!/bin/sh
case $0 in */*) d=${0%/*} ;; *) d=. ;; esac
exec nix develop --no-write-lock-file --quiet "$d" --command "$@"
```

The `case` line resolves the flake from the script's own location, so it behaves
the same from the repository root, from `nix/`, or by absolute path. It is shell
syntax and parameter expansion rather than `dirname`, because a generated script
calls no external tool (`AGENTS.md` §6); the second arm carries the one thing
stripping a suffix cannot say by itself — a `$0` with no `/` means the current
directory. `"$@"` passes the argument vector through unsplit, which is what lets
a step keep quoting of its own —
`./nix/deno/run deno eval 'console.log(Deno.version.deno)'` arrives as three
arguments rather than as text to re-parse. `exec` replaces the shell, so the
command's exit status is the script's.

## `--quiet`, and why not `-q`

`--quiet` is the noise reduction. It drops Nix's own logging from `info` to
`notice`, which removes the substitution chatter — `copying N paths`, started at
`lvlInfo` in `store-api.cc` — while leaving warnings and errors, which sit below
`notice`. Neither flag reaches the command being run, since `--command` execs it
with stdio inherited, so `node --test`, `npm run cov` and `deno task cov` print
exactly what they printed before.

**`nix develop -q` is not available**, which I checked in the Nix source rather
than assuming. `--verbose` declares `.shortName = 'v'`; `--quiet` declares no
short name; and no lowercase `-q` is defined anywhere in the CLI. The one short
flag nearby is `-Q` (`--no-build-output`), declared in `LegacyArgs` — so it
reaches `nix-build` and `nix-shell`, not `nix develop`.

## The executable bit

The generator writes the script's **content**; it cannot write its mode. Nothing
in `fjs/effects/node` takes one — `writeFile` is `(path, data)`, there is no
`chmod`, and the virtual filesystem models no modes at all.

That is survivable rather than broken, for a reason the whole design rests on:
**`fs.writeFile` preserves the mode of a file that already exists**, truncating
rather than recreating. A script committed once as `100755` therefore stays
executable through every regeneration — verified by `chmod +x`, then
`npm run ci-update`, then `ls -l`: still `-rwxr-xr-x`.

The one exposed case is a job generated for the *first* time: its `run` lands as
`100644` and the job fails with `Permission denied` at its first step. Loud, not
silent, and one command to fix (`git update-index --chmod=+x nix/<job>/run`).
The drift check cannot catch it, since a new file has no recorded mode to differ
from. `fjs/ci/todo/generated-run-script-mode.md` owns closing the gap, and
weighs the two shapes it could take — a `chmod` operation, or an `executable`
flag on `writeFile` — including what either means on Windows, where `fjs ci`
must keep running.

## Verification

CI has now run the scripts on real runners across three heads, which is the only
place any of this could be proven: `node22`, `node24`, `node26` and `deno` all
pass, so Git preserved `100755` through a fresh clone and `./nix/<job>/run`
executed directly.

The script was also exercised against a stub `nix` on `PATH`, covering what CI
does not vary:

| behaviour | result |
|---|---|
| flake path, from the repository root | `--quiet ./nix/node26 --command …` |
| flake path, run from `nix/` | `--quiet ./node22 --command …` |
| flake path, by absolute path | `--quiet /…/nix/deno --command …` |
| flake path, no `/` in `$0` | `--quiet . --command …` |
| argument vector preserved unsplit | `a` and `b c` arrive as 2 arguments |
| exit status propagates | `sh -c 'exit 7'` → `7` |
| POSIX syntax | `dash -n` clean |

Verified on `c0a97b3`, which merges `main` in after #1785 and #1774: `npx tsc`
clean, `fjs t` 3579 / 0 failed, `npm run cov` 3517 / 0 at 100% lines, branches
and functions, `npm run ci-update` idempotent — including the modes, which
survive regeneration. The counts moved from earlier heads because that merge
brought code, not because anything here changed.

A proof pins the script's text character for character. That assertion is also
the whole of what holds it to §6: the text is fixed, so reintroducing `dirname`
fails there. A separate scan for tool names was added and then removed — it
added no coverage the exact assertion lacks, and was itself the kind of
text-pattern check §6 rules out.

Changelog:
- `ci`: each generated Nix job directory now holds a `run` script, and workflow
  steps invoke it — `./nix/node26/run npm run cov` — instead of spelling out
  `nix develop`. The script passes `--quiet`, which drops Nix's substitution
  chatter from the logs without touching warnings, errors, or the command's own
  output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSZbnNEKjvNRbPijo6wt61

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSZbnNEKjvNRbPijo6wt61)_