### PR TITLE
Upgrade FunctionalScript dependency to 0.48.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.47.0"
+          "run": "npm install -g functionalscript@0.48.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -203,7 +203,7 @@
           }
         },
         {
-          "run": "npm install -g functionalscript@0.47.0"
+          "run": "npm install -g functionalscript@0.48.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"

--- a/fjs/ci/config/module.f.mjs
+++ b/fjs/ci/config/module.f.mjs
@@ -25,7 +25,7 @@ export const images = /** @type {const} */({
 // published FunctionalScript release; do not tie it to package.json's current
 // in-repo version.
 // https://www.npmjs.com/package/functionalscript
-export const functionalscript = /** @type {const} */ '0.47.0'
+export const functionalscript = /** @type {const} */ '0.48.0'
 
 // The one runtime a generated flake takes from outside the pinned snapshot.
 // Nixpkgs ships 1.3.13 — on the pin and on `master` — and two of this


### PR DESCRIPTION
## Summary
Updates the FunctionalScript dependency from version 0.47.0 to 0.48.0 across the CI configuration and module configuration files.

## Changes
- Updated FunctionalScript version in CI workflow configuration (`.github/workflows/ci.yml`) from 0.47.0 to 0.48.0 in two workflow jobs
- Updated FunctionalScript version in module configuration (`fjs/ci/config/module.f.mjs`) from 0.47.0 to 0.48.0

## Details
This is a routine dependency upgrade that ensures the CI pipeline and build configuration use the latest stable release of FunctionalScript. The version is maintained in a centralized configuration file and referenced in the CI workflows to keep them in sync.

https://claude.ai/code/session_01WXvL8CdQhUCbuNs5fiMEMm