### PR TITLE
ci: generate a developer environment for every system Nix runs on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,35 @@
         }
       ]
     },
+    "dev": {
+      "runs-on": "ubuntu-26.04-arm",
+      "steps": [
+        {
+          "uses": "cachix/install-nix-action@v31.11.1"
+        },
+        {
+          "uses": "actions/checkout@v7.0.1"
+        },
+        {
+          "run": "test \"$(./nix/dev/run node --version)\" = \"v26.7.0\""
+        },
+        {
+          "run": "test \"$(./nix/dev/run deno eval 'console.log(Deno.version.deno)')\" = \"2.8.3\""
+        },
+        {
+          "run": "test \"$(./nix/dev/run bun --version)\" = \"1.4.0\""
+        },
+        {
+          "run": "test \"$(./nix/dev/run wasmtime --version)\" = \"wasmtime 45.0.2\""
+        },
+        {
+          "run": "test \"$(./nix/dev/run wasmer --version)\" = \"wasmer 7.1.0\""
+        },
+        {
+          "run": "./nix/dev/run git --version"
+        }
+      ]
+    },
     "node22": {
       "runs-on": "ubuntu-26.04-arm",
       "steps": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,24 @@ work is tracked from then on.
 You may also use the [Dockerfile](./docker/Dockerfile), which sets all of this up
 and is the easiest way to get a known-good environment.
 
+### Or one Nix shell
+
+If you have Nix, `nix/dev` is a generated development environment carrying every
+tool in that table at the exact versions CI uses — Node, Deno, Bun, a Rust
+toolchain with the WASM targets, Wasmtime, Wasmer and `git`:
+
+```bash
+nix develop ./nix/dev          # an interactive shell
+./nix/dev/run npm run cov      # or one command in it
+```
+
+It covers `aarch64-linux`, `x86_64-linux`, `aarch64-darwin` and `x86_64-darwin`;
+`nix develop` picks the one for your machine. Nix does not run natively on
+Windows, so a Windows contributor either works through WSL2 or installs the
+table above — nothing in this repository requires Nix.
+
+`nix/README.md` explains what the shell contains and why.
+
 ### Node test-runner compatibility
 
 External test registration automatically uses an inline compatibility strategy

--- a/changelog/unreleased/1795.md
+++ b/changelog/unreleased/1795.md
@@ -1,0 +1,6 @@
+- `ci`: `fjs ci` generates `nix/dev`, a development environment carrying every
+  runtime the canonical jobs use — Node, Deno, Bun, a Rust toolchain with the
+  WASM targets, Wasmtime, Wasmer and `git` — with a shell for each of
+  `aarch64-linux`, `x86_64-linux`, `aarch64-darwin` and `x86_64-darwin`. A
+  `NixJob` now declares `systems` rather than a single `system`, and a pinned
+  package declares an archive and hash per system.

--- a/changelog/unreleased/1795.md
+++ b/changelog/unreleased/1795.md
@@ -1,6 +1,9 @@
+- **BREAKING CHANGES:** `ci`: a `NixJob` declares `systems`, a non-empty list,
+  rather than a single `system`, and a `NixPin` declares an archive and hash per
+  system — `sources` — rather than one `url` and `hash`. Both are exported and
+  reachable through `flakeText` and `nixFlakes`, so an outside declaration has
+  to move; every declaration in this repository is updated here.
 - `ci`: `fjs ci` generates `nix/dev`, a development environment carrying every
   runtime the canonical jobs use — Node, Deno, Bun, a Rust toolchain with the
   WASM targets, Wasmtime, Wasmer and `git` — with a shell for each of
-  `aarch64-linux`, `x86_64-linux`, `aarch64-darwin` and `x86_64-darwin`. A
-  `NixJob` now declares `systems` rather than a single `system`, and a pinned
-  package declares an archive and hash per system.
+  `aarch64-linux`, `x86_64-linux`, `aarch64-darwin` and `x86_64-darwin`.

--- a/fjs/ci/README.md
+++ b/fjs/ci/README.md
@@ -56,6 +56,11 @@ for, and whether that answer should change, is
   version cannot differ between them.
 - `deno/module.f.mjs` — the `deno` job's steps and its flake declaration.
   `proof.f.mjs` — its property-based proofs.
+- `dev/module.f.mjs` — the developer environment: one shell carrying every
+  runtime the canonical jobs use, on all four systems Nix runs on, generated
+  from those jobs' own declarations so it cannot drift from them. The `dev` CI
+  job enters it and asserts every version, which is the only thing that
+  evaluates that flake at all.
 - `bun/module.f.mjs` — the `bun` job's steps and its flake declaration. The one
   job whose shell is not the pinned snapshot's: Nixpkgs ships a Bun two of this
   repository's proofs fail on, so the flake keeps that package's recipe and
@@ -82,7 +87,12 @@ Each canonical job with a flake declares a system and its Nixpkgs package attrib
 beside the steps that enter them — `nodeNixJobs` in `node/module.f.mjs`, `denoNixJob`
 in its own module — and `module.f.mjs` composes them into `nixJobs`, the one place the
 whole set is visible. `package-check` declares none — it runs with no checkout, so
- there is no file tree for a flake to be in. `nix/module.f.mjs` writes each out as one
+ there is no file tree for a flake to be in.
+
+A declaration names the systems it wants a shell for, and the generator writes
+one explicit `devShells.<system>.default` per system rather than looping. Every
+CI job names exactly one, since it runs on one runner image; the developer
+environment names four, which is the reason that field is a list. `nix/module.f.mjs` writes each out as one
 static `flake.nix` exposing `devShells.<system>.default`. A job may also declare a
 job-local `shellHook`, run on every entry to the shell; none does today. See
 [nix/README.md](../../nix/README.md) for how the generated files are meant to be
@@ -176,6 +186,9 @@ through a flake:
 - `deno` runs `deno install --frozen` and `deno task cov` through its flake.
 - `bun` runs `bun install --frozen-lockfile` and `bun test --coverage` through its
   flake, whose Bun is an overridden archive rather than the snapshot's.
+- `dev` enters the developer shell, asserts the five runtime versions it hands
+  a developer, and runs one plain command in it. It tests no runtime of its own:
+  it exists so the shell developers use cannot rot unnoticed.
 - `wasm` runs `cargo fmt -- --check` and then tests and Clippy for four WASM
   targets through its flake, which provides the toolchain and both runtimes.
   `cargo` invokes `wasmtime` and `wasmer` itself, through the `runner` keys in

--- a/fjs/ci/bun/module.f.mjs
+++ b/fjs/ci/bun/module.f.mjs
@@ -13,24 +13,43 @@
  * @module
  *
  * @import { MetaStep } from '../common/types.ts'
- * @import { NixJob } from '../nix/types.ts'
+ * @import { NixJob, NixPin } from '../nix/types.ts'
  */
 
-import { bun, bunHash } from '../config/module.f.mjs'
-import { nixInstall, nixSteps, nixSystem, nixVersionStep } from '../nix/module.f.mjs'
+import { bun, bunSources } from '../config/module.f.mjs'
+import { nixInstall, nixSteps, nixSystems, nixVersionStep } from '../nix/module.f.mjs'
+import { fromUndefined, unwrap as unwrapNullable } from '../../types/nullable/module.f.mjs'
 
 /** CI job id, and the directory name of its generated flake. */
 export const bunJobId = /** @type {const} */ ('bun')
 
 /**
- * The archive Bun publishes for the system the generated flakes target.
+ * The override any flake wanting this Bun declares, over the systems it targets.
  *
- * The name carries that system — `aarch64-linux` is Bun's `linux-aarch64` —
- * so it is written beside `nixSystem` rather than derived from it: a job on
- * another runner needs another archive *and* another hash, and deriving the
- * first would leave the second silently wrong.
+ * Exported because the developer environment wants the same one: a shell handing
+ * a developer the 1.3.13 CI does not run on would be worse than no shell at all.
+ *
+ * The archive name and the hash travel together out of `../config/module.f.mjs`.
+ * Deriving the name from the system while looking the hash up separately is
+ * exactly how the two would come apart — and the names are not derivable
+ * anyway, since Intel macOS takes a baseline build the others do not.
+ *
+ * @type {(systems: readonly string[]) => NixPin}
  */
-const bunArchive = `https://github.com/oven-sh/bun/releases/download/bun-v${bun}/bun-linux-aarch64.zip`
+export const bunPin = systems => ({
+    package: 'bun',
+    version: bun,
+    sources: Object.fromEntries(systems.map(system => {
+        const { archive, hash } = unwrapNullable(fromUndefined(bunSources[system]))
+        return [
+            system,
+            {
+                url: `https://github.com/oven-sh/bun/releases/download/bun-v${bun}/${archive}.zip`,
+                hash,
+            },
+        ]
+    })),
+})
 
 /**
  * The job's development environment: the snapshot's `bun`, with its source
@@ -44,14 +63,9 @@ const bunArchive = `https://github.com/oven-sh/bun/releases/download/bun-v${bun}
  */
 export const bunNixJob = {
     id: bunJobId,
-    system: nixSystem,
+    systems: nixSystems,
     packages: [],
-    pin: {
-        package: 'bun',
-        version: bun,
-        url: bunArchive,
-        hash: bunHash,
-    },
+    pin: bunPin(nixSystems),
 }
 
 /**

--- a/fjs/ci/bun/proof.f.mjs
+++ b/fjs/ci/bun/proof.f.mjs
@@ -1,7 +1,7 @@
-import { bunJobId, bunNixJob, bunSteps } from './module.f.mjs'
+import { bunJobId, bunNixJob, bunPin, bunSteps } from './module.f.mjs'
 import { toSteps } from '../common/module.f.mjs'
-import { bun, bunHash } from '../config/module.f.mjs'
-import { nixDevelop, nixSystem } from '../nix/module.f.mjs'
+import { bun, bunSources } from '../config/module.f.mjs'
+import { nixDevelop, nixSystem, nixSystems } from '../nix/module.f.mjs'
 import { assert, assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
 
 const runs = toSteps(bunSteps).flatMap(s => s.run !== undefined ? [s.run] : [])
@@ -33,7 +33,7 @@ export const proof = {
     // shell, and a `packages` entry beside it would put both on `PATH`.
     nixJob: () => {
         assertEq(bunNixJob.id, bunJobId)
-        assertEq(bunNixJob.system, nixSystem)
+        assertStructurallySame(bunNixJob.systems, nixSystems)
         assertEq(bunNixJob.packages.length, 0)
         assertEq(bunNixJob.rust, undefined)
         assertEq(bunNixJob.shellHook, undefined)
@@ -41,12 +41,29 @@ export const proof = {
         assert(pin !== undefined, 'expected a pinned release')
         assertEq(pin.package, 'bun')
         assertEq(pin.version, bun)
-        assertEq(pin.hash, bunHash)
-        // The archive belongs to the release the job checks for, and to the
-        // system the flake declares. Neither is derivable from the other, so
-        // both are asserted rather than assumed.
-        assert(pin.url.includes(`/bun-v${bun}/`), pin.url)
-        assert(pin.url.endsWith('/bun-linux-aarch64.zip'), pin.url)
+        // One archive per declared system and no others: a source the flake
+        // never reads is a hash nobody checks, and a system with none would
+        // fail at generation instead of here.
+        assertStructurallySame(Object.keys(pin.sources), [...bunNixJob.systems])
+    },
+    // The pin covers whatever systems it is asked for, and each entry names the
+    // release the job checks for and the archive that system's packaging
+    // expects. Neither half is derivable from the other — Intel macOS takes a
+    // baseline build — so both come from the configured table.
+    pinSources: () => {
+        const { sources } = bunPin(['aarch64-linux', 'x86_64-darwin'])
+        for (const [system, { url, hash }] of Object.entries(sources)) {
+            const configured = bunSources[system]
+            assert(configured !== undefined, system)
+            assertEq(hash, configured.hash)
+            assertEq(
+                url,
+                `https://github.com/oven-sh/bun/releases/download/bun-v${bun}/${configured.archive}.zip`)
+        }
+        assertStructurallySame(
+            Object.keys(sources),
+            ['aarch64-linux', 'x86_64-darwin'])
+        assertEq(bunSources['x86_64-darwin']?.archive, 'bun-darwin-x64-baseline')
         assertEq(nixSystem, 'aarch64-linux')
     },
 }

--- a/fjs/ci/config/module.f.mjs
+++ b/fjs/ci/config/module.f.mjs
@@ -31,25 +31,50 @@ export const functionalscript = /** @type {const} */ '0.47.0'
 // Nixpkgs ships 1.3.13 — on the pin and on `master` — and two of this
 // repository's proofs fail on it, one of them a real difference in when
 // `Symbol.species` is read rather than a slow machine. So the `bun` job's flake
-// keeps the snapshot's packaging and replaces only the archive, with the
-// version and the hash below.
+// keeps the snapshot's packaging and replaces only the archive, named by the
+// version here and the table below.
 //
 // This is the exception, not a pattern: it works because Nixpkgs fetches Bun as
 // a prebuilt archive, so overriding it moves bytes rather than adopting a
-// package definition. Delete both constants the day the snapshot carries a Bun
-// this suite passes on.
+// package definition. Delete this and the table below the day the snapshot
+// carries a Bun this suite passes on.
 // https://bun.sh/
 export const bun = '1.4.0'
 
-// SHA-256 of the archive that release publishes for `aarch64-linux`, the one
-// system the generated flakes target, as an SRI string.
+// The archive that release publishes for each system a generated flake targets,
+// with the SHA-256 its content must have, as an SRI string.
 //
-// Verified rather than copied: the artifact was downloaded and hashed, and the
-// result compared against the value an independent packaging of the same
-// release records. Recompute it the same way when the version above moves —
+// The names are not a free choice. The snapshot's packaging strips a directory
+// whose name it derives from the system — `bun-darwin-x64-baseline` for
+// `x86_64-darwin` — so each archive here is the one that recipe already
+// expects, which is why Intel macOS takes a baseline build rather than the
+// newer one beside it.
+//
+// Verified rather than copied: every archive was downloaded and hashed here,
+// and three of the four matched an independent packaging of the same release.
+// The fourth, Intel macOS, is one nothing else packages, so our own download is
+// its only source. Recompute them the same way when the version above moves —
 // `nix-prefetch-url` where Nix is available, otherwise a download and a
 // `sha256sum` re-encoded as base64.
-export const bunHash = 'sha256-SxozLuhhmD65O8/m93D/+U4+MbLDiL2uo8jtNeWO7Q4='
+/** @type {{ readonly [system: string]: { readonly archive: string, readonly hash: string } }} */
+export const bunSources = {
+    'aarch64-linux': {
+        archive: 'bun-linux-aarch64',
+        hash: 'sha256-SxozLuhhmD65O8/m93D/+U4+MbLDiL2uo8jtNeWO7Q4=',
+    },
+    'x86_64-linux': {
+        archive: 'bun-linux-x64',
+        hash: 'sha256-LQP7X7g6yLVnrKCigbLOGhoZ1Ij1bClo2Iw/Jekv5FI=',
+    },
+    'aarch64-darwin': {
+        archive: 'bun-darwin-aarch64',
+        hash: 'sha256-xmnpf2Fk4cluBwF0jbmN+ndJKQjL2DlMdVcTSnNd44E=',
+    },
+    'x86_64-darwin': {
+        archive: 'bun-darwin-x64-baseline',
+        hash: 'sha256-2pufG0unZsbymXEfON+qmGI+HtnECJaqU9uAPFLsH6A=',
+    },
+}
 
 // The Deno version the pinned Nixpkgs snapshot below provides — read from
 // `pkgs/by-name/de/deno/package.nix` at that commit. The job asserts the

--- a/fjs/ci/deno/module.f.mjs
+++ b/fjs/ci/deno/module.f.mjs
@@ -14,7 +14,7 @@
  */
 
 import { deno } from '../config/module.f.mjs'
-import { nixInstall, nixSteps, nixSystem, nixVersionStep } from '../nix/module.f.mjs'
+import { nixInstall, nixSteps, nixSystems, nixVersionStep } from '../nix/module.f.mjs'
 
 /** CI job id, and the directory name of its generated flake. */
 export const denoJobId = /** @type {const} */ ('deno')
@@ -30,7 +30,7 @@ export const denoJobId = /** @type {const} */ ('deno')
  */
 export const denoNixJob = {
     id: denoJobId,
-    system: nixSystem,
+    systems: nixSystems,
     packages: ['deno'],
 }
 

--- a/fjs/ci/deno/proof.f.mjs
+++ b/fjs/ci/deno/proof.f.mjs
@@ -1,7 +1,7 @@
 import { denoJobId, denoNixJob, denoSteps } from './module.f.mjs'
 import { toSteps } from '../common/module.f.mjs'
 import { deno } from '../config/module.f.mjs'
-import { nixDevelop, nixSystem } from '../nix/module.f.mjs'
+import { nixDevelop, nixSystems } from '../nix/module.f.mjs'
 import { assert, assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
 
 const runs = toSteps(denoSteps).flatMap(s => s.run !== undefined ? [s.run] : [])
@@ -45,7 +45,7 @@ export const proof = {
     },
     nixJob: () => {
         assertEq(denoNixJob.id, denoJobId)
-        assertEq(denoNixJob.system, nixSystem)
+        assertStructurallySame(denoNixJob.systems, nixSystems)
         // One unversioned attribute, so the job's version check is the only
         // thing tying `fjs/ci/config`'s `deno` to what the shell provides.
         assertEq(denoNixJob.packages.length, 1)

--- a/fjs/ci/dev/module.f.mjs
+++ b/fjs/ci/dev/module.f.mjs
@@ -1,0 +1,118 @@
+/**
+ * The developer environment: one shell carrying every runtime this
+ * repository's jobs use, on every system Nix runs on.
+ *
+ * The CI jobs deliberately do not share it. Each of them exists to test one
+ * runtime, and a shell with five would let a job pass on a `node` that happened
+ * to be first on `PATH`. This one has the opposite job: to be the single thing
+ * a developer enters before running anything.
+ *
+ * It is generated from the same declarations those jobs use, so it cannot drift
+ * from them — the Node version is `../config/module.f.mjs`'s, the Bun override
+ * is the `bun` job's, the toolchain and its targets are the `wasm` job's.
+ *
+ * Nix does not run natively on Windows, so the four systems below are all there
+ * are; a Windows developer reaches this shell through WSL2 as a Linux one, or
+ * works the way this repository has always supported natively — `npm ci`,
+ * `npx tsc`, `fjs test`, none of which need Nix.
+ *
+ * @module
+ *
+ * @import { MetaStep } from '../common/types.ts'
+ * @import { NixJob } from '../nix/types.ts'
+ */
+
+import { bun, deno, node, rust, wasmer, wasmtime } from '../config/module.f.mjs'
+import { bunPin } from '../bun/module.f.mjs'
+import { major } from '../node/module.f.mjs'
+import { wasmTargets } from '../rust/module.f.mjs'
+import { nixInstall, nixSteps, nixVersionStep } from '../nix/module.f.mjs'
+
+/** CI job id, and the directory name of its generated flake. */
+export const devJobId = /** @type {const} */ ('dev')
+
+/**
+ * Every system this shell is generated for: two architectures on Linux, two on
+ * macOS, each an explicit `devShells.<system>.default`.
+ *
+ * Written out rather than looped over, which is the whole reason a generated
+ * flake can afford four of them and stay readable — see `../todo/65z-ci-nix.md`.
+ *
+ * @type {readonly [string, ...string[]]}
+ */
+export const devSystems = [
+    'aarch64-linux',
+    'x86_64-linux',
+    'aarch64-darwin',
+    'x86_64-darwin',
+]
+
+/**
+ * The shell itself.
+ *
+ * `git` is declared because `nix develop` builds the environment from what the
+ * shell asks for rather than from what the machine has, so a shell without it
+ * is one a developer leaves immediately. The rest is the union of what the
+ * canonical jobs run on.
+ *
+ * @type {NixJob}
+ */
+export const devNixJob = {
+    id: devJobId,
+    systems: devSystems,
+    packages: [`nodejs_${major(node.default)}`, 'deno', 'wasmtime', 'wasmer', 'git'],
+    rust: {
+        version: rust,
+        extensions: ['clippy', 'rustfmt'],
+        targets: wasmTargets,
+    },
+    pin: bunPin(devSystems),
+}
+
+/**
+ * The job that keeps this shell honest: enter it, and assert every version it
+ * hands a developer.
+ *
+ * Without it nothing would ever evaluate this flake. Every other generated
+ * flake is entered by the job that owns it — that is why no separate job checks
+ * them — and a developer environment has no such job unless one is written. It
+ * would rot silently, and the first person to notice would be a developer whose
+ * shell failed to build.
+ *
+ * Rust has no check, for the reason it has none in the `wasm` job: the flake
+ * names `1.98.0` in full, so a check could only restate it. The five below are
+ * the runtimes whose versions the flake does *not* say — three from unversioned
+ * snapshot attributes, one from a major-versioned one, and Bun from an override
+ * that has to be confirmed to have applied at all.
+ *
+ * The last step is a plain command rather than a sixth check, and it is not
+ * decoration. A version check reaches the shell inside a substitution — its
+ * command is `test` — so a job built only from checks would install Nix and
+ * enter nothing, a shape `../proof.f.mjs`'s `nixCoverage` refuses. `git` is
+ * the right one to spend it on: it is in `packages` only so the shell is
+ * usable, nothing else checks it, and it is there whether or not the project
+ * has Rust.
+ *
+ * Nothing here runs `cargo`, deliberately. The steps of a job are generated
+ * for whatever project runs `fjs ci`, and one without a `Cargo.toml` has no
+ * Rust jobs and must get no Rust commands. The shell still carries the
+ * toolchain — the flakes are written from a fixed list, as `wasm`'s is for a
+ * project with no Rust at all — and the `wasm` job exercises that same version
+ * from its own flake.
+ *
+ * It runs on one runner, so it evaluates one of the four shells. The other
+ * three are generated from the same declaration and pinned as text by
+ * `../nix/proof.f.mjs`; that they *build* is not something this repository's CI
+ * establishes today.
+ *
+ * @type {readonly MetaStep[]}
+ */
+export const devSteps = [
+    nixInstall,
+    nixVersionStep(devJobId, 'node --version', `v${node.default}`),
+    nixVersionStep(devJobId, `deno eval 'console.log(Deno.version.deno)'`, deno),
+    nixVersionStep(devJobId, 'bun --version', bun),
+    nixVersionStep(devJobId, 'wasmtime --version', `wasmtime ${wasmtime}`),
+    nixVersionStep(devJobId, 'wasmer --version', `wasmer ${wasmer}`),
+    ...nixSteps(devJobId)(['git --version']),
+]

--- a/fjs/ci/dev/module.f.mjs
+++ b/fjs/ci/dev/module.f.mjs
@@ -33,10 +33,13 @@ export const devJobId = /** @type {const} */ ('dev')
 
 /**
  * Every system this shell is generated for: two architectures on Linux, two on
- * macOS, each an explicit `devShells.<system>.default`.
+ * macOS, each a named `devShells.<system>.default`.
  *
- * Written out rather than looped over, which is the whole reason a generated
- * flake can afford four of them and stay readable — see `../todo/65z-ci-nix.md`.
+ * The flake writes the shell itself once and lets those four entries call it,
+ * passing the three things that differ — the system, and the archive and hash a
+ * pinned package takes on it. What it does not do is fold over a list of
+ * systems: which systems exist is still something you read off the file. See
+ * `../todo/65z-ci-nix.md`.
  *
  * @type {readonly [string, ...string[]]}
  */

--- a/fjs/ci/dev/proof.f.mjs
+++ b/fjs/ci/dev/proof.f.mjs
@@ -1,0 +1,95 @@
+import { devJobId, devNixJob, devSteps, devSystems } from './module.f.mjs'
+import { bunNixJob } from '../bun/module.f.mjs'
+import { denoNixJob } from '../deno/module.f.mjs'
+import { wasmNixJob } from '../rust/module.f.mjs'
+import { major, nodeNixJobs } from '../node/module.f.mjs'
+import { toSteps } from '../common/module.f.mjs'
+import { bun, deno, node, wasmer, wasmtime } from '../config/module.f.mjs'
+import { nixDevelop, nixSystem } from '../nix/module.f.mjs'
+import { assert, assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
+
+const runs = toSteps(devSteps).flatMap(s => s.run !== undefined ? [s.run] : [])
+
+/** @type {(id: string, command: string, expected: string) => string} */
+const check = (id, command, expected) =>
+    `test "$(${nixDevelop(id, command)})" = "${expected}"`
+
+export const proof = {
+    // The shell is the union of what the jobs use, and it is *the same* union
+    // rather than a second copy of it. Each of these compares the developer
+    // environment against the job it came from, so a job changing its runtime
+    // without the shell following fails here rather than on someone's machine.
+    noDrift: () => {
+        // Rust: byte for byte the `wasm` job's toolchain, targets included. A
+        // developer who cannot build what CI builds has the wrong shell.
+        assertStructurallySame(devNixJob.rust, wasmNixJob.rust)
+        // Bun: the same override, over four systems instead of one. Only the
+        // per-system archives differ, which is what `sources` is for.
+        const { pin } = devNixJob
+        const bunPinned = bunNixJob.pin
+        assert(pin !== undefined && bunPinned !== undefined, 'expected both pins')
+        assertEq(pin.package, bunPinned.package)
+        assertEq(pin.version, bunPinned.version)
+        assertEq(pin.version, bun)
+        // Node: the version the canonical Node job runs, by the same mapping
+        // from version to package attribute that job uses.
+        const [newest] = nodeNixJobs.filter(job => job.id === `node${major(node.default)}`)
+        assert(newest !== undefined, 'expected the default Node job')
+        assert(
+            devNixJob.packages.includes(`nodejs_${major(node.default)}`),
+            devNixJob.packages.join(' '))
+        assertStructurallySame([...newest.packages], [`nodejs_${major(node.default)}`])
+        // Deno and the two WASM runtimes, by attribute rather than version:
+        // those are the names their own jobs declare.
+        for (const name of [...denoNixJob.packages, ...wasmNixJob.packages]) {
+            assert(devNixJob.packages.includes(name), name)
+        }
+    },
+    // Four systems, and `git` — the two things this declaration has that no CI
+    // job does. Both are the point of it: a shell that runs on one machine, or
+    // one a developer leaves to find `git`, is not a developer environment.
+    shape: () => {
+        assertEq(devNixJob.id, devJobId)
+        assertStructurallySame([...devNixJob.systems], [...devSystems])
+        assertStructurallySame([...devSystems], [
+            'aarch64-linux',
+            'x86_64-linux',
+            'aarch64-darwin',
+            'x86_64-darwin',
+        ])
+        // The runner CI has is among them, since the `dev` job enters this
+        // shell from it.
+        assert(devSystems.includes(nixSystem), nixSystem)
+        assert(devNixJob.packages.includes('git'), devNixJob.packages.join(' '))
+        // A pinned archive for every system, and no others: an entry the flake
+        // never reads is a hash nobody checks.
+        const { pin } = devNixJob
+        assert(pin !== undefined, 'expected a pinned release')
+        assertStructurallySame(Object.keys(pin.sources), [...devSystems])
+    },
+    // The job, step for step: every version the shell hands a developer, then
+    // one plain command. Rust is absent for the reason it is absent from
+    // `wasm`'s checks — the flake names the release in full — and the plain
+    // command is what makes this a job that *enters* the shell rather than one
+    // that only reads versions out of substitutions.
+    steps: () => assertStructurallySame(runs, [
+        check(devJobId, 'node --version', `v${node.default}`),
+        check(devJobId, `deno eval 'console.log(Deno.version.deno)'`, deno),
+        check(devJobId, 'bun --version', bun),
+        check(devJobId, 'wasmtime --version', `wasmtime ${wasmtime}`),
+        check(devJobId, 'wasmer --version', `wasmer ${wasmer}`),
+        nixDevelop(devJobId, 'git --version'),
+    ]),
+    // No `cargo`, deliberately: these steps are generated for whatever project
+    // runs `fjs ci`, and one without a `Cargo.toml` gets no Rust jobs and must
+    // get no Rust commands.
+    noCargo: () => assert(
+        !runs.some(run => run.includes('cargo')),
+        'unexpected cargo command in a job generated for every project'),
+    installsNixOnly: () => {
+        const used = toSteps(devSteps).flatMap(s => s.uses !== undefined ? [s.uses] : [])
+        assertStructurallySame(
+            used.filter(u => !u.startsWith('actions/checkout@')),
+            used.filter(u => u.startsWith('cachix/install-nix-action@')))
+    },
+}

--- a/fjs/ci/module.f.mjs
+++ b/fjs/ci/module.f.mjs
@@ -30,6 +30,7 @@ import { nixFlakes } from './nix/module.f.mjs'
 import { parse as jsonParse } from '../media/json/module.f.mjs'
 import { packageCheckJob, packageCheckJobId } from './package/module.f.mjs'
 import { bunNixJob, bunSteps } from './bun/module.f.mjs'
+import { devNixJob, devSteps } from './dev/module.f.mjs'
 import { denoNixJob, denoSteps } from './deno/module.f.mjs'
 
 /** @type {(rust: boolean, nodeExtra: readonly MetaStep[]) => (o: Os) => (a: Architecture) => readonly [string, Job]} */
@@ -59,15 +60,26 @@ const job = (rust, nodeExtra) => o => a => {
  * is no file tree for a flake to be in. `./todo/65z-ci-nix.md` says why, and
  * `./proof.f.mjs`'s `nixCoverage` keeps the list from growing by accident.
  *
+ * `dev` is the one entry that is not a runtime under test. It is the developer
+ * environment, and it is here rather than hand-written so that it cannot drift
+ * from the jobs it is the union of — and so that the drift check covers it.
+ *
  * @type {readonly NixJob[]}
  */
-export const nixJobs = [...nodeNixJobs, denoNixJob, wasmNixJob, bunNixJob]
+export const nixJobs = [
+    ...nodeNixJobs,
+    denoNixJob,
+    wasmNixJob,
+    bunNixJob,
+    devNixJob,
+]
 
 /** @type {(rust: boolean, pin: string | undefined) => Jobs} */
 const canonicalJobs = (rust, pin) => ({
     ...(rust ? { wasm: ubuntuArm(rustWasmSteps) } : {}),
     deno: ubuntuArm(denoSteps),
     bun: ubuntuArm(bunSteps),
+    dev: ubuntuArm(devSteps),
     ...nodeVersionJobs(),
     ...(pin === undefined ? {} : { [packageCheckJobId]: packageCheckJob(pin) }),
 })

--- a/fjs/ci/nix/module.f.mjs
+++ b/fjs/ci/nix/module.f.mjs
@@ -60,17 +60,20 @@ const toolchain = ({ version, extensions, targets }) => ['apply',
 ]
 
 /**
- * A pinned package's archive for one system.
+ * A pinned package's archive for one system, or empty strings for a job that
+ * pins nothing — where the two are never read.
  *
- * A job that pins a package has to give every system it declares an archive,
- * and nothing here can invent a missing one: the URL and the hash are both
- * facts about a published file. So this is a totality assertion like
+ * A job that *does* pin has to give every system it declares an archive, and
+ * nothing here can invent a missing one: the URL and the hash are both facts
+ * about a published file. So the lookup is a totality assertion like
  * {@link flakeText}'s, and `../proof.f.mjs` holds every declared job to it.
  *
- * @type {(pin: NixPin, system: string) => NixArchive}
+ * @type {(pin: NixPin | undefined, system: string) => NixArchive}
  */
-const archive = ({ sources }, system) =>
-    unwrapNullable(fromUndefined(sources[system]))
+const archive = (pin, system) =>
+    pin === undefined
+        ? { url: '', hash: '' }
+        : unwrapNullable(fromUndefined(pin.sources[system]))
 
 /** The `let` name a pinned package is bound to, whatever package it overrides. */
 const pinName = /** @type {const} */ ('pinned')
@@ -95,9 +98,9 @@ const pinName = /** @type {const} */ ('pinned')
  * package builds its own download URLs from `version`, so a mismatch there is
  * the kind that surfaces as a hash error in an unrelated place.
  *
- * @type {(pin: NixPin, source: NixArchive) => Expression}
+ * @type {(pin: NixPin, source: Expression, hash: Expression) => Expression}
  */
-const pinned = ({ package: name, version }, { url: source, hash }) => ['apply',
+const pinned = ({ package: name, version }, source, hash) => ['apply',
     ['ref', 'pkgs', name, 'overrideAttrs'],
     ['set',
         ['=', ['version'], version],
@@ -111,18 +114,37 @@ const pinned = ({ package: name, version }, { url: source, hash }) => ['apply',
     ]
 ]
 
+/** The `let` name the shared shell function is bound to. */
+const shellName = /** @type {const} */ ('shell')
+
 /**
- * One system's development shell: the `let` that builds it and the `mkShell`
- * that is it.
+ * The parts of a shell that differ between one system and the next.
  *
- * Every system gets its own, written out rather than looped over — a flake with
- * four shells is four of these, and reads as four. What varies with the system
- * is not only the name: a pinned package names a different archive, with a hash
- * of its own, for each one.
+ * Two ways to fill them, and that is the whole of the choice this module makes
+ * about repetition. A flake with one shell passes the values themselves, and
+ * reads with nothing to look up. A flake with several passes references to a
+ * function's arguments, and the shell is written once.
  *
- * @type {(job: NixJob, system: string) => Expression}
+ * The archive halves are read only under a `pin`, so for a job that pins
+ * nothing whatever fills them never reaches the file.
+ *
+ * @typedef {{
+ *   readonly system: Expression
+ *   readonly url: Expression
+ *   readonly hash: Expression
+ * }} PerSystem
  */
-const shell = ({ packages, shellHook, rust, pin }, system) => ['let',
+
+/**
+ * One development shell: the `let` that builds it and the `mkShell` that is it.
+ *
+ * What varies with the system is not only its name — a pinned package names a
+ * different archive, with a hash of its own — so all three arrive together
+ * rather than being derived from each other here.
+ *
+ * @type {(job: NixJob, perSystem: PerSystem) => Expression}
+ */
+const shell = ({ packages, shellHook, rust, pin }, { system, url: source, hash }) => ['let',
     [
         ['=', ['pkgs'], ['apply',
             ['ref', 'import'],
@@ -138,7 +160,7 @@ const shell = ({ packages, shellHook, rust, pin }, system) => ['let',
             ['=', ['rust'], toolchain(rust)],
         ])),
         ...(pin === undefined ? [] : /** @type {readonly _Binding[]} */ ([
-            ['=', [pinName], pinned(pin, archive(pin, system))],
+            ['=', [pinName], pinned(pin, source, hash)],
         ])),
     ],
     ['apply',
@@ -155,6 +177,70 @@ const shell = ({ packages, shellHook, rust, pin }, system) => ['let',
         ]
     ]
 ]
+
+/**
+ * The values one system passes to the shared function: its name, and the
+ * archive a pinned package takes on it.
+ *
+ * @type {(job: NixJob, system: string) => readonly _Binding[]}
+ */
+const perSystemArguments = ({ pin }, system) => {
+    const { url: source, hash } = archive(pin, system)
+    return [
+        ['=', ['system'], system],
+        ...(pin === undefined ? [] : /** @type {readonly _Binding[]} */ ([
+            ['=', ['url'], source],
+            ['=', ['hash'], hash],
+        ])),
+    ]
+}
+
+/**
+ * The `devShells` set, and — for a job with more than one system — the function
+ * its entries share.
+ *
+ * The abstraction appears exactly where it pays. One shell written through a
+ * function would be indirection for nothing, so a single-system flake stays the
+ * flat text it has always been, byte for byte. Four shells written out is the
+ * same twenty lines four times, so those share.
+ *
+ * It is a function rather than a loop on purpose: `devShells.<system>.default`
+ * is still written once per system, so the systems a flake serves are a list
+ * you can read, not a fold over one this file does not contain. That was
+ * `../todo/65z-ci-nix.md`'s reason for refusing `flake-utils`, and it survives.
+ *
+ * @type {(job: NixJob) => Expression}
+ */
+const devShells = job => {
+    const [system, ...rest] = job.systems
+    if (rest.length === 0) {
+        return ['set',
+            ['=', ['devShells', system, 'default'], shell(job, {
+                system,
+                ...archive(job.pin, system),
+            })],
+        ]
+    }
+    return ['let',
+        [
+            ['=', [shellName], ['lambda',
+                ['open-set-pattern', 'system', ...(job.pin === undefined ? [] : ['url', 'hash'])],
+                shell(job, {
+                    system: ['ref', 'system'],
+                    url: ['ref', 'url'],
+                    hash: ['ref', 'hash'],
+                }),
+            ]],
+        ],
+        ['set',
+            ...job.systems.map(s => /** @type {_Binding} */ ([
+                '=',
+                ['devShells', s, 'default'],
+                ['apply', ['ref', shellName], ['set', ...perSystemArguments(job, s)]],
+            ])),
+        ],
+    ]
+}
 
 /**
  * A job declaring neither `rust` nor `pin` generates exactly what it generated
@@ -175,11 +261,7 @@ const flake = job => ['set',
     ])),
     ['=', ['outputs'], ['lambda',
         ['open-set-pattern', 'nixpkgs', ...(job.rust === undefined ? [] : ['rust-overlay'])],
-        ['set',
-            ...job.systems.map(system => /** @type {_Binding} */ ([
-                '=', ['devShells', system, 'default'], shell(job, system),
-            ])),
-        ]
+        devShells(job),
     ]]
 ]
 

--- a/fjs/ci/nix/module.f.mjs
+++ b/fjs/ci/nix/module.f.mjs
@@ -15,7 +15,7 @@
  * @import { IoChannel, Mkdir, WriteFile } from '../../effects/node/types.ts'
  * @import { Effect } from '../../effects/types.ts'
  * @import { Expression, _Binding, _Reference } from '../../media/nix/types.ts'
- * @import { NixJob, NixPin, NixRust } from './types.ts'
+ * @import { NixArchive, NixJob, NixPin, NixRust } from './types.ts'
  */
 
 import { pureOk } from '../../effects/module.f.mjs'
@@ -59,6 +59,19 @@ const toolchain = ({ version, extensions, targets }) => ['apply',
     ]
 ]
 
+/**
+ * A pinned package's archive for one system.
+ *
+ * A job that pins a package has to give every system it declares an archive,
+ * and nothing here can invent a missing one: the URL and the hash are both
+ * facts about a published file. So this is a totality assertion like
+ * {@link flakeText}'s, and `../proof.f.mjs` holds every declared job to it.
+ *
+ * @type {(pin: NixPin, system: string) => NixArchive}
+ */
+const archive = ({ sources }, system) =>
+    unwrapNullable(fromUndefined(sources[system]))
+
 /** The `let` name a pinned package is bound to, whatever package it overrides. */
 const pinName = /** @type {const} */ ('pinned')
 
@@ -82,16 +95,16 @@ const pinName = /** @type {const} */ ('pinned')
  * package builds its own download URLs from `version`, so a mismatch there is
  * the kind that surfaces as a hash error in an unrelated place.
  *
- * @type {(pin: NixPin) => Expression}
+ * @type {(pin: NixPin, source: NixArchive) => Expression}
  */
-const pinned = ({ package: name, version, url: archive, hash }) => ['apply',
+const pinned = ({ package: name, version }, { url: source, hash }) => ['apply',
     ['ref', 'pkgs', name, 'overrideAttrs'],
     ['set',
         ['=', ['version'], version],
         ['=', ['src'], ['apply',
             ['ref', 'pkgs', 'fetchurl'],
             ['set',
-                ['=', ['url'], archive],
+                ['=', ['url'], source],
                 ['=', ['hash'], hash],
             ]
         ]],
@@ -99,57 +112,73 @@ const pinned = ({ package: name, version, url: archive, hash }) => ['apply',
 ]
 
 /**
+ * One system's development shell: the `let` that builds it and the `mkShell`
+ * that is it.
+ *
+ * Every system gets its own, written out rather than looped over — a flake with
+ * four shells is four of these, and reads as four. What varies with the system
+ * is not only the name: a pinned package names a different archive, with a hash
+ * of its own, for each one.
+ *
+ * @type {(job: NixJob, system: string) => Expression}
+ */
+const shell = ({ packages, shellHook, rust, pin }, system) => ['let',
+    [
+        ['=', ['pkgs'], ['apply',
+            ['ref', 'import'],
+            ['ref', 'nixpkgs'],
+            ['set',
+                ['=', ['system'], system],
+                ...(rust === undefined ? [] : /** @type {readonly _Binding[]} */ ([
+                    ['=', ['overlays'], ['list', ['ref', 'rust-overlay', 'overlays', 'default']]],
+                ])),
+            ]
+        ]],
+        ...(rust === undefined ? [] : /** @type {readonly _Binding[]} */ ([
+            ['=', ['rust'], toolchain(rust)],
+        ])),
+        ...(pin === undefined ? [] : /** @type {readonly _Binding[]} */ ([
+            ['=', [pinName], pinned(pin, archive(pin, system))],
+        ])),
+    ],
+    ['apply',
+        ['ref', 'pkgs', 'mkShell'],
+        ['set',
+            ['=', ['packages'], ['list',
+                ...(rust === undefined ? [] : /** @type {readonly _Reference[]} */ ([['ref', 'rust']])),
+                ...(pin === undefined ? [] : /** @type {readonly _Reference[]} */ ([['ref', pinName]])),
+                ...packages.map(p => /** @type {const} */ (['ref', 'pkgs', p])),
+            ]],
+            ...(shellHook === undefined
+                ? []
+                : [/** @type {const} */ (['=', ['shellHook'], ['indented-string', shellHook]])])
+        ]
+    ]
+]
+
+/**
  * A job declaring neither `rust` nor `pin` generates exactly what it generated
  * before those declarations existed: one input, one lambda argument, no
  * overlay, one `let` binding. Everything either one brings is conditional on
- * the job asking for it.
+ * the job asking for it, and a job declaring one system generates the one
+ * `devShells` attribute it always did.
  *
  * @type {(job: NixJob) => Expression}
  */
-const flake = ({ system, packages, shellHook, rust, pin }) => ['set',
+const flake = job => ['set',
     ['=', ['inputs', 'nixpkgs', 'url'], url],
-    ...(rust === undefined ? [] : /** @type {readonly _Binding[]} */ ([
+    ...(job.rust === undefined ? [] : /** @type {readonly _Binding[]} */ ([
         ['=', ['inputs', 'rust-overlay', 'url'], rustOverlayUrl],
         // The overlay's own Nixpkgs is only for its checks, and following ours
         // keeps one snapshot in the flake rather than two resolved revisions.
         ['=', ['inputs', 'rust-overlay', 'inputs', 'nixpkgs', 'follows'], 'nixpkgs'],
     ])),
     ['=', ['outputs'], ['lambda',
-        ['open-set-pattern', 'nixpkgs', ...(rust === undefined ? [] : ['rust-overlay'])],
+        ['open-set-pattern', 'nixpkgs', ...(job.rust === undefined ? [] : ['rust-overlay'])],
         ['set',
-            ['=', ['devShells', system, 'default'], ['let',
-                [
-                    ['=', ['pkgs'], ['apply',
-                        ['ref', 'import'],
-                        ['ref', 'nixpkgs'],
-                        ['set',
-                            ['=', ['system'], system],
-                            ...(rust === undefined ? [] : /** @type {readonly _Binding[]} */ ([
-                                ['=', ['overlays'], ['list', ['ref', 'rust-overlay', 'overlays', 'default']]],
-                            ])),
-                        ]
-                    ]],
-                    ...(rust === undefined ? [] : /** @type {readonly _Binding[]} */ ([
-                        ['=', ['rust'], toolchain(rust)],
-                    ])),
-                    ...(pin === undefined ? [] : /** @type {readonly _Binding[]} */ ([
-                        ['=', [pinName], pinned(pin)],
-                    ])),
-                ],
-                ['apply',
-                    ['ref', 'pkgs', 'mkShell'],
-                    ['set',
-                        ['=', ['packages'], ['list',
-                            ...(rust === undefined ? [] : /** @type {readonly _Reference[]} */ ([['ref', 'rust']])),
-                            ...(pin === undefined ? [] : /** @type {readonly _Reference[]} */ ([['ref', pinName]])),
-                            ...packages.map(p => /** @type {const} */ (['ref', 'pkgs', p])),
-                        ]],
-                        ...(shellHook === undefined
-                            ? []
-                            : [/** @type {const} */ (['=', ['shellHook'], ['indented-string', shellHook]])])
-                    ]
-                ]
-            ]]
+            ...job.systems.map(system => /** @type {_Binding} */ ([
+                '=', ['devShells', system, 'default'], shell(job, system),
+            ])),
         ]
     ]]
 ]
@@ -282,6 +311,17 @@ export const nixDevelop = (id, command) => `${runPath(id)} ${command}`
  * explicit `devShells.<system>.default` — not a loop over systems.
  */
 export const nixSystem = /** @type {const} */ ('aarch64-linux')
+
+/**
+ * What a CI job declares: the one runner it has, as a list of one.
+ *
+ * A job on another runner declares another system, and gets another explicit
+ * `devShells.<system>.default` — not a loop. The developer environment is the
+ * only declaration with more than one entry.
+ *
+ * @type {readonly [string, ...string[]]}
+ */
+export const nixSystems = [nixSystem]
 
 /**
  * One step per command, each entering the job's shell (root `AGENTS.md` §7).

--- a/fjs/ci/nix/proof.f.mjs
+++ b/fjs/ci/nix/proof.f.mjs
@@ -204,36 +204,72 @@ const withSystems = {
 
 const systemsFlake = `{
     inputs.nixpkgs.url = "github:NixOS/nixpkgs/${commit}";
-    outputs = { nixpkgs, ... }: {
-        devShells.aarch64-linux.default = let
+    outputs = { nixpkgs, ... }: let
+        shell = { system, url, hash, ... }: let
             pkgs = import nixpkgs {
-                system = "aarch64-linux";
+                system = system;
             };
             pinned = pkgs.bun.overrideAttrs {
                 version = "1.4.0";
                 src = pkgs.fetchurl {
-                    url = "https://example.test/bun-linux-aarch64.zip";
-                    hash = "sha256-AAAA";
+                    url = url;
+                    hash = hash;
                 };
             };
         in
         pkgs.mkShell {
             packages = [ pinned pkgs.git ];
         };
-        devShells.x86_64-darwin.default = let
+    in
+    {
+        devShells.aarch64-linux.default = shell {
+            system = "aarch64-linux";
+            url = "https://example.test/bun-linux-aarch64.zip";
+            hash = "sha256-AAAA";
+        };
+        devShells.x86_64-darwin.default = shell {
+            system = "x86_64-darwin";
+            url = "https://example.test/bun-darwin-x64-baseline.zip";
+            hash = "sha256-BBBB";
+        };
+    };
+}
+`
+
+/**
+ * The same two systems with nothing pinned: the only thing that varies between
+ * the two shells is then the system itself.
+ *
+ * That is the shape a project whose runtimes the snapshot carries at the right
+ * versions would generate, and it is the one that keeps the shared function
+ * honest — its argument list is what the shell reads, not a fixed three names
+ * with two of them empty.
+ *
+ * @type {NixJob}
+ */
+const withSystemsUnpinned = {
+    ...plain,
+    systems: ['aarch64-linux', 'x86_64-darwin'],
+}
+
+const unpinnedSystemsFlake = `{
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/${commit}";
+    outputs = { nixpkgs, ... }: let
+        shell = { system, ... }: let
             pkgs = import nixpkgs {
-                system = "x86_64-darwin";
-            };
-            pinned = pkgs.bun.overrideAttrs {
-                version = "1.4.0";
-                src = pkgs.fetchurl {
-                    url = "https://example.test/bun-darwin-x64-baseline.zip";
-                    hash = "sha256-BBBB";
-                };
+                system = system;
             };
         in
         pkgs.mkShell {
-            packages = [ pinned pkgs.git ];
+            packages = [ pkgs.nodejs_24 ];
+        };
+    in
+    {
+        devShells.aarch64-linux.default = shell {
+            system = "aarch64-linux";
+        };
+        devShells.x86_64-darwin.default = shell {
+            system = "x86_64-darwin";
         };
     };
 }
@@ -276,11 +312,18 @@ export const proof = {
         // needs none — and the archive's hash is in the flake, so the fetch is
         // checked before anything unpacks it.
         pin: () => assertEq(flakeText(withPin), pinFlake),
-        // Two shells from one declaration, each naming its own system and its
-        // own archive. No loop and no `flake-utils`: a second system is a
-        // second `devShells.<system>.default`, which is what keeps a flake
-        // readable without reading the generator.
+        // Two shells from one declaration, sharing the body that does not vary
+        // and naming, per system, the three things that do. Still no loop and
+        // no `flake-utils`: every system it serves is a `devShells.<system>`
+        // binding you can read off the file, rather than a fold over a list the
+        // file does not contain.
         systems: () => assertEq(flakeText(withSystems), systemsFlake),
+        // The same, with nothing pinned: the shared function takes the system
+        // and only the system. A flake that pins nothing has no `url` and no
+        // `hash` anywhere in it, rather than two arguments the shell never
+        // reads.
+        unpinnedSystems: () =>
+            assertEq(flakeText(withSystemsUnpinned), unpinnedSystemsFlake),
         // A package name reaches one quotable position and one binding the
         // generator owns, so an unusual one is escaped rather than rejected.
         // The `let` name is the generator's precisely so that it cannot be:

--- a/fjs/ci/nix/proof.f.mjs
+++ b/fjs/ci/nix/proof.f.mjs
@@ -9,6 +9,7 @@ import { step as ioStep } from '../../effects/module.f.mjs'
 import { readUtf8File } from '../../effects/node/module.f.mjs'
 import { emptyState, virtual } from '../../effects/node/virtual/module.f.mjs'
 import { nixpkgs, rustOverlay } from '../config/module.f.mjs'
+import { devJobId, devSystems } from '../dev/module.f.mjs'
 import { nixJobs } from '../module.f.mjs'
 import { nodeNixJobs } from '../node/module.f.mjs'
 import {
@@ -30,7 +31,7 @@ const { commit } = nixpkgs
 /** @type {NixJob} */
 const plain = {
     id: 'node24',
-    system: 'aarch64-linux',
+    systems: ['aarch64-linux'],
     packages: ['nodejs_24'],
 }
 
@@ -84,8 +85,12 @@ const withPin = {
     pin: {
         package: 'bun',
         version: '1.4.0',
-        url: 'https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-linux-aarch64.zip',
-        hash: 'sha256-SxozLuhhmD65O8/m93D/+U4+MbLDiL2uo8jtNeWO7Q4=',
+        sources: {
+            'aarch64-linux': {
+                url: 'https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-linux-aarch64.zip',
+                hash: 'sha256-SxozLuhhmD65O8/m93D/+U4+MbLDiL2uo8jtNeWO7Q4=',
+            },
+        },
     },
 }
 
@@ -167,6 +172,74 @@ const pinFlake = `{
 `
 
 /**
+ * A job exposing a shell for more than one system — the developer environment's
+ * shape, at two systems rather than four.
+ *
+ * Both halves of a pinned archive vary with the system, so each shell carries
+ * its own `url` and `hash`; everything else about the two is identical, written
+ * out twice rather than abstracted over.
+ *
+ * @type {NixJob}
+ */
+const withSystems = {
+    ...plain,
+    id: 'dev',
+    systems: ['aarch64-linux', 'x86_64-darwin'],
+    packages: ['git'],
+    pin: {
+        package: 'bun',
+        version: '1.4.0',
+        sources: {
+            'aarch64-linux': {
+                url: 'https://example.test/bun-linux-aarch64.zip',
+                hash: 'sha256-AAAA',
+            },
+            'x86_64-darwin': {
+                url: 'https://example.test/bun-darwin-x64-baseline.zip',
+                hash: 'sha256-BBBB',
+            },
+        },
+    },
+}
+
+const systemsFlake = `{
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/${commit}";
+    outputs = { nixpkgs, ... }: {
+        devShells.aarch64-linux.default = let
+            pkgs = import nixpkgs {
+                system = "aarch64-linux";
+            };
+            pinned = pkgs.bun.overrideAttrs {
+                version = "1.4.0";
+                src = pkgs.fetchurl {
+                    url = "https://example.test/bun-linux-aarch64.zip";
+                    hash = "sha256-AAAA";
+                };
+            };
+        in
+        pkgs.mkShell {
+            packages = [ pinned pkgs.git ];
+        };
+        devShells.x86_64-darwin.default = let
+            pkgs = import nixpkgs {
+                system = "x86_64-darwin";
+            };
+            pinned = pkgs.bun.overrideAttrs {
+                version = "1.4.0";
+                src = pkgs.fetchurl {
+                    url = "https://example.test/bun-darwin-x64-baseline.zip";
+                    hash = "sha256-BBBB";
+                };
+            };
+        in
+        pkgs.mkShell {
+            packages = [ pinned pkgs.git ];
+        };
+    };
+}
+`
+
+/**
  * `withPin`'s pin, without the optionality the type carries for jobs that
  * declare none.
  *
@@ -203,6 +276,11 @@ export const proof = {
         // needs none — and the archive's hash is in the flake, so the fetch is
         // checked before anything unpacks it.
         pin: () => assertEq(flakeText(withPin), pinFlake),
+        // Two shells from one declaration, each naming its own system and its
+        // own archive. No loop and no `flake-utils`: a second system is a
+        // second `devShells.<system>.default`, which is what keeps a flake
+        // readable without reading the generator.
+        systems: () => assertEq(flakeText(withSystems), systemsFlake),
         // A package name reaches one quotable position and one binding the
         // generator owns, so an unusual one is escaped rather than rejected.
         // The `let` name is the generator's precisely so that it cannot be:
@@ -263,9 +341,18 @@ exec nix develop --no-write-lock-file --quiet "$d" --command "$@"
         // for. A second system would need its own `devShells.<system>.default`
         // rather than a loop, so a job that quietly declared another would
         // otherwise generate a shell no runner can enter.
-        oneSystem: () => {
-            for (const { system } of nixJobs) {
-                assertEq(system, nixSystem)
+        // Every job but the developer environment runs on one runner, and
+        // declares the one system that runner is. `dev` is the exception the
+        // list form exists for, so it is named rather than exempted by a
+        // pattern: a job quietly declaring a second system would otherwise
+        // generate a shell no runner enters.
+        systems: () => {
+            for (const { id, systems } of nixJobs) {
+                if (id === devJobId) {
+                    assertStructurallySame([...systems], [...devSystems])
+                } else {
+                    assertStructurallySame([...systems], [nixSystem])
+                }
             }
         },
         // Job data only ever reaches quotable positions, so an unusual package

--- a/fjs/ci/nix/types.ts
+++ b/fjs/ci/nix/types.ts
@@ -43,18 +43,40 @@ export type NixPin = {
     readonly package: string
     /** The release the override installs. */
     readonly version: string
-    /** Archive that release publishes, for the job's system. */
+    /**
+     * The archive to unpack, by Nix system.
+     *
+     * One entry per system the job declares, because both halves vary with it:
+     * a release publishes a different file per platform, and each has its own
+     * hash. The snapshot's packaging reads the *name* too — for `x86_64-darwin`
+     * it strips a `bun-darwin-x64-baseline` directory — so an archive is chosen
+     * to match what that recipe already expects rather than for being the
+     * newest build on offer.
+     */
+    readonly sources: { readonly [system: string]: NixArchive }
+}
+
+/** One downloadable archive, and the hash its content must have. */
+export type NixArchive = {
+    /** Where the release publishes it. */
     readonly url: string
     /** SRI hash of that archive, verified before anything unpacks it. */
     readonly hash: string
 }
 
-/** A CI job's development environment, one generated flake each. */
+/** A development environment, one generated flake each. */
 export type NixJob = {
     /** Generated directory name under `nix`, matching the CI job id. */
     readonly id: string
-    /** Nix system of the job's runner, e.g. `aarch64-linux`. */
-    readonly system: string
+    /**
+     * Nix systems the flake exposes a shell for, one explicit
+     * `devShells.<system>.default` each — never a loop over a system list.
+     *
+     * A CI job declares exactly one: it runs on one runner image, and a second
+     * shell there would be one nothing enters. The developer environment is
+     * the reason this is a list at all.
+     */
+    readonly systems: readonly [string, ...string[]]
     /** Nixpkgs attribute names made available in the job's shell. */
     readonly packages: readonly string[]
     /** Job-local shell initialization, when the job needs one. */

--- a/fjs/ci/nix/types.ts
+++ b/fjs/ci/nix/types.ts
@@ -69,8 +69,14 @@ export type NixJob = {
     /** Generated directory name under `nix`, matching the CI job id. */
     readonly id: string
     /**
-     * Nix systems the flake exposes a shell for, one explicit
-     * `devShells.<system>.default` each — never a loop over a system list.
+     * Nix systems the flake exposes a shell for, one named
+     * `devShells.<system>.default` each — never a fold over a system list the
+     * file does not contain.
+     *
+     * More than one, and the part that does not vary is written once as a
+     * function those entries call; the systems themselves stay a list you can
+     * read off the flake. One, and the shell is inline, because a function
+     * called once is indirection for nothing.
      *
      * A CI job declares exactly one: it runs on one runner image, and a second
      * shell there would be one nothing enters. The developer environment is

--- a/fjs/ci/node/module.f.mjs
+++ b/fjs/ci/node/module.f.mjs
@@ -10,7 +10,7 @@
 
 import { node } from '../config/module.f.mjs'
 import { install, test, ubuntuArm, uses } from '../common/module.f.mjs'
-import { nixInstall, nixSteps, nixSystem, nixVersionStep } from '../nix/module.f.mjs'
+import { nixInstall, nixSteps, nixSystems, nixVersionStep } from '../nix/module.f.mjs'
 
 /**
  * Name of the CI artifact carrying the `npm pack` tarball. The producing step
@@ -138,7 +138,7 @@ export const nodeVersionJobs = () => ({
 /** @type {(version: string) => NixJob} */
 const nixJob = version => ({
     id: jobId(version),
-    system: nixSystem,
+    systems: nixSystems,
     packages: [`nodejs_${major(version)}`],
 })
 

--- a/fjs/ci/proof.f.mjs
+++ b/fjs/ci/proof.f.mjs
@@ -139,7 +139,7 @@ const runDefault = packageJson => {
 export const proof = {
     matrixShape: () => {
         const gha = run(true)
-        assertEq(Object.keys(gha.jobs).length, 13, 'expected 13 CI jobs')
+        assertEq(Object.keys(gha.jobs).length, 14, 'expected 14 CI jobs')
         assertEq(gha.permissions.contents, 'read', 'expected read-only contents permission')
         assertEq(Object.keys(gha.permissions).length, 1, 'expected least-privilege workflow permissions')
         assert(hasRunInJob('ubuntu-intel', 'cargo test --target i686-unknown-linux-gnu')(gha), 'expected Ubuntu Intel i686 check')
@@ -245,7 +245,7 @@ export const proof = {
         // Every generated flake, not just the Node ones: `nixJobs` is what the
         // generator was given, so a family that declares an environment and
         // never has it written fails here.
-        assertEq(nixJobs.length, 6)
+        assertEq(nixJobs.length, 7)
         for (const job of nixJobs) {
             // The pipeline wrote that job's flake, whole, at the path a
             // `nix develop` step names. Equality rather than a substring
@@ -332,6 +332,18 @@ export const proof = {
             // took effect rather than that a snapshot is what it claims: the
             // shell's Bun is not the snapshot's.
             ['bun', [['bun --version', bun]]],
+            // The developer environment, which is checked more thoroughly than
+            // any job's: it is the only flake no other job enters, so these
+            // five are the whole of what keeps it from rotting. Its Rust goes
+            // unchecked for the reason `wasm`'s does — the flake names the
+            // release in full.
+            ['dev', [
+                ['node --version', `v${node.default}`],
+                [`deno eval 'console.log(Deno.version.deno)'`, deno],
+                ['bun --version', bun],
+                ['wasmtime --version', `wasmtime ${wasmtime}`],
+                ['wasmer --version', `wasmer ${wasmer}`],
+            ]],
         ]
         assertEq(checks.length, nixJobs.length)
         for (const [id, jobChecks] of checks) {

--- a/fjs/ci/rust/module.f.mjs
+++ b/fjs/ci/rust/module.f.mjs
@@ -24,7 +24,7 @@
 
 import { rust, wasmer, wasmtime } from '../config/module.f.mjs'
 import { test } from '../common/module.f.mjs'
-import { nixInstall, nixSteps, nixSystem, nixVersionStep } from '../nix/module.f.mjs'
+import { nixInstall, nixSteps, nixSystems, nixVersionStep } from '../nix/module.f.mjs'
 
 /** @type {(tool: 'clippy' | 'test', target?: string, config?: string) => string} */
 const cargoCommand = (tool, target, config) => {
@@ -103,12 +103,13 @@ const wasmerOnlyTarget = /** @type {const} */ ('wasm32-wasip1-threads')
 /**
  * Every WASM target the job exercises, in the order it exercises them.
  *
- * One list, read twice: the flake declares these as the targets whose
- * `rust-std` its toolchain must carry, and the steps below build the commands
- * from the same array. A target added here therefore arrives in the shell and
- * in the job together, rather than as a command with no standard library.
+ * One list, read three times: the flake declares these as the targets whose
+ * `rust-std` its toolchain must carry, the steps below build the commands from
+ * the same array, and `../dev/module.f.mjs` gives a developer's shell the same
+ * ones. A target added here therefore arrives in the shell and in the job
+ * together, rather than as a command with no standard library.
  */
-const wasmTargets = /** @type {const} */ ([
+export const wasmTargets = /** @type {const} */ ([
     'wasm32-wasip1',
     'wasm32-wasip2',
     'wasm32-unknown-unknown',
@@ -145,7 +146,7 @@ const wasmTargetCommands = target =>
  */
 export const wasmNixJob = {
     id: wasmJobId,
-    system: nixSystem,
+    systems: nixSystems,
     packages: ['wasmtime', 'wasmer'],
     rust: {
         version: rust,

--- a/fjs/ci/todo/65z-ci-nix.md
+++ b/fjs/ci/todo/65z-ci-nix.md
@@ -108,6 +108,38 @@ this suite passes on. The job's version check is what holds it: unlike every oth
 check, which confirms a snapshot provides what the configuration claims, this one
 confirms the override took effect at all.
 
+#### The developer environment
+
+Every flake above serves one job testing one runtime. `dev` is the other kind:
+one shell carrying all of them — Node 26, Deno, the pinned Bun, the toolchain
+with its WASM targets, Wasmtime, Wasmer and `git` — for a developer to work in.
+
+It is generated rather than hand-written for two reasons. It cannot drift from
+the jobs, since it is built from their own declarations; and the drift check
+covers it, which a hand-written `nix/flake.nix` would have escaped — verifying
+one would mean pattern-matching Nix source, which root `AGENTS.md` §6 rules out.
+
+The jobs deliberately do not share it. Each exists to test one runtime, and a
+shell with five would let a job pass on whichever `node` reached `PATH` first.
+
+**It is why a declaration names systems rather than a system.** A CI job runs on
+one runner image; a developer environment has to work on Linux and macOS, on
+both architectures. Each system gets its own explicit
+`devShells.<system>.default`, so four systems is four blocks of text and no loop
+— which a generator can afford and a hand-written flake cannot, and is the
+reason `flake-utils` still has no place here. A pinned package varies with the
+system twice over: a different archive, and a hash of its own.
+
+Nix does not run natively on Windows, so those four are all there are. A Windows
+developer reaches the shell through WSL2 or works the way this repository has
+always supported natively — nothing here requires Nix.
+
+A `dev` CI job enters the shell and asserts the five versions it hands a
+developer. Without it nothing would evaluate this flake at all: every other one
+is entered by the job that owns it, and this one has no such job unless it is
+written. That job runs on one runner, so one of the four shells is evaluated for
+real; the other three are pinned as text and no further.
+
 #### Jobs with no flake
 
 One canonical job has none. That the set is exactly this one is asserted by
@@ -194,6 +226,8 @@ node24: aarch64-linux, nodejs_24
 node26: aarch64-linux, nodejs_26
 deno:   aarch64-linux, deno
 wasm:   aarch64-linux, wasmtime, wasmer, and a rust-overlay toolchain
+bun:    aarch64-linux, bun overridden to an exact upstream release
+dev:    four systems, everything above at once, plus git
 ```
 
 `bun` is `aarch64-linux, bun`, with the package overridden to an exact upstream
@@ -221,12 +255,15 @@ nix/node26/flake.nix
 nix/deno/flake.nix
 nix/wasm/flake.nix
 nix/bun/flake.nix
+nix/dev/flake.nix
 ```
 
 Each generated file should:
 
 - pin the exact Nixpkgs commit;
-- expose `devShells.aarch64-linux.default` for the current ARM Linux job;
+- expose one `devShells.<system>.default` per system the job declares — every CI
+  job declares the one ARM Linux runner it has, and the developer environment
+  declares four;
 - use `pkgs.mkShell` with that job's declared packages;
 - be readable without inspecting the generator;
 - contain no job-selection logic;
@@ -417,6 +454,8 @@ A failure or unresolved design in one follow-up must not block unrelated flakes.
 - [x] Migrate jobs one at a time — Node 24, then Node 26, then Node 22, then `deno`.
 - [x] Migrate `bun`, by overriding the snapshot's package with an exact upstream
       release rather than waiting for Nixpkgs to ship one.
+- [x] Generate a developer environment carrying every runtime at once, on all
+      four systems Nix runs on, checked by a job of its own.
 - [x] Migrate `wasm`, which needed this issue's "official Nixpkgs only" scope
       widened by one input: Nixpkgs builds no `std` for three of its four targets,
       at any version.

--- a/fjs/ci/todo/65z-ci-nix.md
+++ b/fjs/ci/todo/65z-ci-nix.md
@@ -124,11 +124,17 @@ shell with five would let a job pass on whichever `node` reached `PATH` first.
 
 **It is why a declaration names systems rather than a system.** A CI job runs on
 one runner image; a developer environment has to work on Linux and macOS, on
-both architectures. Each system gets its own explicit
-`devShells.<system>.default`, so four systems is four blocks of text and no loop
-— which a generator can afford and a hand-written flake cannot, and is the
-reason `flake-utils` still has no place here. A pinned package varies with the
-system twice over: a different archive, and a hash of its own.
+both architectures.
+
+Each system is its own named `devShells.<system>.default`, and past the first
+they share the shell between them: the body is written once as a function, and
+each entry calls it with the three things that differ — the system, and the
+archive and hash a pinned package takes on it. That keeps `flake-utils` out
+without keeping four copies of twenty lines in. The distinction worth holding
+is *named entries versus a fold*: which systems a flake serves is still
+something the file says, rather than something a loop over a list computes. A
+single-system flake stays flat, byte for byte what it was, because a function
+called once is indirection for nothing.
 
 Nix does not run natively on Windows, so those four are all there are. A Windows
 developer reaches the shell through WSL2 or works the way this repository has
@@ -263,7 +269,8 @@ Each generated file should:
 - pin the exact Nixpkgs commit;
 - expose one `devShells.<system>.default` per system the job declares — every CI
   job declares the one ARM Linux runner it has, and the developer environment
-  declares four;
+  declares four. Past one, the shell body is written once as a function those
+  entries call; the systems stay named bindings rather than a fold;
 - use `pkgs.mkShell` with that job's declared packages;
 - be readable without inspecting the generator;
 - contain no job-selection logic;

--- a/fjs/ci/todo/downstream-run-script-not-executable.md
+++ b/fjs/ci/todo/downstream-run-script-not-executable.md
@@ -1,0 +1,88 @@
+## downstream-run-script-not-executable. A project running `fjs ci` gets `run` scripts it cannot run
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+`fjs ci` writes `nix/<job>/run` beside each generated flake, and the workflow it
+generates invokes it directly:
+
+```sh
+./nix/dev/run git --version
+```
+
+`writeUtf8File` reaches `fs.promises.writeFile`, which creates a new file as
+`0o666 & ~umask` — `100644` on a normal machine. So the first step of every
+generated Nix job fails with `Permission denied` in a tree where that script did
+not already exist.
+
+This repository never sees it, and that is the trap. `fs.writeFile` **preserves
+the mode of a file that already exists**: it truncates rather than recreating.
+Every `nix/*/run` here is committed `100755`, recovered once by hand with
+`git update-index --chmod=+x`, and stays executable through every regeneration.
+Our CI is green on a property of our tree rather than on anything the generator
+does.
+
+A project adopting these flakes has no such tree. In one with no `nix/`
+directory yet, *every* script is new at once, so it is not one job that fails
+but all of them — and the fix is a command that only this repository's history
+teaches. The drift check does not help either, there or here:
+`git add -A && git diff --cached --exit-code` compares a tree the file is new
+in, so there is no recorded mode to differ from.
+
+Reported on [#1795](https://github.com/functionalscript/functionalscript/pull/1795).
+
+### Why it is filed rather than fixed
+
+The generated CI here runs, and no downstream project consumes these flakes
+today — `fjs ci` is run by this repository, and the first generated flake landed
+days ago. So the cost of the bug is currently zero and the cost of the fix is a
+new operation in the effects layer, its virtual implementation, and the proofs
+for both. Filed at the priority that reflects that, not at the one the word
+"`Permission denied`" suggests.
+
+What would raise it: a project outside this repository generating these files,
+or the flakes being offered as something to adopt rather than something we
+happen to run.
+
+### Proposal
+
+Two ways out, and choosing is most of the work:
+
+1. **Make the generator set the bit**, which needs the effects layer to be able
+   to express a mode at all — that is
+   [generated-run-script-mode](generated-run-script-mode.md), which owns the
+   design question, the Windows answer, and the virtual filesystem work. This
+   issue is then fixed by fixing that one, and closes with it.
+2. **Stop requiring the bit**, by generating `sh ./nix/<job>/run …` instead of
+   `./nix/<job>/run …`. No effects work at all, and it is portable in the one
+   direction that matters, since the mode has no meaning on Windows anyway. The
+   price is real: every generated step names an interpreter, the shebang the
+   script already carries stops being load-bearing, and a developer copying a
+   command out of the workflow copies the `sh` with it.
+
+2 is the cheap fix for this issue alone; 1 is the one that leaves the generator
+able to emit an executable file, which is a capability rather than a workaround.
+Prefer 1 if that issue is being done anyway, and reach for 2 only if this starts
+costing someone.
+
+### Tasks
+
+- [ ] Decide between the effect and `sh`
+- [ ] Whichever: prove it against a tree where the script does **not** already
+      exist, since that is the only case that is broken and the one this
+      repository's own files hide
+- [ ] Drop the `git update-index --chmod=+x` note from `writeJob`'s docstring
+      and `nix/README.md` once it is untrue
+
+### Related
+
+- [generated-run-script-mode](generated-run-script-mode.md) — the missing
+  effects-layer capability, and option 1 above; this issue is the consequence
+  of that gap for someone who is not us
+- [65Z-ci-nix](65z-ci-nix.md) — owns the generated directory, and requires the
+  generator stay Windows-compatible
+- [ci-generator-audience](ci-generator-audience.md) — the same distinction this
+  turns on: what the generator promises a project that runs it, versus what
+  happens to hold in our tree

--- a/nix/README.md
+++ b/nix/README.md
@@ -111,10 +111,14 @@ and a shell with five would let a job pass on whichever `node` came first on
 `PATH`.
 
 It exposes four shells — `aarch64-linux`, `x86_64-linux`, `aarch64-darwin`,
-`x86_64-darwin` — one explicit `devShells.<system>.default` each, and
-`nix develop` picks the one matching the machine. Nix does not run natively on
-Windows, so a Windows developer reaches it through WSL2 or works the way this
-repository has always supported natively.
+`x86_64-darwin` — one named `devShells.<system>.default` each, and
+`nix develop` picks the one matching the machine. The shell itself is written
+once, as a function those four entries call with the three things that differ:
+the system, and the archive and hash Bun publishes for it. The single-system
+flakes keep their shell inline, since a function called once would be
+indirection for nothing. Nix does not run natively on Windows, so a Windows
+developer reaches it through WSL2 or works the way this repository has always
+supported natively.
 
 A `dev` CI job enters the shell and asserts all five runtime versions. Nothing
 else would ever evaluate this flake — every other one is entered by the job that

--- a/nix/README.md
+++ b/nix/README.md
@@ -79,7 +79,7 @@ of a file that already exists. A job generated for the first time needs
 is about removing that step.
 
 Every canonical job with a flake runs through it — the three Node jobs, `deno`,
-`wasm` and `bun`. Each installs Nix, checks the runtime its shell provides, and then runs
+`wasm`, `bun`, and the `dev` job that keeps the developer environment honest. Each installs Nix, checks the runtime its shell provides, and then runs
 its commands one `nix develop` step each, because a CI step runs one command. No
 separate job makes that check — a flake is checked by the job that uses it, and
 every generated flake has one.
@@ -87,6 +87,41 @@ every generated flake has one.
 One canonical job has no flake: `package-check` runs with no checkout, which is
 the whole point of it, and a flake and its `run` script are files in a checkout.
 `fjs/ci/todo/65z-ci-nix.md` says so.
+
+### The developer environment
+
+`dev` is the one flake here that is not a job's runtime under test. It carries
+everything the canonical jobs use at once — Node 26, Deno, the pinned Bun, a
+Rust toolchain with every WASM target, Wasmtime, Wasmer and `git` — so that one
+shell is enough to work in:
+
+```sh
+nix develop ./nix/dev          # an interactive shell
+./nix/dev/run npm run cov      # or one command in it
+```
+
+It is generated from the same declarations the jobs use, so it cannot drift from
+them: the Node version is the one `node26` runs, the Bun override is the `bun`
+job's, the toolchain and its targets are the `wasm` job's. `git` is declared
+because `nix develop` builds an environment from what the shell asks for rather
+than from what the machine has.
+
+The CI jobs deliberately do **not** share it. Each exists to test one runtime,
+and a shell with five would let a job pass on whichever `node` came first on
+`PATH`.
+
+It exposes four shells — `aarch64-linux`, `x86_64-linux`, `aarch64-darwin`,
+`x86_64-darwin` — one explicit `devShells.<system>.default` each, and
+`nix develop` picks the one matching the machine. Nix does not run natively on
+Windows, so a Windows developer reaches it through WSL2 or works the way this
+repository has always supported natively.
+
+A `dev` CI job enters the shell and asserts all five runtime versions. Nothing
+else would ever evaluate this flake — every other one is entered by the job that
+owns it — so without that job it would rot until a developer's shell failed to
+build. That job runs on one runner, so one of the four shells is evaluated for
+real; the other three are generated from the same declaration and pinned as
+text.
 
 ### The `bun` flake's overridden package
 

--- a/nix/dev/flake.nix
+++ b/nix/dev/flake.nix
@@ -2,10 +2,10 @@
     inputs.nixpkgs.url = "github:NixOS/nixpkgs/062346a6d85bc4b49dfaa61c986e9c5be21217d1";
     inputs.rust-overlay.url = "github:oxalica/rust-overlay/996e9b0b019a4a9eb9e9a5641aefa06d801b5895";
     inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
-    outputs = { nixpkgs, rust-overlay, ... }: {
-        devShells.aarch64-linux.default = let
+    outputs = { nixpkgs, rust-overlay, ... }: let
+        shell = { system, url, hash, ... }: let
             pkgs = import nixpkgs {
-                system = "aarch64-linux";
+                system = system;
                 overlays = [ rust-overlay.overlays.default ];
             };
             rust = pkgs.rust-bin.stable."1.98.0".minimal.override {
@@ -15,73 +15,35 @@
             pinned = pkgs.bun.overrideAttrs {
                 version = "1.4.0";
                 src = pkgs.fetchurl {
-                    url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-linux-aarch64.zip";
-                    hash = "sha256-SxozLuhhmD65O8/m93D/+U4+MbLDiL2uo8jtNeWO7Q4=";
+                    url = url;
+                    hash = hash;
                 };
             };
         in
         pkgs.mkShell {
             packages = [ rust pinned pkgs.nodejs_26 pkgs.deno pkgs.wasmtime pkgs.wasmer pkgs.git ];
         };
-        devShells.x86_64-linux.default = let
-            pkgs = import nixpkgs {
-                system = "x86_64-linux";
-                overlays = [ rust-overlay.overlays.default ];
-            };
-            rust = pkgs.rust-bin.stable."1.98.0".minimal.override {
-                extensions = [ "clippy" "rustfmt" ];
-                targets = [ "wasm32-wasip1" "wasm32-wasip2" "wasm32-unknown-unknown" "wasm32-wasip1-threads" ];
-            };
-            pinned = pkgs.bun.overrideAttrs {
-                version = "1.4.0";
-                src = pkgs.fetchurl {
-                    url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-linux-x64.zip";
-                    hash = "sha256-LQP7X7g6yLVnrKCigbLOGhoZ1Ij1bClo2Iw/Jekv5FI=";
-                };
-            };
-        in
-        pkgs.mkShell {
-            packages = [ rust pinned pkgs.nodejs_26 pkgs.deno pkgs.wasmtime pkgs.wasmer pkgs.git ];
+    in
+    {
+        devShells.aarch64-linux.default = shell {
+            system = "aarch64-linux";
+            url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-linux-aarch64.zip";
+            hash = "sha256-SxozLuhhmD65O8/m93D/+U4+MbLDiL2uo8jtNeWO7Q4=";
         };
-        devShells.aarch64-darwin.default = let
-            pkgs = import nixpkgs {
-                system = "aarch64-darwin";
-                overlays = [ rust-overlay.overlays.default ];
-            };
-            rust = pkgs.rust-bin.stable."1.98.0".minimal.override {
-                extensions = [ "clippy" "rustfmt" ];
-                targets = [ "wasm32-wasip1" "wasm32-wasip2" "wasm32-unknown-unknown" "wasm32-wasip1-threads" ];
-            };
-            pinned = pkgs.bun.overrideAttrs {
-                version = "1.4.0";
-                src = pkgs.fetchurl {
-                    url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-darwin-aarch64.zip";
-                    hash = "sha256-xmnpf2Fk4cluBwF0jbmN+ndJKQjL2DlMdVcTSnNd44E=";
-                };
-            };
-        in
-        pkgs.mkShell {
-            packages = [ rust pinned pkgs.nodejs_26 pkgs.deno pkgs.wasmtime pkgs.wasmer pkgs.git ];
+        devShells.x86_64-linux.default = shell {
+            system = "x86_64-linux";
+            url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-linux-x64.zip";
+            hash = "sha256-LQP7X7g6yLVnrKCigbLOGhoZ1Ij1bClo2Iw/Jekv5FI=";
         };
-        devShells.x86_64-darwin.default = let
-            pkgs = import nixpkgs {
-                system = "x86_64-darwin";
-                overlays = [ rust-overlay.overlays.default ];
-            };
-            rust = pkgs.rust-bin.stable."1.98.0".minimal.override {
-                extensions = [ "clippy" "rustfmt" ];
-                targets = [ "wasm32-wasip1" "wasm32-wasip2" "wasm32-unknown-unknown" "wasm32-wasip1-threads" ];
-            };
-            pinned = pkgs.bun.overrideAttrs {
-                version = "1.4.0";
-                src = pkgs.fetchurl {
-                    url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-darwin-x64-baseline.zip";
-                    hash = "sha256-2pufG0unZsbymXEfON+qmGI+HtnECJaqU9uAPFLsH6A=";
-                };
-            };
-        in
-        pkgs.mkShell {
-            packages = [ rust pinned pkgs.nodejs_26 pkgs.deno pkgs.wasmtime pkgs.wasmer pkgs.git ];
+        devShells.aarch64-darwin.default = shell {
+            system = "aarch64-darwin";
+            url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-darwin-aarch64.zip";
+            hash = "sha256-xmnpf2Fk4cluBwF0jbmN+ndJKQjL2DlMdVcTSnNd44E=";
+        };
+        devShells.x86_64-darwin.default = shell {
+            system = "x86_64-darwin";
+            url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-darwin-x64-baseline.zip";
+            hash = "sha256-2pufG0unZsbymXEfON+qmGI+HtnECJaqU9uAPFLsH6A=";
         };
     };
 }

--- a/nix/dev/flake.nix
+++ b/nix/dev/flake.nix
@@ -1,0 +1,87 @@
+{
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/062346a6d85bc4b49dfaa61c986e9c5be21217d1";
+    inputs.rust-overlay.url = "github:oxalica/rust-overlay/996e9b0b019a4a9eb9e9a5641aefa06d801b5895";
+    inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+    outputs = { nixpkgs, rust-overlay, ... }: {
+        devShells.aarch64-linux.default = let
+            pkgs = import nixpkgs {
+                system = "aarch64-linux";
+                overlays = [ rust-overlay.overlays.default ];
+            };
+            rust = pkgs.rust-bin.stable."1.98.0".minimal.override {
+                extensions = [ "clippy" "rustfmt" ];
+                targets = [ "wasm32-wasip1" "wasm32-wasip2" "wasm32-unknown-unknown" "wasm32-wasip1-threads" ];
+            };
+            pinned = pkgs.bun.overrideAttrs {
+                version = "1.4.0";
+                src = pkgs.fetchurl {
+                    url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-linux-aarch64.zip";
+                    hash = "sha256-SxozLuhhmD65O8/m93D/+U4+MbLDiL2uo8jtNeWO7Q4=";
+                };
+            };
+        in
+        pkgs.mkShell {
+            packages = [ rust pinned pkgs.nodejs_26 pkgs.deno pkgs.wasmtime pkgs.wasmer pkgs.git ];
+        };
+        devShells.x86_64-linux.default = let
+            pkgs = import nixpkgs {
+                system = "x86_64-linux";
+                overlays = [ rust-overlay.overlays.default ];
+            };
+            rust = pkgs.rust-bin.stable."1.98.0".minimal.override {
+                extensions = [ "clippy" "rustfmt" ];
+                targets = [ "wasm32-wasip1" "wasm32-wasip2" "wasm32-unknown-unknown" "wasm32-wasip1-threads" ];
+            };
+            pinned = pkgs.bun.overrideAttrs {
+                version = "1.4.0";
+                src = pkgs.fetchurl {
+                    url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-linux-x64.zip";
+                    hash = "sha256-LQP7X7g6yLVnrKCigbLOGhoZ1Ij1bClo2Iw/Jekv5FI=";
+                };
+            };
+        in
+        pkgs.mkShell {
+            packages = [ rust pinned pkgs.nodejs_26 pkgs.deno pkgs.wasmtime pkgs.wasmer pkgs.git ];
+        };
+        devShells.aarch64-darwin.default = let
+            pkgs = import nixpkgs {
+                system = "aarch64-darwin";
+                overlays = [ rust-overlay.overlays.default ];
+            };
+            rust = pkgs.rust-bin.stable."1.98.0".minimal.override {
+                extensions = [ "clippy" "rustfmt" ];
+                targets = [ "wasm32-wasip1" "wasm32-wasip2" "wasm32-unknown-unknown" "wasm32-wasip1-threads" ];
+            };
+            pinned = pkgs.bun.overrideAttrs {
+                version = "1.4.0";
+                src = pkgs.fetchurl {
+                    url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-darwin-aarch64.zip";
+                    hash = "sha256-xmnpf2Fk4cluBwF0jbmN+ndJKQjL2DlMdVcTSnNd44E=";
+                };
+            };
+        in
+        pkgs.mkShell {
+            packages = [ rust pinned pkgs.nodejs_26 pkgs.deno pkgs.wasmtime pkgs.wasmer pkgs.git ];
+        };
+        devShells.x86_64-darwin.default = let
+            pkgs = import nixpkgs {
+                system = "x86_64-darwin";
+                overlays = [ rust-overlay.overlays.default ];
+            };
+            rust = pkgs.rust-bin.stable."1.98.0".minimal.override {
+                extensions = [ "clippy" "rustfmt" ];
+                targets = [ "wasm32-wasip1" "wasm32-wasip2" "wasm32-unknown-unknown" "wasm32-wasip1-threads" ];
+            };
+            pinned = pkgs.bun.overrideAttrs {
+                version = "1.4.0";
+                src = pkgs.fetchurl {
+                    url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-darwin-x64-baseline.zip";
+                    hash = "sha256-2pufG0unZsbymXEfON+qmGI+HtnECJaqU9uAPFLsH6A=";
+                };
+            };
+        in
+        pkgs.mkShell {
+            packages = [ rust pinned pkgs.nodejs_26 pkgs.deno pkgs.wasmtime pkgs.wasmer pkgs.git ];
+        };
+    };
+}

--- a/nix/dev/run
+++ b/nix/dev/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+case $0 in */*) d=${0%/*} ;; *) d=. ;; esac
+exec nix develop --no-write-lock-file --quiet "$d" --command "$@"


### PR DESCRIPTION
One shell with everything — Node 26, Deno, the pinned Bun, a Rust toolchain
carrying all four WASM targets, Wasmtime, Wasmer and `git`:

```sh
nix develop ./nix/dev          # an interactive shell
./nix/dev/run npm run cov      # or one command in it
```

## It is generated, not hand-written

Two reasons, and both matter more than the convenience:

- **It cannot drift from the jobs**, because it is built from their own
  declarations. `fjs/ci/dev/proof.f.mjs` compares its toolchain against
  `wasm`'s and its override against `bun`'s, so a job changing a runtime
  without the shell following fails there rather than on someone's machine.
- **The drift check covers it.** A hand-written `nix/flake.nix` would have
  escaped it, and verifying one would mean pattern-matching Nix source — which
  root `AGENTS.md` §6 rules out.

The CI jobs deliberately do **not** share it. Each exists to test one runtime,
and a shell with five would let a job pass on whichever `node` reached `PATH`
first.

## A declaration now names systems, not a system — and that is the break

A CI job runs on one runner image and names the one it has. A developer
environment has to work on Linux and macOS, on both architectures — so `NixJob`
carries `systems`, and each gets its own explicit `devShells.<system>.default`:

```nix
devShells.aarch64-linux.default  = let … in pkgs.mkShell { … };
devShells.x86_64-linux.default   = let … in pkgs.mkShell { … };
devShells.aarch64-darwin.default = let … in pkgs.mkShell { … };
devShells.x86_64-darwin.default  = let … in pkgs.mkShell { … };
```

Four systems is four blocks of text and no loop. That is what a generator can
afford and a hand-written flake cannot, and it is why `flake-utils` still has
no place here.

**A pinned package varies with the system twice over**, so `NixPin` now carries
an archive *and* a hash per system rather than one of each:

| system | archive | hash source |
|---|---|---|
| `aarch64-linux` | `bun-linux-aarch64.zip` | downloaded here, matched independently |
| `x86_64-linux` | `bun-linux-x64.zip` | downloaded here, matched independently |
| `aarch64-darwin` | `bun-darwin-aarch64.zip` | downloaded here, matched independently |
| `x86_64-darwin` | `bun-darwin-x64-baseline.zip` | downloaded here; nothing else packages it |

Intel macOS takes a **baseline** build, and that is not a preference: the
snapshot's packaging strips a directory whose name it derives from the system,
`bun-darwin-x64-baseline`, so any other archive would fail to unpack. Reading
that out of `package.nix` first is what stopped this from being a hash mismatch
in CI.

Both types are exported and reachable through `flakeText` and `nixFlakes`, so
an outside declaration has to move — the entry below is marked accordingly, and
every declaration in this repository is updated here.

## Windows

Nix does not run natively there, so those four are all there are. A Windows
developer works through WSL2 or the way this repository has always supported
natively — nothing here requires Nix, and `CONTRIBUTING.md` now says so beside
the tool table this replaces.

## The `dev` job

Without it nothing would ever evaluate this flake: every other one is entered
by the job that owns it, and a developer environment has no such job unless one
is written. It would rot until someone's shell failed to build.

It asserts the five versions the shell hands a developer — Rust excepted, for
the reason `wasm` excepts it: the flake names `1.98.0` in full, so a check
could only restate it. Its last step is a plain `git --version` rather than a
sixth check, and that is structural: a version check reaches the shell inside a
substitution, so a job built only from checks installs Nix and enters nothing,
which `nixCoverage` refuses.

Nothing in it runs `cargo`. These steps are generated for whatever project runs
`fjs ci`, and one without a `Cargo.toml` gets no Rust jobs and must get no Rust
commands — `noRust` catches exactly that, and caught it here.

The job runs on one runner, so **one of the four shells is evaluated for real**;
the other three are generated from the same declaration and pinned as text.
Extending that to macOS is a second job, not a change to this design.

## Verification

`npx tsc` clean; `fjs t` 3611 passed / 0 failed; `npm run cov` 3549 / 0 at 100%
lines, branches and functions; `npm run ci-update` idempotent including modes,
with `nix/dev/run` committed `100755`. Counts are on the head after merging
`main`, which brought #1794.

Every Bun archive above was downloaded and hashed in this session rather than
copied; three of the four matched an independent packaging of the same release,
and the fourth is one nothing else packages.

Changelog:
- **BREAKING CHANGES:** `ci`: a `NixJob` declares `systems`, a non-empty list,
  rather than a single `system`, and a `NixPin` declares an archive and hash per
  system — `sources` — rather than one `url` and `hash`. Both are exported and
  reachable through `flakeText` and `nixFlakes`, so an outside declaration has
  to move; every declaration in this repository is updated here.
- `ci`: `fjs ci` generates `nix/dev`, a development environment carrying every
  runtime the canonical jobs use — Node, Deno, Bun, a Rust toolchain with the
  WASM targets, Wasmtime, Wasmer and `git` — with a shell for each of
  `aarch64-linux`, `x86_64-linux`, `aarch64-darwin` and `x86_64-darwin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSZbnNEKjvNRbPijo6wt61