### PR TITLE
emergent_testing: describing a thrown value no longer kills the summary

### DIFF
--- a/changelog/unreleased/1832.md
+++ b/changelog/unreleased/1832.md
@@ -5,3 +5,7 @@
 - **BREAKING CHANGES:** `emergent_testing`: `defaultReporter` answers
   `Reporter<Write | Sandbox | Catch>` — a runner driving it must dispatch
   `catch`
+- **BREAKING CHANGES:** `emergent_testing`: `unknownValue` moved from
+  `emergent_testing/browser/module.f.mjs` to `emergent_testing/module.f.mjs`,
+  where both runners read it. Update the import path; no compatibility export
+  is left behind

--- a/changelog/unreleased/1832.md
+++ b/changelog/unreleased/1832.md
@@ -1,0 +1,7 @@
+- `emergent_testing`: `fjs t` describes a failure's thrown value through the
+  shared `text`, so a value whose `toString` throws is reported as
+  `Unknown thrown value` instead of killing the summary after every test has
+  already run
+- **BREAKING CHANGES:** `emergent_testing`: `defaultReporter` answers
+  `Reporter<Write | Sandbox | Catch>` — a runner driving it must dispatch
+  `catch`

--- a/fjs/emergent_testing/browser/module.f.mjs
+++ b/fjs/emergent_testing/browser/module.f.mjs
@@ -28,7 +28,9 @@
  */
 
 import { catch_, import_ } from '../../effects/common/module.f.mjs'
-import { addResult, collectTests, defaultTest, runEntries, zeroState, zeroTotals } from '../module.f.mjs'
+import {
+    addResult, collectTests, defaultTest, runEntries, text, zeroState, zeroTotals,
+} from '../module.f.mjs'
 import { do_, errorMessage, foldStep, mapStep, pureOk, resultStep, step } from '../../effects/module.f.mjs'
 import { error } from '../../types/result/module.f.mjs'
 
@@ -56,27 +58,6 @@ const report = do_('report')
  */
 const attempt = f =>
     resultStep(catch_(f), r => pureOk(r[0] === 'ok' ? r[1] : error(r[1])))
-
-/**
- * What a value that cannot be read is called.
- *
- * A value reaches the report by being described, and describing runs the
- * value's own code — a `toString`, a getter, a proxy trap — which can throw in
- * its turn. Every route that meets one says this, so a reader meets one phrase
- * rather than three spellings of the same defeat.
- */
-export const unknownValue = 'Unknown thrown value'
-
-/**
- * The text of a value that may not want to be read. `String` runs user code —
- * a `toString`, a proxy trap — so it is attempted rather than called.
- *
- * @type {(value: unknown) => Effect<Catch, string, never>}
- */
-const text = value =>
-    mapStep(
-        attempt(() => String(value)),
-        r => r[0] === 'ok' ? /** @type {string} */(r[1]) : unknownValue)
 
 /**
  * The `message` and `stack` of a thrown value, read in one attempt.

--- a/fjs/emergent_testing/browser/module.mjs
+++ b/fjs/emergent_testing/browser/module.mjs
@@ -27,8 +27,11 @@
  */
 
 import {
-    errorDetails, loadProofs, moduleFailure, reportOf, runProofs, runnerSource, unknownValue,
+    errorDetails, loadProofs, moduleFailure, reportOf, runProofs, runnerSource,
 } from './module.f.mjs'
+// The phrase for a value that will not be read is the runners' shared one:
+// this host meets such a value at its `import` boundary, where the walk cannot.
+import { unknownValue } from '../module.f.mjs'
 import { asyncRun } from '../../effects/module.mjs'
 import { commonOperationMap } from '../../effects/common/module.mjs'
 import { ioError, toIoError } from '../../effects/module.f.mjs'

--- a/fjs/emergent_testing/catch.proof.mjs
+++ b/fjs/emergent_testing/catch.proof.mjs
@@ -13,13 +13,15 @@
  * @import { Catch, Sandbox } from '../effects/common/types.ts'
  * @import { Commands } from '../effects/types.ts'
  * @import { Reporter } from './types.ts'
+ * @import { NodeProgramOptions } from '../effects/node/types.ts'
  * @import { Vec } from '../types/bit_vec/types.ts'
  */
 
 import { assert } from '../asserts/module.f.mjs'
 import { log } from '../effects/node/module.f.mjs'
 import { partialRun, run as mockRun } from '../effects/mock/module.f.mjs'
-import { defaultTest, runModuleMap } from './module.f.mjs'
+import { defaultReporter, defaultTest, runModuleMap } from './module.f.mjs'
+import { defaultNodeProgramOptions } from '../effects/node/virtual/module.f.mjs'
 import { error, ok } from '../types/result/module.f.mjs'
 import { utf8ToString } from '../text/module.f.mjs'
 
