### PR TITLE
emergent_testing: prove the two runners answer the same fixtures

### DIFF
--- a/changelog/unreleased/1837.md
+++ b/changelog/unreleased/1837.md
@@ -1,0 +1,4 @@
+- `emergent_testing`: the browser runner and `fjs t` are proved to answer
+  identically from the same fixtures — one transcript of names, statuses and
+  totals, compared as a whole, so a disagreement about which leaves ran fails
+  it as loudly as a disagreement about a status

--- a/fjs/emergent_testing/equivalence.proof.mjs
+++ b/fjs/emergent_testing/equivalence.proof.mjs
@@ -1,0 +1,151 @@
+/**
+ * **The two runners answer the same thing about the same fixtures.**
+ *
+ * The last property the sharing plan asks for, and the only one the individual
+ * proofs cannot state: `browser/proof.mjs` asserts the page against `fmtImport`
+ * and `testResult`, and `catch.proof.mjs` asserts the console traversal against
+ * literals, so each is right about its own side. What neither can say is that
+ * *one* suite produces *one* answer — which is the property a reader comparing
+ * a CI log with a browser page depends on.
+ *
+ * So this file runs one fixture through both and compares the transcripts as
+ * text. The comparison is deliberately narrow: name, status, and the run's
+ * totals. `message` and `stack` are the page's own part and have no console
+ * counterpart, and a duration is a measurement rather than an answer.
+ *
+ * `.mjs` rather than `.f.mjs`, for the reason `catch.proof.mjs` gives: the
+ * console side needs a runner that can really `catch`, and the browser side is
+ * a host module.
+ *
+ * @import { RunInstance } from '../effects/mock/types.ts'
+ * @import { Write } from '../effects/node/types.ts'
+ * @import { Catch, Sandbox } from '../effects/common/types.ts'
+ * @import { Reporter } from './types.ts'
+ * @import { Vec } from '../types/bit_vec/types.ts'
+ */
+
+import { assertEq } from '../asserts/module.f.mjs'
+import { log } from '../effects/node/module.f.mjs'
+import { run as mockRun } from '../effects/mock/module.f.mjs'
+import { pureOk } from '../effects/module.f.mjs'
+import { defaultTest, runModuleMap } from './module.f.mjs'
+import { runBrowserProofs } from './browser/module.mjs'
+import { error, ok } from '../types/result/module.f.mjs'
+import { utf8ToString } from '../text/module.f.mjs'
+
+/**
+ * The module both runners are given.
+ *
+ * One of each thing the plan names: a plain leaf, a leaf whose *returned* tree
+ * is walked (so the counts are recursive rather than one-per-export), a leaf
+ * that throws, a name that needs quoting in a path, and a `throw` group where
+ * throwing is the pass and returning is the failure.
+ */
+const fixture = {
+    passes: () => undefined,
+    nested: () => ({ child: () => undefined }),
+    fails: () => { throw 'boom' },
+    'a.b': () => undefined,
+    throw: {
+        threw: () => { throw 'expected' },
+        didNot: () => undefined,
+    },
+}
+
+/** The module's name, spelled the same for both runners so the names can be compared at all. */
+const source = './m.proof.f.mjs'
+
+/**
+ * The fixture's transcript from the shared traversal, driven by a runner whose
+ * `sandbox` and `catch` are a real `try`.
+ *
+ * @type {() => string}
+ */
+const consoleTranscript = () => {
+    /** @type {RunInstance<Catch | Sandbox | Write, string>} */
+    const runner = mockRun(/** @type {Parameters<typeof mockRun<Catch | Sandbox | Write, string>>[0]} */ ({
+        sandbox: (/** @type {() => unknown} */ f) => (/** @type {string} */ s) => {
+            try {
+                return [s, ok({ result: ok(f()), duration: 0 })]
+            } catch (e) {
+                return [s, ok({ result: error(e), duration: 0 })]
+            }
+        },
+        catch: (/** @type {() => unknown} */ f) => (/** @type {string} */ s) => {
+            try {
+                return [s, ok(ok(f()))]
+            } catch (e) {
+                return [s, ok(error(e))]
+            }
+        },
+        write: (_stream, /** @type {Vec} */ data) => (/** @type {string} */ s) =>
+            [s + utf8ToString(data), ok(undefined)],
+    }))
+    /** @type {Reporter<Catch | Sandbox | Write>} */
+    const reporter = {
+        // `start` writes nothing, so the transcript is answers only. A page
+        // publishes no before-it-ran record, so there is nothing on the other
+        // side to compare one against; that the console runner announces a
+        // leaf first is `catch.proof.mjs`'s subject, not this file's.
+        start: () => pureOk(undefined),
+        result: t => log(`${t.name} ${t.status}`),
+        summary: ({ totals: { passed, failed } }) => log(`${passed} passed, ${failed} failed`),
+        test: defaultTest,
+    }
+    const [written] = runner('')(runModuleMap(reporter)({ [source]: { proof: fixture } }))
+    return written
+}
+
+/**
+ * The same transcript, built from what the page publishes.
+ *
+ * `report.results` is the page's own list rather than anything replayed, so
+ * this reads the published record the way a consumer of the report would.
+ *
+ * @type {() => Promise<string>}
+ */
+const browserTranscript = async () => {
+    const report = await runBrowserProofs([[source, fixture]])
+    const lines = report.results.map(r => `${r.name} ${r.status}\n`)
+    const { passed, failed } = report.totals
+    return `${lines.join('')}${passed} passed, ${failed} failed\n`
+}
+
+export const proof = {
+    /**
+     * **One suite, one answer.**
+     *
+     * The whole transcript is compared rather than a field at a time, so a
+     * disagreement about *which* leaves ran — a walk that stops early, a
+     * returned tree one runner recurses into and the other does not — fails
+     * here too, and not only a disagreement about a status.
+     *
+     * Mutation-checked: give the page's `collectTests` a root `throws` of
+     * `true` — a divergence in one runner only, which every proof asserting a
+     * runner against a shared function still passes — and this fails.
+     */
+    transcriptsAgree: async () => {
+        assertEq(await browserTranscript(), consoleTranscript())
+    },
+    /**
+     * The comparison above is only worth something if the fixture actually
+     * exercises what it claims, so this pins the transcript itself: five leaves
+     * from four exports, a nested one named through its parent's call, a
+     * quoted path segment, and a `throw` group in which throwing passes and
+     * returning fails.
+     *
+     * Without it, two runners that both walked nothing would agree.
+     */
+    theFixtureIsWorthComparing: async () => {
+        assertEq(await browserTranscript(),
+            `import("./m.proof.f.mjs").proof.passes() passed
+import("./m.proof.f.mjs").proof.nested() passed
+import("./m.proof.f.mjs").proof.nested().child() passed
+import("./m.proof.f.mjs").proof.fails() failed
+import("./m.proof.f.mjs").proof["a.b"]() passed
+import("./m.proof.f.mjs").proof.throw.threw() passed
+import("./m.proof.f.mjs").proof.throw.didNot() failed
+5 passed, 2 failed
+`)
+    },
+}

