### PR TITLE
djs: accept ; as a statement terminator, for the DataJS inclusion

### DIFF
--- a/changelog/unreleased/1798.md
+++ b/changelog/unreleased/1798.md
@@ -1,6 +1,7 @@
 - `djs`/`spec`: a statement may end with a `;` as well as with the end of the
   line — the acceptance the DataJS inclusion requires, since DataJS demands a
-  `;` after every statement. A normalized DataJS document now parses verbatim.
-  One terminator per statement: `;;` and a `;` on the line after a statement
-  stay errors. `spec/README.md`'s module-structure rule states the new
-  terminator; the previous rule named `export default 5;` an error.
+  `;` after every statement. A normalized DataJS document now parses verbatim,
+  and whitespace (newlines included) may precede the `;`, matching DataJS's
+  whitespace-insignificance. One terminator per statement: `;;` stays an
+  error. `spec/README.md`'s module-structure rule states the new terminator;
+  the previous rule named `export default 5;` an error.

--- a/changelog/unreleased/1798.md
+++ b/changelog/unreleased/1798.md
@@ -1,0 +1,6 @@
+- `djs`/`spec`: a statement may end with a `;` as well as with the end of the
+  line — the acceptance the DataJS inclusion requires, since DataJS demands a
+  `;` after every statement. A normalized DataJS document now parses verbatim.
+  One terminator per statement: `;;` and a `;` on the line after a statement
+  stay errors. `spec/README.md`'s module-structure rule states the new
+  terminator; the previous rule named `export default 5;` an error.

--- a/fjs/djs/parser/README.md
+++ b/fjs/djs/parser/README.md
@@ -10,14 +10,22 @@ the tokenizer turns code points into tokens, and this turns tokens into an
 ## The grammar is written down
 
 ```
-module ::= t import* const* export t eof
+module ::= t import* const* export lt (';' | ) t eof
 import ::= 'import' t id t 'from' t string   sep
 const  ::= 'const'  t id t '=' t value       sep
 export ::= 'export' t 'default' t value
 value  ::= primitive | id | array | object
 key    ::= id | string | '[' t string t ']'
-sep    ::= (ws | comment)* nl
+sep    ::= lt (';' | nl) t
+lt     ::= (ws | comment)*
 ```
+
+A statement ends at a `;` or at the end of the line — both are terminators,
+which is what lets every DataJS document (where the `;` is required) parse
+here. One terminator per statement: `;;` is not an empty statement but a
+stray token, and a `;` after the newline terminates nothing, because the
+newline already did. The export statement may end with a `;` too, but needs
+no terminator — the end of input closes it.
 
 This replaced a hand-written state machine whose grammar existed nowhere: a
 nine-state value alphabet plus module framing, where the only way to learn what

--- a/fjs/djs/parser/README.md
+++ b/fjs/djs/parser/README.md
@@ -10,22 +10,24 @@ the tokenizer turns code points into tokens, and this turns tokens into an
 ## The grammar is written down
 
 ```
-module ::= t import* const* export lt (';' | ) t eof
+module ::= t import* const* export (t ';' | ) t eof
 import ::= 'import' t id t 'from' t string   sep
 const  ::= 'const'  t id t '=' t value       sep
 export ::= 'export' t 'default' t value
 value  ::= primitive | id | array | object
 key    ::= id | string | '[' t string t ']'
-sep    ::= lt (';' | nl) t
+sep    ::= t ';' t | lt nl t
 lt     ::= (ws | comment)*
 ```
 
-A statement ends at a `;` or at the end of the line — both are terminators,
-which is what lets every DataJS document (where the `;` is required) parse
-here. One terminator per statement: `;;` is not an empty statement but a
-stray token, and a `;` after the newline terminates nothing, because the
-newline already did. The export statement may end with a `;` too, but needs
-no terminator — the end of input closes it.
+A statement ends at a `;`, or, absent one, at the first line break — which is
+what lets every DataJS document (where the `;` is required) parse here. The
+`;` is reached through full trivia, newlines included, because DataJS
+whitespace is insignificant between any two tokens — `export default 1` and
+its `;` may sit on different lines; a newline is a terminator only when no
+`;` follows with just trivia between. One terminator per statement: `;;` is
+not an empty statement but a stray token. The export statement may end with a
+`;` too, but needs no terminator — the end of input closes it.
 
 This replaced a hand-written state machine whose grammar existed nowhere: a
 nine-state value alphabet plus module framing, where the only way to learn what

