### PR TITLE
emergent_testing: prove the browser runner's own rejection

### DIFF
--- a/changelog/unreleased/1836.md
+++ b/changelog/unreleased/1836.md
@@ -1,0 +1,4 @@
+- `emergent_testing`: a browser run whose own interpreter rejects resolves its
+  published report with `infrastructure-error` — proved, where before the
+  branch existed but nothing exercised it and a regression would have left the
+  page in `running` forever

--- a/fjs/emergent_testing/browser/module.mjs
+++ b/fjs/emergent_testing/browser/module.mjs
@@ -21,7 +21,7 @@
  * } from '../types.ts'
  * @import { Catch, Import, Sandbox, SandboxResult } from '../../effects/common/types.ts'
  * @import { IoChannel } from '../../effects/node/types.ts'
- * @import { Effect, Func } from '../../effects/types.ts'
+ * @import { Effect, Func, ToAsyncOperationMap } from '../../effects/types.ts'
  * @import { Result } from '../../types/result/types.ts'
  * @import { List } from '../../types/list/types.ts'
  */
@@ -66,16 +66,26 @@ const failureOf = async (source, duration, cause) => {
 }
 
 /**
- * Runs named proof exports and returns the serializable browser report.
+ * {@link runBrowserProofs} with the page's own operation map handed to
+ * `operations` before it is interpreted.
  *
- * `result` is the page's subscription to the leaf-landed event — the same
- * event `fjs t`'s `Reporter.result` carries, a shared `TestResult` plus the
- * browser's own `message`/`stack` part — and the resolved report is its
- * run-ended event, with totals folded by the shared `addResult`.
+ * **A testing seam, not a public-API widening.** The page's published entry
+ * point is {@link runBrowserProofs} and is unchanged; this export exists
+ * because one branch below is otherwise unreachable. `runProofs` has no error
+ * channel, so every failure a *proof* can produce arrives as a value — the one
+ * thing that can reject the run is this file's own interpreter, and a caller
+ * that cannot replace it cannot produce that. The alternative rejected in
+ * `todo/share-browser-console-runner.md` was widening the published entry
+ * point to reach the branch, which pays for a proof in API surface every page
+ * then carries.
  *
- * @type {(modules: readonly (readonly [string, unknown])[], result?: (result: _BrowserTestResult) => void) => Promise<BrowserTestReport>}
+ * Two rejections reach `runnerFailure` through it, and they are the same
+ * failure at different depths: a handler that throws, and a command with no
+ * handler at all — `match` panics on the second, inside the same awaited loop.
+ *
+ * @type {(operations: (map: ToAsyncOperationMap<Catch | _BrowserReport | Sandbox>) => ToAsyncOperationMap<Catch | _BrowserReport | Sandbox>) => (modules: readonly (readonly [string, unknown])[], result?: (result: _BrowserTestResult) => void) => Promise<BrowserTestReport>}
  */
