### PR TITLE
effects: fan-out joins the operations more than one host implements

### DIFF
--- a/changelog/unreleased/1815.md
+++ b/changelog/unreleased/1815.md
@@ -1,0 +1,4 @@
+- `effects`: `All`, `all`, `allOk` and `both` moved from `effects/node` to
+  `effects/common`, where operations with more than one implementer live — a
+  browser page fans out its module loads. `effects/node` re-exports all four,
+  so importing them through it is unchanged

--- a/changelog/unreleased/1815.md
+++ b/changelog/unreleased/1815.md
@@ -1,4 +1,4 @@
 - `effects`: `All`, `all`, `allOk` and `both` moved from `effects/node` to
-  `effects/common`, where operations with more than one implementer live — a
-  browser page fans out its module loads. `effects/node` re-exports all four,
+  `effects/common`, where host-neutral operations live — fan-out is an
+  interpreter's job rather than one host's. `effects/node` re-exports all four,
   so importing them through it is unchanged

--- a/fjs/effects/common/module.f.mjs
+++ b/fjs/effects/common/module.f.mjs
@@ -4,12 +4,14 @@
  *
  * @module
  *
- * @import { Effect, Func, NotImplemented } from '../types.ts'
+ * @import { Effect, Func, NotImplemented, Operation } from '../types.ts'
+ * @import { Result } from '../../types/result/types.ts'
  * @import { Console, Read, ReadConsoles, Write, WriteConsoles, _UtfList } from './types.ts'
- * @import { Catch, Import, Sandbox, SandboxResult } from './types.ts'
+ * @import { All, Catch, Import, Sandbox, SandboxResult } from './types.ts'
  */
 
-import { do_, pureOk, resultMapStep, step } from '../module.f.mjs'
+import { do_, pure, pureOk, resultMapStep, step } from '../module.f.mjs'
+import { ok as resultOk, unwrap } from '../../types/result/module.f.mjs'
 import { utf8 } from '../../text/module.f.mjs'
 import { toCodePointList } from '../../text/utf8/module.f.mjs'
 import { codePointListToString } from '../../text/utf16/module.f.mjs'
@@ -40,6 +42,70 @@ export const sandbox = do_('sandbox')
  * @type {Func<Catch>}
  */
 export const catch_ = do_('catch')
+
+// all
+
+/**
+ * To run the operation `O` should be known by the runner/engine.
+ * This is the reason why we merge `O` with `All` in the resulting effect.
+ */
+export const all =
+    // `Func` cannot express a variadic generic operation, so the declared type
+    // is written out here and `do_`'s is set aside.
+    /** @type {<O extends Operation, T, E>(...a: readonly Effect<O, T, E>[]) => Effect<O | All, readonly Result<T, E>[], NotImplemented>} */
+    (/** @type {unknown} */ (do_('all')))
+
+/**
+ * Collapses a list of results into a result of the list, keeping the **first**
+ * error in list order and discarding the later ones.
+ *
+ * Keeping one is what makes this a `Result` rather than a report: the callers
+ * that need it are chains, and a chain has one error channel. A site that wants
+ * every failure wants a different return type and should not reach for this.
+ *
+ * @type {<T, E>(list: readonly Result<T, E>[]) => Result<readonly T[], E>}
+ */
+const okList = list => {
+    for (const r of list) {
+        if (r[0] === 'error') { return r }
+    }
+    return resultOk(list.map(unwrap))
+}
+
+/**
+ * {@link all} in the `ok` channel: collects the values when every effect
+ * succeeded, and answers with the first failure otherwise.
+ *
+ * `all` alone cannot serve a fallible chain. Its envelope is the runner's
+ * (`OpResult`, saying whether the *operation* could be dispatched), so handing
+ * it `Effect`s nests one `Result` inside another and the caller receives
+ * `readonly Result<T, E>[]`. That has to be collapsed before the chain can
+ * `step` again, and a continuation that forgets to is the value-discarding
+ * hazard this migration exists to remove — one level in, where it is harder to
+ * see.
+ *
+ * **Every effect still runs.** The short-circuit is in the *result*, not in the
+ * execution: `all` performs them concurrently and this reads the answers once
+ * they are all in, so a failure does not cancel its siblings the way it stops
+ * the sequential `forEachStep` in `../module.f.mjs`. The error channel
+ * unions the runner's
+ * `NotImplemented` with the effects' own `E` for the same reason every other
+ * step does — either can be what went wrong.
+ *
+ * @type {<O extends Operation, T, E>(...a: readonly Effect<O, T, E>[]) => Effect<O | All, readonly T[], NotImplemented | E>}
+ */
+export const allOk = (...a) =>
+    step(all(...a), rs => pure(okList(rs)))
+
+/**
+ * @template {Operation} O0
+ * @template T0
+ * @template E0
+ * @param {Effect<O0, T0, E0>} a
+ * @returns {<O1 extends Operation, T1, E1>(b: Effect<O1, T1, E1>) => Effect<O0 | O1 | All, readonly[Result<T0, E0>, Result<T1, E1>], NotImplemented>}
+ */
+export const both = a => b =>
+    /** @type {any} */ (all)(a, b)
 
 // import
 

--- a/fjs/effects/common/module.f.mjs
+++ b/fjs/effects/common/module.f.mjs
@@ -1,6 +1,7 @@
 /**
- * Operations more than one host implements. See [`./types.ts`](./types.ts) for
- * why they are not in `../node`.
+ * Operations that are nobody's host in particular. See
+ * [`./types.ts`](./types.ts) for which of them a second host implements today
+ * and which are here because nothing about them is Node's.
  *
  * @module
  *

--- a/fjs/effects/common/proof.f.mjs
+++ b/fjs/effects/common/proof.f.mjs
@@ -1,7 +1,9 @@
 /**
  * @import { RunInstance } from '../mock/types.ts'
- * @import { Catch, Import, Module, Read, Sandbox, Write } from './types.ts'
+ * @import { All, Catch, Import, Module, Read, Sandbox, Write } from './types.ts'
  * @import { Vec } from '../../types/bit_vec/types.ts'
+ * @import { Effect, NotImplemented } from '../types.ts'
+ * @import { Result } from '../../types/result/types.ts'
  */
 
 import { assert, assertEq } from '../../asserts/module.f.mjs'
