### PR TITLE
ci: enable nix-command and flakes from the generated run scripts

### DIFF
--- a/changelog/unreleased/1831.md
+++ b/changelog/unreleased/1831.md
@@ -1,3 +1,3 @@
-- `ci`: the generated `run` scripts pass `--extra-experimental-features
-  'nix-command flakes'`, so they work on a stock Nix install rather than only
-  where `nix.conf` already enables both.
+- `ci`: the generated `run` scripts and `nix/lock-update.sh` pass
+  `--extra-experimental-features 'nix-command flakes'`, so they work on a stock
+  Nix install rather than only where `nix.conf` already enables both.

--- a/changelog/unreleased/1831.md
+++ b/changelog/unreleased/1831.md
@@ -1,0 +1,3 @@
+- `ci`: the generated `run` scripts pass `--extra-experimental-features
+  'nix-command flakes'`, so they work on a stock Nix install rather than only
+  where `nix.conf` already enables both.

--- a/fjs/ci/README.md
+++ b/fjs/ci/README.md
@@ -135,11 +135,10 @@ constant, so the two cannot drift.
 
 A generated `run` script sits beside every flake, and a workflow step reads as
 the command it runs — `./nix/run npm run cov` — rather than as a `nix develop`
-invocation repeated fifteen times. The script carries `--no-update-lock-file`
-(error rather than silently resolve a mismatched input — a plain
-`--no-write-lock-file` would leave the checkout untouched but still resolve
-in memory and warn) and one `--quiet`, which drops the `copying N paths`
-substitution chatter and leaves every warning.
+invocation repeated once per step. Its flags live in that one generated place,
+and `nix/module.f.mjs` says what each buys: a stale lock fails rather than
+resolving silently, substitution progress stays out of the log, and the script
+works on a stock Nix install rather than only a configured one.
 
 [`dev.sh`](../../dev.sh) at the repository root is the interactive counterpart,
 for a person who wants the shell rather than one command in it. It is committed

