### PR TITLE
emergent_testing: one line per test, opened before it runs

### DIFF
--- a/changelog/unreleased/1790.md
+++ b/changelog/unreleased/1790.md
@@ -2,8 +2,8 @@
   with a `TestId` before a leaf runs, and `summary` receives a `RunState` — the
   totals, the run's failures in order, and what abandoned it — where it took
   `RunTotals`
-- `fjs t`: each test is named before it runs — `name: running` — so a slow test
-  is visible while it runs and a run that dies names the test it died in
+- `fjs t`: each test is named before it runs, so a slow test is visible while
+  it runs and a run that dies names the test it died in
 - `fjs t`: a failing test writes only its pass/fail line as it runs; the value
   it failed with is written with the other failures once the run has ended,
   and survives a run that ends early

--- a/changelog/unreleased/1799.md
+++ b/changelog/unreleased/1799.md
@@ -1,0 +1,2 @@
+- `fjs t`: a test's name and its result are one line, not two — the name is
+  written before the test runs and the line is completed when it lands

--- a/fjs/emergent_testing/module.f.mjs
+++ b/fjs/emergent_testing/module.f.mjs
@@ -609,9 +609,15 @@ const resultOf = (id, { result: [s], duration }) => ({
  */
 export const testResult = (file, path, r) => resultOf(testId(file, path), r)
 
-/** @type {(r: TestResult, color: string, label: string) => string} */
-const fmtResultLine = ({ name, duration }, color, label) =>
-    `${name}: ${color}${label}${reset}, ${timeFormat(duration)}`
+/**
+ * The *end* of a leaf's line. The name is already on the stream — `start` wrote
+ * it before the leaf ran — so this completes that line rather than repeating
+ * it.
+ *
+ * @type {(r: TestResult, color: string, label: string) => string}
+ */
+const fmtResultEnd = ({ duration }, color, label) =>
+    `${color}${label}${reset}, ${timeFormat(duration)}`
 
 /**
  * The terminal/GitHub reporter used by `fjs t`. Output goes through
@@ -629,11 +635,7 @@ export const defaultReporter = options => {
     // decide that here: the failure travels to the program's tail, which ends
     // the run with the reason on `stderr` and exit `1`. That is the same
     // outcome a panic produced, minus the stack trace.
-    /** @type {(w: WriteConsoles) => (s: string) => Effect<Write, void, NotImplemented>} */
-    const line = w => {
-        const x = write(w)
-        return s => x(s + '\n')
-    }
+    const out = write('stdout')
     // **Every record a run produces goes to `stdout`, failures included.** The
     // two streams are not ordered against each other, so splitting the report
     // across them means a reader — or a consumer collecting the log — cannot
@@ -642,7 +644,7 @@ export const defaultReporter = options => {
     // left for a runner *crash*: the tail's channel-failure message, written by
     // `errorExit` after the run is over, where nothing remains to correlate it
     // with.
-    const csiLog = line('stdout')
+    const csiLog = (/** @type {string} */ s) => out(s + '\n')
     const isGitHub = options.env['GITHUB_ACTIONS'] !== undefined
     // What a failure *was* is written once the run has ended, not where it
     // happened: an error's detail — a message, a whole stack — is as many lines
@@ -663,18 +665,22 @@ export const defaultReporter = options => {
                 csiLog(`${fgRed}${t.name}${reset}`),
                 () => csiLog(`${fgRed}${error}${reset}`))
     return {
-        // Two self-contained records per leaf, not one line completed in place.
-        // No *other* leaf runs between a start and its own result under the
-        // sequential traversal, but the leaf itself does, and anything it puts
-        // on this stream — a proof that logs at runtime, a node warning — would
-        // splice into an open line and attach the later `ok` to unrelated
-        // output. Both records name the test, which is what keeps the pair
-        // legible when something lands between them.
-        start: ({ name }) => csiLog(`${name}: running`),
+        // One line per leaf, opened before it runs and closed when it lands:
+        // `name: ` here, `ok, 1.2345 ms` from `result`. A reader watching a
+        // suite sees the name of the test that is running now, and the finished
+        // line says the same thing a single-record reporter would.
+        //
+        // The line is open while the leaf runs, so anything the leaf itself
+        // puts on this stream — a proof that logs, a node warning — splices
+        // into it, and the same happens to a leaf whose run never reports: the
+        // line stays open. Both are visible rather than silent, the name is on
+        // the stream either way, and `summary` closes a line left open by a run
+        // that was abandoned.
+        start: ({ name }) => out(`${name}: `),
         result: (t, _r, throws) =>
             t.status === 'passed'
-                ? csiLog(fmtResultLine(t, fgGreen, 'ok') + (throws ? ' # EXPECTED TO THROW' : ''))
-                : csiLog(fmtResultLine(t, fgRed, 'error')),
+                ? csiLog(fmtResultEnd(t, fgGreen, 'ok') + (throws ? ' # EXPECTED TO THROW' : ''))
+                : csiLog(fmtResultEnd(t, fgRed, 'error')),
         // The details come before the counts, so the numbers a reader is
         // looking for are still the last thing on the screen.
         // A run that was abandoned gets its failures described and no counts:
@@ -682,8 +688,13 @@ export const defaultReporter = options => {
         // finished run and is not one. What ended it is the tail's to report.
         summary: ({ totals: { passed, failed, duration }, failures, aborted }) => {
             const fgFail = failed === 0 ? fgGreen : fgRed
+            // A run that was abandoned left its last leaf's line open — the
+            // leaf was announced and never landed. Close it before anything
+            // else is written, so the detail below starts where a line starts.
             return step(
-                forEachStep(pureOk(failures), detail),
+                step(
+                    aborted === null ? pureOk(undefined) : csiLog(''),
+                    () => forEachStep(pureOk(failures), detail)),
                 () => aborted !== null
                     ? pureOk(undefined)
                     : step(

--- a/fjs/emergent_testing/proof.f.mjs
+++ b/fjs/emergent_testing/proof.f.mjs
@@ -275,8 +275,8 @@ export const defaultReporterOutput = () => {
     assertEq(stderr, '')
     assertEq(
         stdout,
-        'import("./a.proof.f.ts").proof.x(): running\n'
-        + 'import("./a.proof.f.ts").proof.x(): ok, 0.0000 ms\n'
+        'import("./a.proof.f.ts").proof.x(): '
+        + 'ok, 0.0000 ms\n'
         + 'Number of tests: pass: 1, fail: 0, total: 1\n'
         + 'Time: 0.0000 ms\n',
     )
@@ -290,8 +290,8 @@ export const defaultReporterOutputLargeDuration = () => {
     assertEq(exit, 0)
     assertEq(
         stdout,
-        'import("./a.proof.f.ts").proof.x(): running\n'
-        + 'import("./a.proof.f.ts").proof.x(): ok, 1.0000 ms\n'
+        'import("./a.proof.f.ts").proof.x(): '
+        + 'ok, 1.0000 ms\n'
         + 'Number of tests: pass: 1, fail: 0, total: 1\n'
         + 'Time: 1.0000 ms\n',
     )
@@ -317,8 +317,8 @@ export const defaultReporterFailOutput = () => {
     assertEq(stderr, '')
     assertEq(
         stdout,
-        'import("./a.proof.f.ts").proof.bad(): running\n'
-        + 'import("./a.proof.f.ts").proof.bad(): error, 0.0000 ms\n'
+        'import("./a.proof.f.ts").proof.bad(): '
+        + 'error, 0.0000 ms\n'
         + 'import("./a.proof.f.ts").proof.bad()\n'
         + 'oops\n'
         + 'Number of tests: pass: 0, fail: 1, total: 1\n'
@@ -349,12 +349,12 @@ export const defaultReporterFailuresAtEnd = () => {
     assertEq(exit, 1)
     assertEq(
         stdout,
-        'import("./a.proof.f.ts").proof.one(): running\n'
-        + 'import("./a.proof.f.ts").proof.one(): error, 0.0000 ms\n'
-        + 'import("./a.proof.f.ts").proof.two(): running\n'
-        + 'import("./a.proof.f.ts").proof.two(): ok, 0.0000 ms\n'
-        + 'import("./a.proof.f.ts").proof.three(): running\n'
-        + 'import("./a.proof.f.ts").proof.three(): error, 0.0000 ms\n'
+        'import("./a.proof.f.ts").proof.one(): '
+        + 'error, 0.0000 ms\n'
+        + 'import("./a.proof.f.ts").proof.two(): '
+        + 'ok, 0.0000 ms\n'
+        + 'import("./a.proof.f.ts").proof.three(): '
+        + 'error, 0.0000 ms\n'
         + 'import("./a.proof.f.ts").proof.one()\n'
         + 'first\n'
         + 'import("./a.proof.f.ts").proof.three()\n'
@@ -374,10 +374,10 @@ export const defaultReporterFailuresAcrossModules = () => {
     assertEq(exit, 1)
     assertEq(
         stdout,
-        'import("./a.proof.f.ts").proof.x(): running\n'
-        + 'import("./a.proof.f.ts").proof.x(): error, 0.0000 ms\n'
-        + 'import("./b.proof.f.ts").proof.y(): running\n'
-        + 'import("./b.proof.f.ts").proof.y(): error, 0.0000 ms\n'
+        'import("./a.proof.f.ts").proof.x(): '
+        + 'error, 0.0000 ms\n'
+        + 'import("./b.proof.f.ts").proof.y(): '
+        + 'error, 0.0000 ms\n'
         + 'import("./a.proof.f.ts").proof.x()\n'
         + 'from-a\n'
         + 'import("./b.proof.f.ts").proof.y()\n'
@@ -428,9 +428,9 @@ export const defaultReporterOutputDuringATest = () => {
     assertEq(exitCode(code), 0)
     assertEq(
         finalState.stdout,
-        'import("./a.proof.f.ts").proof.x(): running\n'
+        'import("./a.proof.f.ts").proof.x(): '
         + 'a line from inside the test\n'
-        + 'import("./a.proof.f.ts").proof.x(): ok, 0.0000 ms\n'
+        + 'ok, 0.0000 ms\n'
         + 'Number of tests: pass: 1, fail: 0, total: 1\n'
         + 'Time: 0.0000 ms\n',
     )
@@ -469,9 +469,9 @@ export const startSurvivesARunThatDies = () => {
     // there anyway.
     assertEq(
         finalState.stdout,
-        'import("./a.proof.f.ts").proof.x(): running\n'
-        + 'import("./a.proof.f.ts").proof.x(): ok, 0.0000 ms\n'
-        + 'import("./a.proof.f.ts").proof.y(): running\n',
+        'import("./a.proof.f.ts").proof.x(): '
+        + 'ok, 0.0000 ms\n'
+        + 'import("./a.proof.f.ts").proof.y(): \n',
     )
 }
 
@@ -508,9 +508,9 @@ export const failuresSurviveARunThatDies = () => {
     assertEq(exitCode(code), 1)
     assertEq(
         finalState.stdout,
-        'import("./a.proof.f.ts").proof.bad(): running\n'
-        + 'import("./a.proof.f.ts").proof.bad(): error, 0.0000 ms\n'
-        + 'import("./a.proof.f.ts").proof.later(): running\n'
+        'import("./a.proof.f.ts").proof.bad(): '
+        + 'error, 0.0000 ms\n'
+        + 'import("./a.proof.f.ts").proof.later(): \n'
         + 'import("./a.proof.f.ts").proof.bad()\n'
         + 'oops\n',
     )
@@ -543,7 +543,7 @@ export const aLeafSurvivesItsOwnReportFailing = () => {
     assertEq(exitCode(code), 1)
     assertEq(
         finalState.stdout,
-        'import("./a.proof.f.ts").proof.bad(): running\n'
+        'import("./a.proof.f.ts").proof.bad(): \n'
         + 'import("./a.proof.f.ts").proof.bad()\n'
         + 'oops\n',
     )
@@ -578,7 +578,7 @@ export const nothingRunsAfterARunIsAbandoned = () => {
     }
     const [finalState, code] = virtual({ ...emptyState, root })(testAll(dying)(opts))
     assertEq(exitCode(code), 1)
-    assertEq(finalState.stdout, 'import("./a.proof.f.ts").proof.stop(): running\n')
+    assertEq(finalState.stdout, 'import("./a.proof.f.ts").proof.stop(): \n')
 }
 
 // the GitHub reporter emits an `::error` annotation with a percent-encoded

--- a/fjs/emergent_testing/todo/211-reporter-modes.md
+++ b/fjs/emergent_testing/todo/211-reporter-modes.md
@@ -48,6 +48,13 @@ Selected via a CLI flag or env. See
 [test-framework-silent-mode](./test-framework-silent-mode.md), the retired `i21`
 under its current slug.
 
+### TTY and non-TTY are different formats
+
+The mode question this file lists is joined by one the open-line format raised:
+a terminal and a line-oriented consumer want different records for the same
+run. See [TTY and line-oriented consumers](tty-and-line-consumers.md), which
+also notes that CI-ness is a second axis rather than the same one.
+
 ### Dynamic progress reporter
 
 When stdout is a TTY, a reporter that shows a running counter and the currently-executing

--- a/fjs/emergent_testing/todo/211-reporter-modes.md
+++ b/fjs/emergent_testing/todo/211-reporter-modes.md
@@ -17,9 +17,9 @@ exactly what a reader of a test log is asking. `stderr` is for a runner
 run to correlate anything with.
 
 `fjs t` was split across both until functionalscript#1790 — failures and
-GitHub annotations on `stderr`, progress on `stdout` — which also meant its two
-records for one leaf (`running`, then the verdict) landed on different streams
-when the leaf failed. A mode that wants a separate error stream has to answer
+GitHub annotations on `stderr`, progress on `stdout` — which also meant a
+leaf's announcement and its verdict landed on different streams when the leaf
+failed, and they are now two halves of one line. A mode that wants a separate error stream has to answer
 the ordering question first.
 
 ### GitHub Actions reporter

--- a/fjs/emergent_testing/todo/report-before-running.md
+++ b/fjs/emergent_testing/todo/report-before-running.md
@@ -35,18 +35,22 @@ start event is adding a third event kind, not building the stream first.
 Add a `start` (or `begin`) event to the reporter, called with the file and path
 before the leaf is sandboxed, and let each host decide what to do with it:
 
-- **`fjs t`** prints a complete, newline-terminated start record, then a
-  separate result line that names the test again. Not an open line completed
-  in place: no *other leaf* runs between a start and its own result under the
-  sequential runner, but the leaf itself does, and anything it writes to the
-  terminal — a proof that logs at runtime (purity is a convention the sandbox
-  does not enforce; see [hostile-proof-values](hostile-proof-values.md)), a
-  Node warning on stderr — would splice into an open line and attach the
-  later `ok`/`error` to unrelated output, corrupting the log for readers and
-  line-oriented consumers alike. Two self-contained lines per leaf survive
-  that; in the common case the result still directly follows its own start,
-  and the repeated name is what keeps the pair legible when something
-  intervenes.
+- **`fjs t`** opens the leaf's line before it runs — `name: ` with no
+  newline — and closes it when the leaf lands: `ok, 1.2345 ms`. One line per
+  leaf, the same line a reader of a finished log has always seen, with the
+  name arriving early enough to say what is running now.
+
+  The alternative considered and rejected was two complete records, the start
+  naming the test and the result naming it again. It is the more defensive
+  shape: no *other* leaf runs between a start and its own result under the
+  sequential runner, but the leaf itself does, and anything it writes — a
+  proof that logs at runtime (purity is a convention the sandbox does not
+  enforce; see [hostile-proof-values](hostile-proof-values.md)), a Node
+  warning — splices into an open line. That defence costs every reader a
+  doubled log on every run to keep a rare case tidy, which is the wrong trade:
+  the splice is *visible* when it happens, the name is on the stream either
+  way, and a leaf that logs has already told the reader something worth
+  seeing next to its own name.
 - **The browser page** renders a row in a pending state and settles it in
   place — the same list it renders now with one more state per row — **and
   its start handler awaits one macrotask after rendering the pending row**,
@@ -81,8 +85,8 @@ still the argument for settling it in the shared core rather than twice.
   benefits from: one leaf's events no longer interleave with another's, so a
   start is followed by its own result, in both hosts. What sequential does
   *not* buy is an empty gap between them — the leaf itself runs there, and
-  its output can land on the same stream — which is why the terminal format
-  above emits two complete records rather than completing an open line.
+  its output can land on the same stream — which the terminal format above
+  accepts rather than doubling every line to guard against.
 - Whatever is emitted has to be as useful to an automated consumer as to a
   reader — a start with no matching result is precisely the signal a crashed
   run leaves behind, and a controller should be able to read it.
@@ -98,10 +102,13 @@ workflow). `Reporter` grew a `start` event carrying a `TestId` —
 the identity half of `TestResult`, split out so the two events that name a leaf
 name it the same way — called inside the leaf's own chain ahead of `test`, so a
 reporter that cannot announce a leaf ends the run rather than running one it
-failed to announce. `fjs t` writes `name: running`, then the existing result
-line; two complete records, per the terminal format above. Both go to `stdout`,
-with everything else a run says — see [reporter modes](211-reporter-modes.md) —
-which is what makes them readable as a pair.
+failed to announce. Its first form wrote two complete records — `name: running`
+and then the result line naming the test again — and that doubling is what a
+reader met first: every run twice as long, to guard a case that announces
+itself when it happens. The format above replaced it: `start` opens the line
+with `name: `, `result` closes it, and a run that is abandoned leaves its last
+line open with the name on it, which was the point of the event. Everything
+still goes to `stdout` — see [reporter modes](211-reporter-modes.md).
 
 The browser half is **not** done and was deliberately left out of that change:
 the page still renders a row only once a leaf has settled, and the pending row

--- a/fjs/emergent_testing/todo/report-before-running.md
+++ b/fjs/emergent_testing/todo/report-before-running.md
@@ -110,6 +110,12 @@ with `name: `, `result` closes it, and a run that is abandoned leaves its last
 line open with the name on it, which was the point of the event. Everything
 still goes to `stdout` — see [reporter modes](211-reporter-modes.md).
 
+What that format does *not* serve is a consumer that reads lines: `name: ` is
+not a record until the leaf lands, so a pipe or a log collector learns nothing
+early and a killed run's last name can be dropped. That is a second format for
+a second audience rather than a defect in this one — see
+[TTY and line-oriented consumers](tty-and-line-consumers.md).
+
 The browser half is **not** done and was deliberately left out of that change:
 the page still renders a row only once a leaf has settled, and the pending row
 plus its macrotask yield — the part with the real proof problem, since a fake

--- a/fjs/emergent_testing/todo/tty-and-line-consumers.md
+++ b/fjs/emergent_testing/todo/tty-and-line-consumers.md
@@ -1,0 +1,90 @@
+## One line per test serves a terminal, not a line-oriented consumer
+
+**Priority:** P2
+**Status:** open
+
+### Problem
+
+`fjs t` opens a leaf's line before the leaf runs — `name: ` with no newline —
+and closes it when the leaf lands: `ok, 1.2345 ms`. That is the right shape for
+someone watching a terminal, and it is what
+[report a test's name before running it](report-before-running.md) landed.
+
+It is not a record until the newline arrives, and two of the reasons the
+announcement exists are reasons a *consumer* needs it, not a reader:
+
+- **A slow test is invisible again to anything that reads lines.** A pipe, a CI
+  log collector, a controller watching the stream: none of them see `name: `
+  until the leaf finishes and the line is closed, which is exactly when the
+  result would have told them anyway.
+- **A killed run can lose the name.** The unterminated final line is the one
+  fact worth having when a proof takes the process down, and a consumer that
+  discards an incomplete final line drops it.
+
+Neither costs a terminal reader anything — a terminal shows an unterminated
+line the moment it is written — so this is not an argument for going back to
+two complete records per leaf. It is the observation that **the two audiences
+want different output**, and that `fjs t` currently picks one.
+
+### The design question
+
+A TTY and a pipe are not the same destination, and the difference is bigger
+than a newline:
+
+- **On a TTY** the runner may move the cursor. Rewriting a line in place,
+  overwriting a running test's name with its result, a counter that stays on
+  one row, a spinner, colour: the terminal is a canvas, and the announcement is
+  transient rather than part of the log.
+- **On a pipe** every event has to be a complete, self-contained record,
+  written once and never revised, because that is all a line reader can
+  observe. What is transient on a TTY has to be *emitted* here — or framed
+  some other way the consumer can act on immediately.
+
+So the answer is not a flag on the current format. It is that the reporter has
+two modes with different event shapes, and the run's records — which a reader
+of [reporter modes](211-reporter-modes.md) will recognise as one more mode
+question — have to be defined for each rather than derived from the other.
+
+`options.std` already carries `isTTY` per stream, so the *selection* is
+available today and costs nothing; what is missing is the second format and the
+decision about what each mode owes a consumer. Note that a CI log collector is
+a non-TTY destination that also wants the GitHub annotation format, so the two
+axes — TTY-ness and CI-ness — are not the same axis and should not be collapsed
+into one flag.
+
+### Constraints
+
+- **Not two records on a TTY.** Doubling every line to keep a rare splice tidy
+  is the trade [report-before-running](report-before-running.md) reversed
+  deliberately; a non-TTY requirement is not a reason to reinstate it where it
+  was rejected.
+- **One stream.** Whatever each mode emits still goes to `stdout`, for the
+  ordering reason in [reporter modes](211-reporter-modes.md). `stderr` stays
+  for a runner crash.
+- **The browser is a third destination**, not a variant of these two: it
+  renders rows, and its pending-row half of
+  [report-before-running](report-before-running.md) is still open. A mode
+  system that only distinguishes TTY from pipe should not make that harder to
+  add.
+- **Whatever a mode emits has to be provable through `effects/node/virtual`**,
+  which is neither a TTY nor a pipe but answers `isTTY` either way. A format
+  that can only be observed by looking at a real terminal is a format with no
+  proof.
+
+### Tasks
+
+- [ ] Decide what a non-TTY run emits per leaf, and whether the announcement is
+      a record of its own there.
+- [ ] Decide what a TTY run may do with the cursor, and whether the current
+      open-line format is already that answer or a step towards it.
+- [ ] Select on `options.std['stdout'].isTTY`, keeping CI-ness a separate axis.
+- [ ] Prove both modes through the virtual runner.
+
+### Related
+
+- [report a test's name before running it](report-before-running.md) — where
+  the open-line format came from, and the trade it made
+- [reporter modes](211-reporter-modes.md) — the mode system this belongs in,
+  including the dynamic-progress reporter a TTY mode overlaps with
+- [test framework silent mode](test-framework-silent-mode.md) — brief progress
+  output, the other consumer of a TTY-aware format


### PR DESCRIPTION
`fjs t` reported every leaf twice: `name: running` on its own line when the
leaf was announced, then `name: ok, 1.2345 ms` when it landed. A run's output
doubled, and the name a reader is scanning for appeared twice per test.

`start` now opens the line — `name: ` with no newline — and `result` closes it
with `ok, 1.2345 ms`. One line per leaf, the same line a reader of a finished
log has always seen, with the name arriving early enough to say what is running
*now*:

```
import("./fjs/website/proof.f.mjs").proof.run(): ok, 4.8674 ms
import("./todo/proof.f.mjs").proof.ownProperty.null.throw(): ok, 0.0607 ms # EXPECTED TO THROW
```

## Why the two records existed, and why they go

They were the defensive shape. A leaf's line is open while the leaf runs, and
the leaf can write to the same stream — a proof that logs at runtime (purity is
a convention the sandbox does not enforce), a Node warning — which splices into
the open line and attaches the later `ok` to unrelated output.

That defence costs every reader a doubled log on every run to keep a rare case
tidy, which is the wrong trade. The splice is *visible* when it happens, the
name is on the stream either way, and a leaf that logs has already told the
reader something worth seeing next to its own name. `todo/report-before-running.md`
now records the trade instead of the old rationale.

## What the change is

- `fmtResultLine` → `fmtResultEnd`: it no longer carries the name, only
  `color label, duration`.
- `start` writes through the raw `stdout` writer rather than the line writer.
- `summary` closes a line left open by a run that was **abandoned**. When a run
  dies mid-leaf, `result` never comes, so the line stays open with the dying
  test's name on it — which is the point of the start event — but the deferred
  failure details would otherwise begin on that same line. One newline when
  `aborted !== null`, so a detail still starts where a line starts.
- The affected proofs assert the new stream exactly, the splice case included.
- The `name: running` example is dropped from the unreleased `1790.md` entry:
  that format never shipped.

## Verification

`npx tsc` clean · `fjs t` 3601/3601 · `node --test` 3539/3539 · coverage 100% ·
`npm run ci-update` no diff.

## Changelog

- `fjs t`: a test's name and its result are one line, not two — the name is
  written before the test runs and the line is completed when it lands


---
_Generated by [Claude Code](https://claude.ai/code/session_016PyLwDNkPQM1uD1Tg5ApBg)_