-export const runBrowserProofs = (modules, result = () => undefined) => {
+export const _runBrowserProofsWith = operations => (modules, result = () => undefined) => {
     const start = performance.now()
     // Reporting each result as it lands is the page's own code. A renderer that
     // throws must not take the run down with it: the report it fails to show is
@@ -96,7 +106,7 @@ export const runBrowserProofs = (modules, result = () => undefined) => {
         }
     }
     /** @type {<T, E>(e: Effect<Catch | _BrowserReport | Sandbox, T, E>) => Promise<Result<T, E>>} */
-    const run = asyncRun({
+    const run = asyncRun(operations({
         ...commonOperationMap,
         // **The page's only operation, and the port's only scheduling.** The
         // await is a real macrotask boundary: a run is otherwise one
@@ -109,7 +119,7 @@ export const runBrowserProofs = (modules, result = () => undefined) => {
             await macrotask()
             return ok(undefined)
         },
-    })
+    }))
     /**
      * The failure of a *runner* that did not even answer through its error
      * channel: a handler of this interpreter threw, so the whole run rejected.
@@ -144,6 +154,18 @@ export const runBrowserProofs = (modules, result = () => undefined) => {
             toArray(ended === null ? landed : concat(landed)([ended])),
             ended === null ? null : 'infrastructure-error'))
 }
+
+/**
+ * Runs named proof exports and returns the serializable browser report.
+ *
+ * `result` is the page's subscription to the leaf-landed event — the same
+ * event `fjs t`'s `Reporter.result` carries, a shared `TestResult` plus the
+ * browser's own `message`/`stack` part — and the resolved report is its
+ * run-ended event, with totals folded by the shared `addResult`.
+ *
+ * @type {(modules: readonly (readonly [string, unknown])[], result?: (result: _BrowserTestResult) => void) => Promise<BrowserTestReport>}
+ */
+export const runBrowserProofs = _runBrowserProofsWith(map => map)
 
 /**
  * What a page hands `import()` for one of its sources.

--- a/fjs/emergent_testing/browser/proof.mjs
+++ b/fjs/emergent_testing/browser/proof.mjs
@@ -5,13 +5,18 @@
  * the DOM stand-in below is enough to drive every rendering branch from Node —
  * no headless browser, and no global `window`/`document` for these proofs to
  * install and unset.
+ *
+ * @import { _BrowserReport } from '../types.ts'
+ * @import { Catch, Sandbox } from '../../effects/common/types.ts'
+ * @import { ToAsyncOperationMap } from '../../effects/types.ts'
  */
 
 import { runInNewContext } from 'node:vm'
 
 import { assert, assertEq, assertNotNullish, assertStructurallySame } from '../../asserts/module.f.mjs'
-import { renderBrowserReport, runBrowserProofs, startBrowserTests, startBrowserTestSources } from './module.mjs'
+import { _runBrowserProofsWith, renderBrowserReport, runBrowserProofs, startBrowserTests, startBrowserTestSources } from './module.mjs'
 import { fmtImport, testResult } from '../module.f.mjs'
+import { runnerSource } from './module.f.mjs'
 import { error, ok } from '../../types/result/module.f.mjs'
 
 /**
@@ -333,6 +338,51 @@ export const proof = {
         assertEq(report.results[0]?.message, 'getter')
         assertStructurallySame([...p.states], ['running', 'failed'])
         assertEq(p.view.events.length, 1)
+    },
+
+    /**
+     * **The run's own failure, not any proof's.** A handler of the page's
+     * interpreter throws, so the whole run rejects — the one route
+     * `runProofs` cannot decide, because its error channel is `never` and a
+     * rejection is not a value it was handed.
+     *
+     * What the page depends on is that the rejection still *resolves* the
+     * published report: a run that rejected without this guard leaves the page
+     * in `running` forever, waiting on a promise that will not settle. So the
+     * assertions are the report's, not the promise's — it arrives, it says
+     * `infrastructure-error`, and its one row is named after the runner rather
+     * than after a module, because the walk is one effect and a rejection is
+     * not attributable to the module it happened under.
+     *
+     * Mutation-checked: delete `.catch(runnerFailure)` and this rejects
+     * instead of reporting, which is the failure mode itself.
+     */
+    aThrowingHandlerIsTheRunnersOwnFailure: async () => {
+        const report = await _runBrowserProofsWith(map => ({
+            ...map,
+            sandbox: () => { throw new Error('interpreter') },
+        }))([['m', { t: () => undefined }]])
+        assertEq(report.status, 'infrastructure-error')
+        assertStructurallySame({ ...report.totals }, { tests: 1, passed: 0, failed: 1 })
+        assertEq(report.results[0]?.module, runnerSource)
+        assertEq(report.results[0]?.message, 'interpreter')
+    },
+    /**
+     * The same route reached one level deeper: a command the interpreter
+     * cannot dispatch at all. `match` panics on a missing handler — an omitted
+     * operation is a malformed program, not a capability answer — and that
+     * panic is inside the awaited loop, so it arrives as the same rejection.
+     *
+     * Worth its own case because the two are indistinguishable *after* the
+     * `catch` and not before it: this one never reaches a handler, so a fix
+     * that only guarded handler bodies would leave it hanging the page.
+     */
+    anUndispatchableCommandIsTheSameFailure: async () => {
+        const report = await _runBrowserProofsWith(({ sandbox, ...rest }) =>
+            /** @type {ToAsyncOperationMap<Catch | _BrowserReport | Sandbox>} */ (rest))(
+            [['m', { t: () => undefined }]])
+        assertEq(report.status, 'infrastructure-error')
+        assertEq(report.results[0]?.module, runnerSource)
     },
 
     reportingThrows: async () => {

--- a/fjs/emergent_testing/todo/share-browser-console-runner.md
+++ b/fjs/emergent_testing/todo/share-browser-console-runner.md
@@ -1,11 +1,9 @@
 ## Share the browser and console proof runners
 
 **Priority:** P3
-**Status:** open — every step has landed. Two proofs are left: that the two
-runners answer identically from the same fixtures, and that the page reports an
-`infrastructure-error` when its *own interpreter* **rejects**, which 7b named
-and did not build. The other runner-failure route, an operation answering
-through its error channel, is proved by `refusedReportEndsTheRun`.
+**Status:** open — every step has landed and both runner-failure routes are
+proved. One proof is left: that the two runners answer identically from the
+same fixtures.
 
 ### Problem
 
@@ -986,17 +984,26 @@ are shared.
       regenerating them produces the new path rather than that a hand edit
       matched: `npm run website` rewrites the entry, and the browser suite
       manifest is derived the same way.
-- [ ] Prove the page's *rejection* runner-failure route: an operation the
-      interpreter cannot dispatch, which rejects rather than answering. The
-      other route landed in 7b — an operation answering through its error
-      channel is `refusedReportEndsTheRun` in `browser/proof.f.mjs`, which
-      pins that the run stops and that the failure is answered. What has no
-      proof is `runBrowserProofs`' `.catch(runnerFailure)` in
-      `browser/module.mjs`: the `infrastructure-error` cases in
-      `browser/proof.mjs` all come from the loading path's own `catch`, one
-      function away. The seam 7b specifies is the page's run core taking its
-      interpreter as an argument, exported for proofs from the page's own
-      module — a testing seam, not a public-API widening.
+- [x] Prove the page's *rejection* runner-failure route. **Landed**, with the
+      seam 7b specified: `_runBrowserProofsWith` hands the page's own operation
+      map to a function before interpreting it, so a proof can replace one
+      handler. The published `runBrowserProofs` is that core applied to the
+      identity, so the page's entry point is unchanged — a testing seam, not
+      the API widening this file rejected.
+
+      Two proofs, because the rejection has two depths and only one of them
+      reaches a handler: `aThrowingHandlerIsTheRunnersOwnFailure` (a `sandbox`
+      handler throws) and `anUndispatchableCommandIsTheSameFailure` (no
+      `sandbox` handler at all, which `match` panics on inside the same awaited
+      loop). Both assert what the page actually depends on — the report still
+      *resolves*, says `infrastructure-error`, and names the runner rather than
+      a module. Mutation-checked: delete `.catch(runnerFailure)` and they
+      reject instead of reporting, which is the page-stuck-in-`running`
+      failure itself.
+
+      The other route landed in 7b without a seam: an operation answering
+      through its error channel is `refusedReportEndsTheRun` in
+      `browser/proof.f.mjs`.
 - [ ] Prove both runners produce equivalent paths, throw outcomes, recursive
       test counts, and normalized failures from the same fixtures. The
       existing `nameMatchesTheConsoleRunner`,
@@ -1063,22 +1070,22 @@ are shared.
       proofs from the page's own module, so proofs could drive **each failure
       route separately**.
 
-      **What landed is smaller, and covers one route.** Making the
-      orchestration an effect was enough for the error channel: a mock runner
-      that declares `report` and does not implement it answers `notImplemented`
-      through the ordinary continuation, which is `refusedReportEndsTheRun`
-      above — no seam needed. The rejection route did not follow.
-      `browser/module.mjs` still builds its interpreter internally, so
-      `.catch(runnerFailure)` has no way in and no proof. The seam described
-      here is therefore **still to be built**, by the open task above and for
-      that route alone; it is not something to go looking for in the code.
+      **7b landed one route without the seam, and the seam came after.**
+      Making the orchestration an effect was enough for the error channel: a
+      mock runner that declares `report` and does not implement it answers
+      `notImplemented` through the ordinary continuation, which is
+      `refusedReportEndsTheRun`. The rejection route could not follow, because
+      `browser/module.mjs` built its interpreter internally and
+      `.catch(runnerFailure)` had no way in. `_runBrowserProofsWith` is that
+      seam, at its smallest: the page's own operation map passes through a
+      function before it is interpreted, and the published
+      `runBrowserProofs` is the core applied to the identity, so the entry
+      point is unchanged — a testing seam, not the API widening the
+      "widen the API to reach the branch" alternative proposed.
 
-      When it is built: two routes need two mutations — delete either half of
-      the guard alone and its case fails while the other stays green, or the
-      surviving half is masking an untested branch that can still leave the
-      page in `running` forever. It is a testing seam, not a public-API
-      widening — the page's published entry point is unchanged, which is what
-      the rejected "widen the API to reach the branch" alternative got wrong.
+      What it made provable is the failure mode this was about: with the guard
+      deleted, both cases reject instead of reporting, which is the page left
+      in `running` forever.
 
 ### Related
 


### PR DESCRIPTION
`runBrowserProofs`' `.catch(runnerFailure)` had no proof. It is the branch that
decides whether a page whose *interpreter* fails shows an `infrastructure-error`
or hangs in `running` forever — the failure mode
[`todo/share-browser-console-runner.md`](https://github.com/functionalscript/functionalscript/blob/main/fjs/emergent_testing/todo/share-browser-console-runner.md)
catalogs as item 11.

No caller could reach it. `runProofs` has no error channel, so every failure a
*proof* can produce arrives as a value it decides about; the only thing that can
reject the run is one of the page's own handlers, and a caller cannot replace
those.

## The seam

`_runBrowserProofsWith` passes the page's operation map through a function
before it is interpreted:

```js
export const _runBrowserProofsWith = operations => (modules, result = () => undefined) => { … }
export const runBrowserProofs = _runBrowserProofsWith(map => map)
```

The published entry point is unchanged — a testing seam, not the API widening
the plan rejected, which would have made every page carry the cost of one proof.

## Two proofs, for two depths

Only one of them reaches a handler, which is why they are two cases and not one:

| proof | what rejects |
|-|-|
| `aThrowingHandlerIsTheRunnersOwnFailure` | a `sandbox` handler throws |
| `anUndispatchableCommandIsTheSameFailure` | no `sandbox` handler at all — `match` panics inside the same awaited loop |

Both assert what the page actually depends on: the report still *resolves*, it
says `infrastructure-error`, and its one row is named after the runner rather
than after a module — the walk is one effect now, so a rejection is not
attributable to the module it happened under.

**Mutation-checked.** Deleting `.catch(runnerFailure)` fails exactly these two
and nothing else; they reject instead of reporting, which is the page-stuck-in-
`running` failure itself.

## Plan status

The runner-failure task is ticked, and the 7b paragraph that described the seam
as delivered now says when it actually arrived. One task is left in the plan:
that both runners answer identically from the same fixtures.

## Verification

`npx tsc` clean · `npm run cov` 100% lines/branches/functions, 0 failures ·
`node --test` 3746 pass / 0 fail · `npm run gen` no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PyLwDNkPQM1uD1Tg5ApBg

---
_Generated by [Claude Code](https://claude.ai/code/session_016PyLwDNkPQM1uD1Tg5ApBg)_