### PR TITLE
Add shared operator test cases for `/` (division)

### DIFF
--- a/fjs/nanvm/module.f.mjs
+++ b/fjs/nanvm/module.f.mjs
@@ -36,7 +36,7 @@
  * ```js
  * import { data } from './module.f.mjs'
  *
- * data.groups.length // 5
+ * data.groups.length // 6
  * ```
  */
 
@@ -345,6 +345,142 @@ const mulCases = [
 ]
 
 /**
+ * `/` is not implemented in `nanvm-lib` yet (see the operator table in
+ * `nanvm-lib/README.md`), so every case below carries this as its `rust`
+ * reason: the generated Rust keeps each as a commented-out `TODO`, while the
+ * JavaScript proof still runs it. Removing the reason per case is what turns
+ * it on for Rust once `/` lands there.
+ *
+ * @type {string}
+ */
+const divNotImplemented = '`/` is not implemented in nanvm-lib yet'
+
+/**
+ * `/` coerces both operands with `ToNumeric` like `*`, and like `%` is
+ * neither commutative nor symmetric between mixed sign operands. Number `/`
+ * never throws: dividing by `0` or `-0` produces a signed `Infinity` (unless
+ * the dividend is also zero, giving `NaN`), and dividing by an infinite
+ * divisor produces a signed zero for a finite dividend. BigInt `/` truncates
+ * toward zero and throws — instead of producing `Infinity` — on a zero
+ * divisor; mixed number/bigint operands throw too, the same as every other
+ * arithmetic operator here.
+ *
+ * @type {readonly Case<2>[]}
+ */
+const divCases = [
+    { name: 'nullDividedByFour', args: [null, 4], expected: 0, rust: divNotImplemented },
+    { name: 'undefinedDividedByFour', args: [undefined, 4], expected: NaN, rust: divNotImplemented },
+    { name: 'trueDividedByFour', args: [true, 4], expected: 0.25, rust: divNotImplemented },
+    { name: 'falseDividedByFour', args: [false, 4], expected: 0, rust: divNotImplemented },
+    { name: 'stringTenDividedByFour', args: ['10', 4], expected: 2.5, rust: divNotImplemented },
+    { name: 'stringLetterDividedByFour', args: ['a', 4], expected: NaN, rust: divNotImplemented },
+    { name: 'emptyArrayDividedByFour', args: [[], 4], expected: 0, rust: divNotImplemented },
+    { name: 'arrayTenDividedByFour', args: [[10], 4], expected: 2.5, rust: divNotImplemented },
+    {
+        name: 'arrayStringTenDividedByFour',
+        args: [['10'], 4],
+        expected: 2.5,
+        rust: divNotImplemented,
+    },
+    { name: 'arrayPairDividedByFour', args: [[0, 0], 4], expected: NaN, rust: divNotImplemented },
+    { name: 'emptyObjectDividedByFour', args: [{}, 4], expected: NaN, rust: divNotImplemented },
+    // The one binary case that escapes: `functionValue` has no expression, so
+    // both consumers take the direct path with two operands rather than one.
+    { name: 'functionDividedByFour', args: [functionValue, 4], expected: NaN, rust: divNotImplemented },
+    { name: 'zeroDividedByOne', args: [0, 1], expected: 0, rust: divNotImplemented },
+    { name: 'negativeZeroDividedByOne', args: [-0, 1], expected: -0, rust: divNotImplemented },
+    { name: 'tenDividedByFour', args: [10, 4], expected: 2.5, rust: divNotImplemented },
+    { name: 'negativeTenDividedByFour', args: [-10, 4], expected: -2.5, rust: divNotImplemented },
+    { name: 'tenDividedByNegativeFour', args: [10, -4], expected: -2.5, rust: divNotImplemented },
+    {
+        name: 'negativeTenDividedByNegativeFour',
+        args: [-10, -4],
+        expected: 2.5,
+        rust: divNotImplemented,
+    },
+    { name: 'fiveDividedByZero', args: [5, 0], expected: Infinity, rust: divNotImplemented },
+    { name: 'negativeFiveDividedByZero', args: [-5, 0], expected: -Infinity, rust: divNotImplemented },
+    { name: 'fiveDividedByNegativeZero', args: [5, -0], expected: -Infinity, rust: divNotImplemented },
+    {
+        name: 'negativeFiveDividedByNegativeZero',
+        args: [-5, -0],
+        expected: Infinity,
+        rust: divNotImplemented,
+    },
+    { name: 'zeroDividedByZero', args: [0, 0], expected: NaN, rust: divNotImplemented },
+    { name: 'negativeZeroDividedByZero', args: [-0, 0], expected: NaN, rust: divNotImplemented },
+    { name: 'zeroDividedByNegativeZero', args: [0, -0], expected: NaN, rust: divNotImplemented },
+    {
+        name: 'negativeZeroDividedByNegativeZero',
+        args: [-0, -0],
+        expected: NaN,
+        rust: divNotImplemented,
+    },
+    { name: 'infinityDividedByFive', args: [Infinity, 5], expected: Infinity, rust: divNotImplemented },
+    {
+        name: 'infinityDividedByNegativeFive',
+        args: [Infinity, -5],
+        expected: -Infinity,
+        rust: divNotImplemented,
+    },
+    {
+        name: 'negativeInfinityDividedByFive',
+        args: [-Infinity, 5],
+        expected: -Infinity,
+        rust: divNotImplemented,
+    },
+    { name: 'fiveDividedByInfinity', args: [5, Infinity], expected: 0, rust: divNotImplemented },
+    { name: 'negativeFiveDividedByInfinity', args: [-5, Infinity], expected: -0, rust: divNotImplemented },
+    {
+        name: 'fiveDividedByNegativeInfinity',
+        args: [5, -Infinity],
+        expected: -0,
+        rust: divNotImplemented,
+    },
+    {
+        name: 'infinityDividedByInfinity',
+        args: [Infinity, Infinity],
+        expected: NaN,
+        rust: divNotImplemented,
+    },
+    {
+        name: 'infinityDividedByNegativeInfinity',
+        args: [Infinity, -Infinity],
+        expected: NaN,
+        rust: divNotImplemented,
+    },
+    { name: 'nanDividedByOne', args: [NaN, 1], expected: NaN, rust: divNotImplemented },
+    { name: 'oneDividedByNan', args: [1, NaN], expected: NaN, rust: divNotImplemented },
+    { name: 'sevenDividedByTwo', args: [7, 2], expected: 3.5, rust: divNotImplemented },
+    { name: 'oneDividedByThree', args: [1, 3], expected: 1 / 3, rust: divNotImplemented },
+    { name: 'bigTenDividedByThree', args: [10n, 3n], expected: 3n, rust: divNotImplemented },
+    {
+        name: 'bigNegativeTenDividedByThree',
+        args: [-10n, 3n],
+        expected: -3n,
+        rust: divNotImplemented,
+    },
+    {
+        name: 'bigTenDividedByNegativeThree',
+        args: [10n, -3n],
+        expected: -3n,
+        rust: divNotImplemented,
+    },
+    {
+        name: 'bigNegativeTenDividedByNegativeThree',
+        args: [-10n, -3n],
+        expected: 3n,
+        rust: divNotImplemented,
+    },
+    { name: 'bigSevenDividedByTwo', args: [7n, 2n], expected: 3n, rust: divNotImplemented },
+    { name: 'bigNegativeSevenDividedByTwo', args: [-7n, 2n], expected: -3n, rust: divNotImplemented },
+    { name: 'bigZeroDividedByFive', args: [0n, 5n], expected: 0n, rust: divNotImplemented },
+    { name: 'bigTenDividedByZero', args: [10n, 0n], expected: throws, rust: divNotImplemented },
+    { name: 'numberDividedByBigint', args: [1, 1n], expected: throws, rust: divNotImplemented },
+    { name: 'bigintDividedByNumber', args: [1n, 1], expected: throws, rust: divNotImplemented },
+]
+
+/**
  * Subtraction has the same numeric coercion and mixed-number-kind rejection
  * as multiplication, but its operand order is observable.
  *
@@ -503,6 +639,7 @@ export const data = {
             ],
         },
         { op: '*', commutative: true, cases: mulCases },
+        { op: '/', cases: divCases },
         { op: '-', cases: subCases },
         { op: '+', cases: addCases },
         { op: 'String', cases: stringCoercionCases },

--- a/fjs/nanvm/proof.f.mjs
+++ b/fjs/nanvm/proof.f.mjs
@@ -64,6 +64,7 @@ const op1Js = {
 /** The same, for the binary operations. @type {{ readonly [k in OpId]?: (a: any, b: any) => unknown }} */
 const op2Js = {
     '*': (a, b) => a * b,
+    '/': (a, b) => a / b,
     '-': (a, b) => a - b,
     '+': (a, b) => a + b,
     '===': (a, b) => a === b,

--- a/fjs/nanvm/rust/module.f.mjs
+++ b/fjs/nanvm/rust/module.f.mjs
@@ -83,6 +83,7 @@ export const rustName = {
     unaryPlus: 'unary_plus',
     neg: 'neg',
     '*': 'mul',
+    '/': 'div',
     '-': 'sub',
     '+': 'add',
     String: 'string_coercion',
@@ -99,9 +100,18 @@ const op1Rust = {
     String: a => `${a}.to_string().map(|v| v.to_any())`,
 }
 
-/** The same, for the binary operations. @type {{ readonly [k in OpId]?: (a: string, b: string) => string }} */
+/**
+ * The same, for the binary operations.
+ *
+ * `/` has no `nanvm-lib` implementation yet, so every `/` case carries a
+ * `rust` reason and `emit` prints this text as a comment rather than a
+ * statement — this entry only has to read as the operation, not compile.
+ *
+ * @type {{ readonly [k in OpId]?: (a: string, b: string) => string }}
+ */
 const op2Rust = {
     '*': (a, b) => `${a} * ${b}`,
+    '/': (a, b) => `${a} / ${b}`,
     '-': (a, b) => `${a} - ${b}`,
     '+': (a, b) => `${a} + ${b}`,
 }

--- a/fjs/nanvm/rust/proof.f.mjs
+++ b/fjs/nanvm/rust/proof.f.mjs
@@ -193,7 +193,7 @@ export const proof = {
          * generated file would otherwise carry a statement that does not
          * compile, or worse, one that does and means something else.
          */
-        unknownOperation: () => nodeExpr(['/', 1, 2]),
+        unknownOperation: () => nodeExpr(['**', 1, 2]),
         /** An object key the corpus cannot produce and Rust cannot spell. */
         computedKey: () => nodeExpr(['{}', [[':', ['undefined'], 1]]]),
         /**

--- a/nanvm-lib/tests/test/generated.rs
+++ b/nanvm-lib/tests/test/generated.rs
@@ -177,6 +177,106 @@ fn mul<A: IVm>() {
 }
 
 #[rustfmt::skip]
+fn div<A: IVm>() {
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("nullDividedByFour", Nullish::Null.to_any() / (4f64).to_any(), (0f64).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("undefinedDividedByFour", Nullish::Undefined.to_any() / (4f64).to_any(), (f64::NAN).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("trueDividedByFour", true.to_any() / (4f64).to_any(), (0.25f64).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("falseDividedByFour", false.to_any() / (4f64).to_any(), (0f64).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("stringTenDividedByFour", string_any("10") / (4f64).to_any(), (2.5f64).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("stringLetterDividedByFour", string_any("a") / (4f64).to_any(), (f64::NAN).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("emptyArrayDividedByFour", Array::default().to_any() / (4f64).to_any(), (0f64).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("arrayTenDividedByFour", [(10f64).to_any()].to_array().to_any() / (4f64).to_any(), (2.5f64).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("arrayStringTenDividedByFour", [string_any("10")].to_array().to_any() / (4f64).to_any(), (2.5f64).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("arrayPairDividedByFour", [(0f64).to_any(), (0f64).to_any()].to_array().to_any() / (4f64).to_any(), (f64::NAN).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("emptyObjectDividedByFour", Object::default().to_any() / (4f64).to_any(), (f64::NAN).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("functionDividedByFour", function_any() / (4f64).to_any(), (f64::NAN).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("zeroDividedByOne", (0f64).to_any() / (1f64).to_any(), (0f64).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("negativeZeroDividedByOne", (-0f64).to_any() / (1f64).to_any(), (-0f64).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("tenDividedByFour", (10f64).to_any() / (4f64).to_any(), (2.5f64).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("negativeTenDividedByFour", (-10f64).to_any() / (4f64).to_any(), (-2.5f64).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("tenDividedByNegativeFour", (10f64).to_any() / (-4f64).to_any(), (-2.5f64).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("negativeTenDividedByNegativeFour", (-10f64).to_any() / (-4f64).to_any(), (2.5f64).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("fiveDividedByZero", (5f64).to_any() / (0f64).to_any(), (f64::INFINITY).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("negativeFiveDividedByZero", (-5f64).to_any() / (0f64).to_any(), (f64::NEG_INFINITY).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("fiveDividedByNegativeZero", (5f64).to_any() / (-0f64).to_any(), (f64::NEG_INFINITY).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("negativeFiveDividedByNegativeZero", (-5f64).to_any() / (-0f64).to_any(), (f64::INFINITY).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("zeroDividedByZero", (0f64).to_any() / (0f64).to_any(), (f64::NAN).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("negativeZeroDividedByZero", (-0f64).to_any() / (0f64).to_any(), (f64::NAN).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("zeroDividedByNegativeZero", (0f64).to_any() / (-0f64).to_any(), (f64::NAN).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("negativeZeroDividedByNegativeZero", (-0f64).to_any() / (-0f64).to_any(), (f64::NAN).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("infinityDividedByFive", (f64::INFINITY).to_any() / (5f64).to_any(), (f64::INFINITY).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("infinityDividedByNegativeFive", (f64::INFINITY).to_any() / (-5f64).to_any(), (f64::NEG_INFINITY).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("negativeInfinityDividedByFive", (f64::NEG_INFINITY).to_any() / (5f64).to_any(), (f64::NEG_INFINITY).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("fiveDividedByInfinity", (5f64).to_any() / (f64::INFINITY).to_any(), (0f64).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("negativeFiveDividedByInfinity", (-5f64).to_any() / (f64::INFINITY).to_any(), (-0f64).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("fiveDividedByNegativeInfinity", (5f64).to_any() / (f64::NEG_INFINITY).to_any(), (-0f64).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("infinityDividedByInfinity", (f64::INFINITY).to_any() / (f64::INFINITY).to_any(), (f64::NAN).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("infinityDividedByNegativeInfinity", (f64::INFINITY).to_any() / (f64::NEG_INFINITY).to_any(), (f64::NAN).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("nanDividedByOne", (f64::NAN).to_any() / (1f64).to_any(), (f64::NAN).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("oneDividedByNan", (1f64).to_any() / (f64::NAN).to_any(), (f64::NAN).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("sevenDividedByTwo", (7f64).to_any() / (2f64).to_any(), (3.5f64).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("oneDividedByThree", (1f64).to_any() / (3f64).to_any(), (0.3333333333333333f64).to_any());
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("bigTenDividedByThree", bigint_any(10) / bigint_any(3), bigint_any(3));
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("bigNegativeTenDividedByThree", bigint_any(-10) / bigint_any(3), bigint_any(-3));
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("bigTenDividedByNegativeThree", bigint_any(10) / bigint_any(-3), bigint_any(-3));
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("bigNegativeTenDividedByNegativeThree", bigint_any(-10) / bigint_any(-3), bigint_any(3));
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("bigSevenDividedByTwo", bigint_any(7) / bigint_any(2), bigint_any(3));
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("bigNegativeSevenDividedByTwo", bigint_any(-7) / bigint_any(2), bigint_any(-3));
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check::<A>("bigZeroDividedByFive", bigint_any(0) / bigint_any(5), bigint_any(0));
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check_throws::<A>("bigTenDividedByZero", bigint_any(10) / bigint_any(0));
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check_throws::<A>("numberDividedByBigint", (1f64).to_any() / bigint_any(1));
+    // TODO: `/` is not implemented in nanvm-lib yet
+    // check_throws::<A>("bigintDividedByNumber", bigint_any(1) / (1f64).to_any());
+}
+
+#[rustfmt::skip]
 fn sub<A: IVm>() {
     check::<A>("nullMinusNull", Nullish::Null.to_any() - Nullish::Null.to_any(), (0f64).to_any());
     check::<A>("nullMinusZero", Nullish::Null.to_any() - (0f64).to_any(), (0f64).to_any());
@@ -257,6 +357,7 @@ pub fn all<A: IVm>() {
     unary_plus::<A>();
     neg::<A>();
     mul::<A>();
+    div::<A>();
     sub::<A>();
     add::<A>();
     string_coercion::<A>();


### PR DESCRIPTION
## Summary

- Adds a `divCases` corpus (48 cases) for `/` to the shared operator test data in `fjs/nanvm/module.f.mjs`, following the same pattern established for `%` (see `nanvm-lib/tests/README.md`).
- `nanvm-lib` does not implement `/` yet (see the operator table in `nanvm-lib/README.md`), so every case carries a `rust` reason: the generated Rust keeps each as a commented-out TODO, while the JavaScript proof runs all of them against a real JS engine.
- Coverage: `ToNumeric` coercion of non-numeric operands, signed-zero/`Infinity`/`NaN` division edge cases for `Number`, `BigInt` truncating division (including division by `0n` throwing `RangeError`), and the mixed number/bigint `TypeError`.
- Wires `/` into `fjs/nanvm/proof.f.mjs` (`op2Js`) and `fjs/nanvm/rust/module.f.mjs` (`rustName`, `op2Rust`), and regenerates `nanvm-lib/tests/test/generated.rs`.
- Repoints the Rust printer's "unknown operation" proof (`fjs/nanvm/rust/proof.f.mjs`) from `/` to `**`, since `/` now has a printable (if unreachable) Rust spelling.

## Test plan

- [x] `npm test` — 3867/3867 passing, including all 48 new `/` cases evaluated against Node.
- [x] `cargo test -p nanvm-lib` — generated Rust compiles with the new cases commented out.
- [x] `cargo fmt -p nanvm-lib -- --check` — clean.
- [x] `npm run gen` — no drift after regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtpceTFc1653SDSG7Rsggt

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtpceTFc1653SDSG7Rsggt)_