### PR TITLE
Make repo type declarations consistently readonly

### DIFF
--- a/changelog/unreleased/1822.md
+++ b/changelog/unreleased/1822.md
@@ -1,13 +1,4 @@
 - **BREAKING CHANGES:** several public `types.ts` declarations gained
-  `readonly` on members that were mutable before: `bnf`'s `Option.some` and
-  `Option.none`, `cas`'s `FileCas.url`, `edag/amnesia`'s `TagMap`,
-  `djs/transpiler`'s `djsResult.djs`, `djs/ast`'s `AstModule`,
-  `AstModuleRef` and `AstArray`, `effects/node/virtual`'s `State`,
-  `types/object`'s `OneKey`, `types/range_map`'s `Entry`, and the brand
-  fields of `types/nominal`'s `Nominal` and `_SymbolIntersectionBranded`. A
-  consumer assigning through one of these fields (e.g. `option.some = v`)
-  now fails type checking. `AGENTS.md` now requires `readonly` on every
-  array, tuple, and object member in a repository type declaration, with a
-  narrow, documented exception for host/library API shapes this repository
-  doesn't own and for a handful of already-tracked, deliberately-deferred
-  operation tuples in `fjs/effects`.
+  `readonly` on array/tuple/object members that were mutable before
+  (`bnf`'s `Option`, `cas`'s `FileCas`, `types/range_map`'s `Entry`, and
+  others). Assigning through one of these fields now fails type checking.

--- a/changelog/unreleased/1822.md
+++ b/changelog/unreleased/1822.md
@@ -1,4 +1,4 @@
 - **BREAKING CHANGES:** several public `types.ts` declarations gained