--- a/fjs/djs/parser/module.f.mjs
+++ b/fjs/djs/parser/module.f.mjs
@@ -194,18 +194,24 @@ const lineTrivia = repeat0Plus({
 })
 
 /**
- * What ends a statement: a `;` or the end of the line. DataJS requires the
- * `;` and FunctionalScript must accept every DataJS document, so both are
- * terminators here — the newline is the one the hand-written parser's `'nl'`
- * state enforced, the semicolon the one `spec/README.md`'s module-structure
- * rule adds for the inclusion. One terminator each: a second `;` is not an
- * empty statement, it is a stray token the next rule rejects.
+ * What ends a statement: a `;`, or, absent one, the first newline. DataJS
+ * requires the `;` and FunctionalScript must accept every DataJS document, so
+ * both are terminators here — the newline is the one the hand-written
+ * parser's `'nl'` state enforced, the semicolon the one `spec/README.md`'s
+ * module-structure rule adds for the inclusion.
+ *
+ * The `;` branch reaches through *full* trivia, newlines included: DataJS
+ * whitespace is insignificant between any two tokens, so `export default 1`
+ * and its `;` may sit on different lines. A newline is a terminator only when
+ * no `;` follows with just trivia between — which the branch order expresses,
+ * the semicolon branch rewinding to the newline one when it finds no `;`.
+ * One terminator each: a second `;` is not an empty statement, it is a stray
+ * token the next rule rejects.
  */
-const statementEnd = () => [
-    lineTrivia,
-    { semicolon: sym(';'), newline: sym('nl') },
-    trivia,
-]
+const statementEnd = {
+    semicolon: () => [trivia, sym(';'), trivia],
+    newline: () => [lineTrivia, sym('nl'), trivia],
+}
 
 /**
  * Every word that may stand where an identifier is expected: a plain `id` and
@@ -321,11 +327,10 @@ const djsModule = () => [
     repeat0Plus([importStatement, statementEnd]),
     repeat0Plus([constStatement, statementEnd]),
     exportStatement,
-    // the export statement may end with a `;` too, but needs no terminator:
-    // the end of input closes it. The `;` must precede any newline — once the
-    // line has ended, the statement has too, and a later `;` is a stray token.
-    lineTrivia,
-    { semicolon: sym(';'), none: [] },
+    // the export statement may end with a `;` too — reached through full
+    // trivia, like every terminator — but needs none: the end of input
+    // closes it.
+    { semicolon: () => [trivia, sym(';')], none: [] },
     trivia,
     eof,
 ]

--- a/fjs/djs/parser/module.f.mjs
+++ b/fjs/djs/parser/module.f.mjs
@@ -91,7 +91,7 @@ const splitEof = tokenList => {
  */
 export const _tokenKindNames = /** @type {const} */ ([
     'true', 'false', 'null', 'undefined',
-    '{', '}', ':', ',', '[', ']', '.', '=',
+    '{', '}', ':', ',', '[', ']', '.', '=', ';',
     'string', 'number', 'error', 'id', 'bigint',
     'ws', 'nl', '//', '/*',
 ])
@@ -183,14 +183,27 @@ const trivia = repeat0Plus({
 })
 
 /**
- * Trivia that stops at a newline, for the one place a newline is not trivia:
- * the statement separator. `import`/`const` statements must be newline-separated
- * — the `'nl'` state in the hand-written parser — so a rule that swallowed
- * newlines as trivia everywhere could not express it.
+ * Trivia that stops at a newline, for the places a newline is not trivia: a
+ * statement ends at one, so a rule that swallowed newlines as trivia everywhere
+ * could not express the terminator.
+ */
+const lineTrivia = repeat0Plus({
+    ws: sym('ws'),
+    lineComment: sym('//'),
+    blockComment: sym('/*'),
+})
+
+/**
+ * What ends a statement: a `;` or the end of the line. DataJS requires the
+ * `;` and FunctionalScript must accept every DataJS document, so both are
+ * terminators here — the newline is the one the hand-written parser's `'nl'`
+ * state enforced, the semicolon the one `spec/README.md`'s module-structure
+ * rule adds for the inclusion. One terminator each: a second `;` is not an
+ * empty statement, it is a stray token the next rule rejects.
  */
 const statementEnd = () => [
-    repeat0Plus({ ws: sym('ws'), lineComment: sym('//'), blockComment: sym('/*') }),
-    sym('nl'),
+    lineTrivia,
+    { semicolon: sym(';'), newline: sym('nl') },
     trivia,
 ]
 
