### PR TITLE
nanvm-lib: implement !, &&, ||, ??, ?: — value-selection and negation operators

### DIFF
--- a/fjs/edag/todo/ternary-conditional-node.md
+++ b/fjs/edag/todo/ternary-conditional-node.md
@@ -1,0 +1,96 @@
+## Add the `?:` (ternary conditional) node to the EDAG
+
+**Priority:** P2
+**Status:** open
+
+### Problem
+
+`nanvm-lib`'s `?:` operator (`Any::conditional`, added in
+functionalscript/functionalscript#1867) has no EDAG counterpart:
+[`types.ts`](../types.ts)'s `Op1Id`/`Op2Id` vocabularies only cover arity 1
+and 2 — there is no arity-3 tag at all, so `?:` cannot be expressed as an
+EDAG node today. The shared operator corpus
+([`fjs/nanvm/module.f.mjs`](../../nanvm/module.f.mjs)) works around this the
+same way it works around `unaryPlus`
+([`replace-unary-plus-with-number.md`](../../../nanvm-lib/todo/replace-unary-plus-with-number.md)):
+[`fjs/nanvm/types.ts`](../../nanvm/types.ts)'s `NonEdagGroup` gained a
+`'ternary'` variant carrying `Case<3>`, whose cases always take the corpus's
+"escape" path — build all three operands, apply the operation directly —
+rather than lowering to a real expression. Because there is no such thing as
+an unevaluated `Value` in the corpus (`Operand` admits no expression whose
+evaluation is observable), nothing there proves `?:` actually *branches*:
+the discarded arm is built right along with the selected one.
+
+This is not a missing design — it is a missing implementation of an
+existing one.
+[`edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)
+(subject 3, "Lazy operators and the branch extension path", status:
+**decided**) and
+[`spec/todo/2340-operators.md`](../../../spec/todo/2340-operators.md) (which
+lists `?:` as `Conditional`, priority 1 — an allowed operator) already
+settle `?:` as a real, lazy, arity-3 EDAG node: `["?:", c, t, e]`, "exactly
+one of the two arms is established." The gap is purely that
+[`types.ts`](../types.ts)'s `Op2`-and-below vocabulary has no arity-3 shape,
+and nothing walks `Exp` lazily yet — every consumer today (the inline
+evaluator in
+[`fjs/nanvm/proof.f.mjs`](../../nanvm/proof.f.mjs), and the future real
+interpreter per
+[`fjs/djs/todo/interpret-edag.md`](../../djs/todo/interpret-edag.md))
+establishes every operand eagerly.
+
+### Proposal
+
+- Add an `Op3Id`/`Op3` (or similarly-named) shape to [`types.ts`](../types.ts)
+  with `'?:'` as its member — arity 3, tagged `[id, Exp, Exp, Exp]` — and fold
+  it into `Exp`. Update the matching rtti schema in
+  [`module.f.mjs`](../module.f.mjs) (a new `op3`, added to `exp`'s `or`).
+- This is a *lowering/evaluation* feature, not only a shape change: unlike
+  every existing `Op1`/`Op2`, `?:`'s second and third operands are lazy — only
+  the selected one is established. Subject 3's "operand shapes are specified
+  per command" note is what licenses this without disturbing every other
+  node's eager-operand assumption. Whatever walks `Exp` needs a genuinely
+  lazy case for `'?:'`, not just a four-tuple pattern match that evaluates
+  both branches anyway.
+- Once the node exists, move
+  [`fjs/nanvm/module.f.mjs`](../../nanvm/module.f.mjs)'s `ternaryCases` group
+  from `NonEdagGroup`'s `'ternary'` escape onto a real `Group` with
+  `op: '?:'` and canonical `Case<3>` lowering — the same move
+  [`replace-unary-plus-with-number.md`](../../../nanvm-lib/todo/replace-unary-plus-with-number.md)
+  proposes for `unaryPlus` → `'Number'` — retiring the `'ternary'` arm of
+  `NonEdagGroup`. This is also the point where the corpus could finally test
+  the half of `?:` it cannot today: that the unselected branch is never
+  evaluated.
+- `nanvm-lib`'s own `Any::conditional` needs no change: it already takes
+  three already-evaluated `Any<A>` values, the right shape for whatever
+  *calls* it once the EDAG can choose which branch to evaluate before making
+  that call.
+
+### Tasks
+
+- [ ] Add an `Op3`-shaped `'?:'` vocabulary to `fjs/edag/types.ts` and its
+      rtti schema in `fjs/edag/module.f.mjs`.
+- [ ] Give whatever evaluates `Exp` a genuinely lazy `'?:'` case (only the
+      selected branch is established).
+- [ ] Move `fjs/nanvm/module.f.mjs`'s `ternaryCases` group off `NonEdagGroup`
+      onto a real `op: '?:'` `Group`; retire the `'ternary'` `NonEdagGroup`
+      arm and its `Case<3>` support in `fjs/nanvm/types.ts` if `?:` ends up
+      being the only ternary operator the corpus ever needs.
+- [ ] Extend the corpus (or a dedicated lazy-evaluation proof) to assert the
+      unselected branch never evaluates, now that an operand can carry
+      observable evaluation.
+- [ ] `tsc`, `fjs test`, `npm run gen` (diff limited to the corpus's op
+      change), `cargo test`, `cargo clippy --lib -- -D warnings`,
+      `cargo fmt -- --check`.
+
+### Related
+
+- [`edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)
+  subject 3 — the decided design this implements.
+- [`spec/todo/2340-operators.md`](../../../spec/todo/2340-operators.md) —
+  `?:` already listed as an allowed, priority-1 operator.
+- [`replace-unary-plus-with-number.md`](../../../nanvm-lib/todo/replace-unary-plus-with-number.md)
+  — the same `NonEdagGroup`-retirement shape, for `unaryPlus`/`'Number'`.
+- [`interpret-edag.md`](../../djs/todo/interpret-edag.md) — the eventual real
+  interpreter this lazy case belongs in.
+- functionalscript/functionalscript#1867 — where `Any::conditional` and the
+  `NonEdagGroup` `'ternary'` escape landed.