-  `readonly` on array/tuple/object members that were mutable before
-  (`bnf`'s `Option`, `cas`'s `FileCas`, `types/range_map`'s `Entry`, and
-  others). Assigning through one of these fields now fails type checking.
+  `readonly` on tuple/object members that were mutable before (`bnf`'s
+  `Option`, `types/range_map`'s `Entry`, and others). A mutable tuple no
+  longer fits, and assigning through an object field now fails type checking.

--- a/changelog/unreleased/1822.md
+++ b/changelog/unreleased/1822.md
@@ -1,0 +1,10 @@
+- **BREAKING CHANGES:** several public `types.ts` declarations gained
+  `readonly` on members that were mutable before: `bnf`'s `Option.some` and
+  `Option.none`, `cas`'s `FileCas.url`, `edag/amnesia`'s `TagMap`,
+  `djs/transpiler`'s `djsResult.djs`, `djs/ast`'s `AstModule`,
+  `AstModuleRef` and `AstArray`, `effects/node/virtual`'s `State`,
+  `types/object`'s `OneKey`, and the brand fields of `types/nominal`'s
+  `Nominal` and `_SymbolIntersectionBranded`. A consumer assigning through
+  one of these fields (e.g. `option.some = v`) now fails type checking.
+  `AGENTS.md` now requires `readonly` on every array, tuple, and object
+  member in a repository type declaration.

--- a/changelog/unreleased/1822.md
+++ b/changelog/unreleased/1822.md
@@ -3,8 +3,11 @@
   `Option.none`, `cas`'s `FileCas.url`, `edag/amnesia`'s `TagMap`,
   `djs/transpiler`'s `djsResult.djs`, `djs/ast`'s `AstModule`,
   `AstModuleRef` and `AstArray`, `effects/node/virtual`'s `State`,
-  `types/object`'s `OneKey`, and the brand fields of `types/nominal`'s
-  `Nominal` and `_SymbolIntersectionBranded`. A consumer assigning through
-  one of these fields (e.g. `option.some = v`) now fails type checking.
-  `AGENTS.md` now requires `readonly` on every array, tuple, and object
-  member in a repository type declaration.
+  `types/object`'s `OneKey`, `types/range_map`'s `Entry`, and the brand
+  fields of `types/nominal`'s `Nominal` and `_SymbolIntersectionBranded`. A
+  consumer assigning through one of these fields (e.g. `option.some = v`)
+  now fails type checking. `AGENTS.md` now requires `readonly` on every
+  array, tuple, and object member in a repository type declaration, with a
+  narrow, documented exception for host/library API shapes this repository
+  doesn't own and for a handful of already-tracked, deliberately-deferred
+  operation tuples in `fjs/effects`.

--- a/changelog/unreleased/1822.md
+++ b/changelog/unreleased/1822.md
@@ -1,4 +1,4 @@
-- **BREAKING CHANGES:** several public `types.ts` declarations gained
-  `readonly` on tuple/object members that were mutable before (`bnf`'s
-  `Option`, `types/range_map`'s `Entry`, and others). A mutable tuple no
-  longer fits, and assigning through an object field now fails type checking.
+- **BREAKING CHANGES:** several public `types.ts` declarations (`bnf`'s
+  `Option`, `types/range_map`'s `Entry`, and others) gained `readonly` on
+  tuple/object members. A value no longer fits a mutable-tuple slot, and
+  mutating it or assigning through an object field now fails type checking.

--- a/fjs/AGENTS.md
+++ b/fjs/AGENTS.md
@@ -482,6 +482,17 @@ track exactly this kind of already-known, deliberately-deferred gap; a type
 left mutable for this reason needs a comment pointing to its tracking issue,
 same as any other approved exception.
 
+A third legitimate shape: the compiler itself rejects the `readonly` spelling.
+`fjs/media/html/types.ts`'s `Element1`/`Element2` rest tail stays a plain
+`Node[]` because `readonly Node[]` there makes `tsc` report TS2456
+("circularly references itself") on the mutually-recursive
+`Element1`/`Element2` → `Node` → `Element` cycle, which the identical
+structure with a mutable rest array does not trigger. Verify against the
+pinned compiler before claiming this exception — most recursive types in this
+repository (e.g. `fjs/rtti/ts/types.ts`'s `_SelfArray`) take `readonly` without
+issue, so this is a specific compiler limitation on that shape, not a general
+excuse for anything recursive.
+
 If a type must genuinely expose a mutable field for some other reason, it
 needs the same explicit reviewer sign-off on the PR that introduces it, with
 a comment on the field explaining why it is mutable. Do not add a

--- a/fjs/AGENTS.md
+++ b/fjs/AGENTS.md
@@ -432,6 +432,29 @@ TypeScript one, but the public type contract must not become weaker for being
 written in JavaScript. Types authored in `types.ts` use ordinary TypeScript
 syntax and declaration emit.
 
+#### Types are `readonly`
+
+Every array, tuple, and object member in a repository type declaration
+(`types.ts`, `private.ts`, or a JSDoc `@typedef`) must be `readonly` —
+`readonly T[]`, not `T[]`; `readonly [A, B]`, not `[A, B]`; `readonly a: T`,
+not `a: T`. This is the type-level counterpart of
+[§3.1](#31-immutability-and-purity): FunctionalScript data is immutable, and a
+type that admits mutation misdescribes the value even where nothing ever
+mutates it.
+
+Function parameters are exempt — `(name: string, fn: () => void) => …` needs
+no `readonly` on `name`/`fn`, since a parameter list is not itself a mutable
+container. A mapped type's brand/index signature is not exempt just because
+the field is never assigned a real value at runtime (e.g. `Nominal`'s
+`{ readonly[k in N]: … }` in `fjs/types/nominal/types.ts`).
+
+**No unapproved exceptions.** If a type must genuinely expose a mutable
+field (rather than being an oversight), it needs an explicit reviewer
+sign-off on the PR that introduces it, with a comment on the field
+explaining why it is mutable — the same bar as any other rule exception in
+this document. Do not add a non-`readonly` member and assume it will pass
+review silently.
+
 #### Prefer inference
 
 Let TypeScript infer the type of private constants, local variables, and return
@@ -766,9 +789,9 @@ satisfy the rule. The cases in this repository:
   the base under a field there would describe something that isn't there — and
   for a wire format it would change the encoding, not just the type.
 - **A facade adding a member to a generic interface.**
-  `FileCas = Cas<FileCasOperation> & { url: (v: Vec) => string }` — composition
-  would route every consumer through an extra hop (`fileCas.cas.read(…)`) to
-  express one added member.
+  `FileCas = Cas<FileCasOperation> & { readonly url: (v: Vec) => string }` —
+  composition would route every consumer through an extra hop
+  (`fileCas.cas.read(…)`) to express one added member.
 - **Opening a record type to dynamic keys.** A record type restricts its fields:
   unknown keys are neither writable in a literal nor readable off a value.
   Intersecting it with `StringMap<unknown>` keeps the declared fields

--- a/fjs/AGENTS.md
+++ b/fjs/AGENTS.md
@@ -434,19 +434,31 @@ syntax and declaration emit.
 
 #### Types are `readonly`
 
-Every array, tuple, and object member in a repository type declaration
-(`types.ts`, `private.ts`, or a JSDoc `@typedef`) must be `readonly` —
-`readonly T[]`, not `T[]`; `readonly [A, B]`, not `[A, B]`; `readonly a: T`,
-not `a: T`. This is the type-level counterpart of
-[§3.1](#31-immutability-and-purity): FunctionalScript data is immutable, and a
-type that admits mutation misdescribes the value even where nothing ever
-mutates it.
+Every array, tuple, and object member in a repository type declaration —
+`types.ts` or `private.ts` — must be `readonly`: `readonly T[]`, not `T[]`;
+`readonly [A, B]`, not `[A, B]`; `readonly a: T`, not `a: T`. This is the
+type-level counterpart of [§3.1](#31-immutability-and-purity):
+FunctionalScript data is immutable, and a type that admits mutation
+misdescribes the value even where nothing ever mutates it.
+
+**Scope: TypeScript source, not JSDoc.** A function-local JSDoc `@typedef`
+(§3.2, "JavaScript/JSDoc type declarations") is out of scope — the `@property`
+list style has no established `readonly` spelling in this codebase, and every
+such typedef is proof-local, describing one call's shape rather than named,
+reusable repository data. Inlining the type instead of using `@property`
+(`@typedef {{ readonly a: T }} _Name`) can still take `readonly`, and should
+where it reads no worse; nothing here requires converting existing
+`@property` typedefs.
 
 Function parameters are exempt — `(name: string, fn: () => void) => …` needs
 no `readonly` on `name`/`fn`, since a parameter list is not itself a mutable
 container. A mapped type's brand/index signature is not exempt just because
 the field is never assigned a real value at runtime (e.g. `Nominal`'s
-`{ readonly[k in N]: … }` in `fjs/types/nominal/types.ts`).
+`{ readonly[k in N]: … }` in `fjs/types/nominal/types.ts`), and neither is a
+mapped type used only inside a conditional/indexed-access type-level check and
+never as a value's own type (e.g. `NotUnion`'s `readonly [U] extends
+readonly [T]` in `fjs/types/object/types.ts`) — the rule is about what the
+declaration says, not about whether a mismatch is currently observable.
 
 **Exceptions need explicit reviewer sign-off, and most legitimate ones share
 one shape: the type describes an object that lives outside FunctionalScript

--- a/fjs/AGENTS.md
+++ b/fjs/AGENTS.md
@@ -448,12 +448,32 @@ container. A mapped type's brand/index signature is not exempt just because
 the field is never assigned a real value at runtime (e.g. `Nominal`'s
 `{ readonly[k in N]: … }` in `fjs/types/nominal/types.ts`).
 
-**No unapproved exceptions.** If a type must genuinely expose a mutable
-field (rather than being an oversight), it needs an explicit reviewer
-sign-off on the PR that introduces it, with a comment on the field
-explaining why it is mutable — the same bar as any other rule exception in
-this document. Do not add a non-`readonly` member and assume it will pass
-review silently.
+**Exceptions need explicit reviewer sign-off, and most legitimate ones share
+one shape: the type describes an object that lives outside FunctionalScript
+files** — a host or library API this repository does not own and cannot
+redeclare, mutable by that API's own contract (a Node.js builtin, a
+third-party SDK's object). `IncomingMessage = Readable & {…}` in
+`fjs/effects/node/module.mjs` (§3.2, "Composition over intersection") is the
+existing example: it describes Node's own object, not FunctionalScript data.
+Even there, prefer `readonly` on any member this codebase only reads — the
+exception is for a member the external API itself requires writable or
+reassigns, not a blanket pass for the whole type.
+
+A type over data this repository defines and constructs is not exempt just
+because a change would be a breaking API change for consumers — that is a
+reason to plan and land the fix deliberately (see "Breaking changes and
+versioning" in [changelog/README.md](../changelog/README.md)), not a reason
+to leave the member mutable. `fjs/effects/node/todo/state-types-conventions.md`
+and the "Six operation tuples are not `readonly`" section of
+[`fjs/effects/todo/node-module-layering.md`](./effects/todo/node-module-layering.md)
+track exactly this kind of already-known, deliberately-deferred gap; a type
+left mutable for this reason needs a comment pointing to its tracking issue,
+same as any other approved exception.
+
+If a type must genuinely expose a mutable field for some other reason, it
+needs the same explicit reviewer sign-off on the PR that introduces it, with
+a comment on the field explaining why it is mutable. Do not add a
+non-`readonly` member and assume it will pass review silently.
 
 #### Prefer inference
 

--- a/fjs/bnf/types.ts
+++ b/fjs/bnf/types.ts
@@ -72,8 +72,8 @@ export type None = readonly[]
  * Optional grammar branch.
  */
 export type Option<S> = {
-    some: S
-    none: None
+    readonly some: S
+    readonly none: None
 }
 
 export type Repeat0Plus<T> = () => Option<readonly[T, Repeat0Plus<T>]>

--- a/fjs/cas/types.ts
+++ b/fjs/cas/types.ts
@@ -52,5 +52,5 @@ export type Cas<O extends Operation> = {
 }
 
 export type FileCas = Cas<FileCasOperation> & {
-    url: (v: Vec) => string
+    readonly url: (v: Vec) => string
 }

--- a/fjs/ci/nix/types.ts
+++ b/fjs/ci/nix/types.ts
@@ -84,7 +84,7 @@ export type NixJob = {
      * shell there would be one nothing enters. The developer environment is
      * the reason this is a list at all.
      */
-    readonly systems: readonly [string, ...string[]]
+    readonly systems: readonly [string, ...readonly string[]]
     /** Nixpkgs attribute names made available in the job's shell. */
     readonly packages: readonly string[]
     /** Job-local shell initialization, when the job needs one. */

--- a/fjs/djs/ast/types.ts
+++ b/fjs/djs/ast/types.ts
@@ -14,7 +14,7 @@ import type { Primitive } from '../types.ts'
  *
  * The specifier list indexes `['aref', i]`.
  */
-export type AstModule = [readonly string[], AstBody]
+export type AstModule = readonly [readonly string[], AstBody]
 
 /** A value in a module body: a primitive, a reference, an array, or an object. */
 export type AstConst = Primitive|AstModuleRef|AstArray|AstObject
@@ -35,10 +35,10 @@ export type AstConst = Primitive|AstModuleRef|AstArray|AstObject
  * later entry is unsatisfiable. It is not rejected: it resolves to the most
  * recently evaluated entry instead.
  */
-export type AstModuleRef = ['aref' | 'cref', number]
+export type AstModuleRef = readonly ['aref' | 'cref', number]
 
 /** An array value; its elements are evaluated in order. */
-export type AstArray = ['array', readonly AstConst[]]
+export type AstArray = readonly ['array', readonly AstConst[]]
 
 /** An object value, keyed by property name. */
 export type AstObject = { readonly[k in string]?: AstConst }

--- a/fjs/djs/tokenizer/private.ts
+++ b/fjs/djs/tokenizer/private.ts
@@ -9,13 +9,13 @@ import type { TokenMetadata } from '../../js/tokenizer/types.ts'
 import type { List } from '../../types/list/types.ts'
 
 /** A tag, the metadata of the token's first code point, and its code points. */
-export type _Token = [string, TokenMetadata, readonly number[]]
+export type _Token = readonly [string, TokenMetadata, readonly number[]]
 
 /** One item of a flattened match: a tag, or a code point with its metadata. */
 export type _FlatToken = string | CodePointMeta<TokenMetadata>
 
 /** A token being accumulated: its tag, start metadata, and code points so far. */
-export type _TokenScanState = [string, TokenMetadata | null, List<number>]
+export type _TokenScanState = readonly [string, TokenMetadata | null, List<number>]
 
 /** Where a string-literal decode is: plain text, after `\`, or inside `\uXXXX`. */
 export type _StringDecodeState =

--- a/fjs/djs/transpiler/types.ts
+++ b/fjs/djs/transpiler/types.ts
@@ -9,7 +9,7 @@ import type { List } from '../../types/list/types.ts'
 import type { OrderedMap } from '../../types/ordered_map/types.ts'
 
 /** The evaluated DJS value produced for one successfully transpiled module. */
-export type djsResult = { djs: Unknown }
+export type djsResult = { readonly djs: Unknown }
 
 /**
  * State threaded through the recursive transpilation of a DJS module graph.

--- a/fjs/edag/amnesia/types.ts
+++ b/fjs/edag/amnesia/types.ts
@@ -20,7 +20,7 @@ type Get0<T extends ExpOp, K extends ExpOp[0]> =
 // workaround (microsoft/TypeScript#47109). Indexing `Map` with a
 // non-generic union key still yields the uncallable union, so dispatch
 // must go through such a `K`.
-export type TagMap = { [K in ExpOp[0]]: Get0<ExpOp, K> }
+export type TagMap = { readonly[K in ExpOp[0]]: Get0<ExpOp, K> }
 
 export type Map = {
     readonly[K in ExpOp[0]]: (c: Context, r: TagMap[K]) => unknown

--- a/fjs/effects/common/types.ts
+++ b/fjs/effects/common/types.ts
@@ -135,6 +135,12 @@ export type Catch = readonly['catch', <T>(f: () => T) => OpResult<Result<T, unkn
  * the whole reason: unlike its neighbours here, this operation has one
  * implementer today, the Node runners and the registration path they serve.
  * Nothing in a browser dispatches it yet.
+ *
+ * The tuple itself is a documented exception to the repo-wide `readonly`
+ * rule (`fjs/AGENTS.md` §3.2): making it `readonly` is a breaking change a
+ * consumer's mutable tuple could fail, tracked and deferred deliberately —
+ * see "Six operation tuples are not `readonly`" in
+ * `fjs/effects/todo/node-module-layering.md`.
  */
 export type All = ['all', <T, E>(...effects: Effect<never, T, E>[]) => OpResult<readonly Result<T, E>[]>]
 
@@ -156,6 +162,9 @@ export type Module = StringMap<unknown>
  * fails: a module that will not parse, a path that resolves to nothing, a
  * network that dropped. A caller that must report such a failure rather than
  * die needs the reason as a value, which is what the error channel carries.
+ *
+ * The tuple itself is a documented exception to the repo-wide `readonly`
+ * rule (`fjs/AGENTS.md` §3.2) — see the note on `All` above.
  */
 export type Import = ['import', (path: string) => IoResult<Module>]
 

--- a/fjs/effects/node/private.ts
+++ b/fjs/effects/node/private.ts
@@ -17,7 +17,7 @@ export type _Socket = {
 export type _Server = {
     readonly listen: (port: number, host: string) => void
     readonly once: (event: string, f: (e: unknown) => void) => void
-    on(event: string, f: (req: unknown, socket: _Socket) => void): void
+    readonly on: (event: string, f: (req: unknown, socket: _Socket) => void) => void
     readonly removeListener: (event: string, f: (e: unknown) => void) => void
 }
 

--- a/fjs/effects/node/private.ts
+++ b/fjs/effects/node/private.ts
@@ -14,6 +14,18 @@ export type _Socket = {
     readonly end: (data: string) => void
 }
 
+/**
+ * `on` is written as a property, like its three siblings here, not as a
+ * method-shorthand member — TypeScript has no `readonly` spelling for method
+ * shorthand, and every other member of this type is already a property.
+ * Under `strictFunctionTypes` a property function type checks its parameter
+ * contravariantly where method shorthand stays bivariant, so this is
+ * marginally stricter than the method-shorthand form it replaced; nothing in
+ * this module hits that difference; the sole call site
+ * (`fjs/effects/node/module.mjs`'s `server.on('connect', …)`) matches the
+ * signature exactly, and `_Server` values only ever arrive via a cast from
+ * Node's real `http.Server`, never as a wider handler passed into this type.
+ */
 export type _Server = {
     readonly listen: (port: number, host: string) => void
     readonly once: (event: string, f: (e: unknown) => void) => void

--- a/fjs/effects/node/todo/state-types-conventions.md
+++ b/fjs/effects/node/todo/state-types-conventions.md
@@ -5,7 +5,8 @@
 
 ### Problem
 
-Three deviations from rules AGENTS.md states explicitly:
+Two deviations from rules AGENTS.md states explicitly (a third, `State`'s
+fields all being mutable, is fixed — see Tasks):
 
 1. **`Env` re-rolls `StringMap` in a file that already imports it.**
    `fjs/effects/node/types.ts:291-293` spells out
@@ -21,21 +22,19 @@ Three deviations from rules AGENTS.md states explicitly:
    `result === undefined` on a read the type says is always a `Vec`. Both
    should be `StringMap<…>`. (The recursive `Dir` in the same file is the
    documented inline-form exception and stays.)
-3. **`State`'s fields are all mutable.** `virtual/types.ts:28-41` — no
-   `readonly` on `stdout`, `stderr`, `stdin`, `root`, `internet`, `epochNs`,
-   `memoryNext`, `memoryValues`, `randomNext`, while every operation rebuilds
-   the record by spread. The mutability is unused and unenforced; `Dir` and
-   `_Entity` in the same file already have `readonly`.
 
 ### Proposal
 
 `Env = StringMap<string>`, `internet: StringMap<Vec>`,
-`memoryValues: StringMap<unknown>`, and `readonly` on every `State` field.
+`memoryValues: StringMap<unknown>`.
 
 ### Tasks
 
 - [ ] Replace the three inline record types with `StringMap`
-- [ ] Mark `State` fields `readonly`; fix any compile fallout
+- [x] Mark `State` fields `readonly`; fix any compile fallout — done in
+      functionalscript#1822, together with the repo-wide `readonly` rule in
+      [AGENTS.md §3.2](../../AGENTS.md#32-types). `Dir` and `_Entity` in the
+      same file already had `readonly`.
 
 ### Related
 

--- a/fjs/effects/node/todo/state-types-conventions.md
+++ b/fjs/effects/node/todo/state-types-conventions.md
@@ -33,7 +33,7 @@ fields all being mutable, is fixed — see Tasks):
 - [ ] Replace the three inline record types with `StringMap`
 - [x] Mark `State` fields `readonly`; fix any compile fallout — done in
       functionalscript#1822, together with the repo-wide `readonly` rule in
-      [AGENTS.md §3.2](../../AGENTS.md#32-types). `Dir` and `_Entity` in the
+      [AGENTS.md §3.2](../../../AGENTS.md#32-types). `Dir` and `_Entity` in the
       same file already had `readonly`.
 
 ### Related

--- a/fjs/effects/node/types.ts
+++ b/fjs/effects/node/types.ts
@@ -56,6 +56,11 @@ export type {
 
 // fetch
 
+/**
+ * The tuple itself is a documented exception to the repo-wide `readonly`
+ * rule (`fjs/AGENTS.md` §3.2) — see "Six operation tuples are not
+ * `readonly`" in `fjs/effects/todo/node-module-layering.md`.
+ */
 export type Fetch = ['fetch', (url: string) => IoResult<Vec>]
 
 // mkdir
@@ -211,6 +216,10 @@ export type ServerResponse = {
  */
 export type RequestListener<O extends Operation> = (_: IncomingMessage) => Effect<O, ServerResponse, never>
 
+/**
+ * The tuple itself is a documented exception to the repo-wide `readonly`
+ * rule (`fjs/AGENTS.md` §3.2) — see the note on `Fetch` above.
+ */
 export type CreateServer = ['createServer', (listener: RequestListener<Operation>) => OpResult<Server>]
 
 // listen
@@ -229,6 +238,9 @@ export type CreateServer = ['createServer', (listener: RequestListener<Operation
  * arrives asynchronously, as the server's `error` event. An operation that
  * answered the moment `listen` was *called* would report a server that never
  * started, and leave the host to kill the process a moment later.
+ *
+ * The tuple itself is a documented exception to the repo-wide `readonly`
+ * rule (`fjs/AGENTS.md` §3.2) — see the note on `Fetch` above.
  */
 export type Listen = ['listen', (server: Server, port: number, host: string) => IoResult<void>]
 
@@ -238,6 +250,10 @@ export type Http = CreateServer | Listen
 
 // Wait forever
 
+/**
+ * The tuple itself is a documented exception to the repo-wide `readonly`
+ * rule (`fjs/AGENTS.md` §3.2) — see the note on `Fetch` above.
+ */
 export type Forever = ['forever', () => OpResult<never>]
 
 // import — `Import` and `Module` are `../common`'s, re-exported above: a

--- a/fjs/effects/node/virtual/types.ts
+++ b/fjs/effects/node/virtual/types.ts
@@ -72,30 +72,30 @@ export type _Binding = {
 }
 
 export type State = {
-    stdout: string
-    stderr: string
+    readonly stdout: string
+    readonly stderr: string
     /** Remaining stdin bytes; each `read` pops the first, `null` at EOF. */
-    stdin: readonly number[]
-    root: Dir
-    internet: {
+    readonly stdin: readonly number[]
+    readonly root: Dir
+    readonly internet: {
         readonly[url: string]: Vec
     }
-    epochNs: number
-    memoryNext: number
-    memoryValues: { readonly [key: string]: unknown }
+    readonly epochNs: number
+    readonly memoryNext: number
+    readonly memoryValues: { readonly [key: string]: unknown }
     /** Monotonically increasing counter returned by `randomInt`; starts at 0. */
-    randomNext: number
+    readonly randomNext: number
     /**
      * What is listening, oldest first. An address appears once: a second
      * `listen` on one that is taken fails, as it does on a host.
      */
-    listening: readonly _Binding[]
+    readonly listening: readonly _Binding[]
     /**
      * The requests a fixture queues for the server to answer. `listen` delivers
      * every one of them to the {@link _VirtualListener} its handle carries, and
      * empties the queue — the virtual counterpart of accepting connections.
      */
-    requests: readonly IncomingMessage[]
+    readonly requests: readonly IncomingMessage[]
     /** What the listener answered, oldest first. */
-    responses: readonly ServerResponse[]
+    readonly responses: readonly ServerResponse[]
 }

--- a/fjs/effects/todo/node-module-layering.md
+++ b/fjs/effects/todo/node-module-layering.md
@@ -306,18 +306,28 @@ Judgement calls worth deciding explicitly rather than by accident:
 ### Six operation tuples are not `readonly`
 
 `Fetch`, `CreateServer`, `Listen` and `Forever` in
-[`../node/types.ts`](../node/types.ts), and `All` in
+[`../node/types.ts`](../node/types.ts), and `All` and `Import` in
 [`../common/types.ts`](../common/types.ts), are declared as plain tuples where
-every other operation is `readonly`. `Import` was a sixth until it moved, and
+every other operation is `readonly`. `Import` moved here from `../node/types.ts`;
 making it `readonly` on the way looked like tidying — but a `readonly` tuple is
 not assignable to a mutable one, so it is a break a consumer could hit, for
 cosmetics. It was reverted rather than shipped with a `**BREAKING CHANGES:**`
-entry attached to a rename; `All` moved afterwards and kept its plain tuple for
-the same reason.
+entry attached to a rename, kept its plain tuple in its new home, and `All`
+moved afterwards and kept its plain tuple for the same reason. All six —
+`Fetch`, `CreateServer`, `Listen`, `Forever`, `All`, `Import` — remain plain
+tuples today.
 
-The five that remain are worth aligning *deliberately*, in one change that says
-so and takes the version bump for the set rather than smuggling it inside a
-move. Nothing depends on it.
+The six are worth aligning *deliberately*, in one change that says so and takes
+the version bump for the set rather than smuggling it inside a move. Nothing
+depends on it.
+
+functionalscript#1822 (which added the repo-wide `readonly`-types rule in
+`fjs/AGENTS.md`) considered aligning these six as part of that sweep and
+deliberately deferred them here instead, even though that PR's own other
+changes already forced a version bump: each of the six now carries an inline
+comment pointing back at this section, and folding them in without giving the
+rename its own changelog entry and its own look at every call site would have
+been exactly the kind of smuggled break this section exists to avoid.
 
 ### Tasks
 

--- a/fjs/media/html/types.ts
+++ b/fjs/media/html/types.ts
@@ -10,6 +10,13 @@ type Tag = string
 
 type Attributes = StringMap<string>
 
+// The rest tail stays a plain `Node[]` rather than `readonly Node[]`: TypeScript
+// (TS2456, "circularly references itself") cannot resolve this tuple's own
+// mutually-recursive cycle (`Element1`/`Element2` -> `Node` -> `Element` ->
+// `Element1`/`Element2`) through a `readonly` array rest element, only through
+// a mutable one — verified against the pinned compiler. Approved exception to
+// the repo-wide readonly rule (`fjs/AGENTS.md` §3.2) for that reason alone.
+
 type Element1 = readonly [Tag, ...Node[]]
 
 type Element2 = readonly [Tag, Attributes, ...Node[]]

--- a/fjs/media/nix/types.ts
+++ b/fjs/media/nix/types.ts
@@ -8,26 +8,26 @@ type _Identifier = string
 
 type _AttributeName = string
 
-export type _AttributePath = readonly [_AttributeName, ..._AttributeName[]]
+export type _AttributePath = readonly [_AttributeName, ...readonly _AttributeName[]]
 
 export type _Binding = readonly ['=', _AttributePath, Expression]
 
-export type _Reference = readonly ['ref', _Identifier, ..._AttributeName[]]
+export type _Reference = readonly ['ref', _Identifier, ...readonly _AttributeName[]]
 
-export type _AttributeSet = readonly ['set', ..._Binding[]]
+export type _AttributeSet = readonly ['set', ...readonly _Binding[]]
 
 /**
  * A list literal. Items are references or strings — the two forms the
  * generators need, and the two the serializer can render without deciding when
  * a nested expression has to be parenthesised.
  */
-export type _NixList = readonly ['list', ...(_Reference | string)[]]
+export type _NixList = readonly ['list', ...readonly (_Reference | string)[]]
 
 type _ApplicationArgument = _Reference | _AttributeSet
 
-export type _Application = readonly ['apply', _Reference, ..._ApplicationArgument[]]
+export type _Application = readonly ['apply', _Reference, ...readonly _ApplicationArgument[]]
 
-export type _OpenSetPattern = readonly ['open-set-pattern', ..._Identifier[]]
+export type _OpenSetPattern = readonly ['open-set-pattern', ...readonly _Identifier[]]
 
 export type _Lambda = readonly ['lambda', _OpenSetPattern, Expression]
 
@@ -41,7 +41,7 @@ export type _Let = readonly ['let', readonly _Binding[], Expression]
  * `${a.b}` and resolved by Nix — which is the only way a generated hook can
  * name a package, since a store path is not knowable when the file is written.
  */
-export type _IndentedString = readonly ['indented-string', ...(string | _Reference)[]]
+export type _IndentedString = readonly ['indented-string', ...readonly (string | _Reference)[]]
 
 /** The Nix syntax supported by the serializer. */
 export type Expression =

--- a/fjs/rtti/ts/types.ts
+++ b/fjs/rtti/ts/types.ts
@@ -78,7 +78,7 @@ export type _AdmitsAbsence<T> =
     true extends _AdmitsAbsence1<T> ? true : false
 
 type _AdmitsAbsence1<T> =
-    T extends { readonly [phantomKey]?: infer O } ? ([O] extends [{ readonly [absentKey]: unknown }] ? true : false) :
+    T extends { readonly [phantomKey]?: infer O } ? (readonly [O] extends readonly [{ readonly [absentKey]: unknown }] ? true : false) :
     T extends () => infer I
         ? I extends readonly['option'] ? true
         : I extends readonly['or', ...infer A extends readonly Type[]] ? _AdmitsAbsence1<A[number]>
@@ -109,7 +109,7 @@ type _IsAbsentOnly<T> =
 
 type _IsAbsentOnly1<T> =
     T extends { readonly [phantomKey]?: infer O }
-        ? ([O] extends [{ readonly [absentKey]: infer P }] ? ([Exclude<P, undefined>] extends [never] ? true : false) : false) :
+        ? (readonly [O] extends readonly [{ readonly [absentKey]: infer P }] ? (readonly [Exclude<P, undefined>] extends readonly [never] ? true : false) : false) :
     T extends () => infer I
         ? I extends readonly['option'] ? true
         : I extends readonly['or', ...infer A extends readonly Type[]] ? _IsAbsentOnly1<A[number]>
@@ -359,7 +359,7 @@ export type RestTs<C extends ConstObject, R extends Type> =
  * tail is a union.
  */
 type TupleRestTs<C extends Tuple, R extends Type> =
-    [R] extends [Or<readonly []>]
+    readonly [R] extends readonly [Or<readonly []>]
         ? TupleTs<C>
         : TupleTs<C> extends infer M extends readonly unknown[]
             ? readonly [...M, ...ReadonlyArray<Ts<R> | undefined>]
@@ -458,7 +458,7 @@ export type Ts<T extends Type> =
     // wrapper is unwrapped here; either way the optional-field `undefined`
     // artifact is stripped.
     T extends { readonly [phantomKey]?: infer O }
-        ? ([O] extends [{ readonly [absentKey]: infer P }] ? Exclude<P, undefined> : Exclude<O, undefined>) :
+        ? (readonly [O] extends readonly [{ readonly [absentKey]: infer P }] ? Exclude<P, undefined> : Exclude<O, undefined>) :
     T extends () => infer I ? (
         I extends readonly['const', infer C] ? ConstTs<C> :
         // Info0
@@ -499,7 +499,7 @@ export type Ts<T extends Type> =
 export type _TsRaw<T extends Type> =
     unknown extends T ? Unknown :
     T extends { readonly [phantomKey]?: infer O }
-        ? ([O] extends [{ readonly [absentKey]: infer P }] ? Absent | Exclude<P, undefined> : Exclude<O, undefined>) :
+        ? (readonly [O] extends readonly [{ readonly [absentKey]: infer P }] ? Absent | Exclude<P, undefined> : Exclude<O, undefined>) :
     T extends () => infer I ? (
         I extends readonly['option'] ? Absent :
         I extends readonly['or', ...infer A extends readonly Type[]] ? _TsRaw<A[number]> :
@@ -542,9 +542,9 @@ export type Check3<T, R0 extends Type, R1 extends Type> = And<Equal<T, Ts<R0>>, 
  * unwrapped, and this then agrees with {@link Check} on the raw thunk.
  */
 export type CheckRaw<A, B extends Type> = And<
-    Equal<[A] extends [{ readonly [absentKey]: unknown }] ? true : false, _AdmitsAbsence<B>>,
+    Equal<readonly [A] extends readonly [{ readonly [absentKey]: unknown }] ? true : false, _AdmitsAbsence<B>>,
     Equal<
-        [A] extends [{ readonly [absentKey]: infer P }] ? P : A,
+        readonly [A] extends readonly [{ readonly [absentKey]: infer P }] ? P : A,
         Exclude<_TsRaw<B>, Absent>
     >
 >

--- a/fjs/types/function/compare/types.ts
+++ b/fjs/types/function/compare/types.ts
@@ -13,8 +13,8 @@ export type Cmp<T> = (a: T) => Compare<T>
 export type Cmp1 = boolean | string | number | bigint
 
 export type Cmp2<A, B> =
-    [A, B] extends [boolean, boolean] ? boolean :
-    [A, B] extends [string, string] ? string :
-    [A, B] extends [number, number] ? number :
-    [A, B] extends [bigint, bigint] ? bigint :
+    readonly [A, B] extends readonly [boolean, boolean] ? boolean :
+    readonly [A, B] extends readonly [string, string] ? string :
+    readonly [A, B] extends readonly [number, number] ? number :
+    readonly [A, B] extends readonly [bigint, bigint] ? bigint :
     never

--- a/fjs/types/nominal/types.ts
+++ b/fjs/types/nominal/types.ts
@@ -26,4 +26,4 @@ declare const brand: unique symbol
 export type _SymbolKeyBranded = { readonly [noCompareBrand]: void }
 
 /** A `symbol` intersection brand. `<` on this is TS2469, so the proof only comments it. */
-export type _SymbolIntersectionBranded = symbol & { [brand]: 'SafeId' }
+export type _SymbolIntersectionBranded = symbol & { readonly [brand]: 'SafeId' }

--- a/fjs/types/nominal/types.ts
+++ b/fjs/types/nominal/types.ts
@@ -11,7 +11,7 @@
  * It doesn't allow `<`, `>`, `<=`, `>=` comparisons at all.
  */
 export type Nominal<N extends string, R extends string, B> =
-    symbol & { [k in N]: readonly [R, B] }
+    symbol & { readonly[k in N]: readonly [R, B] }
 
 // Brand carriers for the comparison experiments in `proof.f.mjs`. They live
 // here because `declare const` / `unique symbol` have no JavaScript form; the
@@ -23,7 +23,7 @@ declare const noCompareBrand: unique symbol
 declare const brand: unique symbol
 
 /** A unique-symbol-keyed brand. TypeScript still permits `<` between two of these. */
-export type _SymbolKeyBranded = { [noCompareBrand]: void }
+export type _SymbolKeyBranded = { readonly [noCompareBrand]: void }
 
 /** A `symbol` intersection brand. `<` on this is TS2469, so the proof only comments it. */
 export type _SymbolIntersectionBranded = symbol & { [brand]: 'SafeId' }

--- a/fjs/types/object/types.ts
+++ b/fjs/types/object/types.ts
@@ -42,7 +42,7 @@ export type Entry<T> = readonly[string, T]
  */
 export type OneKey<K extends string, V> = {
     [P in K]: (RequiredMap<P, V> & OptionalMap<Exclude<K, P>, never>) extends infer O
-        ? { [Q in keyof O]: O[Q] }
+        ? { readonly [Q in keyof O]: O[Q] }
         : never
 }[K];
 

--- a/fjs/types/object/types.ts
+++ b/fjs/types/object/types.ts
@@ -41,7 +41,7 @@ export type Entry<T> = readonly[string, T]
  * https://stackoverflow.com/questions/57571664/typescript-type-for-an-object-with-only-one-key-no-union-type-allowed-as-a-key
  */
 export type OneKey<K extends string, V> = {
-    [P in K]: (RequiredMap<P, V> & OptionalMap<Exclude<K, P>, never>) extends infer O
+    readonly [P in K]: (RequiredMap<P, V> & OptionalMap<Exclude<K, P>, never>) extends infer O
         ? { readonly [Q in keyof O]: O[Q] }
         : never
 }[K];
@@ -51,7 +51,7 @@ export type OneKey<K extends string, V> = {
  */
 export type NotUnion<T, U = T> =
   T extends unknown ?
-    [U] extends [T] ? T
+    readonly [U] extends readonly [T] ? T
     : never
   : never;
 

--- a/fjs/types/range_map/types.ts
+++ b/fjs/types/range_map/types.ts
@@ -8,7 +8,7 @@ import type { Equal, Reduce } from '../function/operator/types.ts'
 import type { Range } from '../range/types.ts'
 import type { SortedList } from '../sorted_list/types.ts'
 
-export type Entry<T> = [T, number]
+export type Entry<T> = readonly [T, number]
 
 /**
  * A sorted list of entries, where each entry is a tuple `[T, number]` that maps

--- a/fjs/types/ts/types.ts
+++ b/fjs/types/ts/types.ts
@@ -13,7 +13,7 @@ export type Equal<A, B> =
         : false
 
 export type And<A extends boolean, B extends boolean> =
-    [A, B] extends [true, true] ? true : false
+    readonly [A, B] extends readonly [true, true] ? true : false
 
 type _AndFF = Assert<Equal<And<false, false>, false>>
 type _AndFT = Assert<Equal<And<false, true>, false>>

--- a/fjs/types/ts/types.ts
+++ b/fjs/types/ts/types.ts
@@ -43,7 +43,7 @@ export type Printer = {
 
 // Don't use!
 
-type _T0 = {[k:string]: bigint}
+type _T0 = {readonly [k:string]: bigint}
 
 declare const x0: _T0
 
@@ -51,7 +51,7 @@ type _X0 = Assert<Equal<typeof x0['hello'], bigint>>
 
 // Use for finite sets
 
-type _T1 = {[k in 'hello']: bigint}
+type _T1 = {readonly [k in 'hello']: bigint}
 
 declare const x1: _T1
 
@@ -59,7 +59,7 @@ type _X1 = Assert<Equal<typeof x1['hello'], bigint>>
 
 // Don't use it
 
-type _T2 = {[k in string]: bigint}
+type _T2 = {readonly [k in string]: bigint}
 
 declare const x2: _T2
 
@@ -67,10 +67,10 @@ type _X2 = Assert<Equal<typeof x2['hello'], bigint>>
 
 // Use it for infinite sets
 
-type _T3 = {[k in string]?: bigint}
+type _T3 = {readonly [k in string]?: bigint}
 
 declare const x3: _T3
 
 type _X3 = Assert<Equal<typeof x3['hello'], bigint | undefined>>
 
-// type T4 = {[k:string]?: bigint} //< compilation error.
+// type T4 = {readonly [k:string]?: bigint} //< compilation error.


### PR DESCRIPTION
## Summary

- Adds `readonly` to array/tuple/object members that were missing it
  across `types.ts`/`private.ts` declarations, matching the immutable
  style used everywhere else in the repo — `fjs/bnf`'s `Option`,
  `fjs/cas`'s `FileCas`, `fjs/effects/node/virtual`'s `State`,
  `fjs/edag/amnesia`'s `TagMap`, `fjs/djs`'s `transpiler`/`ast` types,
  `fjs/types/nominal`'s brand fields, `fjs/types/object`'s
  `OneKey`/`NotUnion`, `fjs/types/range_map`'s `Entry`,
  `fjs/djs/tokenizer/private.ts`'s tuples, `fjs/types/ts`'s `And`,
  `fjs/types/function/compare`'s `Cmp2`, several tuple checks in
  `fjs/rtti/ts/types.ts`, and rest-tail arrays in `fjs/media/nix` and
  `fjs/ci/nix`.
- Adds a new rule to `fjs/AGENTS.md` (§3.2 Types): array, tuple, and
  object members in `types.ts`/`private.ts` declarations must be
  `readonly`. Exceptions need explicit reviewer sign-off plus a comment;
  most legitimate ones are either a type describing a host/library API
  this repo doesn't own (e.g. `IncomingMessage` wrapping Node's own
  object), an already-tracked, deliberately-deferred breaking change
  (the six operation tuples in `fjs/effects`, tracked in
  `fjs/effects/todo/node-module-layering.md`), or a spot where `tsc`
  itself rejects the `readonly` spelling (`fjs/media/html/types.ts`'s
  mutually-recursive `Element1`/`Element2`, TS2456).
- Updates the `FileCas` example in `fjs/AGENTS.md`'s "Composition over
  intersection" section, and `fjs/effects/node/todo/state-types-conventions.md`,
  to match.
- Corrects `fjs/effects/todo/node-module-layering.md`'s "Six operation
  tuples" section, which had drifted to say five remain (`Import`'s move
  had kept it a sixth plain tuple, not removed it from the count), and
  records that this PR considered aligning those six as part of its own
  sweep and deliberately deferred them rather than folding an unrelated
  rename into it.

## Changelog

- **BREAKING CHANGES:** several public `types.ts` declarations gained
  `readonly` on tuple/object members that were mutable before (`bnf`'s
  `Option`, `types/range_map`'s `Entry`, and others). A mutable tuple no
  longer fits, and assigning through an object field now fails type checking.

## Test plan

- [x] `tsc` — clean, no errors
- [x] `node ./fjs/module.mjs t` — 3712/3712 tests pass