--- a/fjs/emergent_testing/todo/share-browser-console-runner.md
+++ b/fjs/emergent_testing/todo/share-browser-console-runner.md
@@ -1,9 +1,16 @@
 ## Share the browser and console proof runners
 
 **Priority:** P3
-**Status:** open — every step has landed and both runner-failure routes are
-proved. One proof is left: that the two runners answer identically from the
-same fixtures.
+**Status:** open — the work is finished: every step has landed, both
+runner-failure routes are proved, and the two runners are proved to answer
+identically from the same fixtures. What is left is this file's own retirement,
+the last task below. It is retained under `todo/README.md`'s exception rather
+than as a tombstone: twenty files cite its pitfall catalog and its
+boundary argument, and neither exists anywhere else yet — among them
+`browser-testing.md`, `browser-runner-functional-script.md`,
+`report-before-running.md`, `65z-tf-test-tree-walker.md`,
+`../../effects/todo/all-argument-limit.md`, `../../website/todo/generate-website.md`
+and `DESIGN.md`.
 
 ### Problem
 
@@ -1004,13 +1011,39 @@ are shared.
       The other route landed in 7b without a seam: an operation answering
       through its error channel is `refusedReportEndsTheRun` in
       `browser/proof.f.mjs`.
-- [ ] Prove both runners produce equivalent paths, throw outcomes, recursive
-      test counts, and normalized failures from the same fixtures. The
-      existing `nameMatchesTheConsoleRunner`,
+- [x] Prove both runners produce equivalent paths, throw outcomes, recursive
+      test counts, and normalized failures from the same fixtures. **Landed**
+      as `equivalence.proof.mjs`: one fixture module — a plain leaf, a leaf
+      whose returned tree is walked, a leaf that throws, a name that needs
+      quoting, and a `throw` group where throwing is the pass — run through
+      `runBrowserProofs` and through `runModuleMap` on a runner that can really
+      `catch`, with the two transcripts of name, status and totals compared as
+      one string.
+
+      **Comparing the whole transcript rather than a field is the point.** A
+      disagreement about *which* leaves ran — a walk that stops early, a
+      returned tree one runner recurses into and the other does not — fails it
+      too, and that is the class of divergence the per-runner proofs cannot
+      see: `nameMatchesTheConsoleRunner`,
       `expectedThrowStatusMatchesTheSharedOne` and