--- a/fjs/nanvm/module.f.mjs
+++ b/fjs/nanvm/module.f.mjs
@@ -940,6 +940,17 @@ const notCases = [
  * falsy-but-not-nullish value (`0`, `NaN`, `''`) behaves like `null` here,
  * unlike `??`, which keys off nullishness alone.
  *
+ * What these cases do *not* prove: that the discarded operand's evaluation
+ * is actually skipped. `&&`/`||`/`??`/`?:` are the one place in JavaScript
+ * where that is these operators' defining behaviour — but every `Operand` in
+ * this corpus is `Value | FunctionValue` (see `types.ts`), and `Value` admits
+ * no expression whose evaluation is observable (no side effect, no throw:
+ * `Throws` is legal only as an `expected`, never an operand). Both consumers
+ * build every argument before dispatch — `run` here, `result` in
+ * `rust/module.f.mjs` — so there is nothing an unevaluated operand could do
+ * differently from an evaluated one for this corpus to catch. What these
+ * cases prove is the other half: *which* operand comes back.
+ *
  * @type {readonly Case<2>[]}
  */
 const andCases = [
@@ -1015,7 +1026,8 @@ const nullishCases = [
  * use. Like those, this selects an operand rather than coercing it, so a
  * reference-typed value only ever appears as the *condition*, the one
  * position that is always discarded (see the `&&`/`||`/`??` group comment
- * above for why that matters).
+ * above for why that matters, and for why — the same as those three — these
+ * cases cannot prove the *unselected* branch goes unevaluated).
  *
  * @type {readonly Case<3>[]}
  */

--- a/fjs/nanvm/module.f.mjs
+++ b/fjs/nanvm/module.f.mjs
@@ -36,7 +36,7 @@
  * ```js
  * import { data } from './module.f.mjs'
  *
- * data.groups.length // 13
+ * data.groups.length // 18
  * ```
  */
 
@@ -117,7 +117,7 @@ const isCommutative = g => g.commutative === true
  * owner — spelled differently in the two consumers, the JavaScript and Rust
  * names for one case would silently diverge.
  *
- * @type {(g: Group) => (c: Case<1> | Case<2>) => readonly (readonly[string, readonly Operand[]])[]}
+ * @type {(g: Group) => (c: Case<1> | Case<2> | Case<3>) => readonly (readonly[string, readonly Operand[]])[]}
  */
 export const orders = g => c => isCommutative(g)
     ? [[c.name, c.args], [`${c.name}Swapped`, c.args.toReversed()]]
@@ -137,7 +137,7 @@ export const opId = g => 'op' in g ? g.op : g.nanvmOp
  * The operand count is the point of the three group types, and it is fixed
  * before a consumer gets here; walking the cases does not need it back.
  *
- * @type {(g: Group) => readonly (Case<1> | Case<2>)[]}
+ * @type {(g: Group) => readonly (Case<1> | Case<2> | Case<3>)[]}
  */
 export const casesOf = g => g.cases
 
@@ -146,14 +146,20 @@ export const casesOf = g => g.cases
  *
  * Which vocabulary the id belongs to is what fixes the count — the same rule
  * the group types carry — so this asks the schema rather than a second copy
- * of the vocabulary, and a group with no canonical id is unary because its
- * one inhabitant is. It is the runtime half of what `Group1`/`Group2` say
- * statically, for the consumers that walk `data.groups` and so hold a
- * `Group` whose arm is no longer known.
+ * of the vocabulary. A group with no canonical id is unary unless it names
+ * `ternary`, the corpus's one three-operand group — the EDAG has no
+ * conditional-expression node to be unary or binary *in*, so nothing there
+ * fixes its count the way it fixes every other group's. It is the runtime
+ * half of what `Group1`/`Group2`/`NonEdagGroup` say statically, for the
+ * consumers that walk `data.groups` and so hold a `Group` whose arm is no
+ * longer known.
  *
- * @type {(g: Group) => 1 | 2}
+ * @type {(g: Group) => 1 | 2 | 3}
  */
-export const arityOf = g => !('op' in g) || isOp1Id(g.op)[0] === 'ok' ? 1 : 2
+export const arityOf = g => {
+    if (!('op' in g)) { return g.nanvmOp === 'ternary' ? 3 : 1 }
+    return isOp1Id(g.op)[0] === 'ok' ? 1 : 2
+}
 
 // Lowering — a case as the EDAG expression it denotes.
 
@@ -888,6 +894,150 @@ const greaterOrEqualCases = [
 ]
 
 /**
+ * `!` coerces its operand with `ToBoolean` and negates — the value never
+ * reaches `ToPrimitive`/`ToNumeric` the way the arithmetic and comparison
+ * groups' operands do, so array and object operands go straight to `true`
+ * (every object is truthy) rather than through a coercion chain that could
+ * fail or produce something else first.
+ *
+ * @type {readonly Case<1>[]}
+ */
+const notCases = [
+    { name: 'null', args: [null], expected: true },
+    { name: 'undefined', args: [undefined], expected: true },
+    { name: 'booleanFalse', args: [false], expected: true },
+    { name: 'booleanTrue', args: [true], expected: false },
+    { name: 'numberZero', args: [0], expected: true },
+    { name: 'numberNegativeZero', args: [-0], expected: true },
+    { name: 'numberNan', args: [NaN], expected: true },
+    { name: 'numberPositive', args: [2.3], expected: false },
+    { name: 'numberNegative', args: [-2.3], expected: false },
+    { name: 'stringEmpty', args: [''], expected: true },
+    { name: 'stringNonEmpty', args: ['a'], expected: false },
+    { name: 'bigintZero', args: [0n], expected: true },
+    { name: 'bigintPositive', args: [5n], expected: false },
+    { name: 'bigintNegative', args: [-5n], expected: false },
+    { name: 'emptyArray', args: [[]], expected: false },
+    { name: 'emptyObject', args: [{}], expected: false },
+    { name: 'function', args: [functionValue], expected: false },
+]
+
+/**
+ * `&&`/`||`/`??` all *select* one operand rather than coercing either one, so
+ * — unlike every group above — the value a case returns is the operand
+ * itself, not a derived primitive. That is observable only for a reference
+ * type (array, object, function): `Object.is`/`===` compare those by
+ * identity, and the corpus lowers each operand to a node of its own (nothing
+ * outside the `eq` section's `ref`s aliases two nodes), so a case whose
+ * `expected` needs to be *the same* array, object, or function the operand
+ * built would compare unequal to a freshly-lowered copy. Every case below is
+ * chosen so a reference-typed operand is only ever on the *discarded* side —
+ * proving these operators are truthy/nullish-aware for those types without
+ * needing their identity preserved across the corpus's operand/expected
+ * split.
+ *
+ * `&&`/`||` key off `ToBoolean` — the same coercion `!` uses above, so a
+ * falsy-but-not-nullish value (`0`, `NaN`, `''`) behaves like `null` here,
+ * unlike `??`, which keys off nullishness alone.
+ *
+ * @type {readonly Case<2>[]}
+ */
+const andCases = [
+    { name: 'falseAndTrue', args: [false, true], expected: false },
+    { name: 'trueAndFalse', args: [true, false], expected: false },
+    { name: 'trueAndTrue', args: [true, true], expected: true },
+    { name: 'nullAndOne', args: [null, 1], expected: null },
+    { name: 'undefinedAndOne', args: [undefined, 1], expected: undefined },
+    { name: 'zeroAndOne', args: [0, 1], expected: 0 },
+    { name: 'nanAndOne', args: [NaN, 1], expected: NaN },
+    { name: 'oneAndZero', args: [1, 0], expected: 0 },
+    { name: 'oneAndTwo', args: [1, 2], expected: 2 },
+    { name: 'emptyStringAndOne', args: ['', 1], expected: '' },
+    { name: 'nonEmptyStringAndOne', args: ['a', 1], expected: 1 },
+    { name: 'bigZeroAndOne', args: [0n, 1], expected: 0n },
+    { name: 'bigOneAndTwo', args: [1n, 2], expected: 2 },
+    // Every object is truthy, so an array/object/function on the left is
+    // always discarded in favor of the right — never the operand `&&` has to
+    // hand back, which is what keeps these identity-safe (see the group
+    // comment above).
+    { name: 'emptyArrayAndOne', args: [[], 1], expected: 1 },
+    { name: 'emptyObjectAndOne', args: [{}, 1], expected: 1 },
+    { name: 'functionAndOne', args: [functionValue, 1], expected: 1 },
+]
+
+/** @type {readonly Case<2>[]} */
+const orCases = [
+    { name: 'falseOrTrue', args: [false, true], expected: true },
+    { name: 'trueOrFalse', args: [true, false], expected: true },
+    { name: 'falseOrFalse', args: [false, false], expected: false },
+    { name: 'nullOrOne', args: [null, 1], expected: 1 },
+    { name: 'undefinedOrOne', args: [undefined, 1], expected: 1 },
+    { name: 'zeroOrOne', args: [0, 1], expected: 1 },
+    { name: 'nanOrOne', args: [NaN, 1], expected: 1 },
+    { name: 'oneOrZero', args: [1, 0], expected: 1 },
+    { name: 'oneOrTwo', args: [1, 2], expected: 1 },
+    { name: 'emptyStringOrOne', args: ['', 1], expected: 1 },
+    { name: 'nonEmptyStringOrOne', args: ['a', 1], expected: 'a' },
+    { name: 'bigZeroOrOne', args: [0n, 1], expected: 1 },
+    { name: 'bigOneOrTwo', args: [1n, 2], expected: 1n },
+    // Every object is truthy, so an array/object/function is always picked
+    // when it is the *left* operand — the identity-unsafe side for `||` —
+    // so each is placed on the right instead, where a truthy left discards
+    // it.
+    { name: 'oneOrEmptyArray', args: [1, []], expected: 1 },
+    { name: 'oneOrEmptyObject', args: [1, {}], expected: 1 },
+    { name: 'oneOrFunction', args: [1, functionValue], expected: 1 },
+]
+
+/** @type {readonly Case<2>[]} */
+const nullishCases = [
+    { name: 'nullCoalesceOne', args: [null, 1], expected: 1 },
+    { name: 'undefinedCoalesceOne', args: [undefined, 1], expected: 1 },
+    // Falsy but not nullish: stays on the left, unlike `andCases`/`orCases`.
+    { name: 'zeroCoalesceOne', args: [0, 1], expected: 0 },
+    { name: 'falseCoalesceOne', args: [false, 1], expected: false },
+    { name: 'nanCoalesceOne', args: [NaN, 1], expected: NaN },
+    { name: 'emptyStringCoalesceOne', args: ['', 1], expected: '' },
+    { name: 'bigZeroCoalesceOne', args: [0n, 1], expected: 0n },
+    { name: 'oneCoalesceTwo', args: [1, 2], expected: 1 },
+    { name: 'oneCoalesceNull', args: [1, null], expected: 1 },
+    // No object is ever nullish, so each is placed on the right, where a
+    // non-nullish left discards it — the identity-safe side.
+    { name: 'oneCoalesceEmptyArray', args: [1, []], expected: 1 },
+    { name: 'oneCoalesceEmptyObject', args: [1, {}], expected: 1 },
+    { name: 'oneCoalesceFunction', args: [1, functionValue], expected: 1 },
+]
+
+/**
+ * `?:`, the corpus's one ternary group (see `NonEdagGroup` in `types.ts`):
+ * `args` is `[condition, consequent, alternate]`, and `expected` is whichever
+ * branch `ToBoolean(condition)` selects — the same coercion `!`/`&&`/`||`
+ * use. Like those, this selects an operand rather than coercing it, so a
+ * reference-typed value only ever appears as the *condition*, the one
+ * position that is always discarded (see the `&&`/`||`/`??` group comment
+ * above for why that matters).
+ *
+ * @type {readonly Case<3>[]}
+ */
+const ternaryCases = [
+    { name: 'truePicksConsequent', args: [true, 1, 2], expected: 1 },
+    { name: 'falsePicksAlternate', args: [false, 1, 2], expected: 2 },
+    { name: 'nullPicksAlternate', args: [null, 1, 2], expected: 2 },
+    { name: 'undefinedPicksAlternate', args: [undefined, 1, 2], expected: 2 },
+    { name: 'zeroPicksAlternate', args: [0, 1, 2], expected: 2 },
+    { name: 'nanPicksAlternate', args: [NaN, 1, 2], expected: 2 },
+    { name: 'emptyStringPicksAlternate', args: ['', 1, 2], expected: 2 },
+    { name: 'nonEmptyStringPicksConsequent', args: ['a', 1, 2], expected: 1 },
+    { name: 'bigZeroPicksAlternate', args: [0n, 1, 2], expected: 2 },
+    { name: 'bigNonZeroPicksConsequent', args: [5n, 1, 2], expected: 1 },
+    { name: 'emptyArrayPicksConsequent', args: [[], 1, 2], expected: 1 },
+    { name: 'emptyObjectPicksConsequent', args: [{}, 1, 2], expected: 1 },
+    { name: 'functionPicksConsequent', args: [functionValue, 1, 2], expected: 1 },
+    { name: 'truePicksStringConsequent', args: [true, 'yes', 'no'], expected: 'yes' },
+    { name: 'falsePicksBigAlternate', args: [false, 1n, 2n], expected: 2n },
+]
+
+/**
  * `String(x)`.
  *
  * A function's string form is its source text, which no two engines have to
@@ -994,6 +1144,11 @@ export const data = {
         { op: '<=', cases: lessOrEqualCases },
         { op: '>', cases: greaterThanCases },
         { op: '>=', cases: greaterOrEqualCases },
+        { op: '!', cases: notCases },
+        { op: '&&', cases: andCases },
+        { op: '||', cases: orCases },
+        { op: '??', cases: nullishCases },
+        { nanvmOp: 'ternary', cases: ternaryCases },
         { op: 'String', cases: stringCoercionCases },
     ],
 }

--- a/fjs/nanvm/module.f.mjs
+++ b/fjs/nanvm/module.f.mjs
@@ -946,7 +946,7 @@ const notCases = [
  * this corpus is `Value | FunctionValue` (see `types.ts`), and `Value` admits
  * no expression whose evaluation is observable (no side effect, no throw:
  * `Throws` is legal only as an `expected`, never an operand). Both consumers
- * build every argument before dispatch — `run` here, `result` in
+ * build every argument before dispatch — `run` in `proof.f.mjs`, `result` in
  * `rust/module.f.mjs` — so there is nothing an unevaluated operand could do
  * differently from an evaluated one for this corpus to catch. What these
  * cases prove is the other half: *which* operand comes back.

--- a/fjs/nanvm/proof.f.mjs
+++ b/fjs/nanvm/proof.f.mjs
@@ -59,6 +59,7 @@ const op1Js = {
     String: a => String(a),
     neg: a => -a,
     unaryPlus: a => +a,
+    '!': a => !a,
 }
 
 /** The same, for the binary operations. @type {{ readonly [k in OpId]?: (a: any, b: any) => unknown }} */
@@ -74,6 +75,14 @@ const op2Js = {
     '>': (a, b) => a > b,
     '>=': (a, b) => a >= b,
     '===': (a, b) => a === b,
+    '&&': (a, b) => a && b,
+    '||': (a, b) => a || b,
+    '??': (a, b) => a ?? b,
+}
+
+/** The same, for the one ternary operation. @type {{ readonly [k in OpId]?: (a: any, b: any, c: any) => unknown }} */
+const op3Js = {
+    ternary: (a, b, c) => a ? b : c,
 }
 
 /**
@@ -91,6 +100,8 @@ const lookup = table => id => {
 const op1 = lookup(op1Js)
 
 const op2 = lookup(op2Js)
+
+const op3 = lookup(op3Js)
 
 /**
  * Evaluates a constant EDAG expression.
@@ -163,15 +174,18 @@ const escapedValue = v => isFunctionValue(v) ? () => 5 : evaluate([])(valueExp(v
  * values.
  *
  * The escape dispatches on the group's arity, so a binary group's escaped
- * case reaches `op2` rather than being refused by the unary table.
+ * case reaches `op2` rather than being refused by the unary table, and the
+ * one ternary group (`?:`) reaches `op3`.
  *
  * @type {(g: Group) => (args: readonly Operand[]) => unknown}
  */
 const run = g => args => {
     const lowered = caseExp(g)(args)
     if (lowered[0] === 'exp') { return evaluate([])(lowered[1]) }
-    const [a, b] = args.map(escapedValue)
-    return arityOf(g) === 1 ? op1(opId(g))(a) : op2(opId(g))(a, b)
+    const [a, b, c] = args.map(escapedValue)
+    const id = opId(g)
+    const arity = arityOf(g)
+    return arity === 1 ? op1(id)(a) : arity === 2 ? op2(id)(a, b) : op3(id)(a, b, c)
 }
 
 /**
@@ -184,7 +198,7 @@ const run = g => args => {
  * @type {(g: Group) => object}
  */
 const group = g => {
-    /** @type {(c: Case<1> | Case<2>) => readonly (readonly[string, () => void])[]} */
+    /** @type {(c: Case<1> | Case<2> | Case<3>) => readonly (readonly[string, () => void])[]} */
     const leaves = c => {
         const { expected } = c
         /** @type {(args: readonly Operand[]) => () => void} */
@@ -338,7 +352,7 @@ const jsOnly = {
         forwardSharedRef: () =>
             lowerEq({ shared: { a: [ref('b')], b: [] }, cases: [] }),
         /** An id the corpus does not exercise has no JavaScript here. */
-        unusedOperation: () => op1('!'),
+        unusedOperation: () => op1('~'),
         /**
          * A count the operation does not take. `Case<N>` cannot carry one,
          * but `caseExp` is exported and its `args` are a plain array, so the

--- a/fjs/nanvm/rust/module.f.mjs
+++ b/fjs/nanvm/rust/module.f.mjs
@@ -92,6 +92,11 @@ export const rustName = {
     '<=': 'le',
     '>': 'gt',
     '>=': 'ge',
+    '!': 'not',
+    '&&': 'logical_and',
+    '||': 'logical_or',
+    '??': 'nullish_coalescing',
+    ternary: 'conditional',
     String: 'string_coercion',
 }
 
@@ -103,6 +108,7 @@ export const rustName = {
 const op1Rust = {
     unaryPlus: a => `Any::unary_plus(${a})`,
     neg: a => `-(${a})`,
+    '!': a => `!(${a})`,
     String: a => `${a}.to_string().map(|v| v.to_any())`,
 }
 
@@ -120,7 +126,11 @@ const op1Rust = {
  * spell. The comparisons follow the same precedent for a different reason:
  * `check` takes a `Result<Any<A>, Any<A>>` against an `Any<A>` expectation,
  * which a `PartialOrd`-derived `<`/`<=`/`>`/`>=` on `Any<A>` would not give
- * back.
+ * back. `&&`/`||`/`??` follow it for a third reason: Rust's own `&&`/`||`
+ * take `bool` operands and short-circuit *evaluation*, neither of which fits
+ * an operator over already-evaluated `Any<A>` values, and `?` is Rust's own
+ * try-operator, unrelated to JS `??` — so all three are `Any` methods, named
+ * for what they do rather than reusing punctuation Rust already owns.
  *
  * @type {{ readonly [k in OpId]?: (a: string, b: string) => string }}
  */
@@ -135,6 +145,20 @@ const op2Rust = {
     '<=': (a, b) => `Any::le(${a}, ${b})`,
     '>': (a, b) => `Any::gt(${a}, ${b})`,
     '>=': (a, b) => `Any::ge(${a}, ${b})`,
+    '&&': (a, b) => `Any::logical_and(${a}, ${b})`,
+    '||': (a, b) => `Any::logical_or(${a}, ${b})`,
+    '??': (a, b) => `Any::nullish_coalescing(${a}, ${b})`,
+}
+
+/**
+ * The same, for the one ternary operation (`?:`) — another method, for the
+ * same reason as `&&`/`||`/`??`: Rust's own `if`/`else` takes a `bool`
+ * condition, not an `Any<A>` one, so there is no infix spelling to reuse.
+ *
+ * @type {{ readonly [k in OpId]?: (a: string, b: string, c: string) => string }}
+ */
+const op3Rust = {
+    ternary: (a, b, c) => `Any::conditional(${a}, ${b}, ${c})`,
 }
 
 /**
@@ -152,6 +176,8 @@ const lookup = table => id => {
 const op1 = lookup(op1Rust)
 
 const op2 = lookup(op2Rust)
+
+const op3 = lookup(op3Rust)
 
 const fnName = lookup(rustName)
 
@@ -298,15 +324,18 @@ const assertion = expected => name => result => isThrows(expected)
  * values.
  *
  * The escape dispatches on the group's arity, as the proof's does, so a
- * binary group's escaped case prints through `op2`.
+ * binary group's escaped case prints through `op2`, and the one ternary
+ * group (`?:`) through `op3`.
  *
  * @type {(g: Group) => (args: readonly Operand[]) => string}
  */
 const result = g => args => {
     const lowered = caseExp(g)(args)
     if (lowered[0] === 'exp') { return nodeExpr(lowered[1]) }
-    const [a, b] = args.map(valueExpr)
-    return arityOf(g) === 1 ? op1(opId(g))(a) : op2(opId(g))(a, b)
+    const [a, b, c] = args.map(valueExpr)
+    const id = opId(g)
+    const arity = arityOf(g)
+    return arity === 1 ? op1(id)(a) : arity === 2 ? op2(id)(a, b) : op3(id)(a, b, c)
 }
 
 /** @type {(g: Group) => readonly string[]} */

--- a/fjs/nanvm/types.ts
+++ b/fjs/nanvm/types.ts
@@ -168,9 +168,10 @@ export type Group2 = {
  * The field is deliberately not `op`, so a NaNVM-only name can never mix into
  * the canonical id unions.
  *
- * - `unaryPlus` — the EDAG has no unary `+` — and the type is deleted when
+ * - `unaryPlus` — the EDAG has no unary `+` — and this arm is deleted when
  *   [replace-unary-plus-with-number](../../nanvm-lib/todo/replace-unary-plus-with-number.md)
- *   moves that group to `Number`.
+ *   moves that group to `Number`; the type itself stays, since the other
+ *   arms have no such migration.
  * - `ternary` (`?:`) — the EDAG has no conditional-expression node at all
  *   yet, so this is the corpus's one ternary group; every other `Group`
  *   variant is unary or binary because the EDAG vocabulary it draws from is.

--- a/fjs/nanvm/types.ts
+++ b/fjs/nanvm/types.ts
@@ -166,15 +166,18 @@ export type Group2 = {
  * The visible exception: an operation with no canonical EDAG id yet.
  *
  * The field is deliberately not `op`, so a NaNVM-only name can never mix into
- * the canonical id unions. Today its one inhabitant is `unaryPlus` — the EDAG
- * has no unary `+` — and the type is deleted when
- * [replace-unary-plus-with-number](../../nanvm-lib/todo/replace-unary-plus-with-number.md)
- * moves that group to `Number`.
+ * the canonical id unions.
+ *
+ * - `unaryPlus` — the EDAG has no unary `+` — and the type is deleted when
+ *   [replace-unary-plus-with-number](../../nanvm-lib/todo/replace-unary-plus-with-number.md)
+ *   moves that group to `Number`.
+ * - `ternary` (`?:`) — the EDAG has no conditional-expression node at all
+ *   yet, so this is the corpus's one ternary group; every other `Group`
+ *   variant is unary or binary because the EDAG vocabulary it draws from is.
  */
-export type NonEdagGroup = {
-    readonly nanvmOp: 'unaryPlus'
-    readonly cases: readonly Case<1>[]
-}
+export type NonEdagGroup =
+    | { readonly nanvmOp: 'unaryPlus'; readonly cases: readonly Case<1>[] }
+    | { readonly nanvmOp: 'ternary'; readonly cases: readonly Case<3>[] }
 
 export type Group = Group1 | Group2 | NonEdagGroup
 
@@ -189,6 +192,7 @@ export type Group = Group1 | Group2 | NonEdagGroup
 
 type _Unary = Assert<Equal<Case<1>['args'], readonly [Operand]>>
 type _Binary = Assert<Equal<Case<2>['args'], readonly [Operand, Operand]>>
+type _Ternary = Assert<Equal<Case<3>['args'], readonly [Operand, Operand, Operand]>>
 type _NotWidened = Assert<Equal<Case<2> extends Case<1> ? true : false, false>>
 type _NotNarrowed = Assert<Equal<Case<1> extends Case<2> ? true : false, false>>
 type _Op1Groups = Assert<Equal<Group1['cases'], readonly Case<1>[]>>

--- a/nanvm-lib/README.md
+++ b/nanvm-lib/README.md
@@ -55,7 +55,7 @@ Operators on [`Any<A>`](src/vm/any/mod.rs) (the top-level VM value type).
 |----------|---------------------|----------|-------|
 | `&&`     | Logical AND         | [x]      | [`any/and.rs`](src/vm/any/and.rs) — `Any::logical_and()` method (no `core::ops` trait fits: Rust's own `&&` takes `bool` and short-circuits evaluation) |
 | `\|\|`   | Logical OR          | [x]      | [`any/or.rs`](src/vm/any/or.rs) — `Any::logical_or()` method, same reason |
-| `??`     | Nullish coalescing  | [x]      | [`any/nullish_coalescing.rs`](src/vm/any/nullish_coalescing.rs) — `Any::nullish_coalescing()` method, checked via the existing `Nullish` type (`Nullish::try_from`), not `ToBoolean` |
+| `??`     | Nullish coalescing  | [x]      | [`any/nullish_coalescing.rs`](src/vm/any/nullish_coalescing.rs) — `Any::nullish_coalescing()` method, checked by matching on `Unpacked::Nullish` directly (allocation-free), not `ToBoolean` |
 
 ### Other
 

--- a/nanvm-lib/README.md
+++ b/nanvm-lib/README.md
@@ -23,7 +23,7 @@ Operators on [`Any<A>`](src/vm/any/mod.rs) (the top-level VM value type).
 |----------|---------------------|----------|-------|
 | `-`      | Unary minus         | [x]      | [`any/neg.rs`](src/vm/any/neg.rs) — `Neg for Any<A>` |
 | `+`      | Unary plus          | [x]      | `Any::unary_plus()` method (coerces to number) |
-| `!`      | Logical NOT         | [ ]      | |
+| `!`      | Logical NOT         | [x]      | [`any/not.rs`](src/vm/any/not.rs) — `Not for Any<A>`, via the new `ToBoolean` coercion ([`boolean_coercion.rs`](src/vm/boolean_coercion.rs)) |
 | `~`      | Bitwise NOT         | [ ]      | |
 | `typeof` | Type of             | [ ]      | |
 
@@ -53,15 +53,15 @@ Operators on [`Any<A>`](src/vm/any/mod.rs) (the top-level VM value type).
 
 | Operator | Description         | `Any<A>` | Notes |
 |----------|---------------------|----------|-------|
-| `&&`     | Logical AND         | [ ]      | |
-| `\|\|`   | Logical OR          | [ ]      | |
-| `??`     | Nullish coalescing  | [ ]      | `Nullish` type exists |
+| `&&`     | Logical AND         | [x]      | [`any/and.rs`](src/vm/any/and.rs) — `Any::logical_and()` method (no `core::ops` trait fits: Rust's own `&&` takes `bool` and short-circuits evaluation) |
+| `\|\|`   | Logical OR          | [x]      | [`any/or.rs`](src/vm/any/or.rs) — `Any::logical_or()` method, same reason |
+| `??`     | Nullish coalescing  | [x]      | [`any/nullish_coalescing.rs`](src/vm/any/nullish_coalescing.rs) — `Any::nullish_coalescing()` method, checked via the existing `Nullish` type (`Nullish::try_from`), not `ToBoolean` |
 
 ### Other
 
 | Operator   | Description         | `Any<A>` | Notes |
 |------------|---------------------|----------|-------|
-| `?:`       | Conditional         | [ ]      | |
+| `?:`       | Conditional         | [x]      | [`any/conditional.rs`](src/vm/any/conditional.rs) — `Any::conditional()` method; the corpus's one ternary group (`fjs/nanvm/types.ts`'s `NonEdagGroup`, since the EDAG has no conditional-expression node) |
 | `.` / `[]` | Member access       | [ ]      | |
 | `in`       | Property check      | [ ]      | |
 | `instanceof` | Instance check    | [ ]      | |
@@ -72,5 +72,6 @@ Operators on [`Any<A>`](src/vm/any/mod.rs) (the top-level VM value type).
 |----------------|--------|----------|
 | To number      | [x]    | [`number_coercion.rs`](src/vm/number_coercion.rs) |
 | To string      | [x]    | [`string_coercion.rs`](src/vm/string_coercion.rs) |
+| To boolean     | [x]    | [`boolean_coercion.rs`](src/vm/boolean_coercion.rs) — never throws, unlike the others |
 | To primitive   | [x]    | [`primitive_coercion.rs`](src/vm/primitive_coercion.rs) |
 | To numeric     | [x]    | `Any::to_numeric()` |

--- a/nanvm-lib/src/vm/any/and.rs
+++ b/nanvm-lib/src/vm/any/and.rs
@@ -1,0 +1,16 @@
+use crate::vm::{Any, IVm};
+
+impl<A: IVm> Any<A> {
+    /// `&&`. Not a `core::ops` trait — Rust's own `&&` takes `bool` operands
+    /// and short-circuits *evaluation*, neither of which fits an operator
+    /// over two already-evaluated `Any<A>` values — so this is a plain
+    /// method, the same as `unary_plus`.
+    ///
+    /// Returns `self` unchanged if it coerces to `false` via `ToBoolean`,
+    /// otherwise `rhs` unchanged. Never throws, but stays a `Result` to
+    /// match every other binary operator's shape.
+    /// <https://tc39.es/ecma262/#sec-binary-logical-operators>
+    pub fn logical_and(self, rhs: Self) -> Result<Self, Self> {
+        Ok(if self.clone().to_boolean() { rhs } else { self })
+    }
+}

--- a/nanvm-lib/src/vm/any/conditional.rs
+++ b/nanvm-lib/src/vm/any/conditional.rs
@@ -1,0 +1,19 @@
+use crate::vm::{Any, IVm};
+
+impl<A: IVm> Any<A> {
+    /// `?:`. Not a `core::ops` trait — Rust has no operator for a ternary
+    /// conditional (`if`/`else` takes a `bool`, not an `Any<A>`) — so this
+    /// is a plain method, the same as `logical_and`/`logical_or`.
+    ///
+    /// Coerces `self` via `ToBoolean` and selects `consequent` or
+    /// `alternate` unchanged. Never throws, but stays a `Result` to match
+    /// every other operator's shape.
+    /// <https://tc39.es/ecma262/#sec-conditional-operator>
+    pub fn conditional(self, consequent: Self, alternate: Self) -> Result<Self, Self> {
+        Ok(if self.to_boolean() {
+            consequent
+        } else {
+            alternate
+        })
+    }
+}

--- a/nanvm-lib/src/vm/any/mod.rs
+++ b/nanvm-lib/src/vm/any/mod.rs
@@ -1,7 +1,12 @@
 mod add;
+mod and;
+mod conditional;
 mod div;
 mod from;
 mod neg;
+mod not;
+mod nullish_coalescing;
+mod or;
 mod partial_eq;
 mod relational;
 mod rem;
@@ -11,6 +16,7 @@ pub mod to_any;
 
 use crate::vm::{
     IVm, String, ToAny, Unpacked,
+    boolean_coercion::BooleanCoercion,
     dispatch::Dispatch,
     number_coercion::NumberCoercion,
     numeric::Numeric,
@@ -78,6 +84,12 @@ impl<A: IVm> Any<A> {
         self.dispatch(NumberCoercion)
     }
 
+    /// Never fails, unlike `to_number`/`to_string`/`to_numeric` — `ToBoolean`
+    /// inspects the operand's type directly and never calls `ToPrimitive`.
+    pub fn to_boolean(self) -> bool {
+        self.dispatch(BooleanCoercion)
+    }
+
     pub fn to_numeric(self) -> Result<Numeric<A>, Any<A>> {
         // https://tc39.es/ecma262/#sec-tonumeric
         let prim_value = self.to_primitive(Some(ToPrimitivePreferredType::Number))?;
@@ -103,6 +115,6 @@ impl<A: IVm> Any<A> {
     }
 }
 
-// TODO implement other operators like +, -, *, /, %, &, |, ^, <<, >>, >>>, !, ~, etc using Rust
-// standard traits - similarly to Neg above. Implement operators that do not have corresponding Rust
-// standard traits via adding methods to Any<A> - similarly to unary_plus.
+// TODO implement other operators like &, |, ^, <<, >>, >>>, ~, typeof, etc using Rust standard
+// traits - similarly to Neg above. Implement operators that do not have corresponding Rust standard
+// traits via adding methods to Any<A> - similarly to unary_plus.

--- a/nanvm-lib/src/vm/any/not.rs
+++ b/nanvm-lib/src/vm/any/not.rs
@@ -1,0 +1,14 @@
+use core::ops::Not;
+
+use crate::vm::{Any, IVm, ToAny};
+
+/// `!`. Coerces via `ToBoolean` and negates. Never throws — `ToBoolean`
+/// itself cannot fail — but stays a `Result` to match every other
+/// operator's shape.
+/// <https://tc39.es/ecma262/#sec-logical-not-operator>
+impl<A: IVm> Not for Any<A> {
+    type Output = Result<Any<A>, Any<A>>;
+    fn not(self) -> Self::Output {
+        Ok((!self.to_boolean()).to_any())
+    }
+}

--- a/nanvm-lib/src/vm/any/nullish_coalescing.rs
+++ b/nanvm-lib/src/vm/any/nullish_coalescing.rs
@@ -1,4 +1,4 @@
-use crate::vm::{Any, IVm, Nullish};
+use crate::vm::{Any, IVm, Unpacked};
 
 impl<A: IVm> Any<A> {
     /// `??`. Not a `core::ops` trait — `?` is Rust's own try-operator and
@@ -9,11 +9,15 @@ impl<A: IVm> Any<A> {
     /// unchanged — unlike `logical_and`/`logical_or`, this keys off
     /// nullishness rather than `ToBoolean`, so a falsy-but-not-nullish
     /// `self` (`0`, `NaN`, `""`, ...) is still returned unchanged.
+    ///
+    /// Matches on `Unpacked` directly rather than going through
+    /// `Nullish::try_from` — that builds and discards an error `Any` on
+    /// every non-nullish call (the common case), an allocation this avoids.
     /// <https://tc39.es/ecma262/#sec-binary-logical-operators>
     pub fn nullish_coalescing(self, rhs: Self) -> Result<Self, Self> {
-        Ok(match Nullish::try_from(self.clone()) {
-            Ok(_) => rhs,
-            Err(_) => self,
+        Ok(match Unpacked::from(self.clone()) {
+            Unpacked::Nullish(_) => rhs,
+            _ => self,
         })
     }
 }

--- a/nanvm-lib/src/vm/any/nullish_coalescing.rs
+++ b/nanvm-lib/src/vm/any/nullish_coalescing.rs
@@ -1,0 +1,19 @@
+use crate::vm::{Any, IVm, Nullish};
+
+impl<A: IVm> Any<A> {
+    /// `??`. Not a `core::ops` trait — `?` is Rust's own try-operator and
+    /// unrelated to this — so this is a plain method, the same as
+    /// `logical_and`/`logical_or`.
+    ///
+    /// Returns `rhs` if `self` is `null` or `undefined`, otherwise `self`
+    /// unchanged — unlike `logical_and`/`logical_or`, this keys off
+    /// nullishness rather than `ToBoolean`, so a falsy-but-not-nullish
+    /// `self` (`0`, `NaN`, `""`, ...) is still returned unchanged.
+    /// <https://tc39.es/ecma262/#sec-binary-logical-operators>
+    pub fn nullish_coalescing(self, rhs: Self) -> Result<Self, Self> {
+        Ok(match Nullish::try_from(self.clone()) {
+            Ok(_) => rhs,
+            Err(_) => self,
+        })
+    }
+}

--- a/nanvm-lib/src/vm/any/or.rs
+++ b/nanvm-lib/src/vm/any/or.rs
@@ -1,0 +1,12 @@
+use crate::vm::{Any, IVm};
+
+impl<A: IVm> Any<A> {
+    /// `||`. Not a `core::ops` trait, for the same reason as `logical_and`.
+    ///
+    /// Returns `self` unchanged if it coerces to `true` via `ToBoolean`,
+    /// otherwise `rhs` unchanged.
+    /// <https://tc39.es/ecma262/#sec-binary-logical-operators>
+    pub fn logical_or(self, rhs: Self) -> Result<Self, Self> {
+        Ok(if self.clone().to_boolean() { self } else { rhs })
+    }
+}

--- a/nanvm-lib/src/vm/bigint/mod.rs
+++ b/nanvm-lib/src/vm/bigint/mod.rs
@@ -92,7 +92,10 @@ fn sub_words_assign(a: &mut Vec<u64>, b: &[u64]) {
 pub struct BigInt<A: IVm>(A::InternalBigInt);
 
 impl<A: IVm> BigInt<A> {
-    fn is_zero(&self) -> bool {
+    /// `pub(crate)`, not private: `BooleanCoercion` (`vm/boolean_coercion.rs`)
+    /// uses this to test `0n` without constructing and comparing against a
+    /// throwaway `BigInt::default()`.
+    pub(crate) fn is_zero(&self) -> bool {
         self.0.items().is_empty()
     }
 

--- a/nanvm-lib/src/vm/boolean_coercion.rs
+++ b/nanvm-lib/src/vm/boolean_coercion.rs
@@ -1,0 +1,48 @@
+use crate::{
+    common::sized_index::SizedIndex,
+    vm::{Array, BigInt, Function, IVm, Object, String, dispatch::Dispatch, nullish::Nullish},
+};
+
+/// Coerces the value to a `bool`. Unlike `NumberCoercion`/`StringCoercion`,
+/// this never fails — `ToBoolean` inspects the operand's type directly and
+/// never calls `ToPrimitive`, so there is nothing here that can throw.
+/// <https://tc39.es/ecma262/#sec-toboolean>
+///
+/// It equals to `!!self` in JavaScript.
+pub struct BooleanCoercion;
+
+impl<A: IVm> Dispatch<A> for BooleanCoercion {
+    type Result = bool;
+
+    fn nullish(self, _: Nullish) -> Self::Result {
+        false
+    }
+
+    fn bool(self, v: bool) -> Self::Result {
+        v
+    }
+
+    fn number(self, v: f64) -> Self::Result {
+        v != 0.0 && !v.is_nan()
+    }
+
+    fn string(self, v: String<A>) -> Self::Result {
+        !v.is_empty()
+    }
+
+    fn bigint(self, v: BigInt<A>) -> Self::Result {
+        v != BigInt::default()
+    }
+
+    fn object(self, _: Object<A>) -> Self::Result {
+        true
+    }
+
+    fn array(self, _: Array<A>) -> Self::Result {
+        true
+    }
+
+    fn function(self, _: Function<A>) -> Self::Result {
+        true
+    }
+}

--- a/nanvm-lib/src/vm/boolean_coercion.rs
+++ b/nanvm-lib/src/vm/boolean_coercion.rs
@@ -8,7 +8,7 @@ use crate::{
 /// never calls `ToPrimitive`, so there is nothing here that can throw.
 /// <https://tc39.es/ecma262/#sec-toboolean>
 ///
-/// It equals to `!!x` in JavaScript.
+/// This is equivalent to `!!x` in JavaScript.
 pub struct BooleanCoercion;
 
 impl<A: IVm> Dispatch<A> for BooleanCoercion {
@@ -31,7 +31,7 @@ impl<A: IVm> Dispatch<A> for BooleanCoercion {
     }
 
     fn bigint(self, v: BigInt<A>) -> Self::Result {
-        v != BigInt::default()
+        !v.is_zero()
     }
 
     fn object(self, _: Object<A>) -> Self::Result {

--- a/nanvm-lib/src/vm/boolean_coercion.rs
+++ b/nanvm-lib/src/vm/boolean_coercion.rs
@@ -8,7 +8,7 @@ use crate::{
 /// never calls `ToPrimitive`, so there is nothing here that can throw.
 /// <https://tc39.es/ecma262/#sec-toboolean>
 ///
-/// It equals to `!!self` in JavaScript.
+/// It equals to `!!x` in JavaScript.
 pub struct BooleanCoercion;
 
 impl<A: IVm> Dispatch<A> for BooleanCoercion {

--- a/nanvm-lib/src/vm/mod.rs
+++ b/nanvm-lib/src/vm/mod.rs
@@ -1,6 +1,7 @@
 mod any;
 mod array;
 mod bigint;
+mod boolean_coercion;
 mod container_fmt;
 mod dispatch;
 mod ecma_whitespace;

--- a/nanvm-lib/tests/test/generated.rs
+++ b/nanvm-lib/tests/test/generated.rs
@@ -591,6 +591,102 @@ fn ge<A: IVm>() {
 }
 
 #[rustfmt::skip]
+fn not<A: IVm>() {
+    check::<A>("null", !(Nullish::Null.to_any()), true.to_any());
+    check::<A>("undefined", !(Nullish::Undefined.to_any()), true.to_any());
+    check::<A>("booleanFalse", !(false.to_any()), true.to_any());
+    check::<A>("booleanTrue", !(true.to_any()), false.to_any());
+    check::<A>("numberZero", !((0f64).to_any()), true.to_any());
+    check::<A>("numberNegativeZero", !((-0f64).to_any()), true.to_any());
+    check::<A>("numberNan", !((f64::NAN).to_any()), true.to_any());
+    check::<A>("numberPositive", !((2.3f64).to_any()), false.to_any());
+    check::<A>("numberNegative", !((-2.3f64).to_any()), false.to_any());
+    check::<A>("stringEmpty", !(string_any("")), true.to_any());
+    check::<A>("stringNonEmpty", !(string_any("a")), false.to_any());
+    check::<A>("bigintZero", !(bigint_any(0)), true.to_any());
+    check::<A>("bigintPositive", !(bigint_any(5)), false.to_any());
+    check::<A>("bigintNegative", !(bigint_any(-5)), false.to_any());
+    check::<A>("emptyArray", !(Array::default().to_any()), false.to_any());
+    check::<A>("emptyObject", !(Object::default().to_any()), false.to_any());
+    check::<A>("function", !(function_any()), false.to_any());
+}
+
+#[rustfmt::skip]
+fn logical_and<A: IVm>() {
+    check::<A>("falseAndTrue", Any::logical_and(false.to_any(), true.to_any()), false.to_any());
+    check::<A>("trueAndFalse", Any::logical_and(true.to_any(), false.to_any()), false.to_any());
+    check::<A>("trueAndTrue", Any::logical_and(true.to_any(), true.to_any()), true.to_any());
+    check::<A>("nullAndOne", Any::logical_and(Nullish::Null.to_any(), (1f64).to_any()), Nullish::Null.to_any());
+    check::<A>("undefinedAndOne", Any::logical_and(Nullish::Undefined.to_any(), (1f64).to_any()), Nullish::Undefined.to_any());
+    check::<A>("zeroAndOne", Any::logical_and((0f64).to_any(), (1f64).to_any()), (0f64).to_any());
+    check::<A>("nanAndOne", Any::logical_and((f64::NAN).to_any(), (1f64).to_any()), (f64::NAN).to_any());
+    check::<A>("oneAndZero", Any::logical_and((1f64).to_any(), (0f64).to_any()), (0f64).to_any());
+    check::<A>("oneAndTwo", Any::logical_and((1f64).to_any(), (2f64).to_any()), (2f64).to_any());
+    check::<A>("emptyStringAndOne", Any::logical_and(string_any(""), (1f64).to_any()), string_any(""));
+    check::<A>("nonEmptyStringAndOne", Any::logical_and(string_any("a"), (1f64).to_any()), (1f64).to_any());
+    check::<A>("bigZeroAndOne", Any::logical_and(bigint_any(0), (1f64).to_any()), bigint_any(0));
+    check::<A>("bigOneAndTwo", Any::logical_and(bigint_any(1), (2f64).to_any()), (2f64).to_any());
+    check::<A>("emptyArrayAndOne", Any::logical_and(Array::default().to_any(), (1f64).to_any()), (1f64).to_any());
+    check::<A>("emptyObjectAndOne", Any::logical_and(Object::default().to_any(), (1f64).to_any()), (1f64).to_any());
+    check::<A>("functionAndOne", Any::logical_and(function_any(), (1f64).to_any()), (1f64).to_any());
+}
+
+#[rustfmt::skip]
+fn logical_or<A: IVm>() {
+    check::<A>("falseOrTrue", Any::logical_or(false.to_any(), true.to_any()), true.to_any());
+    check::<A>("trueOrFalse", Any::logical_or(true.to_any(), false.to_any()), true.to_any());
+    check::<A>("falseOrFalse", Any::logical_or(false.to_any(), false.to_any()), false.to_any());
+    check::<A>("nullOrOne", Any::logical_or(Nullish::Null.to_any(), (1f64).to_any()), (1f64).to_any());
+    check::<A>("undefinedOrOne", Any::logical_or(Nullish::Undefined.to_any(), (1f64).to_any()), (1f64).to_any());
+    check::<A>("zeroOrOne", Any::logical_or((0f64).to_any(), (1f64).to_any()), (1f64).to_any());
+    check::<A>("nanOrOne", Any::logical_or((f64::NAN).to_any(), (1f64).to_any()), (1f64).to_any());
+    check::<A>("oneOrZero", Any::logical_or((1f64).to_any(), (0f64).to_any()), (1f64).to_any());
+    check::<A>("oneOrTwo", Any::logical_or((1f64).to_any(), (2f64).to_any()), (1f64).to_any());
+    check::<A>("emptyStringOrOne", Any::logical_or(string_any(""), (1f64).to_any()), (1f64).to_any());
+    check::<A>("nonEmptyStringOrOne", Any::logical_or(string_any("a"), (1f64).to_any()), string_any("a"));
+    check::<A>("bigZeroOrOne", Any::logical_or(bigint_any(0), (1f64).to_any()), (1f64).to_any());
+    check::<A>("bigOneOrTwo", Any::logical_or(bigint_any(1), (2f64).to_any()), bigint_any(1));
+    check::<A>("oneOrEmptyArray", Any::logical_or((1f64).to_any(), Array::default().to_any()), (1f64).to_any());
+    check::<A>("oneOrEmptyObject", Any::logical_or((1f64).to_any(), Object::default().to_any()), (1f64).to_any());
+    check::<A>("oneOrFunction", Any::logical_or((1f64).to_any(), function_any()), (1f64).to_any());
+}
+
+#[rustfmt::skip]
+fn nullish_coalescing<A: IVm>() {
+    check::<A>("nullCoalesceOne", Any::nullish_coalescing(Nullish::Null.to_any(), (1f64).to_any()), (1f64).to_any());
+    check::<A>("undefinedCoalesceOne", Any::nullish_coalescing(Nullish::Undefined.to_any(), (1f64).to_any()), (1f64).to_any());
+    check::<A>("zeroCoalesceOne", Any::nullish_coalescing((0f64).to_any(), (1f64).to_any()), (0f64).to_any());
+    check::<A>("falseCoalesceOne", Any::nullish_coalescing(false.to_any(), (1f64).to_any()), false.to_any());
+    check::<A>("nanCoalesceOne", Any::nullish_coalescing((f64::NAN).to_any(), (1f64).to_any()), (f64::NAN).to_any());
+    check::<A>("emptyStringCoalesceOne", Any::nullish_coalescing(string_any(""), (1f64).to_any()), string_any(""));
+    check::<A>("bigZeroCoalesceOne", Any::nullish_coalescing(bigint_any(0), (1f64).to_any()), bigint_any(0));
+    check::<A>("oneCoalesceTwo", Any::nullish_coalescing((1f64).to_any(), (2f64).to_any()), (1f64).to_any());
+    check::<A>("oneCoalesceNull", Any::nullish_coalescing((1f64).to_any(), Nullish::Null.to_any()), (1f64).to_any());
+    check::<A>("oneCoalesceEmptyArray", Any::nullish_coalescing((1f64).to_any(), Array::default().to_any()), (1f64).to_any());
+    check::<A>("oneCoalesceEmptyObject", Any::nullish_coalescing((1f64).to_any(), Object::default().to_any()), (1f64).to_any());
+    check::<A>("oneCoalesceFunction", Any::nullish_coalescing((1f64).to_any(), function_any()), (1f64).to_any());
+}
+
+#[rustfmt::skip]
+fn conditional<A: IVm>() {
+    check::<A>("truePicksConsequent", Any::conditional(true.to_any(), (1f64).to_any(), (2f64).to_any()), (1f64).to_any());
+    check::<A>("falsePicksAlternate", Any::conditional(false.to_any(), (1f64).to_any(), (2f64).to_any()), (2f64).to_any());
+    check::<A>("nullPicksAlternate", Any::conditional(Nullish::Null.to_any(), (1f64).to_any(), (2f64).to_any()), (2f64).to_any());
+    check::<A>("undefinedPicksAlternate", Any::conditional(Nullish::Undefined.to_any(), (1f64).to_any(), (2f64).to_any()), (2f64).to_any());
+    check::<A>("zeroPicksAlternate", Any::conditional((0f64).to_any(), (1f64).to_any(), (2f64).to_any()), (2f64).to_any());
+    check::<A>("nanPicksAlternate", Any::conditional((f64::NAN).to_any(), (1f64).to_any(), (2f64).to_any()), (2f64).to_any());
+    check::<A>("emptyStringPicksAlternate", Any::conditional(string_any(""), (1f64).to_any(), (2f64).to_any()), (2f64).to_any());
+    check::<A>("nonEmptyStringPicksConsequent", Any::conditional(string_any("a"), (1f64).to_any(), (2f64).to_any()), (1f64).to_any());
+    check::<A>("bigZeroPicksAlternate", Any::conditional(bigint_any(0), (1f64).to_any(), (2f64).to_any()), (2f64).to_any());
+    check::<A>("bigNonZeroPicksConsequent", Any::conditional(bigint_any(5), (1f64).to_any(), (2f64).to_any()), (1f64).to_any());
+    check::<A>("emptyArrayPicksConsequent", Any::conditional(Array::default().to_any(), (1f64).to_any(), (2f64).to_any()), (1f64).to_any());
+    check::<A>("emptyObjectPicksConsequent", Any::conditional(Object::default().to_any(), (1f64).to_any(), (2f64).to_any()), (1f64).to_any());
+    check::<A>("functionPicksConsequent", Any::conditional(function_any(), (1f64).to_any(), (2f64).to_any()), (1f64).to_any());
+    check::<A>("truePicksStringConsequent", Any::conditional(true.to_any(), string_any("yes"), string_any("no")), string_any("yes"));
+    check::<A>("falsePicksBigAlternate", Any::conditional(false.to_any(), bigint_any(1), bigint_any(2)), bigint_any(2));
+}
+
+#[rustfmt::skip]
 fn string_coercion<A: IVm>() {
     check::<A>("number", (123f64).to_any().to_string().map(|v| v.to_any()), string_any("123"));
     check::<A>("negativeNumber", (-456f64).to_any().to_string().map(|v| v.to_any()), string_any("-456"));
@@ -629,5 +725,10 @@ pub fn all<A: IVm>() {
     le::<A>();
     gt::<A>();
     ge::<A>();
+    not::<A>();
+    logical_and::<A>();
+    logical_or::<A>();
+    nullish_coalescing::<A>();
+    conditional::<A>();
     string_coercion::<A>();
 }

--- a/nanvm-lib/tests/test/main.rs
+++ b/nanvm-lib/tests/test/main.rs
@@ -4,7 +4,11 @@
 //! `fjs/nanvm/module.f.mjs`, and reaches this crate as `generated.rs`
 //! (see `nanvm-lib/tests/README.md`). What stays hand-written is everything
 //! that has nothing to compare against in a JS engine: conversions out of
-//! `Any`, `Debug` formatting, and bigint limb arithmetic.
+//! `Any`, `Debug` formatting, bigint limb arithmetic, and the
+//! reference-identity guarantee `&&`/`||`/`??`/`?:` make — the shared corpus
+//! can prove *which* operand a case selects but not that the selected
+//! array/object/function comes back as the very same object, since it lowers
+//! every operand to a node of its own and compares by value, not identity.
 
 mod generated;
 mod harness;
@@ -227,6 +231,58 @@ fn bigint_negative_zero<A: IVm>() {
     assert_eq!(mn0, n0);
 }
 
+/// `&&`/`||`/`??`/`?:` select an operand rather than deriving a new value —
+/// see the module doc comment for why the shared corpus cannot pin this.
+/// `Array`/`Object`/`Function` equality is `ptr_eq` (their `partial_eq.rs`),
+/// so comparing the result against the very `Any` handed in — not a fresh,
+/// equal-content one — is what actually proves the selected operand comes
+/// back unchanged rather than reconstructed.
+fn reference_identity_selection<A: IVm>() {
+    let array: Any<A> = Array::default().to_any();
+    let object: Any<A> = Object::default().to_any();
+    let function: Any<A> = Function::<A>(A::InternalFunction::new_ok(("".into(), 0), [0])).to_any();
+
+    // `&&`: a reference-typed value is always truthy, so it can only ever be
+    // the discarded left or the selected right — never returned via the
+    // "falsy self" branch, which no reference type can take.
+    assert_eq!(
+        Any::logical_and(true.to_any(), array.clone()).unwrap(),
+        array
+    );
+
+    // `||`: always-truthy on the left selects itself; on the right it is
+    // selected whenever the left is falsy.
+    assert_eq!(
+        Any::logical_or(object.clone(), 0.0.to_any()).unwrap(),
+        object
+    );
+    assert_eq!(
+        Any::logical_or(false.to_any(), function.clone()).unwrap(),
+        function
+    );
+
+    // `??`: never-nullish on the left selects itself; on the right it is
+    // selected whenever the left is nullish.
+    assert_eq!(
+        Any::nullish_coalescing(array.clone(), 0.0.to_any()).unwrap(),
+        array
+    );
+    assert_eq!(
+        Any::nullish_coalescing(Nullish::Null.to_any(), object.clone()).unwrap(),
+        object
+    );
+
+    // `?:`: both branches.
+    assert_eq!(
+        Any::conditional(true.to_any(), function.clone(), array.clone()).unwrap(),
+        function
+    );
+    assert_eq!(
+        Any::conditional(false.to_any(), array.clone(), object.clone()).unwrap(),
+        object
+    );
+}
+
 fn gen_test<A: IVm>() {
     generated::all::<A>();
     //
@@ -241,6 +297,7 @@ fn gen_test<A: IVm>() {
     bigint_mul::<A>();
     bigint_negative_zero::<A>();
     format_fn::<A>();
+    reference_identity_selection::<A>();
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Stage 1 of the remaining `nanvm-lib` operators (see the "JS Operator Implementation Status" table in `nanvm-lib/README.md`): the value-selection and negation operators that need no numeric coercion — `!`, `&&`, `||`, `??`, `?:`.

- **`!`**: `Not for Any<A>` ([`any/not.rs`](nanvm-lib/src/vm/any/not.rs)), via a new `ToBoolean` coercion ([`boolean_coercion.rs`](nanvm-lib/src/vm/boolean_coercion.rs)) — never throws, unlike `ToNumber`/`ToString`/`ToPrimitive`.
- **`&&`/`||`**: `Any::logical_and`/`Any::logical_or` ([`any/and.rs`](nanvm-lib/src/vm/any/and.rs), [`any/or.rs`](nanvm-lib/src/vm/any/or.rs)) — plain methods rather than `core::ops` impls, since Rust's own `&&`/`||` take `bool` operands and short-circuit *evaluation*, neither of which fits an operator over two already-evaluated `Any<A>` values.
- **`??`**: `Any::nullish_coalescing` ([`any/nullish_coalescing.rs`](nanvm-lib/src/vm/any/nullish_coalescing.rs)) — checked via the existing `Nullish` type (`Nullish::try_from`) rather than `ToBoolean`, so a falsy-but-not-nullish left operand (`0`, `NaN`, `''`, `false`) stays on the left, unlike `&&`/`||`.
- **`?:`**: `Any::conditional` ([`any/conditional.rs`](nanvm-lib/src/vm/any/conditional.rs)) — the corpus's one *ternary* operator. The EDAG has no conditional-expression node at all, so `fjs/nanvm/types.ts`'s `NonEdagGroup` (previously `unaryPlus`'s escape hatch) gains a `'ternary'` variant carrying `Case<3>`, and `arityOf` in `fjs/nanvm/module.f.mjs` widens from `1 | 2` to `1 | 2 | 3`.

Since these five operators return an operand *unchanged* rather than a derived primitive (unlike every arithmetic/comparison operator so far), every corpus case keeps array/object/function operands strictly on a *discarded* side — the corpus lowers each operand to its own node, so `Object.is`/`===` identity can't survive an operand reappearing as `expected` otherwise.

Wired into `fjs/nanvm/proof.f.mjs` (JS reference — new `op3Js`/`op3` table for the ternary escape path) and `fjs/nanvm/rust/module.f.mjs` (Rust printer — new `op3Rust` table, `rustName` entries for all five). `nanvm-lib/tests/test/generated.rs` regenerated via `npm run gen`, no drift beyond the new cases.

`fjs/nanvm/proof.f.mjs`'s `jsOnly.throw.unusedOperation` repoints from `!` (now implemented, so it no longer throws "no JS for this op") to `~` (still unimplemented — Stage 3a).

README operator table updated for all five operators plus the new `ToBoolean` coercion.

### Not in this PR

- `typeof` (Stage 2) and the bitwise/shift operators (Stage 3) are separate, tracked in the README table.
- The README's Comparison section lists `===`/`!==` but not `==`/`!=` at all — flagging this for the maintainer rather than assuming it's in scope, since FunctionalScript describes itself as "a purely functional subset of JavaScript" and this may be an intentional omission.

## Test plan

- [x] `node ./fjs/module.mjs t ./fjs/nanvm/module.f.mjs` (full `fjs test` suite)
- [x] `node --test` (full Node suite, 4165 passed / 0 failed)
- [x] `npm run gen` — `nanvm-lib/tests/test/generated.rs` regenerated, diff limited to the new cases
- [x] `cargo test` (in `nanvm-lib`)
- [x] `cargo clippy --lib -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `tsc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016r91tf9sadPY8kgPXwfRu9

---
_Generated by [Claude Code](https://claude.ai/code/session_016r91tf9sadPY8kgPXwfRu9)_