### PR TITLE
effects/node/virtual: pin the one-segment guard for the reads too

### DIFF
--- a/fjs/effects/node/virtual/proof.f.mjs
+++ b/fjs/effects/node/virtual/proof.f.mjs
@@ -152,6 +152,27 @@ export const proof = {
         const [, result] = virtual({ ...emptyState, root })(readFile('a/b'))
         assert(result[0] === 'error')
     },
+    // `a/b` where `a` is a *file*, for each read. `readFileIntoDir` and the
+    // size-cap fixture both descend through real directories, so neither
+    // reaches the case `operation` hands the op with two segments left; these
+    // do. Without the one-segment guard — or with the call site collapsing `p`
+    // to its head — both return `a`'s own bytes for a path that names no file,
+    // which is a wrong answer rather than a different error, so the assertion
+    // is that the read failed at all.
+    readFileNestedThroughFile: () => {
+        /** @type {Dir} */
+        const root = { 'a': [vec8(0x42n)] }
+        const [, result] = virtual({ ...emptyState, root })(readFile('a/b'))
+        assert(result[0] === 'error')
+        assertIoCode(result[1], 'ENOENT')
+    },
+    readBytesNestedThroughFile: () => {
+        /** @type {Dir} */
+        const root = { 'a': [vec8(0x42n)] }
+        const [, result] = virtual({ ...emptyState, root })(readBytes('a/b', 0, 1))
+        assert(result[0] === 'error')
+        assertIoCode(result[1], 'ENOENT')
+    },
     awaitNonPromise: () => {
         // a non-promise value passes through the virtual `await` handler as-is
         const [, result] = virtual(emptyState)(awaitIfPromise(42))


### PR DESCRIPTION
Follow-up to [#1845](https://github.com/functionalscript/functionalscript/pull/1845), carrying one commit that missed it: the PR was enqueued at `955e878` and this push landed after, so the queue merged the enqueued SHA and these two fixtures never reached `main`. Nothing about the review was disputed — the work is o2alexanderfedin's second finding on that PR, already written and verified when it merged.

## The gap

`#1845` added `writeBytesNestedThroughFile`, which pins `resolveFile`'s
`p.length !== 1` guard. But the property is stated of **`resolveFile`**, which
has three consumers, and only `writeBytes` had a fixture pointing a path through
a file. The nested-read proofs do not reach the case: `readFileIntoDir` uses
`a/b` where both are directories, and the size-cap fixture uses a genuine nested
directory. `operation` stops descending at the first name that is not a
directory, so a path *through a file* is the only way the op is handed two
segments — and nothing exercised it on the read side.

Collapsing `p` to `[p[0]]` at either read's call site therefore left the whole
suite green, and `readFile('a/b')` against `{ a: [bytes] }` answered with `a`'s
own bytes: a plausible wrong value for a path that names no file, which
[DESIGN.md §10](../blob/main/DESIGN.md#10-refuse-what-you-cannot-handle) ranks
below a crash. That is why these assert `ENOENT` rather than merely that
something failed.

Note the two sides fail differently, which is why one fixture could not cover
both: without the guard `writeBytes` *succeeds* at appending, so its proof has
to assert the state; the reads return a wrong value, so theirs assert the code.

## Checks

- `tsc` — clean.
- `node ./fjs/module.mjs t` — 3818 pass, 0 fail.
- Mutation-tested per call site: collapsing `p` to `[p[0]]` at `readFile`'s call
  site gives 3817/1 with `readFileNestedThroughFile` the only failure, and the
  same at `readBytes`' with `readBytesNestedThroughFile`. Each kills its own
  mutant and only its own, so all three consumers are pinned rather than one.

Test-only, +21 lines; no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xwqdyXm9DSt9bjWwbj9JV

---
_Generated by [Claude Code](https://claude.ai/code/session_019xwqdyXm9DSt9bjWwbj9JV)_