@@ -12,7 +14,10 @@ import { msb, u8List } from '../../types/bit_vec/module.f.mjs'
 import { toCodePointList } from '../../text/utf8/module.f.mjs'
 import { codePointListToString } from '../../text/utf16/module.f.mjs'
 import { toArray } from '../../types/list/module.f.mjs'
-import { catch_, error, errorExit, import_, log, read, readLine, sandbox, write } from './module.f.mjs'
+import {
+    all, allOk, both, catch_, error, errorExit, import_, log, read, readLine, sandbox, write,
+} from './module.f.mjs'
+import { pureError, pureOk } from '../module.f.mjs'
 
 /**
  * A runner claiming both operations by the names they are declared under.
@@ -51,6 +56,22 @@ const runner = mockRun(/** @type {Parameters<typeof mockRun<Catch | Sandbox, nul
 const loader = mockRun(/** @type {Parameters<typeof mockRun<Import, null>>[0]} */ ({
     import: (/** @type {string} */ path) => (/** @type {null} */ s) =>
         [s, ok(/** @type {Module} */ ({ proof: path }))],
+}))
+
+/**
+ * A runner that answers `all` by running each effect through *itself*.
+ *
+ * Sequentially, which is not a compromise: `all` says the effects may run at
+ * once, not that they must, and a host without concurrency answering them in
+ * turn is a correct interpretation. What the operation fixes is the *shape* of
+ * the answer — one `Result` per effect, in argument order — and that is what
+ * these proofs are about. Whether a real host overlaps them is its own business
+ * and is not observable here.
+ *
+ * @type {RunInstance<All, null>} */
+const fanOut = mockRun(/** @type {Parameters<typeof mockRun<All, null>>[0]} */ ({
+    all: (/** @type {readonly Effect<never, unknown, unknown>[]} */ ...effects) =>
+        (/** @type {null} */ s) => [s, ok(effects.map(e => fanOut(s)(e)[1]))],
 }))
 
 /**
@@ -108,6 +129,57 @@ export const proof = {
         const [, r] = loader(null)(import_('a.f.mjs'))
         assert(r[0] === 'ok', r)
         assertEq(r[1].proof, 'a.f.mjs')
+    },
+    all: {
+        // The nesting is the operation's point: the outer `Result` is the
+        // runner's answer about `all` itself, and each inner one is what that
+        // effect answered. A caller sees both failures separately.
+        answersEachResultWhole: () => {
+            const [, r] = fanOut(null)(all(pureOk(1), pureError('no'), pureOk(3)))
+            assert(r[0] === 'ok', r)
+            assertEq(r[1].length, 3)
+            assertEq(r[1][0][1], 1)
+            assert(r[1][1][0] === 'error', r[1][1])
+            assertEq(r[1][1][1], 'no')
+            assertEq(r[1][2][1], 3)
+        },
+        // Nothing to run is not a failure, and the empty list is the answer a
+        // fold over no effects should give.
+        empty: () => {
+            const empty = /** @type {Effect<All, readonly Result<never, never>[], NotImplemented>} */ (
+                all())
+            const [, r] = fanOut(null)(empty)
+            assert(r[0] === 'ok', r)
+            assertEq(r[1].length, 0)
+        },
+    },
+    allOk: {
+        // The collapse a fallible chain wants: one `Result` rather than two
+        // levels of them, so the chain can `step` again.
+        collectsWhenEveryEffectSucceeded: () => {
+            const [, r] = fanOut(null)(allOk(pureOk(1), pureOk(2)))
+            assert(r[0] === 'ok', r)
+            assertEq(r[1][0], 1)
+            assertEq(r[1][1], 2)
+        },
+        // **The first error in list order, not the last and not all of them.**
+        // A chain has one error channel, so keeping one is what makes this a
+        // `Result` rather than a report — and *which* one is a decision worth
+        // pinning, since two failures make either choice look arbitrary from
+        // one example.
+        keepsTheFirstError: () => {
+            const [, r] = fanOut(null)(allOk(pureOk(1), pureError('first'), pureError('second')))
+            assert(r[0] === 'error', r)
+            assertEq(r[1], 'first')
+        },
+    },
+    // `both` is `all` at arity two, with the pair typed as a pair.
+    both: () => {
+        const [, r] = fanOut(null)(both(pureOk('a'))(pureError('b')))
+        assert(r[0] === 'ok', r)
+        assertEq(r[1][0][1], 'a')
+        assert(r[1][1][0] === 'error', r[1][1])
+        assertEq(r[1][1][1], 'b')
     },
     write: {
         // `log` and `error` differ in the stream and in nothing else, and each

--- a/fjs/effects/common/types.ts
+++ b/fjs/effects/common/types.ts
@@ -7,13 +7,22 @@
  * FunctionalScript logic without importing a module named after a different
  * host.
  *
- * Most are here because a second host implements them: a browser interpreter
- * sandboxes, catches, writes and loads modules. {@link All} is here on the
- * layering argument alone — fan-out is an interpreter's job whoever the host
- * is — and has one implementer today. Both are reasons to be in this module;
- * they are not the same reason, and the difference is worth keeping visible,
- * because "everything here has two implementers" is the sort of tidy summary
- * that quietly stops being true.
+ * **Two implementers today**, and it is worth naming which rather than
+ * summarising: {@link Sandbox} and {@link Catch}, both dispatched by the
+ * browser page's interpreter as well as by Node's.
+ *
+ * **Everything else here has one**, and is here on the layering argument
+ * instead — nothing about it is Node's. {@link All} is fan-out, which is an
+ * interpreter's job whoever the host is. {@link Import} resolves a path
+ * against whatever a host resolves paths against, and the browser supplies its
+ * `import()` as an argument today rather than dispatching it, which is the
+ * measurement trap below. {@link Write} and {@link Read} are byte streams named
+ * by a string; a page renders rows through an operation of its own instead,
+ * which is a *different* operation and not an implementation of these.
+ *
+ * Both are good reasons to be in this module. They are not the same reason, and
+ * the count is written out because "everything here has two implementers" is
+ * the sort of tidy summary that is easier to keep than to keep true.
  *
  * `effects/node` re-exports them all, so a node-side caller keeps one import
  * and signatures keep reading as one vocabulary. That re-export is not a shim:

--- a/fjs/effects/common/types.ts
+++ b/fjs/effects/common/types.ts
@@ -1,11 +1,19 @@
 /**
- * Operations more than one host implements.
+ * Operations that are nobody's host in particular.
  *
  * `fjs/effects/node` declared these because Node was the only host that ran
  * them. It is not the criterion — an operation belongs to the layer of whoever
- * *implements* it, and a browser interpreter implements every one of them.
- * Declaring them here is what lets a host talk to the shared FunctionalScript
- * logic without importing a module named after a different host.
+ * *implements* it. Declaring them here is what lets a host talk to the shared
+ * FunctionalScript logic without importing a module named after a different
+ * host.
+ *
+ * Most are here because a second host implements them: a browser interpreter
+ * sandboxes, catches, writes and loads modules. {@link All} is here on the
+ * layering argument alone — fan-out is an interpreter's job whoever the host
+ * is — and has one implementer today. Both are reasons to be in this module;
+ * they are not the same reason, and the difference is worth keeping visible,
+ * because "everything here has two implementers" is the sort of tidy summary
+ * that quietly stops being true.
  *
  * `effects/node` re-exports them all, so a node-side caller keeps one import
  * and signatures keep reading as one vocabulary. That re-export is not a shim:
@@ -110,9 +118,10 @@ export type Catch = readonly['catch', <T>(f: () => T) => OpResult<Result<T, unkn
  * **Fan-out is an interpreter's job, not a walk's.** A host that has
  * concurrency implements this and keeps it; a host that does not answers the
  * effects in turn, and the shared logic above reads the same either way. That
- * is why it sits here rather than in a module named after one host: a browser
- * page fans out its module loads, and a `Promise.all` is as much an
- * implementation of this operation as Node's is.
+ * is why it sits here rather than in a module named after one host — and it is
+ * the whole reason: unlike its neighbours here, this operation has one
+ * implementer today, the Node runners and the registration path they serve.
+ * Nothing in a browser dispatches it yet.
  */
 export type All = ['all', <T, E>(...effects: Effect<never, T, E>[]) => OpResult<readonly Result<T, E>[]>]
 

--- a/fjs/effects/common/types.ts
+++ b/fjs/effects/common/types.ts
@@ -97,6 +97,25 @@ export type Sandbox = readonly['sandbox', <T>(f: () => T) => OpResult<SandboxRes
  */
 export type Catch = readonly['catch', <T>(f: () => T) => OpResult<Result<T, unknown>>]
 
+// all
+
+/**
+ * Runs its effects concurrently and answers each one's whole `Result`.
+ *
+ * The nesting is deliberate and belongs to the runner: this envelope says
+ * whether `all` itself could be dispatched, and each inner `Result` is what
+ * that effect answered. `allOk` (`./module.f.mjs`) is the collapse a fallible
+ * chain wants.
+ *
+ * **Fan-out is an interpreter's job, not a walk's.** A host that has
+ * concurrency implements this and keeps it; a host that does not answers the
+ * effects in turn, and the shared logic above reads the same either way. That
+ * is why it sits here rather than in a module named after one host: a browser
+ * page fans out its module loads, and a `Promise.all` is as much an
+ * implementation of this operation as Node's is.
+ */
+export type All = ['all', <T, E>(...effects: Effect<never, T, E>[]) => OpResult<readonly Result<T, E>[]>]
+
 // import
 
 /** A loaded module: its exported names, as values. */

--- a/fjs/effects/common/types.ts
+++ b/fjs/effects/common/types.ts
@@ -7,18 +7,22 @@
  * FunctionalScript logic without importing a module named after a different
  * host.
  *
- * **Two implementers today**, and it is worth naming which rather than
- * summarising: {@link Sandbox} and {@link Catch}, both dispatched by the
- * browser page's interpreter as well as by Node's.
+ * **Counted by capability, which is the measure the trap below argues for,
+ * three have two implementers.** {@link Sandbox} and {@link Catch} are
+ * dispatched by the browser page's interpreter as well as by Node's.
+ * {@link Import} is supplied by the page rather than dispatched — it hands its
+ * own `import()` in as an argument — and an injected function is an operation
+ * nobody has named, so it counts. The line between the two cases is whether the
+ * host supplies the capability *to shared logic*: the page's `Promise.all`
+ * over its module loads is not injected anywhere, so it is that file's private
+ * business rather than an implementation of {@link All}.
  *
- * **Everything else here has one**, and is here on the layering argument
- * instead — nothing about it is Node's. {@link All} is fan-out, which is an
- * interpreter's job whoever the host is. {@link Import} resolves a path
- * against whatever a host resolves paths against, and the browser supplies its
- * `import()` as an argument today rather than dispatching it, which is the
- * measurement trap below. {@link Write} and {@link Read} are byte streams named
- * by a string; a page renders rows through an operation of its own instead,
- * which is a *different* operation and not an implementation of these.
+ * **{@link All}, {@link Write} and {@link Read} have one implementer**, and are
+ * here on the layering argument instead — nothing about them is Node's. Fan-out
+ * belongs to whichever interpreter has concurrency; a byte stream named by a
+ * string is not a filesystem fact. A page renders rows through an operation of
+ * its own, which is a *different* operation rather than an implementation of
+ * `Write`.
  *
  * Both are good reasons to be in this module. They are not the same reason, and
  * the count is written out because "everything here has two implementers" is

--- a/fjs/effects/node/module.f.mjs
+++ b/fjs/effects/node/module.f.mjs
@@ -10,7 +10,8 @@
  * `all`/`allOk`/`both` fan-out are re-exported from
  * [`../common`](../common/module.f.mjs) rather than declared here: an operation
  * belongs to the layer of whoever implements it, and none of these is Node's by
- * nature. A browser interpreter dispatches `sandbox` and `catch` today.
+ * nature. A browser dispatches `sandbox` and `catch` today, and supplies its
+ * own `import`.
  *
  * See `./types.ts` for the type-level API.
  *
@@ -55,8 +56,9 @@ export { ioError, toIoError }
 // `../common`'s, kept visible here because `NodeOp` unions them and dozens of
 // call sites name them through this module — a live coupling, not a shim. An
 // operation belongs to the layer of whoever implements it: a browser
-// interpreter dispatches `sandbox` and `catch`, and the rest are there because
-// nothing about them is Node's. `../common/types.ts` keeps the count.
+// dispatches `sandbox` and `catch` and supplies its own `import`, and the rest
+// are there because nothing about them is Node's. `../common/types.ts` keeps
+// the count, and says how it counts.
 export { all, allOk, both, catch_, error, errorExit, import_, log, read, readLine, sandbox, write }
 
 /**

--- a/fjs/effects/node/module.f.mjs
+++ b/fjs/effects/node/module.f.mjs
@@ -2,14 +2,15 @@
  * Node.js effect operations: filesystem (`mkdir`, `readFile`, `readdir`,
  * `writeFile`, `rm`, `access`, plus the `readUtf8File`/`writeUtf8File` text
  * helpers), networking (`fetch`, `createServer`, `listen`),
- * subprocess `exec`, `now`, `forever`, and `all`/`both` parallelism;
- * defines the `NodeOp`/`NodeProgram` types used by the Node runner.
+ * subprocess `exec`, `now` and `forever`; defines the `NodeOp`/`NodeProgram`
+ * types used by the Node runner.
  *
  * The console family — `write`, `log`, `error`, `errorExit`, `read`,
- * `readLine` — and `sandbox`, `catch_` and `import_` are re-exported from
+ * `readLine` — together with `sandbox`, `catch_`, `import_` and the
+ * `all`/`allOk`/`both` fan-out are re-exported from
  * [`../common`](../common/module.f.mjs) rather than declared here: an operation
  * belongs to the layer of whoever implements it, and a browser sandboxes,
- * catches, writes and loads modules.
+ * catches, writes, loads modules and runs things at once.
  *
  * See `./types.ts` for the type-level API.
  *
@@ -19,7 +20,7 @@
  * @import { Result } from '../../types/result/types.ts'
  * @import { Commands, CommandSet, Effect, Func, NotImplemented, Operation } from '../types.ts'
  * @import { List } from '../list/types.ts'
- * @import { All, Access, Await, Catch, Console, CreateExclusive, CreateServer, Dirent, Engine, Env, Exec, ExecResult, Fetch, FileStat, Forever, Fs, Headers, Http, IncomingMessage, IoChannel, IoError, IoErrorInfo, Listen, MakeDirectoryOptions, Mkdir, Now, NodeOp, NodeProgramOptions, RandomInt, Read, ReadBytes, ReadConsoles, ReadFile, Readdir, ReaddirOptions, RequestListener, Rename, Rm, Sandbox, SandboxResult, Server, ServerResponse, Stat, Test, TestContext, TestFn, Write, WriteBytes, WriteConsoles, WriteFile, _UtfList, _WriteLoop } from './types.ts'
+ * @import { Access, Await, Catch, Console, CreateExclusive, CreateServer, Dirent, Engine, Env, Exec, ExecResult, Fetch, FileStat, Forever, Fs, Headers, Http, IncomingMessage, IoChannel, IoError, IoErrorInfo, Listen, MakeDirectoryOptions, Mkdir, Now, NodeOp, NodeProgramOptions, RandomInt, Read, ReadBytes, ReadConsoles, ReadFile, Readdir, ReaddirOptions, RequestListener, Rename, Rm, Sandbox, SandboxResult, Server, ServerResponse, Stat, Test, TestContext, TestFn, Write, WriteBytes, WriteConsoles, WriteFile, _UtfList, _WriteLoop } from './types.ts'
  */
 
 import { utf8, utf8ToString } from '../../text/module.f.mjs'
@@ -27,10 +28,9 @@ import { toCodePointList } from '../../text/utf8/module.f.mjs'
 import { codePointListToString } from '../../text/utf16/module.f.mjs'
 import { reverse } from '../../types/list/module.f.mjs'
 import { length } from '../../types/bit_vec/module.f.mjs'
-import { error as resultError, ok as resultOk, unwrap } from '../../types/result/module.f.mjs'
-import { do_, ioError, pure, toIoError } from '../module.f.mjs'
+import { do_, ioError, toIoError } from '../module.f.mjs'
 import {
-    catch_, error, errorExit, import_, log, read, readLine, sandbox, write,
+    all, allOk, both, catch_, error, errorExit, import_, log, read, readLine, sandbox, write,
 } from '../common/module.f.mjs'
 import {
     mapStep as ioMapStep, pureError, pureOk, resultMapStep, resultStep, step as ioStep,
@@ -56,8 +56,9 @@ export { ioError, toIoError }
 // call sites name them through this module — a live coupling, not a shim. An
 // operation belongs to the layer of whoever implements it, and every one of
 // these has, or will have, a second implementer: a browser sandboxes, catches,
-// writes, and loads modules through an `import()` of its own.
-export { catch_, error, errorExit, import_, log, read, readLine, sandbox, write }
+// writes, loads modules through an `import()` of its own, and fans out with a
+// `Promise.all`.
+export { all, allOk, both, catch_, error, errorExit, import_, log, read, readLine, sandbox, write }
 
 /**
  * The host a {@link Listen} refuses.
@@ -160,69 +161,8 @@ const nodeCommandSet = {
  */
 export const nodeCommands = /** @type {Commands<NodeOp>} */ (Object.keys(nodeCommandSet))
 
-// all
-
-/**
- * To run the operation `O` should be known by the runner/engine.
- * This is the reason why we merge `O` with `All` in the resulting effect.
- */
-export const all =
-    // `Func` cannot express a variadic generic operation, so the declared type
-    // is written out here and `do_`'s is set aside.
-    /** @type {<O extends Operation, T, E>(...a: readonly Effect<O, T, E>[]) => Effect<O | All, readonly Result<T, E>[], NotImplemented>} */
-    (/** @type {unknown} */ (do_('all')))
-
-/**
- * Collapses a list of results into a result of the list, keeping the **first**
- * error in list order and discarding the later ones.
- *
- * Keeping one is what makes this a `Result` rather than a report: the callers
- * that need it are chains, and a chain has one error channel. A site that wants
- * every failure wants a different return type and should not reach for this.
- *
- * @type {<T, E>(list: readonly Result<T, E>[]) => Result<readonly T[], E>}
- */
-const okList = list => {
-    for (const r of list) {
-        if (r[0] === 'error') { return r }
-    }
-    return resultOk(list.map(unwrap))
-}
-
-/**
- * {@link all} in the `ok` channel: collects the values when every effect
- * succeeded, and answers with the first failure otherwise.
- *
- * `all` alone cannot serve a fallible chain. Its envelope is the runner's
- * (`OpResult`, saying whether the *operation* could be dispatched), so handing
- * it `Effect`s nests one `Result` inside another and the caller receives
- * `readonly Result<T, E>[]`. That has to be collapsed before the chain can
- * `step` again, and a continuation that forgets to is the value-discarding
- * hazard this migration exists to remove — one level in, where it is harder to
- * see.
- *
- * **Every effect still runs.** The short-circuit is in the *result*, not in the
- * execution: `all` performs them concurrently and this reads the answers once
- * they are all in, so a failure does not cancel its siblings the way it stops
- * the sequential `forEachStep` in `./module.f.mjs`. The error channel
- * unions the runner's
- * `NotImplemented` with the effects' own `E` for the same reason every other
- * step does — either can be what went wrong.
- *
- * @type {<O extends Operation, T, E>(...a: readonly Effect<O, T, E>[]) => Effect<O | All, readonly T[], NotImplemented | E>}
- */
-export const allOk = (...a) =>
-    ioStep(all(...a), rs => pure(okList(rs)))
-
-/**
- * @template {Operation} O0
- * @template T0
- * @template E0
- * @param {Effect<O0, T0, E0>} a
- * @returns {<O1 extends Operation, T1, E1>(b: Effect<O1, T1, E1>) => Effect<O0 | O1 | All, readonly[Result<T0, E0>, Result<T1, E1>], NotImplemented>}
- */
-export const both = a => b =>
-    /** @type {any} */ (all)(a, b)
+// `all`, `allOk` and `both` are `../common`'s, re-exported above: fan-out is an
+// interpreter's job, and a browser page fans out its module loads.
 
 // fetch
 

--- a/fjs/effects/node/module.f.mjs
+++ b/fjs/effects/node/module.f.mjs
@@ -9,8 +9,8 @@
  * `readLine` — together with `sandbox`, `catch_`, `import_` and the
  * `all`/`allOk`/`both` fan-out are re-exported from
  * [`../common`](../common/module.f.mjs) rather than declared here: an operation
- * belongs to the layer of whoever implements it, and a browser sandboxes,
- * catches, writes, loads modules and runs things at once.
+ * belongs to the layer of whoever implements it, and none of these is Node's by
+ * nature. A browser interpreter dispatches `sandbox` and `catch` today.
  *
  * See `./types.ts` for the type-level API.
  *
@@ -54,10 +54,9 @@ export { ioError, toIoError }
 
 // `../common`'s, kept visible here because `NodeOp` unions them and dozens of
 // call sites name them through this module — a live coupling, not a shim. An
-// operation belongs to the layer of whoever implements it, and every one of
-// these has, or will have, a second implementer: a browser sandboxes, catches,
-// writes, loads modules through an `import()` of its own, and fans out with a
-// `Promise.all`.
+// operation belongs to the layer of whoever implements it: a browser
+// interpreter dispatches `sandbox` and `catch`, and the rest are there because
+// nothing about them is Node's. `../common/types.ts` keeps the count.
 export { all, allOk, both, catch_, error, errorExit, import_, log, read, readLine, sandbox, write }
 
 /**

--- a/fjs/effects/node/types.ts
+++ b/fjs/effects/node/types.ts
@@ -16,7 +16,7 @@ import type {
 } from '../types.ts'
 import type { List } from '../list/types.ts'
 import type {
-    Catch, Console, Import, Module, Read, ReadConsoles, Sandbox, SandboxResult, Std, Write,
+    All, Catch, Console, Import, Module, Read, ReadConsoles, Sandbox, SandboxResult, Std, Write,
     WriteConsoles, _UtfList,
 } from '../common/types.ts'
 
@@ -41,22 +41,14 @@ export type { IoChannel, IoError, IoErrorInfo, IoResult, OpResult }
  * a live coupling rather than a shim.
  */
 export type {
-    Catch, Console, Import, Module, Read, ReadConsoles, Sandbox, SandboxResult, Std, Write,
+    All, Catch, Console, Import, Module, Read, ReadConsoles, Sandbox, SandboxResult, Std, Write,
     WriteConsoles, _UtfList,
 }
 
 // all
 
-/**
- * Runs its effects concurrently and answers each one's whole `Result`.
- *
- * The nesting is deliberate and belongs to the runner: this envelope says
- * whether `all` itself could be dispatched, and each inner `Result` is what
- * that effect answered. `allOk` (`./module.f.mjs`) is the collapse a fallible
- * chain wants.
- */
-export type All = ['all', <T, E>(...effects: Effect<never, T, E>[]) => OpResult<readonly Result<T, E>[]>]
-
+// `All` is `../common`'s, re-exported above: fan-out is an interpreter's job,
+// and a browser page fans out its module loads with a `Promise.all`.
 // fetch
 
 export type Fetch = ['fetch', (url: string) => IoResult<Vec>]

--- a/fjs/effects/node/types.ts
+++ b/fjs/effects/node/types.ts
@@ -33,12 +33,11 @@ export type { IoChannel, IoError, IoErrorInfo, IoResult, OpResult }
 /**
  * The console family joins `Sandbox`, `Catch`, `Import` and `All` in
  * [`../common`](../common/types.ts), for two different reasons that the module
- * there keeps apart. Most have a second implementer, and an operation belongs
- * to the layer of whoever implements it: a browser page loads modules too, and
- * its `import()` resolves against a document rather than a filesystem, which is
- * the interpreter's business and not the operation's. `All` is there on the
- * layering argument instead — fan-out is an interpreter's job whoever the host
- * is — and still has one implementer.
+ * there keeps apart and counts out: `Sandbox` and `Catch` have a second
+ * implementer, and the rest are there because nothing about them is Node's —
+ * fan-out belongs to whichever interpreter has concurrency, a path is resolved
+ * against whatever a host resolves paths against, and a byte stream named by a
+ * string is not a filesystem fact.
  *
  * They are re-exported here because `NodeOp` unions them and dozens of
  * signatures name them through this module; that makes this a live coupling

--- a/fjs/effects/node/types.ts
+++ b/fjs/effects/node/types.ts
@@ -33,8 +33,9 @@ export type { IoChannel, IoError, IoErrorInfo, IoResult, OpResult }
 /**
  * The console family joins `Sandbox`, `Catch`, `Import` and `All` in
  * [`../common`](../common/types.ts), for two different reasons that the module
- * there keeps apart and counts out: `Sandbox` and `Catch` have a second
- * implementer, and the rest are there because nothing about them is Node's —
+ * there keeps apart and counts out: `Sandbox`, `Catch` and `Import` have a
+ * second implementer, and the rest are there because nothing about them is
+ * Node's —
  * fan-out belongs to whichever interpreter has concurrency, a path is resolved
  * against whatever a host resolves paths against, and a byte stream named by a
  * string is not a filesystem fact.

--- a/fjs/effects/node/types.ts
+++ b/fjs/effects/node/types.ts
@@ -31,14 +31,18 @@ import type {
 export type { IoChannel, IoError, IoErrorInfo, IoResult, OpResult }
 
 /**
- * The console family joins `Sandbox`, `Catch` and `Import` in
- * [`../common`](../common/types.ts) —
- * they have a second implementer, and an operation belongs to the layer of
- * whoever implements it. A browser page loads modules too: its `import()`
- * resolves against a document rather than a filesystem, which is the
- * interpreter's business and not the operation's. They are re-exported here because `NodeOp` unions
- * them and dozens of signatures name them through this module; that makes this
- * a live coupling rather than a shim.
+ * The console family joins `Sandbox`, `Catch`, `Import` and `All` in
+ * [`../common`](../common/types.ts), for two different reasons that the module
+ * there keeps apart. Most have a second implementer, and an operation belongs
+ * to the layer of whoever implements it: a browser page loads modules too, and
+ * its `import()` resolves against a document rather than a filesystem, which is
+ * the interpreter's business and not the operation's. `All` is there on the
+ * layering argument instead — fan-out is an interpreter's job whoever the host
+ * is — and still has one implementer.
+ *
+ * They are re-exported here because `NodeOp` unions them and dozens of
+ * signatures name them through this module; that makes this a live coupling
+ * rather than a shim.
  */
 export type {
     All, Catch, Console, Import, Module, Read, ReadConsoles, Sandbox, SandboxResult, Std, Write,
@@ -47,8 +51,9 @@ export type {
 
 // all
 
-// `All` is `../common`'s, re-exported above: fan-out is an interpreter's job,
-// and a browser page fans out its module loads with a `Promise.all`.
+// `All` is `../common`'s, re-exported above: fan-out is an interpreter's job
+// whoever the host is.
+
 // fetch
 
 export type Fetch = ['fetch', (url: string) => IoResult<Vec>]

--- a/fjs/effects/todo/all-argument-limit.md
+++ b/fjs/effects/todo/all-argument-limit.md
@@ -51,8 +51,11 @@ batch size — the ceiling is the *variadic operation's*, not fan-out's in gener
 earlier version of this paragraph credited `batchSize = 25` with staying under the limit;
 that was a misattribution, corrected in the pitfall catalog in
 [share-browser-console-runner](../../emergent_testing/todo/share-browser-console-runner.md).)
-Both `Promise.all`s are gone now that the page runs the shared sequential traversal, so the
-page performs no fan-out of any shape.
+Both of the *traversal's* `Promise.all`s are gone now that the page runs the shared
+sequential traversal. The page still fans out once, over its module loading
+(`emergent_testing/browser/module.mjs`), which is a `Promise.all` in its own impure shell
+rather than an `all` dispatched through an interpreter — so it is outside this ceiling
+today, and inside it on the day that loading moves into `.f.mjs`.
 The reverted functionalscript#1759 routed the page through the shared traversal and so
 briefly gave both runners the same ceiling; the sequential plan that replaced it removed
 the traversal's fan-outs entirely (functionalscript#1774). What remains is the registration

--- a/fjs/effects/todo/allvoid-combinator.md
+++ b/fjs/effects/todo/allvoid-combinator.md
@@ -4,12 +4,16 @@
 **Status:** blocked
 **Blocked by:** [node-module-layering](./node-module-layering.md)
 
-> **Destination superseded (2026-07).** The proposal below places `allVoid` in
-> `fjs/effects/node/module.f.mjs` because that is where `all`/`All` live today,
-> and notes that if `All` is ever lowered out of the node module `allVoid`
-> "moves down with it". [node-module-layering](./node-module-layering.md) is
-> that lowering: `All`/`all`/`both` go to `fjs/effects/all/module.f.mjs`, and
-> `allVoid` belongs there with them.
+> **Destination superseded (2026-07), and the lowering has now happened.** The
+> proposal below places `allVoid` in `fjs/effects/node/module.f.mjs` because
+> that is where `all`/`All` lived when it was written, and notes that if `All`
+> is ever lowered out of the node module `allVoid` "moves down with it".
+> [node-module-layering](./node-module-layering.md) was that lowering, and it
+> landed: `All`, `all`, `allOk` and `both` are in
+> **`fjs/effects/common`** — not `fjs/effects/all`, which is the name this file
+> and that one both used before the destination was settled. `allVoid` belongs
+> there with them, and everything below naming the node module as their home
+> is describing the tree before that move.
 >
 > Land the `All` move first, then add `allVoid` to `fjs/effects/all` — writing
 > it into the node module now would only earn it a second, breaking relocation.
@@ -36,12 +40,13 @@ missing, so every call site re-spells the whole fan-out-then-discard dance.
 
 ### Proposal
 
-Add the void sibling in `fjs/effects/node/module.f.mjs`, next to `all` /
-`All` / `both`. It cannot live next to `forEachStep` in the core
-`fjs/effects/module.f.mjs`: `all`/`All` are defined in the node module,
-which already imports the core module — placing `allVoid` in core would
-invert that dependency. (`fjs/emergent_testing` already imports `allOk` from
-the node module, so the call sites need no new import path.)
+Add the void sibling next to `all` / `All` / `both` — in
+`fjs/effects/common/module.f.mjs` as of the move above, `fjs/effects/node` as
+originally written. It cannot live next to `forEachStep` in the core
+`fjs/effects/module.f.mjs`: `all`/`All` are defined in a module that already
+imports the core one, so placing `allVoid` in core would invert that
+dependency. That argument is unchanged by the move; only the module it names
+is.
 
 Build it on `allOk`, not on `all`. `all` answers `readonly Result<T, E>[]` —
 the children's failures arrive *inside* its value — so discarding that value
@@ -111,10 +116,12 @@ recorded as superseded there.)
 
 ### Tasks
 
-- [ ] Wait for [node-module-layering](./node-module-layering.md) to move
+- [x] Wait for [node-module-layering](./node-module-layering.md) to move
       `All`/`all`/`both` **and `allOk`** to `fjs/effects/all/module.f.mjs`.
       `allVoid` is built on `allOk`, so moving one without the other inverts
-      the layering.
+      the layering. **Done** — all four moved together, to
+      `fjs/effects/common/module.f.mjs` rather than the `effects/all` this task
+      guessed at.
 - [ ] Wait for [all-argument-limit](./all-argument-limit.md)'s list-shaped
       `allOk`, and hand it the list: `allVoid` is an arbitrary-length
       fan-out, so a spread in its body would rebuild the argument ceiling it

--- a/fjs/effects/todo/allvoid-combinator.md
+++ b/fjs/effects/todo/allvoid-combinator.md
@@ -15,10 +15,10 @@
 > there with them, and everything below naming the node module as their home
 > is describing the tree before that move.
 >
-> Land the `All` move first, then add `allVoid` to `fjs/effects/all` — writing
-> it into the node module now would only earn it a second, breaking relocation.
-> The proposal's body is otherwise unchanged and still correct; substitute
-> `fjs/effects/all/module.f.mjs` wherever it says `fjs/effects/node/module.f.mjs`.
+> The `All` move has landed, so what remains is to add `allVoid` beside it. The
+> proposal's body is otherwise unchanged and still correct; substitute
+> **`fjs/effects/common/module.f.mjs`** wherever it says
+> `fjs/effects/node/module.f.mjs`.
 
 ### Problem
 

--- a/fjs/effects/todo/node-module-layering.md
+++ b/fjs/effects/todo/node-module-layering.md
@@ -65,7 +65,7 @@ Proposed destinations:
 
 | Moves to | Contents |
 |---|---|
-| `fjs/effects/common` (was `effects/all`) | `All`, `all`, `allOk`, `both`, and `allVoid`/`allReduce` when they land |
+| `fjs/effects/common` (was `effects/all`) | `All`, `all`, `allOk`, `both` — **moved**; `allVoid`/`allReduce` when they land. It moved on the layering argument, and gained a second implementer on the way: a browser page fans out its module loads, so the interpreter's `Promise.all` is as much an implementation of `all` as Node's |
 | `fjs/effects/common` (was `effects/sandbox`) | `Sandbox`, `SandboxResult`, `sandbox`, `Await`, `awaitIfPromise`, and `Catch`/`catch_` (landed after this table was written) — the "run foreign code and observe what happened" family. This row is what [share-browser-console-runner](../../emergent_testing/todo/share-browser-console-runner.md) step 4's "shared module" resolves to: a browser gives `Sandbox` and `Catch` their second implementer; `Await` moves on this issue's layering argument alone, since it belongs to the registration path no browser runs |
 | `fjs/effects/common` (was `effects/console`) | `Read`, `Write`, `ReadConsoles`, `WriteConsoles`, `Console`, `log`, `error`, `readLine`, `errorExit`, and a **new named `Std`** (see below) |
 | `fjs/effects/common` (was `effects/test`) | `Test`, `TestFn`, `TestContext`, `test` — registration with an external framework, not I/O |
@@ -317,7 +317,7 @@ move. Nothing depends on it.
       with `Result<T, unknown>` from `fjs/types/result`, dropping its
       `effects` import — a pure consumer should not name an IO alias, whichever
       module the alias lives in.
-- [ ] Move `All` / `all` / `allOk` / `both` to `fjs/effects/common`.
+- [x] Move `All` / `all` / `allOk` / `both` to `fjs/effects/common`.
       `allOk` is the ok-channel wrapper over `all` and belongs with it;
       [allvoid-combinator](./allvoid-combinator.md) builds on it, so leaving it
       behind would make the combinator import from `effects/node`.

--- a/fjs/effects/todo/node-module-layering.md
+++ b/fjs/effects/todo/node-module-layering.md
@@ -305,13 +305,15 @@ Judgement calls worth deciding explicitly rather than by accident:
 
 ### Six operation tuples are not `readonly`
 
-`All`, `Fetch`, `CreateServer`, `Listen` and `Forever` in
-[`../node/types.ts`](../node/types.ts) are declared as plain tuples where every
-other operation is `readonly`. `Import` was a sixth until it moved, and making
-it `readonly` on the way looked like tidying — but a `readonly` tuple is not
-assignable to a mutable one, so it is a break a consumer could hit, for
+`Fetch`, `CreateServer`, `Listen` and `Forever` in
+[`../node/types.ts`](../node/types.ts), and `All` in
+[`../common/types.ts`](../common/types.ts), are declared as plain tuples where
+every other operation is `readonly`. `Import` was a sixth until it moved, and
+making it `readonly` on the way looked like tidying — but a `readonly` tuple is
+not assignable to a mutable one, so it is a break a consumer could hit, for
 cosmetics. It was reverted rather than shipped with a `**BREAKING CHANGES:**`
-entry attached to a rename.
+entry attached to a rename; `All` moved afterwards and kept its plain tuple for
+the same reason.
 
 The five that remain are worth aligning *deliberately*, in one change that says
 so and takes the version bump for the set rather than smuggling it inside a

--- a/fjs/effects/todo/node-module-layering.md
+++ b/fjs/effects/todo/node-module-layering.md
@@ -65,7 +65,7 @@ Proposed destinations:
 
 | Moves to | Contents |
 |---|---|
-| `fjs/effects/common` (was `effects/all`) | `All`, `all`, `allOk`, `both` — **moved**; `allVoid`/`allReduce` when they land. It moved on the layering argument, and gained a second implementer on the way: a browser page fans out its module loads, so the interpreter's `Promise.all` is as much an implementation of `all` as Node's |
+| `fjs/effects/common` (was `effects/all`) | `All`, `all`, `allOk`, `both` — **moved** on the layering argument alone; `allVoid`/`allReduce` when they land. Its implementers today are still the Node runners and the registration path: the page's `Promise.all` coordinates module-loading promises directly, and its interpreter claims `Catch`, `Sandbox` and `report` and nothing else. Giving `all` a browser implementer is the *plan* for the loading walk, not a fact about the tree |
 | `fjs/effects/common` (was `effects/sandbox`) | `Sandbox`, `SandboxResult`, `sandbox`, `Await`, `awaitIfPromise`, and `Catch`/`catch_` (landed after this table was written) — the "run foreign code and observe what happened" family. This row is what [share-browser-console-runner](../../emergent_testing/todo/share-browser-console-runner.md) step 4's "shared module" resolves to: a browser gives `Sandbox` and `Catch` their second implementer; `Await` moves on this issue's layering argument alone, since it belongs to the registration path no browser runs |
 | `fjs/effects/common` (was `effects/console`) | `Read`, `Write`, `ReadConsoles`, `WriteConsoles`, `Console`, `log`, `error`, `readLine`, `errorExit`, and a **new named `Std`** (see below) |
 | `fjs/effects/common` (was `effects/test`) | `Test`, `TestFn`, `TestContext`, `test` — registration with an external framework, not I/O |
@@ -122,6 +122,16 @@ Judgement calls worth deciding explicitly rather than by accident:
   *step 4's* motivation, not out of this issue's: its move to `effects/all`
   above rests on the layering argument, and its implementers stay the Node
   runners and the registration path.
+
+  **That is still true after the move**, and worth saying because the move
+  invites the opposite reading. `all` is in `effects/common` because fan-out is
+  an interpreter's job, not because a browser dispatches it — the page's
+  `Promise.all` coordinates promises directly and its interpreter does not
+  claim `all` at all. It is expected to: moving the browser's module loading
+  into `.f.mjs` needs a fan-out the walk does not perform itself, which is what
+  the operation is for. Until that lands, this row's second implementer is a
+  plan, and a plan recorded as a fact is how a design comes to hold two
+  incompatible things at once.
 
   Worth recording, because the earlier expectation written here was wrong about
   two of them: "a browser proof run needs a clock and dynamic import" is true of


### PR DESCRIPTION
`All`, `all`, `allOk` and `both` move from `effects/node` to `effects/common`.
`effects/node` re-exports all four — the same live coupling as `Sandbox`,
`Catch` and `Import`, since `NodeOp` unions `All` and call sites name it through
that module.

## The reason is layering, and only layering

`node-module-layering.md` has held this row on one argument: **fan-out is an
interpreter's job rather than a walk's.** A host with concurrency implements it;
a host without answers the effects in turn; the shared logic above reads the
same either way. That was sufficient before this PR and is what the move rests
on.

**`all` has no browser implementer yet**, and an earlier draft of this
description claimed otherwise. It does not: the page's `Promise.all` coordinates
module-loading promises directly, and its interpreter claims `Catch`, `Sandbox`
and `report` — not `all`. Giving it one is the *plan* for moving the browser's
module loading into `.f.mjs`, which needs a fan-out the walk cannot perform
itself. Recorded in the todo as the expectation it is, rather than as a fact
about the tree.

## Details

- `okList` moves with `allOk`, being its other half — it is `allOk`'s collapse
  and has no other caller.
- Four imports the move left unused in `effects/node` are removed with it, and
  `allOk`'s `step as ioStep` alias goes: that alias existed to dodge a shadow in
  `effects/node` that does not exist in `effects/common`.
- `All` stays a plain tuple rather than gaining `readonly`. It is one of the
  five recorded in #1812 for a deliberate pass; aligning whichever one happens
  to be moving is how a cosmetic change becomes a breaking one.
- **The fan-out is now proven where it lives.** Coverage stayed at 100% through
  the move only because `fjs/dev` exercises `allOk` incidentally and `node`'s
  proof reaches `both` through the re-export — coverage by accident, with
  `okList`'s error branch pinned nowhere. `effects/common/proof.f.mjs` gains a
  runner that answers `all` by running each effect through itself, and proofs
  that the nesting survives, that an empty list is not a failure, that `allOk`
  collapses, and that it keeps the **first** error (two failures in the list, so
  the choice is not readable off one example).

## Verification

`npx tsc` clean · `fjs t` 3688/3688 · `node --test` 3631/3631 · coverage 100%,
and an lcov run over `effects/common/module.f.mjs` alone shows no uncovered
branch or function with `dev` and `node` out of the room · `npm run ci-update`
no diff.

## Changelog

- `effects`: `All`, `all`, `allOk` and `both` moved from `effects/node` to
  `effects/common`, where host-neutral operations live — fan-out is an
  interpreter's job rather than one host's. `effects/node` re-exports all four,
  so importing them through it is unchanged

Not breaking: the re-export leaves `effects/node`'s surface identical, and
`effects/common` gains the four names.
