### PR TITLE
Add shared operator test cases for `**` (exponentiation)

### DIFF
--- a/fjs/nanvm/module.f.mjs
+++ b/fjs/nanvm/module.f.mjs
@@ -36,7 +36,7 @@
  * ```js
  * import { data } from './module.f.mjs'
  *
- * data.groups.length // 5
+ * data.groups.length // 6
  * ```
  */
 
@@ -345,6 +345,227 @@ const mulCases = [
 ]
 
 /**
+ * `**` is not implemented in `nanvm-lib` yet (see the operator table in
+ * `nanvm-lib/README.md`), so every case below carries this as its `rust`
+ * reason: the generated Rust keeps each as a commented-out `TODO`, while the
+ * JavaScript proof still runs it. Removing the reason per case is what turns
+ * it on for Rust once `**` lands there.
+ *
+ * @type {string}
+ */
+const expNotImplemented = '`**` is not implemented in nanvm-lib yet'
+
+/**
+ * `**` coerces both operands with `ToNumeric` like `*`, but Number
+ * exponentiation (`Number::exponentiate`) is its own algorithm and not `pow`
+ * applied naively: the exponent's sign and parity decide the result at every
+ * infinity and zero, independently of the base's magnitude, and a few cases
+ * override what the magnitude rule would otherwise give — `NaN ** 0` and
+ * `x ** NaN` are governed by the exponent alone (`1`/`NaN`) regardless of the
+ * base, and `1 ** Infinity` is `NaN` even though `1` is decisive nowhere
+ * else. A finite negative base with a finite non-integer exponent has no
+ * real result and is `NaN`, unlike `Math.pow`, which agrees here. BigInt `**`
+ * throws — instead of coercing to a fraction — on a negative exponent, and
+ * mixed number/bigint operands throw too, the same as every other arithmetic
+ * operator here.
+ *
+ * @type {readonly Case<2>[]}
+ */
+const expCases = [
+    { name: 'nullToThePowerOfTwo', args: [null, 2], expected: 0, rust: expNotImplemented },
+    { name: 'undefinedToThePowerOfTwo', args: [undefined, 2], expected: NaN, rust: expNotImplemented },
+    { name: 'trueToThePowerOfTwo', args: [true, 2], expected: 1, rust: expNotImplemented },
+    { name: 'falseToThePowerOfTwo', args: [false, 2], expected: 0, rust: expNotImplemented },
+    { name: 'stringThreeToThePowerOfTwo', args: ['3', 2], expected: 9, rust: expNotImplemented },
+    { name: 'stringLetterToThePowerOfTwo', args: ['a', 2], expected: NaN, rust: expNotImplemented },
+    { name: 'emptyArrayToThePowerOfTwo', args: [[], 2], expected: 0, rust: expNotImplemented },
+    { name: 'arrayThreeToThePowerOfTwo', args: [[3], 2], expected: 9, rust: expNotImplemented },
+    {
+        name: 'arrayStringThreeToThePowerOfTwo',
+        args: [['3'], 2],
+        expected: 9,
+        rust: expNotImplemented,
+    },
+    { name: 'arrayPairToThePowerOfTwo', args: [[0, 0], 2], expected: NaN, rust: expNotImplemented },
+    { name: 'emptyObjectToThePowerOfTwo', args: [{}, 2], expected: NaN, rust: expNotImplemented },
+    // The one binary case that escapes: `functionValue` has no expression, so
+    // both consumers take the direct path with two operands rather than one.
+    {
+        name: 'functionToThePowerOfTwo',
+        args: [functionValue, 2],
+        expected: NaN,
+        rust: expNotImplemented,
+    },
+    { name: 'twoToThePowerOfTen', args: [2, 10], expected: 1024, rust: expNotImplemented },
+    { name: 'twoToThePowerOfHalf', args: [2, 0.5], expected: 2 ** 0.5, rust: expNotImplemented },
+    { name: 'twoToThePowerOfNegativeOne', args: [2, -1], expected: 0.5, rust: expNotImplemented },
+    {
+        name: 'negativeTwoToThePowerOfThree',
+        args: [-2, 3],
+        expected: -8,
+        rust: expNotImplemented,
+    },
+    { name: 'negativeTwoToThePowerOfTwo', args: [-2, 2], expected: 4, rust: expNotImplemented },
+    { name: 'zeroToThePowerOfZero', args: [0, 0], expected: 1, rust: expNotImplemented },
+    {
+        name: 'negativeZeroToThePowerOfZero',
+        args: [-0, 0],
+        expected: 1,
+        rust: expNotImplemented,
+    },
+    { name: 'nanToThePowerOfZero', args: [NaN, 0], expected: 1, rust: expNotImplemented },
+    { name: 'twoToThePowerOfNan', args: [2, NaN], expected: NaN, rust: expNotImplemented },
+    { name: 'nanToThePowerOfNan', args: [NaN, NaN], expected: NaN, rust: expNotImplemented },
+    {
+        name: 'oneToThePowerOfInfinity',
+        args: [1, Infinity],
+        expected: NaN,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'negativeOneToThePowerOfInfinity',
+        args: [-1, Infinity],
+        expected: NaN,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'oneToThePowerOfNegativeInfinity',
+        args: [1, -Infinity],
+        expected: NaN,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'twoToThePowerOfInfinity',
+        args: [2, Infinity],
+        expected: Infinity,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'negativeTwoToThePowerOfInfinity',
+        args: [-2, Infinity],
+        expected: Infinity,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'halfToThePowerOfInfinity',
+        args: [0.5, Infinity],
+        expected: 0,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'twoToThePowerOfNegativeInfinity',
+        args: [2, -Infinity],
+        expected: 0,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'halfToThePowerOfNegativeInfinity',
+        args: [0.5, -Infinity],
+        expected: Infinity,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'infinityToThePowerOfTwo',
+        args: [Infinity, 2],
+        expected: Infinity,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'infinityToThePowerOfNegativeTwo',
+        args: [Infinity, -2],
+        expected: 0,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'negativeInfinityToThePowerOfThree',
+        args: [-Infinity, 3],
+        expected: -Infinity,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'negativeInfinityToThePowerOfTwo',
+        args: [-Infinity, 2],
+        expected: Infinity,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'negativeInfinityToThePowerOfNegativeThree',
+        args: [-Infinity, -3],
+        expected: -0,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'negativeInfinityToThePowerOfNegativeTwo',
+        args: [-Infinity, -2],
+        expected: 0,
+        rust: expNotImplemented,
+    },
+    { name: 'zeroToThePowerOfTwo', args: [0, 2], expected: 0, rust: expNotImplemented },
+    {
+        name: 'zeroToThePowerOfNegativeTwo',
+        args: [0, -2],
+        expected: Infinity,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'negativeZeroToThePowerOfThree',
+        args: [-0, 3],
+        expected: -0,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'negativeZeroToThePowerOfTwo',
+        args: [-0, 2],
+        expected: 0,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'negativeZeroToThePowerOfNegativeThree',
+        args: [-0, -3],
+        expected: -Infinity,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'negativeZeroToThePowerOfNegativeTwo',
+        args: [-0, -2],
+        expected: Infinity,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'negativeTwoToThePowerOfHalf',
+        args: [-2, 0.5],
+        expected: NaN,
+        rust: expNotImplemented,
+    },
+    { name: 'bigTwoToThePowerOfTen', args: [2n, 10n], expected: 1024n, rust: expNotImplemented },
+    { name: 'bigZeroToThePowerOfZero', args: [0n, 0n], expected: 1n, rust: expNotImplemented },
+    {
+        name: 'bigNegativeTwoToThePowerOfThree',
+        args: [-2n, 3n],
+        expected: -8n,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'bigTwoToThePowerOfNegativeOne',
+        args: [2n, -1n],
+        expected: throws,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'numberToThePowerOfBigint',
+        args: [1, 1n],
+        expected: throws,
+        rust: expNotImplemented,
+    },
+    {
+        name: 'bigintToThePowerOfNumber',
+        args: [1n, 1],
+        expected: throws,
+        rust: expNotImplemented,
+    },
+]
+
+/**
  * Subtraction has the same numeric coercion and mixed-number-kind rejection
  * as multiplication, but its operand order is observable.
  *
@@ -503,6 +724,7 @@ export const data = {
             ],
         },
         { op: '*', commutative: true, cases: mulCases },
+        { op: '**', cases: expCases },
         { op: '-', cases: subCases },
         { op: '+', cases: addCases },
         { op: 'String', cases: stringCoercionCases },

--- a/fjs/nanvm/proof.f.mjs
+++ b/fjs/nanvm/proof.f.mjs
@@ -64,6 +64,7 @@ const op1Js = {
 /** The same, for the binary operations. @type {{ readonly [k in OpId]?: (a: any, b: any) => unknown }} */
 const op2Js = {
     '*': (a, b) => a * b,
+    '**': (a, b) => a ** b,
     '-': (a, b) => a - b,
     '+': (a, b) => a + b,
     '===': (a, b) => a === b,

--- a/fjs/nanvm/rust/module.f.mjs
+++ b/fjs/nanvm/rust/module.f.mjs
@@ -83,6 +83,7 @@ export const rustName = {
     unaryPlus: 'unary_plus',
     neg: 'neg',
     '*': 'mul',
+    '**': 'pow',
     '-': 'sub',
     '+': 'add',
     String: 'string_coercion',
@@ -99,9 +100,22 @@ const op1Rust = {
     String: a => `${a}.to_string().map(|v| v.to_any())`,
 }
 
-/** The same, for the binary operations. @type {{ readonly [k in OpId]?: (a: string, b: string) => string }} */
+/**
+ * The same, for the binary operations.
+ *
+ * `**` has no `nanvm-lib` implementation yet, so every `**` case carries a
+ * `rust` reason and `emit` prints this text as a comment rather than a
+ * statement — this entry only has to read as the operation, not compile.
+ * Rust has no exponentiation operator (unlike `*`, `-`, `+`), so it is
+ * printed as a call rather than an infix expression, following the
+ * `Any::unary_plus` precedent for an operation with no Rust operator to
+ * spell.
+ *
+ * @type {{ readonly [k in OpId]?: (a: string, b: string) => string }}
+ */
 const op2Rust = {
     '*': (a, b) => `${a} * ${b}`,
+    '**': (a, b) => `Any::pow(${a}, ${b})`,
     '-': (a, b) => `${a} - ${b}`,
     '+': (a, b) => `${a} + ${b}`,
 }

--- a/nanvm-lib/tests/test/generated.rs
+++ b/nanvm-lib/tests/test/generated.rs
@@ -177,6 +177,108 @@ fn mul<A: IVm>() {
 }
 
 #[rustfmt::skip]
+fn pow<A: IVm>() {
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("nullToThePowerOfTwo", Any::pow(Nullish::Null.to_any(), (2f64).to_any()), (0f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("undefinedToThePowerOfTwo", Any::pow(Nullish::Undefined.to_any(), (2f64).to_any()), (f64::NAN).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("trueToThePowerOfTwo", Any::pow(true.to_any(), (2f64).to_any()), (1f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("falseToThePowerOfTwo", Any::pow(false.to_any(), (2f64).to_any()), (0f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("stringThreeToThePowerOfTwo", Any::pow(string_any("3"), (2f64).to_any()), (9f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("stringLetterToThePowerOfTwo", Any::pow(string_any("a"), (2f64).to_any()), (f64::NAN).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("emptyArrayToThePowerOfTwo", Any::pow(Array::default().to_any(), (2f64).to_any()), (0f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("arrayThreeToThePowerOfTwo", Any::pow([(3f64).to_any()].to_array().to_any(), (2f64).to_any()), (9f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("arrayStringThreeToThePowerOfTwo", Any::pow([string_any("3")].to_array().to_any(), (2f64).to_any()), (9f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("arrayPairToThePowerOfTwo", Any::pow([(0f64).to_any(), (0f64).to_any()].to_array().to_any(), (2f64).to_any()), (f64::NAN).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("emptyObjectToThePowerOfTwo", Any::pow(Object::default().to_any(), (2f64).to_any()), (f64::NAN).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("functionToThePowerOfTwo", Any::pow(function_any(), (2f64).to_any()), (f64::NAN).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("twoToThePowerOfTen", Any::pow((2f64).to_any(), (10f64).to_any()), (1024f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("twoToThePowerOfHalf", Any::pow((2f64).to_any(), (0.5f64).to_any()), (1.4142135623730951f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("twoToThePowerOfNegativeOne", Any::pow((2f64).to_any(), (-1f64).to_any()), (0.5f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("negativeTwoToThePowerOfThree", Any::pow((-2f64).to_any(), (3f64).to_any()), (-8f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("negativeTwoToThePowerOfTwo", Any::pow((-2f64).to_any(), (2f64).to_any()), (4f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("zeroToThePowerOfZero", Any::pow((0f64).to_any(), (0f64).to_any()), (1f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("negativeZeroToThePowerOfZero", Any::pow((-0f64).to_any(), (0f64).to_any()), (1f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("nanToThePowerOfZero", Any::pow((f64::NAN).to_any(), (0f64).to_any()), (1f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("twoToThePowerOfNan", Any::pow((2f64).to_any(), (f64::NAN).to_any()), (f64::NAN).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("nanToThePowerOfNan", Any::pow((f64::NAN).to_any(), (f64::NAN).to_any()), (f64::NAN).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("oneToThePowerOfInfinity", Any::pow((1f64).to_any(), (f64::INFINITY).to_any()), (f64::NAN).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("negativeOneToThePowerOfInfinity", Any::pow((-1f64).to_any(), (f64::INFINITY).to_any()), (f64::NAN).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("oneToThePowerOfNegativeInfinity", Any::pow((1f64).to_any(), (f64::NEG_INFINITY).to_any()), (f64::NAN).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("twoToThePowerOfInfinity", Any::pow((2f64).to_any(), (f64::INFINITY).to_any()), (f64::INFINITY).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("negativeTwoToThePowerOfInfinity", Any::pow((-2f64).to_any(), (f64::INFINITY).to_any()), (f64::INFINITY).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("halfToThePowerOfInfinity", Any::pow((0.5f64).to_any(), (f64::INFINITY).to_any()), (0f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("twoToThePowerOfNegativeInfinity", Any::pow((2f64).to_any(), (f64::NEG_INFINITY).to_any()), (0f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("halfToThePowerOfNegativeInfinity", Any::pow((0.5f64).to_any(), (f64::NEG_INFINITY).to_any()), (f64::INFINITY).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("infinityToThePowerOfTwo", Any::pow((f64::INFINITY).to_any(), (2f64).to_any()), (f64::INFINITY).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("infinityToThePowerOfNegativeTwo", Any::pow((f64::INFINITY).to_any(), (-2f64).to_any()), (0f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("negativeInfinityToThePowerOfThree", Any::pow((f64::NEG_INFINITY).to_any(), (3f64).to_any()), (f64::NEG_INFINITY).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("negativeInfinityToThePowerOfTwo", Any::pow((f64::NEG_INFINITY).to_any(), (2f64).to_any()), (f64::INFINITY).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("negativeInfinityToThePowerOfNegativeThree", Any::pow((f64::NEG_INFINITY).to_any(), (-3f64).to_any()), (-0f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("negativeInfinityToThePowerOfNegativeTwo", Any::pow((f64::NEG_INFINITY).to_any(), (-2f64).to_any()), (0f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("zeroToThePowerOfTwo", Any::pow((0f64).to_any(), (2f64).to_any()), (0f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("zeroToThePowerOfNegativeTwo", Any::pow((0f64).to_any(), (-2f64).to_any()), (f64::INFINITY).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("negativeZeroToThePowerOfThree", Any::pow((-0f64).to_any(), (3f64).to_any()), (-0f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("negativeZeroToThePowerOfTwo", Any::pow((-0f64).to_any(), (2f64).to_any()), (0f64).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("negativeZeroToThePowerOfNegativeThree", Any::pow((-0f64).to_any(), (-3f64).to_any()), (f64::NEG_INFINITY).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("negativeZeroToThePowerOfNegativeTwo", Any::pow((-0f64).to_any(), (-2f64).to_any()), (f64::INFINITY).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("negativeTwoToThePowerOfHalf", Any::pow((-2f64).to_any(), (0.5f64).to_any()), (f64::NAN).to_any());
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("bigTwoToThePowerOfTen", Any::pow(bigint_any(2), bigint_any(10)), bigint_any(1024));
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("bigZeroToThePowerOfZero", Any::pow(bigint_any(0), bigint_any(0)), bigint_any(1));
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check::<A>("bigNegativeTwoToThePowerOfThree", Any::pow(bigint_any(-2), bigint_any(3)), bigint_any(-8));
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check_throws::<A>("bigTwoToThePowerOfNegativeOne", Any::pow(bigint_any(2), bigint_any(-1)));
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check_throws::<A>("numberToThePowerOfBigint", Any::pow((1f64).to_any(), bigint_any(1)));
+    // TODO: `**` is not implemented in nanvm-lib yet
+    // check_throws::<A>("bigintToThePowerOfNumber", Any::pow(bigint_any(1), (1f64).to_any()));
+}
+
+#[rustfmt::skip]
 fn sub<A: IVm>() {
     check::<A>("nullMinusNull", Nullish::Null.to_any() - Nullish::Null.to_any(), (0f64).to_any());
     check::<A>("nullMinusZero", Nullish::Null.to_any() - (0f64).to_any(), (0f64).to_any());
@@ -257,6 +359,7 @@ pub fn all<A: IVm>() {
     unary_plus::<A>();
     neg::<A>();
     mul::<A>();
+    pow::<A>();
     sub::<A>();
     add::<A>();
     string_coercion::<A>();


### PR DESCRIPTION
## Summary

- Adds an `expCases` corpus (49 cases) for `**` to the shared operator test data in `fjs/nanvm/module.f.mjs`, following the same pattern established for `%` (see `nanvm-lib/tests/README.md`).
- `nanvm-lib` does not implement `**` yet (see the operator table in `nanvm-lib/README.md`), so every case carries a `rust` reason: the generated Rust keeps each as a commented-out TODO, while the JavaScript proof runs all of them against a real JS engine.
- Coverage: `ToNumeric` coercion of non-numeric operands, and the full `Number::exponentiate` special-value matrix — `0 ** 0 === 1`, `NaN ** 0 === 1`, `x ** NaN === NaN` regardless of `x`, `1 ** Infinity === NaN`, sign/parity rules for `±Infinity`/`±0` bases and exponents, and a finite negative base with a finite non-integer exponent giving `NaN`. Plus `BigInt` exponentiation (including a negative exponent throwing `RangeError`) and the mixed number/bigint `TypeError`.
- Wires `**` into `fjs/nanvm/proof.f.mjs` (`op2Js`) and `fjs/nanvm/rust/module.f.mjs` (`rustName`, `op2Rust`), and regenerates `nanvm-lib/tests/test/generated.rs`.
- Rust has no exponentiation operator, so `**` prints as `Any::pow(a, b)` rather than an infix expression — following the existing `Any::unary_plus` precedent for an operation with no Rust operator to spell. This text is only ever emitted inside a commented-out TODO, since `nanvm-lib` doesn't implement `**` either.

## Test plan

- [x] `npm test` — 3868/3868 passing, including all 49 new `**` cases evaluated against Node.
- [x] `cargo test -p nanvm-lib` — generated Rust compiles with the new cases commented out.
- [x] `cargo fmt -p nanvm-lib -- --check` — clean.
- [x] `npm run gen` — no drift after regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtpceTFc1653SDSG7Rsggt

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtpceTFc1653SDSG7Rsggt)_