--- a/fjs/ci/nix/module.f.mjs
+++ b/fjs/ci/nix/module.f.mjs
@@ -303,12 +303,13 @@ export const flakeText = job =>
  */
 export const lockUpdateText = jobs => `#!/bin/sh
 set -e
-${jobs.map(({ id }) => `nix flake lock ${flakePath(id)}`).join('\n')}
+${jobs.map(({ id }) => `nix flake lock ${experimentalFeatures} ${flakePath(id)}`).join('\n')}
 `
 
 /**
- * Enables the two experimental features every command here needs: `nix-command`
- * is `nix develop` itself, and `flakes` is the flake it names.
+ * Enables the two experimental features every generated script needs.
+ * `nix-command` is the modern `nix` CLI — both `nix develop` and `nix flake` —
+ * and `flakes` is the flake each one names.
  *
  * A Nix installation enables them in `nix.conf` or does not, and the ones that
  * do not are not exotic — a plain `sh <(curl -L https://nixos.org/nix/install)`
@@ -317,6 +318,11 @@ ${jobs.map(({ id }) => `nix flake lock ${flakePath(id)}`).join('\n')}
  * is disabled` from a script whose whole purpose is to need no setup. CI's
  * installer action happens to enable them, which is exactly why this went
  * unnoticed there.
+ *
+ * **Both generated scripts, not only `run`.** `nix flake` is gated behind the
+ * same two features as `nix develop`, so leaving {@link lockUpdateText} out
+ * would fix `./nix/run` for exactly the contributor who would then meet the
+ * identical error from `npm run lock-update`.
  *
  * Passing them makes the script say what it needs instead of asking the machine
  * to have been configured for it. It costs nothing where they are already on:

--- a/fjs/ci/nix/module.f.mjs
+++ b/fjs/ci/nix/module.f.mjs
@@ -307,6 +307,25 @@ ${jobs.map(({ id }) => `nix flake lock ${flakePath(id)}`).join('\n')}
 `
 
 /**
+ * Enables the two experimental features every command here needs: `nix-command`
+ * is `nix develop` itself, and `flakes` is the flake it names.
+ *
+ * A Nix installation enables them in `nix.conf` or does not, and the ones that
+ * do not are not exotic — a plain `sh <(curl -L https://nixos.org/nix/install)`
+ * leaves both off, and so does the Determinate installer's non-default path. So
+ * a contributor whose Nix is stock reads `experimental Nix feature 'nix-command'
+ * is disabled` from a script whose whole purpose is to need no setup. CI's
+ * installer action happens to enable them, which is exactly why this went
+ * unnoticed there.
+ *
+ * Passing them makes the script say what it needs instead of asking the machine
+ * to have been configured for it. It costs nothing where they are already on:
+ * `--extra-experimental-features` adds to the configured set rather than
+ * replacing it, so an installation with more of them enabled keeps them.
+ */
+const experimentalFeatures = `--extra-experimental-features 'nix-command flakes'`
+
+/**
  * The `run` script generated beside a flake. `./nix/run npm run cov` is what a
  * workflow step says; this is what makes that a command.
  *
@@ -398,7 +417,7 @@ ${jobs.map(({ id }) => `nix flake lock ${flakePath(id)}`).join('\n')}
  * @type {(id: string) => string}
  */
 export const runText = id => `#!/bin/sh
-exec nix develop --no-update-lock-file --quiet ${flakePath(id)} --command "$@"
+exec nix develop ${experimentalFeatures} --no-update-lock-file --quiet ${flakePath(id)} --command "$@"
 `
 
 /**

--- a/fjs/ci/nix/proof.f.mjs
+++ b/fjs/ci/nix/proof.f.mjs
@@ -410,11 +410,16 @@ export const proof = {
         // One `nix flake lock` per generated directory — Nix has no form that
         // locks several flakes at once — under `set -e`, so a later directory
         // is never silently skipped after an earlier one fails.
+        //
+        // Each line carries the experimental features for the same reason the
+        // `run` scripts do: `nix flake` is gated behind `nix-command` and
+        // `flakes` exactly as `nix develop` is, so a stock installation that
+        // could not run `./nix/run` could not run this either.
         lockUpdateText: () => {
             assertEq(lockUpdateText([plain, withRust]), `#!/bin/sh
 set -e
-nix flake lock ${flakePath(plain.id)}
-nix flake lock ${flakePath(withRust.id)}
+nix flake lock --extra-experimental-features 'nix-command flakes' ${flakePath(plain.id)}
+nix flake lock --extra-experimental-features 'nix-command flakes' ${flakePath(withRust.id)}
 `)
         },
         // What that script must say, pinned rather than described, for the

--- a/fjs/ci/nix/proof.f.mjs
+++ b/fjs/ci/nix/proof.f.mjs
@@ -432,10 +432,10 @@ nix flake lock ${flakePath(withRust.id)}
         // appearing in a comment.
         runText: () => {
             assertEq(runText(nixShell), `#!/bin/sh
-exec nix develop --no-update-lock-file --quiet ./nix --command "$@"
+exec nix develop --extra-experimental-features 'nix-command flakes' --no-update-lock-file --quiet ./nix --command "$@"
 `)
             assertEq(runText(plain.id), `#!/bin/sh
-exec nix develop --no-update-lock-file --quiet ./nix/node24 --command "$@"
+exec nix develop --extra-experimental-features 'nix-command flakes' --no-update-lock-file --quiet ./nix/node24 --command "$@"
 `)
         },
         // One, and the count is arithmetic rather than taste. Nix has a single

--- a/nix/lock-update.sh
+++ b/nix/lock-update.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-nix flake lock ./nix/node22
-nix flake lock ./nix/node24
-nix flake lock ./nix/ubuntu-intel32
-nix flake lock ./nix
+nix flake lock --extra-experimental-features 'nix-command flakes' ./nix/node22
+nix flake lock --extra-experimental-features 'nix-command flakes' ./nix/node24
+nix flake lock --extra-experimental-features 'nix-command flakes' ./nix/ubuntu-intel32
+nix flake lock --extra-experimental-features 'nix-command flakes' ./nix

--- a/nix/node22/run
+++ b/nix/node22/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec nix develop --no-update-lock-file --quiet ./nix/node22 --command "$@"
+exec nix develop --extra-experimental-features 'nix-command flakes' --no-update-lock-file --quiet ./nix/node22 --command "$@"

--- a/nix/node24/run
+++ b/nix/node24/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec nix develop --no-update-lock-file --quiet ./nix/node24 --command "$@"
+exec nix develop --extra-experimental-features 'nix-command flakes' --no-update-lock-file --quiet ./nix/node24 --command "$@"

--- a/nix/run
+++ b/nix/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec nix develop --no-update-lock-file --quiet ./nix --command "$@"
+exec nix develop --extra-experimental-features 'nix-command flakes' --no-update-lock-file --quiet ./nix --command "$@"

--- a/nix/ubuntu-intel32/run
+++ b/nix/ubuntu-intel32/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec nix develop --no-update-lock-file --quiet ./nix/ubuntu-intel32 --command "$@"
+exec nix develop --extra-experimental-features 'nix-command flakes' --no-update-lock-file --quiet ./nix/ubuntu-intel32 --command "$@"


### PR DESCRIPTION
`./nix/run` and its siblings failed with `experimental Nix feature
'nix-command' is disabled` on any Nix installation whose `nix.conf` does not
already enable `nix-command` and `flakes`. A stock installer leaves both off,
so the script whose whole purpose is to need no setup needed setup. CI never
saw it: `cachix/install-nix-action` enables both.

Both generated scripts now pass the features themselves, from one named binding
in `fjs/ci/nix/module.f.mjs` — the four `run` scripts and `nix/lock-update.sh`,
since `nix flake` is gated behind the same two features as `nix develop`.
`--extra-experimental-features` adds to the configured set rather than
replacing it, so an installation that already enables them — or more — is
unaffected.

Changelog:
- `ci`: the generated `run` scripts and `nix/lock-update.sh` pass
  `--extra-experimental-features 'nix-command flakes'`, so they work on a stock
  Nix install rather than only where `nix.conf` already enables both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