@@ -308,6 +321,11 @@ const djsModule = () => [
     repeat0Plus([importStatement, statementEnd]),
     repeat0Plus([constStatement, statementEnd]),
     exportStatement,
+    // the export statement may end with a `;` too, but needs no terminator:
+    // the end of input closes it. The `;` must precede any newline — once the
+    // line has ended, the statement has too, and a later `;` is a stray token.
+    lineTrivia,
+    { semicolon: sym(';'), none: [] },
     trivia,
     eof,
 ]

--- a/fjs/djs/parser/proof.f.mjs
+++ b/fjs/djs/parser/proof.f.mjs
@@ -113,6 +113,17 @@ export const proof = {
                 ["\n\n export default 1 \n\n", "[[],[1]]"],
                 ["const export = 1\nexport default export", "[[],[1,[\"cref\",0]]]"],
                 ["export default { from: 2, default: 3 }", "[[],[{\"default\":3,\"from\":2}]]"],
+                // `;` is a statement terminator alongside the newline — the
+                // acceptance DataJS's inclusion requires (spec/README.md,
+                // module structure). The last case is a normalized DataJS
+                // document verbatim: one line, `$`-names, every statement
+                // `;`-terminated.
+                ["const a = 1;\nexport default a", "[[],[1,[\"cref\",0]]]"],
+                ["export default 1;", "[[],[1]]"],
+                ["const a = 1;export default a", "[[],[1,[\"cref\",0]]]"],
+                ["import x from \"m\";const a = [x];export default [x,a]", "[[\"m\"],[[\"array\",[[\"aref\",0]]],[\"array\",[[\"aref\",0],[\"cref\",0]]]]]"],
+                ["const a = 1 ; // c\nexport default a ;", "[[],[1,[\"cref\",0]]]"],
+                ["const $0=[1];export default [$0,$0];", "[[],[[\"array\",[1]],[\"array\",[[\"cref\",0],[\"cref\",0]]]]]"],
             ]) {
                 const [tag, value] = parseFromTokens(tokenizeString(source))
                 assert(tag === 'ok', [source, tag])
@@ -138,7 +149,15 @@ export const proof = {
                 ["export x from \"m\"\nexport default 1", "unexpected token", [1, 8]],
                 ["const = 1\nexport default 1", "unexpected token", [1, 7]],
                 ["export default {[1]:2}", "unexpected token", [1, 18]],
-                ["const a = 1;\nexport default a", "unexpected token", [1, 12]],
+                // one terminator per statement: a second `;` is not an empty
+                // statement, it is a stray token the next rule rejects — and a
+                // `;` after the line has ended terminates nothing, because the
+                // newline already did
+                ["export default 1;;", "unexpected token", [1, 18]],
+                ["const a = 1;;\nexport default a", "unexpected token", [1, 13]],
+                ["export default 1\n;", "unexpected token", [2, 1]],
+                [";export default 1", "unexpected token", [1, 1]],
+                ["export default ;", "unexpected token", [1, 16]],
                 ["export default 1\nconst b = 2", "unexpected token", [2, 1]],
                 ["import x from \"m\"", "unexpected end", [1, 18]],
                 ["const a = 1", "unexpected end", [1, 12]],

--- a/fjs/djs/parser/proof.f.mjs
+++ b/fjs/djs/parser/proof.f.mjs
@@ -123,6 +123,11 @@ export const proof = {
                 ["const a = 1;export default a", "[[],[1,[\"cref\",0]]]"],
                 ["import x from \"m\";const a = [x];export default [x,a]", "[[\"m\"],[[\"array\",[[\"aref\",0]]],[\"array\",[[\"aref\",0],[\"cref\",0]]]]]"],
                 ["const a = 1 ; // c\nexport default a ;", "[[],[1,[\"cref\",0]]]"],
+                // whitespace may precede the `;`, newlines included — DataJS
+                // whitespace is insignificant between any two tokens, so the
+                // value and its terminator may sit on different lines
+                ["export default 1\n;", "[[],[1]]"],
+                ["const a = 1\n;\nexport default a", "[[],[1,[\"cref\",0]]]"],
                 ["const $0=[1];export default [$0,$0];", "[[],[[\"array\",[1]],[\"array\",[[\"cref\",0],[\"cref\",0]]]]]"],
             ]) {
                 const [tag, value] = parseFromTokens(tokenizeString(source))
@@ -150,12 +155,11 @@ export const proof = {
                 ["const = 1\nexport default 1", "unexpected token", [1, 7]],
                 ["export default {[1]:2}", "unexpected token", [1, 18]],
                 // one terminator per statement: a second `;` is not an empty
-                // statement, it is a stray token the next rule rejects — and a
-                // `;` after the line has ended terminates nothing, because the
-                // newline already did
+                // statement, it is a stray token the next rule rejects,
+                // however much trivia separates it from the first
                 ["export default 1;;", "unexpected token", [1, 18]],
                 ["const a = 1;;\nexport default a", "unexpected token", [1, 13]],
-                ["export default 1\n;", "unexpected token", [2, 1]],
+                ["const a = 1;\n;export default a", "unexpected token", [2, 1]],
                 [";export default 1", "unexpected token", [1, 1]],
                 ["export default ;", "unexpected token", [1, 16]],
                 ["export default 1\nconst b = 2", "unexpected token", [2, 1]],

--- a/fjs/djs/tokenizer/module.f.mjs
+++ b/fjs/djs/tokenizer/module.f.mjs
@@ -150,7 +150,8 @@ const operator = {
     '(': '(',
     ')': ')',
     ',': ',',
-    ':': ':'
+    ':': ':',
+    ';': ';'
 }
 
 /** @type {() => Rule} */
@@ -626,6 +627,7 @@ const mapDjsToken = input => {
         case ']':
         case '.':
         case '=':
+        case ';':
         case 'true':
         case 'false':
         case 'null':

--- a/fjs/djs/tokenizer/proof.f.mjs
+++ b/fjs/djs/tokenizer/proof.f.mjs
@@ -919,6 +919,12 @@ export const proof = {
     // JS-level token shapes already covered above/elsewhere in this file.
     djsTokenize: [
         () => {
+            // `;` is a token of its own — the statement terminator DataJS
+            // requires and the module grammar accepts — not an error
+            const result = toArray(tokenize(stringToList(';'))(''))
+            assertEq(stringify(result), '[{"metadata":{"column":1,"line":1,"path":""},"token":{"kind":";"}},{"metadata":{"column":2,"line":1,"path":""},"token":{"kind":"eof"}}]')
+        },
+        () => {
             // keywords other than true/false/null/undefined become plain ids
             const result = toArray(tokenize(stringToList('break'))(''))
             assertEq(stringify(result), '[{"metadata":{"column":1,"line":1,"path":""},"token":{"kind":"id","value":"break"}},{"metadata":{"column":6,"line":1,"path":""},"token":{"kind":"eof"}}]')

--- a/fjs/djs/tokenizer/types.ts
+++ b/fjs/djs/tokenizer/types.ts
@@ -21,10 +21,12 @@ import type {
 /**
  * DJS-level token set: a narrower view of JsToken (only true/false/null/undefined survive
  * as bare keywords; every other keyword becomes an id) plus its own punctuator kinds.
+ * `;` is a member because a statement may end with one — see the module-structure
+ * rule in `spec/README.md`, and DataJS, which requires it.
  */
 export type DjsToken = |
   {readonly kind: 'true' | 'false' | 'null' | 'undefined'} |
-  {readonly kind: '{' | '}' | ':' | ',' | '[' | ']' | '.' | '=' } |
+  {readonly kind: '{' | '}' | ':' | ',' | '[' | ']' | '.' | '=' | ';' } |
   StringToken |
   NumberToken |
   ErrorToken |

--- a/fjs/js/tokenizer/module.f.mjs
+++ b/fjs/js/tokenizer/module.f.mjs
@@ -57,6 +57,7 @@ import {
     digitRange,
     digit0,
     colon,
+    semicolon,
     //
     hexDigitValue,
     //
@@ -105,6 +106,7 @@ const rangeSetTerminalForNumber = [
     one(comma),
     one(solidus),
     one(colon),
+    one(semicolon),
     one(lessThanSign),
     one(equalsSign),
     one(greaterThanSign),
@@ -138,6 +140,7 @@ const rangeOpStart = [
     one(fullStop),
     one(solidus),
     one(colon),
+    one(semicolon),
     one(lessThanSign),
     one(equalsSign),
     one(greaterThanSign),
@@ -295,6 +298,7 @@ const operatorEntries = [
     ['/', { kind: '/' }],
     ['/=', { kind: '/=' }],
     [':', { kind: ':' }],
+    [';', { kind: ';' }],
     ['<', { kind: '<' }],
     ['<<', { kind: '<<' }],
     ['<<=', { kind: '<<=' }],

--- a/fjs/js/tokenizer/proof.f.mjs
+++ b/fjs/js/tokenizer/proof.f.mjs
@@ -183,13 +183,11 @@ export const proof = {
             // `;` is an operator token here for the same reason it is one in
             // fjs/djs/tokenizer: the two must agree byte for byte, and the DJS
             // module grammar accepts it as a statement terminator.
-            const result = stringify(tokenizeString(';'))
-            if (result !== '[{"kind":";"},{"kind":"eof"}]') { throw result }
+            assertEq(stringify(tokenizeString(';')), '[{"kind":";"},{"kind":"eof"}]')
         },
         () => {
             // ...and it ends the token before it, a number included
-            const result = stringify(tokenizeString('1;'))
-            if (result !== '[{"kind":"number","value":"1"},{"kind":";"},{"kind":"eof"}]') { throw result }
+            assertEq(stringify(tokenizeString('1;')), '[{"kind":"number","value":"1"},{"kind":";"},{"kind":"eof"}]')
         },
         () => {
             const result = stringify(tokenizeString('00'))

--- a/fjs/js/tokenizer/proof.f.mjs
+++ b/fjs/js/tokenizer/proof.f.mjs
@@ -180,6 +180,18 @@ export const proof = {
             if (result !== '[{"kind":"["},{"kind":"number","value":"0"},{"kind":"]"},{"kind":"eof"}]') { throw result }
         },
         () => {
+            // `;` is an operator token here for the same reason it is one in
+            // fjs/djs/tokenizer: the two must agree byte for byte, and the DJS
+            // module grammar accepts it as a statement terminator.
+            const result = stringify(tokenizeString(';'))
+            if (result !== '[{"kind":";"},{"kind":"eof"}]') { throw result }
+        },
+        () => {
+            // ...and it ends the token before it, a number included
+            const result = stringify(tokenizeString('1;'))
+            if (result !== '[{"kind":"number","value":"1"},{"kind":";"},{"kind":"eof"}]') { throw result }
+        },
+        () => {
             const result = stringify(tokenizeString('00'))
             if (result !== '[{"kind":"error","message":"invalid number"},{"kind":"eof"}]') { throw result }
         },

--- a/fjs/js/tokenizer/types.ts
+++ b/fjs/js/tokenizer/types.ts
@@ -78,6 +78,7 @@ export type IdToken = {
 /** @internal */
 export type _OperatorToken =|
     { readonly kind: '{' | '}' | ':' | ',' | '[' | ']' } |
+    { readonly kind: ';' } |
     { readonly kind: '.' | '=' } |
     { readonly kind: '(' | ')' } |
     { readonly kind: '==' | '!=' | '===' | '!==' | '>' | '>=' | '<' | '<=' } |

--- a/spec/README.md
+++ b/spec/README.md
@@ -26,7 +26,8 @@ implemented now.
 **DataJS**, a much narrower interchange format: JSON with two extensions —
 values may be shared, so a document denotes a DAG rather than a tree, and the
 leaf set gains `undefined`, `bigint`, `NaN` and the infinities — and with a
-`;` **terminating** every statement, `export default` included, no `import`,
+`;` **required** after every statement, `export default` included (the DJS
+described here accepts the `;` but does not require it), no `import`,
 no comments, no identifier keys and no trailing commas. The data subset
 described in *this* document is wider and is what the compiler accepts today.
 The two converge as
@@ -502,9 +503,25 @@ See
 
 ## Module Structure
 
-A module is a sequence of statements. Each statement is terminated by the end
-of the line; **semicolons are not part of the language**, and `export default
-5;` is an error.
+A module is a sequence of statements. Each statement is terminated by a
+semicolon or by the end of the line — `export default 5` and `export default
+5;` denote the same module, and the `;` lets several statements share a line.
+One terminator per statement: `;;` is an error, not an empty statement, and a
+`;` on the line after a statement terminates nothing, because the newline
+already did.
+
+The `;` is not a stylistic allowance. [DataJS](./datajs/README.md) *requires*
+one after every statement, and every DataJS document must be a valid
+FunctionalScript module — `const $0=[1];export default [$0,$0];` is normalized
+DataJS, one line, and it parses here. JavaScript accepts both spellings with
+the same meaning, so the subset law permits both; what FunctionalScript still
+refuses from JavaScript is the empty statement and automatic semicolon
+insertion's harder cases — a statement here ends at a `;` or a newline,
+never at a spot an engine infers. Whether the newline terminator survives
+into the compiler-formatted `.f.js` output language is a stage-5 question of
+[`todo/parser-serializer-restructure.md`](../todo/parser-serializer-restructure.md),
+which argues for requiring the `;` there; this document describes what the
+parser accepts, and it accepts both.
 
 |Statement|Form|
 |---------|----|

--- a/spec/README.md
+++ b/spec/README.md
@@ -504,11 +504,13 @@ See
 ## Module Structure
 
 A module is a sequence of statements. Each statement is terminated by a
-semicolon or by the end of the line — `export default 5` and `export default
-5;` denote the same module, and the `;` lets several statements share a line.
-One terminator per statement: `;;` is an error, not an empty statement, and a
-`;` on the line after a statement terminates nothing, because the newline
-already did.
+semicolon, or, absent one, by the end of the line — `export default 5` and
+`export default 5;` denote the same module, and the `;` lets several
+statements share a line. Whitespace may precede the `;`, newlines included:
+a line break before an explicit `;` is insignificant, exactly as it is in
+DataJS and JavaScript, so the newline only terminates a statement that no
+`;` follows. One terminator per statement: `;;` is an error, not an empty
+statement.
 
 The `;` is not a stylistic allowance. [DataJS](./datajs/README.md) *requires*
 one after every statement, and every DataJS document must be a valid

--- a/spec/datajs/README.md
+++ b/spec/datajs/README.md
@@ -72,10 +72,12 @@ exactly one byte sequence.
 ## Status
 
 **This document specifies a target, not the current implementation.** The
-FunctionalScript compiler in this repository does not accept DataJS today: it
-separates statements by newline, so it rejects the `;` this format requires.
-The `;` is the difference that stops a document parsing at all, but it is not
-the only one. The shipped `fjs/djs` serializer also differs from
+`;` this format requires after every statement is accepted — the compiler's
+parser takes a semicolon or a newline as the statement terminator, so a
+document that stays on the finite leaves parses today; `NaN` and the
+infinities do not parse yet, which is the reader-side gap that remains
+(tracked with the numeric-leaf work in the restructure plan below).
+The shipped `fjs/djs` serializer also differs from
 [normalized form](#normalized-form) in four ways, each of them stage 4–6 work
 rather than a bug:
 
@@ -95,8 +97,8 @@ The work that closes all of it is staged in
 
 Note the two nearby uses of "DJS". [`spec/README.md`](../README.md) uses it for
 the data subset the compiler accepts **today**, which is wider than DataJS:
-it has `import`, comments, identifier keys, trailing commas, and newline
-separation. This document specifies **DataJS**, the narrow interchange format.
+it has `import`, comments, identifier keys, trailing commas, and the newline
+as a second statement terminator alongside the `;`. This document specifies **DataJS**, the narrow interchange format.
 "DJS" survives only as an informal abbreviation of DataJS.
 
 ## Principles

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -378,8 +378,11 @@ combined marker would encode a redundant fact.
   FunctionalScript accepts identifiers that do not start with `$`, so it needs
   the restriction for itself; DataJS no longer relies on inheriting it, its
   `$`-leading names making the collision unreachable.
-- The moved parser's separator rule changes from newline to `';'` (the moved
-  tokenizer's operator vocabulary gains `;`).
+- The moved parser's separator rule narrows to `';'` only. The shipped
+  `fjs/djs` already accepts `;` alongside the newline (its tokenizer's
+  operator vocabulary carries `;`), so stage 5's change is dropping the
+  newline terminator, not introducing the semicolon — the breaking half of
+  the two, which is why it waits for the migration this stage owns.
 - **Whether FunctionalScript takes DataJS's positional whitespace rule is a
   stage-5 decision, and DataJS does not depend on the answer.** DataJS requires
   *more* whitespace than a merging-based rule would, so every DataJS document


### PR DESCRIPTION
`DataJS ⊂ FunctionalScript` is the layering law both specs state, and DataJS **requires** a `;` after every statement — so a valid DataJS document was a lexical error in FunctionalScript, which had no `;` token at all. This makes the semicolon a statement terminator alongside the newline, in the spec and the parser together (spec/README.md documents what the parser accepts today, so the two must move as one).

## Grammar

```
sep ::= lt (';' | nl) t          — was: lt nl t
module ::= … export lt (';' | ) t eof
```

- A statement ends at a `;` or at the end of the line; several statements may share a line.
- The export statement may end with a `;` but needs no terminator — end of input closes it.
- **One terminator per statement**: `;;` is a stray token, not an empty statement, and `export default 1\n;` is rejected — the newline already terminated the statement. A subset may refuse what JavaScript accepts, and empty statements plus ASI's inference stay refused.

The proof that matters: `const $0=[1];export default [$0,$0];` — a **normalized DataJS document verbatim** (one line, `$`-names, every statement `;`-terminated) — parses, and the corpus pins it.

## What was touched

The `;` enters every layer it was missing from:

- `fjs/js/tokenizer/types.ts` — `_OperatorToken` gains `{ kind: ';' }` as its **own union member**, because the members are narrowing groups: adding `;` to an existing group would widen what every `case` over that group returns.
- `fjs/djs/tokenizer` — operator vocabulary gains `';': ';'`; `mapDjsToken` passes it through; `DjsToken` carries the kind.
- `fjs/djs/parser` — alphabet gains `';'` (the derived `_OrdinaryTokenName` follows automatically); `statementEnd` becomes `lineTrivia (';' | nl) trivia`; the module tail takes an optional `;`.
- `spec/README.md` — the module-structure rule replaces "semicolons are not part of the language" with both terminators and the DataJS-inclusion rationale, cross-referencing the stage-5 question (whether the compiler-formatted output language later *requires* the `;`).
- `spec/datajs/README.md` — Status drops the `;` from its gap list; what remains reader-side is `NaN` and the infinities.
- `todo/parser-serializer-restructure.md` — stage 5's separator note rebased: the `;` is already accepted, so that stage owns only the breaking half (dropping the newline), which is the direction the plan's own ratchet argument says must wait for the migration.
- `fjs/djs/parser/README.md` — the written-down grammar updated.

## Rejection matrix (pinned in the corpus)

| input | result |
|---|---|
| `const a = 1;\nexport default a` | ok (was: error at the `;`) |
| `const a = 1;export default a` | ok |
| `export default 1;` | ok (spec previously named this exact form an error) |
| `const $0=[1];export default [$0,$0];` | ok — normalized DataJS |
| `export default 1\n;` | ok — whitespace before the `;` is insignificant |
| `const a = 1\n;\nexport default a` | ok |
| `export default 1;;` | error at the second `;` |
| `const a = 1;;\n…` | error at the second `;` |
| `const a = 1;\n;export default a` | error at the second `;` |
| `;export default 1` | error at the `;` |

## Whitespace before the `;`

A statement ends at a `;`, or, **absent one**, at the first line break. The `;` is reached through full trivia, newlines included, because DataJS whitespace is insignificant between any two tokens — so `export default 1\n;` is a valid DataJS document and parses here. A newline terminates only a statement no `;` follows with just trivia between. (This corrects an earlier revision of this PR, which treated the newline as the terminator unconditionally and so still rejected part of DataJS.)

`npx tsc` clean, `fjs t` 3607/3607, `npm run cov` 100%.

Changelog:

- `djs`/`spec`: a statement may end with a `;` as well as with the end of the
  line — the acceptance the DataJS inclusion requires, since DataJS demands a
  `;` after every statement. A normalized DataJS document now parses verbatim,
  and whitespace (newlines included) may precede the `;`, matching DataJS's
  whitespace-insignificance. One terminator per statement: `;;` stays an
  error. `spec/README.md`'s module-structure rule states the new terminator;
  the previous rule named `export default 5;` an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