@@ -31,16 +33,18 @@ import { utf8ToString } from '../text/module.f.mjs'
  * the proof reads the same way a virtual run does and nothing here mutates a
  * value it closed over.
  *
- * @type {(moduleMap: Record<string, { readonly proof: unknown }>) => string}
+ * A reporter can be passed in: most proofs here want the terse one below,
+ * where a line is one assertion, and the two about *describing* a value want
+ * `fjs t`'s own, because the describing is its.
+ *
+ * @type {(moduleMap: Record<string, { readonly proof: unknown }>, reporter?: Reporter<Catch | Sandbox | Write>) => string}
  */
-const runModules = moduleMap => {
-    /** @type {Reporter<Sandbox | Write>} */
-    const reporter = {
-        start: ({ name }) => log(`start:${name}`),
-        result: (t, _r, _throws) => log(`${t.path}:${t.status}`),
-        summary: ({ totals: { passed, failed } }) => log(`summary:${passed}:${failed}`),
-        test: defaultTest,
-    }
+const runModules = (moduleMap, reporter = {
+    start: ({ name }) => log(`start:${name}`),
+    result: (t, _r, _throws) => log(`${t.path}:${t.status}`),
+    summary: ({ totals: { passed, failed } }) => log(`summary:${passed}:${failed}`),
+    test: defaultTest,
+}) => {
     // No `all` handler, and that is not an omission: the shared traversal is
     // sequential, so it issues none — a restored fan-out would panic here as an
     // unclaimed command. What the *order* of a run must be is proved
@@ -189,10 +193,53 @@ const moduleExportIsStillWalked = () => {
     assert(written.includes('summary:2:0'), written)
 }
 
+/**
+ * **A thrown value that will not be read does not take the summary with it.**
+ *
+ * The leaf's own failure is caught by `sandbox` and reported like any other —
+ * that part always worked. What did not is the *end* of the run: `fjs t`
+ * describes each failure after the last leaf, and describing runs the value's
+ * own code, so `{ toString() { throw … } }` killed the report there. Every
+ * test had run and been announced, and the run still printed no totals and no
+ * exit code.
+ *
+ * This drives the real reporter rather than the mock one above, because the
+ * describing is the reporter's and that is what is under test. Both halves are
+ * asserted: the shared phrase in place of the value, and the summary line that
+ * used to be lost.
+ */
+const thrownValueThatCannotBeDescribed = () => {
+    /** @type {NodeProgramOptions} */
+    const options = { ...defaultNodeProgramOptions, env: {} }
+    const written = runModules({
+        './h.proof.f.mjs': {
+            proof: { boom: () => { throw { toString() { throw new Error('trap') } } } },
+        },
+    }, defaultReporter(options))
+    assert(written.includes('Unknown thrown value'), written)
+    assert(written.includes('Number of tests: pass: 0, fail: 1, total: 1'), written)
+}
+
+/**
+ * The same reporter still prints an ordinary value's own text, so the guard
+ * did not replace describing with the fallback phrase.
+ */
+const thrownValueIsStillDescribed = () => {
+    /** @type {NodeProgramOptions} */
+    const options = { ...defaultNodeProgramOptions, env: {} }
+    const written = runModules({
+        './h.proof.f.mjs': { proof: { boom: () => { throw 'plain trouble' } } },
+    }, defaultReporter(options))
+    assert(written.includes('plain trouble'), written)
+    assert(!written.includes('Unknown thrown value'), written)
+}
+
 export const proof = {
     returnedTreeThrows,
     returnedTreeIsStillWalked,
     moduleExportThrows,
     moduleFailureThatCannotBeReported,
     moduleExportIsStillWalked,
+    thrownValueThatCannotBeDescribed,
+    thrownValueIsStillDescribed,
 }

--- a/fjs/emergent_testing/module.f.mjs
+++ b/fjs/emergent_testing/module.f.mjs
@@ -677,13 +677,41 @@ const fmtResultEnd = ({ duration }, color, label) =>
     `${color}${label}${reset}, ${timeFormat(duration)}`
 
 /**
+ * What a value that cannot be read is called.
+ *
+ * A value reaches a report by being described, and describing runs the value's
+ * own code — a `toString`, a getter, a proxy trap — which can throw in its
+ * turn. Every route that meets one says this, so a reader meets one phrase
+ * rather than a spelling per runner.
+ */
+export const unknownValue = 'Unknown thrown value'
+
+/**
+ * The text of a value that may not want to be read. `String` runs user code, so
+ * it is attempted rather than called.
+ *
+ * **A runner that cannot `catch` gets the same phrase**, which is why the
+ * refusal is folded in here rather than propagated: there is no reader for whom
+ * "the value could not be read" and "the runner would not read it" are
+ * different facts, and a describer with an error channel would put that
+ * distinction in every caller.
+ *
+ * @type {(value: unknown) => Effect<Catch, string, never>}
+ */
+export const text = value => resultStep(
+    catch_(() => String(value)),
+    r => pureOk(r[0] === 'ok' && r[1][0] === 'ok'
+        ? /** @type {string} */ (r[1][1])
+        : unknownValue))
+
+/**
  * The terminal/GitHub reporter used by `fjs t`. Output goes through
  * `csiWrite`, so ANSI styles are stripped on non-TTY streams. When
  * `GITHUB_ACTIONS` is set, failures are emitted as `::error` workflow
  * annotations instead of colored lines. Exported as a factory so the
  * GitHub format path can be exercised directly from tests.
  *
- * @type {(options: NodeProgramOptions) => Reporter<Write | Sandbox>}
+ * @type {(options: NodeProgramOptions) => Reporter<Write | Sandbox | Catch>}
  */
 export const defaultReporter = options => {
     const write = csiWrite(options.std)
@@ -711,16 +739,24 @@ export const defaultReporter = options => {
     // afterwards, in the order they landed.
     //
     // https://github.com/OndraM/ci-detector/blob/main/src/Ci/GitHubActions.php
-    /** @type {(f: TestFailure) => Effect<Write, void, NotImplemented>} */
-    const detail = ({ t, error }) =>
+    //
+    // **The value is read through {@link text}, because reading it runs the
+    // value's own code.** A proof that throws `{ toString() { throw … } }` used
+    // to kill the summary *here* — after every leaf had run and been reported —
+    // so a completed run printed no totals and no exit code, which is the one
+    // outcome an automated consumer cannot act on. The page has described
+    // values this way since functionalscript#1802; this is the same read, in
+    // the reporter that needed it.
+    /** @type {(f: TestFailure) => Effect<Write | Catch, void, NotImplemented>} */
+    const detail = ({ t, error }) => step(text(error), described =>
         isGitHub
-            ? csiLog(`::error file=${t.module},line=1,title=${ghEscape(t.name)}::${ghEscape(String(error))}`)
+            ? csiLog(`::error file=${t.module},line=1,title=${ghEscape(t.name)}::${ghEscape(described)}`)
             // `step`, so the value is attempted only when the line naming the
             // test it belongs to was written: two halves of one report, and
             // half of it is worse than none.
             : step(
                 csiLog(`${fgRed}${t.name}${reset}`),
-                () => csiLog(`${fgRed}${error}${reset}`))
+                () => csiLog(`${fgRed}${described}${reset}`)))
     return {
         // One line per leaf, opened before it runs and closed when it lands:
         // `name: ` here, `ok, 1.2345 ms` from `result`. A reader watching a

--- a/fjs/emergent_testing/todo/hostile-proof-values.md
+++ b/fjs/emergent_testing/todo/hostile-proof-values.md
@@ -7,8 +7,8 @@
 
 The browser runner (`../browser/module.mjs`) defended against things `fjs t`
 did not, none of them reachable from ordinary FunctionalScript. That asymmetry
-is the point of this file — one of the three is closed and the other two are
-below: when the two runners are unified
+is the point of this file — two of the three are closed and the cross-realm
+promise below is what is left: when the two runners are unified
 ([share the browser and console proof runners](share-browser-console-runner.md)),
 the shared core has to have *one* answer for each of them, decided rather than
 inherited twice. `fjs t` is the reference, so the honest reading is that these

--- a/fjs/emergent_testing/todo/hostile-proof-values.md
+++ b/fjs/emergent_testing/todo/hostile-proof-values.md
@@ -29,15 +29,22 @@ functionalscript#1830 — in the shared traversal, so both runners answer one
 unreadable value with one failed record and keep going, and `TestResult` says
 so. What it cost is recorded in the task list below.
 
-**`errorDetails` is the half still open**, and it is the one where the two
-runners still differ: reading the *thrown* value is each host's own, because a
-serializable record cannot carry a raw one. `fjs t` prints it with `String(v)`,
-the page reads `message` and `stack` off it, and neither read is guarded in the
-core.
+**Describing a thrown value is closed too** (functionalscript#1832), and it
+closed differently from the other half. What the runners share is not the
+*description* — a report crossing a wire needs `message` and `stack`, a
+terminal line needs the value's own text — but the **read**: `text` lives in
+the core, attempts `String` through `catch`, and answers `unknownValue` when
+the value or the runner will not have it. Both runners read through it, and
+each still says what its own reader needs.
 
-Whichever runner ends up on top of it, the outcome to avoid is unchanged: a
-page left in `running`, or a process that exits with no summary, is what an
-automated controller cannot act on.
+The failure it removes was the far end of a run rather than the middle of one:
+`fjs t` describes its failures *after* the last leaf, so a hostile `toString`
+killed the report when every test had already run and been announced — no
+totals, no exit code, from a run that completed. Measured before the change,
+one hostile leaf beside a passing one: both lines printed, then `Error: trap`
+and nothing else. After: `Unknown thrown value`, the summary, exit 1.
+
+What is left in this file is the cross-realm promise below.
 
 **A promise from another realm is not awaited.** `fjs t`'s `sandbox` asks `p
 instanceof Promise`, which is false for a promise built in an iframe, a worker,
@@ -130,7 +137,15 @@ adopting a `then`, and a proof tree refusing to — which are studied together i
       throw needs a real `try` to write, so it drives `runModuleMap` through a
       mock rather than through the virtual runner, and a mock like that cannot
       be written in `.f.mjs`.
-- [ ] Read a thrown value through it at `errorDetails`' call site.
+- [x] Read a thrown value through it at `errorDetails`' call site — and at
+      `fjs t`'s, which is where it was actually killing runs. `text` and
+      `unknownValue` moved from `browser/module.f.mjs` into the core, so
+      `defaultReporter`'s failure detail and the page's `errorDetails` read
+      through one function. `defaultReporter` is a `Reporter<Write | Sandbox |
+      Catch>` now: describing a value is dispatching an operation, and its
+      signature says so. Pinned by `thrownValueThatCannotBeDescribed` and
+      `thrownValueIsStillDescribed` in `../catch.proof.mjs`, mutation-checked
+      against the unguarded `String(error)` it replaced.
 
 ### Constraints
 


### PR DESCRIPTION
`defaultReporter` printed a failure's value with `${error}`, and describing a
value runs its own code. Measured before the change, one hostile leaf beside a
passing one:

```
import("./bad.f.mjs").proof.boom(): error, 0.0671 ms
import("./good.f.mjs").proof.fine(): ok, 0.0117 ms
import("./bad.f.mjs").proof.boom()
Error: trap          ← the report dies here
```

Both leaves ran and both lines printed — `sandbox` caught the throw correctly.
What died is the *end* of the run: `fjs t` describes its failures after the last
leaf, so a hostile `toString` killed the report when every test had already been
announced. A completed run printed **no totals and no exit code**, which is the
one outcome an automated consumer cannot act on. After:

```
import("./bad.f.mjs").proof.boom()
Unknown thrown value
Number of tests: pass: 1, fail: 1, total: 2
exit code: 1
```

This is the second half of
[hostile-proof-values](https://github.com/functionalscript/functionalscript/blob/main/fjs/emergent_testing/todo/hostile-proof-values.md);
#1830 closed the `collectTests` half.

## What the runners share is the read, not the description

The issue expected one shared answer, and the honest one is narrower than it
looks. A report crossing a wire needs `message` and `stack`; a terminal line
needs the value's own text. That difference is real and stays each host's.

What both need is the **read**: `text` attempts `String` through `catch` and
answers `unknownValue` when the value — or the runner — will not have it. It
moves from `browser/module.f.mjs`, where the page has read values this way since
#1802, into the core, and both runners now go through it. Only the dangerous
part is shared.

A runner that cannot dispatch `catch` gets the same phrase rather than an error
channel, deliberately: no reader distinguishes "the value could not be read"
from "the runner would not read it", and a describer with an error channel puts
that distinction in every caller.

## Signature

`defaultReporter` answers `Reporter<Write | Sandbox | Catch>`. Describing a
value is dispatching an operation, and the type says so.

## Proofs

Two in `catch.proof.mjs`, which drives the *real* reporter rather than the terse
mock the other proofs there use — the describing is the reporter's, so that is
what is under test. Mutation-checked against the `String(error)` they replace.

- `thrownValueThatCannotBeDescribed` — the shared phrase in place of the value,
  **and the summary line that used to be lost**. The second assertion is the
  one that matters.
- `thrownValueIsStillDescribed` — an ordinary thrown value still prints its own
  text, so the guard did not replace describing with the fallback.

The file is `.mjs` for the reason the whole issue rests on: a runner that
reports a throw needs a real `try`, and the virtual runner cannot have one.

## Verification

`npx tsc` clean · `fjs t` 3806/3806 · `node --test` 3744/3744 · coverage
**100%** · `npm run gen` no diff · `npm run website` 148 of 148.

## Changelog

- `emergent_testing`: `fjs t` describes a failure's thrown value through the
  shared `text`, so a value whose `toString` throws is reported as
  `Unknown thrown value` instead of killing the summary after every test has
  already run
- **BREAKING CHANGES:** `emergent_testing`: `defaultReporter` answers
  `Reporter<Write | Sandbox | Catch>` — a runner driving it must dispatch
  `catch`


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PyLwDNkPQM1uD1Tg5ApBg

---
_Generated by [Claude Code](https://claude.ai/code/session_016PyLwDNkPQM1uD1Tg5ApBg)_