-      `normalizedResultMatchesTheSharedOne` already assert against the console
-      runner's own functions; step 7b makes the four properties shared code
-      rather than agreeing implementations.
+      `normalizedResultMatchesTheSharedOne` assert a runner against a shared
+      function, so a runner that calls the shared function differently agrees
+      with it and still disagrees with the other runner. Mutation-checked on
+      exactly that: give the page's `collectTests` a root `throws` of `true`
+      and every one of those three still passes while this fails.
+
+      A second proof pins the transcript itself, because two runners that both
+      walked nothing would otherwise agree.
+- [ ] **Retire this file.** Every task above is done, so `todo/README.md` says
+      it goes — but not by deletion alone: the pitfall catalog (twelve measured
+      ways this was got wrong, cited by item number from other issues and from
+      `browser/module.mjs`) and the boundary argument (why `instanceof Promise`
+      in business logic cost ~150 lines and a reversal) are the parts other
+      documents reach for, and they have no home yet. Move them —
+      `emergent_testing/README.md` for the catalog, `Catch`'s and the browser
+      host module's JSDoc for what belongs next to code — repoint the
+      thirty-six citations across twenty files, then delete this file. It is
+      its own change: the move is larger than any step it records.
 - [x] Record every behaviour the browser file has today and the shared core will
       not keep, as an issue, before the sharing change merges. Two: the
       `batchSize = 25` yielding — whose *constant* was the mistake and whose


### PR DESCRIPTION
The sharing plan's last property, and the only one the per-runner proofs cannot
state.

`browser/proof.mjs` asserts the page against `fmtImport` and `testResult`;
`catch.proof.mjs` asserts the console traversal against literals. Each is right
about its own side, and neither says that **one suite produces one answer** — a
runner that calls a shared function differently agrees with that function and
still disagrees with the other runner.

## What it does

`equivalence.proof.mjs` runs one fixture through both runners and compares the
transcripts of name, status and totals as a single string:

| fixture entry | what it pins |
|-|-|
| `passes` | a plain leaf |
| `nested` returning `{ child }` | the count is recursive, not one-per-export |
| `fails` | a normalized failure |
| `'a.b'` | a path segment that needs quoting |
| `throw: { threw, didNot }` | throwing is the pass, returning is the failure |

The browser side is `runBrowserProofs`; the console side is `runModuleMap` on a
mock runner whose `sandbox` and `catch` are a real `try`, for the reason
`catch.proof.mjs` gives.

**Comparing the whole transcript is the point.** A disagreement about *which*
leaves ran — a walk that stops early, a returned tree one runner recurses into
and the other does not — fails it too, not only a disagreement about a status.
A second proof pins the transcript itself, because two runners that both walked
nothing would agree.

**Mutation-checked.** Give the page's `collectTests` a root `throws` of `true` —
a divergence in one runner only — and `nameMatchesTheConsoleRunner`,
`expectedThrowStatusMatchesTheSharedOne` and `normalizedResultMatchesTheSharedOne`
all still pass while this fails.

## The plan is finished, and the file is not deleted yet

Every task in
[`todo/share-browser-console-runner.md`](https://github.com/functionalscript/functionalscript/blob/main/fjs/emergent_testing/todo/share-browser-console-runner.md)
is now done, so `todo/README.md` says the issue goes. It is retained here under
that rule's own exception rather than as a tombstone, and the status names the
documents that require it: its pitfall catalog is cited **by item number** from
`browser/module.mjs`, `browser-testing.md`, `65z-tf-test-tree-walker.md`,
`all-argument-limit.md`, `generate-website.md`, `DESIGN.md` and others — 36
references across 20 files — and neither the catalog nor the boundary argument
exists anywhere else yet.

The last unchecked task is that retirement: move the catalog to
`emergent_testing/README.md` and the code-adjacent parts to JSDoc, repoint the
citations, then delete. It is its own change — the move is larger than any step
the file records.

## Verification

`npx tsc` clean · `npm run cov` 100% lines/branches/functions ·
`node --test` 3748 pass / 0 fail · `node ./fjs/module.mjs t` 3810 pass / 0 fail ·
`npm run gen` no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PyLwDNkPQM1uD1Tg5ApBg

---
_Generated by [Claude Code](https://claude.ai/code/session_016PyLwDNkPQM1uD1Tg5ApBg)_