### PR TITLE
nanvm-lib: implement typeof

### DIFF
--- a/fjs/edag/todo/typeof-operator.md
+++ b/fjs/edag/todo/typeof-operator.md
@@ -1,0 +1,81 @@
+## `typeof` has no EDAG node — and isn't in the operators spec at all yet
+
+**Priority:** P2
+**Status:** open
+
+### Problem
+
+`nanvm-lib`'s `typeof` (`Any::typeof_`, added in
+functionalscript/functionalscript#1868) has no EDAG counterpart, for a more
+basic reason than `?:`'s
+([`ternary-conditional-node.md`](./ternary-conditional-node.md)): unlike
+`?:`, `typeof` doesn't appear anywhere in
+[`spec/todo/2340-operators.md`](../../../spec/todo/2340-operators.md)'s
+operator table at all — not even as `not allowed`, the way `==`/`!=` are
+listed and explicitly rejected there.
+[`edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)'s own
+EDAG-level "Symbols" operator table doesn't list it either. So this isn't
+only a missing EDAG node the way `?:`'s is (design decided, not yet
+implemented) — the language-level decision to admit `typeof` as FJS syntax
+at all hasn't been made or recorded anywhere.
+
+The shared operator corpus works around the absence the same way
+[`ternary-conditional-node.md`](./ternary-conditional-node.md) describes for
+`?:`: [`fjs/nanvm/types.ts`](../../nanvm/types.ts)'s `NonEdagGroup` has a
+`'typeof'` arm ([`fjs/nanvm/module.f.mjs`](../../nanvm/module.f.mjs)'s
+`typeofCases`), whose cases always take the corpus's escape path rather than
+lowering to a real expression.
+
+### Proposal
+
+- Decide, in
+  [`spec/todo/2340-operators.md`](../../../spec/todo/2340-operators.md),
+  whether `typeof` is admitted as FJS syntax at all — and if so, at what
+  priority and with what return shape. `nanvm-lib`'s implementation returns
+  an `Any<A>` string tag (`"undefined" | "object" | "boolean" | "number" |
+  "bigint" | "string" | "function"`); a `"symbol"` tag never arises, since
+  `Any<A>` has no `Symbol` variant. This is a language-design question
+  outside `nanvm-lib`/`fjs/edag`'s own boundary — not something to answer
+  implicitly by adding the node without the spec entry.
+- **If admitted:** add `'typeof'` to
+  [`fjs/edag/types.ts`](../types.ts)'s `Op1Id` (unary and eager — unlike
+  `?:`, `typeof` needs no laziness machinery, since every operand it can be
+  applied to is already a plain value) and its rtti schema in
+  [`module.f.mjs`](../module.f.mjs). Move
+  [`fjs/nanvm/module.f.mjs`](../../nanvm/module.f.mjs)'s `typeofCases` group
+  off `NonEdagGroup` onto a real `Group1` with `op: 'typeof'`, retiring the
+  `'typeof'` `NonEdagGroup` arm.
+- **If not admitted** (the operators table's silence turns out to be
+  deliberate, the same way `==`/`!=`'s explicit `not allowed` is):
+  `nanvm-lib`'s `Any::typeof_` stays valid regardless — it is `nanvm-lib`'s
+  own operator API, useful to a Rust caller or a future interpreter/runtime
+  layer independent of what FJS source syntax can spell — but the
+  `NonEdagGroup` `'typeof'` arm and its corpus cases should say so
+  explicitly, in a doc comment, rather than reading as "not implemented yet."
+
+### Tasks
+
+- [ ] Decide, and record in `spec/todo/2340-operators.md`, whether `typeof`
+      is FJS syntax.
+- [ ] If yes: add `'typeof'` to `fjs/edag/types.ts`'s `Op1Id` and
+      `fjs/edag/module.f.mjs`'s schema; move `fjs/nanvm/module.f.mjs`'s
+      `typeofCases` group onto a real `op: 'typeof'` `Group1`; retire the
+      `NonEdagGroup` `'typeof'` arm.
+- [ ] If no: document, at the `NonEdagGroup` `'typeof'` arm and in
+      `nanvm-lib/README.md`'s operator table, that this is permanent rather
+      than pending.
+- [ ] `tsc`, `fjs test`, `npm run gen`, `cargo test`,
+      `cargo clippy --lib -- -D warnings`, `cargo fmt -- --check` (whichever
+      path is taken).
+
+### Related
+
+- [`spec/todo/2340-operators.md`](../../../spec/todo/2340-operators.md) —
+  the operator allowlist `typeof` is currently absent from.
+- [`edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md) —
+  the EDAG's own Symbols/operator table, same absence.
+- [`ternary-conditional-node.md`](./ternary-conditional-node.md) — the same
+  `NonEdagGroup`-escape situation for `?:`, but with a design already
+  decided.
+- functionalscript/functionalscript#1868 — where `Any::typeof_` and the
+  `NonEdagGroup` `'typeof'` arm landed.

--- a/fjs/nanvm/module.f.mjs
+++ b/fjs/nanvm/module.f.mjs
@@ -36,7 +36,7 @@
  * ```js
  * import { data } from './module.f.mjs'
  *
- * data.groups.length // 18
+ * data.groups.length // 19
  * ```
  */
 
@@ -1038,6 +1038,32 @@ const ternaryCases = [
 ]
 
 /**
+ * `typeof`, the corpus's other group with no canonical EDAG id (see
+ * `NonEdagGroup` in `types.ts`) — it returns a tag naming the operand's own
+ * kind, so unlike `!`/`&&`/`||`/`??`/`?:` there is no identity concern here:
+ * the result is always a fresh string, never the operand itself.
+ *
+ * @type {readonly Case<1>[]}
+ */
+const typeofCases = [
+    { name: 'undefined', args: [undefined], expected: 'undefined' },
+    { name: 'null', args: [null], expected: 'object' },
+    { name: 'booleanTrue', args: [true], expected: 'boolean' },
+    { name: 'booleanFalse', args: [false], expected: 'boolean' },
+    { name: 'number', args: [2.3], expected: 'number' },
+    { name: 'numberNan', args: [NaN], expected: 'number' },
+    { name: 'string', args: ['a'], expected: 'string' },
+    { name: 'stringEmpty', args: [''], expected: 'string' },
+    { name: 'bigint', args: [5n], expected: 'bigint' },
+    { name: 'bigintZero', args: [0n], expected: 'bigint' },
+    { name: 'emptyArray', args: [[]], expected: 'object' },
+    { name: 'array', args: [[1, 2]], expected: 'object' },
+    { name: 'emptyObject', args: [{}], expected: 'object' },
+    { name: 'object', args: [{ a: 1 }], expected: 'object' },
+    { name: 'function', args: [functionValue], expected: 'function' },
+]
+
+/**
  * `String(x)`.
  *
  * A function's string form is its source text, which no two engines have to
@@ -1149,6 +1175,7 @@ export const data = {
         { op: '||', cases: orCases },
         { op: '??', cases: nullishCases },
         { nanvmOp: 'ternary', cases: ternaryCases },
+        { nanvmOp: 'typeof', cases: typeofCases },
         { op: 'String', cases: stringCoercionCases },
     ],
 }

--- a/fjs/nanvm/module.f.mjs
+++ b/fjs/nanvm/module.f.mjs
@@ -1050,7 +1050,7 @@ const ternaryCases = [
 ]
 
 /**
- * `typeof`, the corpus's other group with no canonical EDAG id (see
+ * `typeof`, another of the corpus's groups with no canonical EDAG id (see
  * `NonEdagGroup` in `types.ts`) — it returns a tag naming the operand's own
  * kind, so unlike `!`/`&&`/`||`/`??`/`?:` there is no identity concern here:
  * the result is always a fresh string, never the operand itself.

--- a/fjs/nanvm/proof.f.mjs
+++ b/fjs/nanvm/proof.f.mjs
@@ -60,6 +60,7 @@ const op1Js = {
     neg: a => -a,
     unaryPlus: a => +a,
     '!': a => !a,
+    typeof: a => typeof a,
 }
 
 /** The same, for the binary operations. @type {{ readonly [k in OpId]?: (a: any, b: any) => unknown }} */

--- a/fjs/nanvm/rust/module.f.mjs
+++ b/fjs/nanvm/rust/module.f.mjs
@@ -97,7 +97,7 @@ export const rustName = {
     '||': 'logical_or',
     '??': 'nullish_coalescing',
     ternary: 'conditional',
-    typeof: 'type_of',
+    typeof: 'typeof_',
     String: 'string_coercion',
 }
 
@@ -110,7 +110,7 @@ const op1Rust = {
     unaryPlus: a => `Any::unary_plus(${a})`,
     neg: a => `-(${a})`,
     '!': a => `!(${a})`,
-    typeof: a => `Any::type_of(${a})`,
+    typeof: a => `Any::typeof_(${a})`,
     String: a => `${a}.to_string().map(|v| v.to_any())`,
 }
 

--- a/fjs/nanvm/rust/module.f.mjs
+++ b/fjs/nanvm/rust/module.f.mjs
@@ -97,6 +97,7 @@ export const rustName = {
     '||': 'logical_or',
     '??': 'nullish_coalescing',
     ternary: 'conditional',
+    typeof: 'type_of',
     String: 'string_coercion',
 }
 
@@ -109,6 +110,7 @@ const op1Rust = {
     unaryPlus: a => `Any::unary_plus(${a})`,
     neg: a => `-(${a})`,
     '!': a => `!(${a})`,
+    typeof: a => `Any::type_of(${a})`,
     String: a => `${a}.to_string().map(|v| v.to_any())`,
 }
 

--- a/fjs/nanvm/types.ts
+++ b/fjs/nanvm/types.ts
@@ -174,10 +174,12 @@ export type Group2 = {
  * - `ternary` (`?:`) — the EDAG has no conditional-expression node at all
  *   yet, so this is the corpus's one ternary group; every other `Group`
  *   variant is unary or binary because the EDAG vocabulary it draws from is.
+ * - `typeof` — the EDAG has no `typeof` node either.
  */
 export type NonEdagGroup =
     | { readonly nanvmOp: 'unaryPlus'; readonly cases: readonly Case<1>[] }
     | { readonly nanvmOp: 'ternary'; readonly cases: readonly Case<3>[] }
+    | { readonly nanvmOp: 'typeof'; readonly cases: readonly Case<1>[] }
 
 export type Group = Group1 | Group2 | NonEdagGroup
 

--- a/nanvm-lib/README.md
+++ b/nanvm-lib/README.md
@@ -25,7 +25,7 @@ Operators on [`Any<A>`](src/vm/any/mod.rs) (the top-level VM value type).
 | `+`      | Unary plus          | [x]      | `Any::unary_plus()` method (coerces to number) |
 | `!`      | Logical NOT         | [x]      | [`any/not.rs`](src/vm/any/not.rs) — `Not for Any<A>`, via the new `ToBoolean` coercion ([`boolean_coercion.rs`](src/vm/boolean_coercion.rs)) |
 | `~`      | Bitwise NOT         | [ ]      | |
-| `typeof` | Type of             | [ ]      | |
+| `typeof` | Type of             | [x]      | [`any/type_of.rs`](src/vm/any/type_of.rs) — `Any::type_of()` method (no Rust operator to spell it with, and `typeof` itself is a reserved word); returns `"undefined"`, `"object"` (`null` and both container types), `"boolean"`, `"number"`, `"bigint"`, `"string"`, or `"function"` |
 
 ### Comparison
 

--- a/nanvm-lib/README.md
+++ b/nanvm-lib/README.md
@@ -25,7 +25,7 @@ Operators on [`Any<A>`](src/vm/any/mod.rs) (the top-level VM value type).
 | `+`      | Unary plus          | [x]      | `Any::unary_plus()` method (coerces to number) |
 | `!`      | Logical NOT         | [x]      | [`any/not.rs`](src/vm/any/not.rs) — `Not for Any<A>`, via the new `ToBoolean` coercion ([`boolean_coercion.rs`](src/vm/boolean_coercion.rs)) |
 | `~`      | Bitwise NOT         | [ ]      | |
-| `typeof` | Type of             | [x]      | [`any/type_of.rs`](src/vm/any/type_of.rs) — `Any::type_of()` method (no Rust operator to spell it with, and `typeof` itself is a reserved word); returns `"undefined"`, `"object"` (`null` and both container types), `"boolean"`, `"number"`, `"bigint"`, `"string"`, or `"function"` |
+| `typeof` | Type of             | [x]      | [`any/typeof_.rs`](src/vm/any/typeof_.rs) — `Any::typeof_()` method (no Rust operator to spell it with; the trailing underscore resolves the collision with Rust's own reserved `typeof`, the same convention FJS and JS use); returns `"undefined"`, `"object"` (`null` and both container types), `"boolean"`, `"number"`, `"bigint"`, `"string"`, or `"function"` |
 
 ### Comparison
 

--- a/nanvm-lib/src/vm/any/mod.rs
+++ b/nanvm-lib/src/vm/any/mod.rs
@@ -11,6 +11,7 @@ mod partial_eq;
 mod relational;
 mod rem;
 mod sub;
+mod type_of;
 
 pub mod to_any;
 
@@ -115,6 +116,6 @@ impl<A: IVm> Any<A> {
     }
 }
 
-// TODO implement other operators like &, |, ^, <<, >>, >>>, ~, typeof, etc using Rust standard
-// traits - similarly to Neg above. Implement operators that do not have corresponding Rust standard
-// traits via adding methods to Any<A> - similarly to unary_plus.
+// TODO implement other operators like &, |, ^, <<, >>, >>>, ~, etc using Rust standard traits -
+// similarly to Neg above. Implement operators that do not have corresponding Rust standard traits
+// via adding methods to Any<A> - similarly to unary_plus.

--- a/nanvm-lib/src/vm/any/mod.rs
+++ b/nanvm-lib/src/vm/any/mod.rs
@@ -11,7 +11,7 @@ mod partial_eq;
 mod relational;
 mod rem;
 mod sub;
-mod type_of;
+mod typeof_;
 
 pub mod to_any;
 

--- a/nanvm-lib/src/vm/any/type_of.rs
+++ b/nanvm-lib/src/vm/any/type_of.rs
@@ -1,0 +1,57 @@
+use crate::vm::{
+    Any, Array, BigInt, Function, IVm, Object, String, dispatch::Dispatch, nullish::Nullish,
+};
+
+/// The tag `Any::type_of` returns, one per `Unpacked` variant.
+struct TypeOf;
+
+impl<A: IVm> Dispatch<A> for TypeOf {
+    type Result = &'static str;
+
+    fn nullish(self, v: Nullish) -> Self::Result {
+        match v {
+            // `null` is famously an object in JavaScript's `typeof`.
+            Nullish::Null => "object",
+            Nullish::Undefined => "undefined",
+        }
+    }
+
+    fn bool(self, _: bool) -> Self::Result {
+        "boolean"
+    }
+
+    fn number(self, _: f64) -> Self::Result {
+        "number"
+    }
+
+    fn string(self, _: String<A>) -> Self::Result {
+        "string"
+    }
+
+    fn bigint(self, _: BigInt<A>) -> Self::Result {
+        "bigint"
+    }
+
+    fn object(self, _: Object<A>) -> Self::Result {
+        "object"
+    }
+
+    fn array(self, _: Array<A>) -> Self::Result {
+        "object"
+    }
+
+    fn function(self, _: Function<A>) -> Self::Result {
+        "function"
+    }
+}
+
+impl<A: IVm> Any<A> {
+    /// `typeof`. Not a `core::ops` trait — Rust has no unary operator to
+    /// spell it with (and `typeof` itself is a reserved word) — so this is a
+    /// plain method, the same as `unary_plus`. Never throws, but stays a
+    /// `Result` to match every other operator's shape.
+    /// <https://tc39.es/ecma262/#sec-typeof-operator>
+    pub fn type_of(self) -> Result<Any<A>, Any<A>> {
+        Ok(self.dispatch(TypeOf).into())
+    }
+}

--- a/nanvm-lib/src/vm/any/typeof_.rs
+++ b/nanvm-lib/src/vm/any/typeof_.rs
@@ -2,7 +2,7 @@ use crate::vm::{
     Any, Array, BigInt, Function, IVm, Object, String, dispatch::Dispatch, nullish::Nullish,
 };
 
-/// The tag `Any::type_of` returns, one per `Unpacked` variant.
+/// The tag `Any::typeof_` returns, one per `Unpacked` variant.
 struct TypeOf;
 
 impl<A: IVm> Dispatch<A> for TypeOf {
@@ -47,11 +47,13 @@ impl<A: IVm> Dispatch<A> for TypeOf {
 
 impl<A: IVm> Any<A> {
     /// `typeof`. Not a `core::ops` trait — Rust has no unary operator to
-    /// spell it with (and `typeof` itself is a reserved word) — so this is a
-    /// plain method, the same as `unary_plus`. Never throws, but stays a
-    /// `Result` to match every other operator's shape.
+    /// spell it with — so this is a plain method, the same as `unary_plus`.
+    /// Named `typeof_`, not `type_of`: `typeof` is itself a reserved word, and
+    /// a trailing underscore — the convention FJS and JS both use for this —
+    /// resolves the collision while keeping the name recognizable. Never
+    /// throws, but stays a `Result` to match every other operator's shape.
     /// <https://tc39.es/ecma262/#sec-typeof-operator>
-    pub fn type_of(self) -> Result<Any<A>, Any<A>> {
+    pub fn typeof_(self) -> Result<Any<A>, Any<A>> {
         Ok(self.dispatch(TypeOf).into())
     }
 }

--- a/nanvm-lib/tests/test/generated.rs
+++ b/nanvm-lib/tests/test/generated.rs
@@ -687,6 +687,25 @@ fn conditional<A: IVm>() {
 }
 
 #[rustfmt::skip]
+fn type_of<A: IVm>() {
+    check::<A>("undefined", Any::type_of(Nullish::Undefined.to_any()), string_any("undefined"));
+    check::<A>("null", Any::type_of(Nullish::Null.to_any()), string_any("object"));
+    check::<A>("booleanTrue", Any::type_of(true.to_any()), string_any("boolean"));
+    check::<A>("booleanFalse", Any::type_of(false.to_any()), string_any("boolean"));
+    check::<A>("number", Any::type_of((2.3f64).to_any()), string_any("number"));
+    check::<A>("numberNan", Any::type_of((f64::NAN).to_any()), string_any("number"));
+    check::<A>("string", Any::type_of(string_any("a")), string_any("string"));
+    check::<A>("stringEmpty", Any::type_of(string_any("")), string_any("string"));
+    check::<A>("bigint", Any::type_of(bigint_any(5)), string_any("bigint"));
+    check::<A>("bigintZero", Any::type_of(bigint_any(0)), string_any("bigint"));
+    check::<A>("emptyArray", Any::type_of(Array::default().to_any()), string_any("object"));
+    check::<A>("array", Any::type_of([(1f64).to_any(), (2f64).to_any()].to_array().to_any()), string_any("object"));
+    check::<A>("emptyObject", Any::type_of(Object::default().to_any()), string_any("object"));
+    check::<A>("object", Any::type_of([(string_key("a"), (1f64).to_any())].to_object().to_any()), string_any("object"));
+    check::<A>("function", Any::type_of(function_any()), string_any("function"));
+}
+
+#[rustfmt::skip]
 fn string_coercion<A: IVm>() {
     check::<A>("number", (123f64).to_any().to_string().map(|v| v.to_any()), string_any("123"));
     check::<A>("negativeNumber", (-456f64).to_any().to_string().map(|v| v.to_any()), string_any("-456"));
@@ -730,5 +749,6 @@ pub fn all<A: IVm>() {
     logical_or::<A>();
     nullish_coalescing::<A>();
     conditional::<A>();
+    type_of::<A>();
     string_coercion::<A>();
 }

--- a/nanvm-lib/tests/test/generated.rs
+++ b/nanvm-lib/tests/test/generated.rs
@@ -687,22 +687,22 @@ fn conditional<A: IVm>() {
 }
 
 #[rustfmt::skip]
-fn type_of<A: IVm>() {
-    check::<A>("undefined", Any::type_of(Nullish::Undefined.to_any()), string_any("undefined"));
-    check::<A>("null", Any::type_of(Nullish::Null.to_any()), string_any("object"));
-    check::<A>("booleanTrue", Any::type_of(true.to_any()), string_any("boolean"));
-    check::<A>("booleanFalse", Any::type_of(false.to_any()), string_any("boolean"));
-    check::<A>("number", Any::type_of((2.3f64).to_any()), string_any("number"));
-    check::<A>("numberNan", Any::type_of((f64::NAN).to_any()), string_any("number"));
-    check::<A>("string", Any::type_of(string_any("a")), string_any("string"));
-    check::<A>("stringEmpty", Any::type_of(string_any("")), string_any("string"));
-    check::<A>("bigint", Any::type_of(bigint_any(5)), string_any("bigint"));
-    check::<A>("bigintZero", Any::type_of(bigint_any(0)), string_any("bigint"));
-    check::<A>("emptyArray", Any::type_of(Array::default().to_any()), string_any("object"));
-    check::<A>("array", Any::type_of([(1f64).to_any(), (2f64).to_any()].to_array().to_any()), string_any("object"));
-    check::<A>("emptyObject", Any::type_of(Object::default().to_any()), string_any("object"));
-    check::<A>("object", Any::type_of([(string_key("a"), (1f64).to_any())].to_object().to_any()), string_any("object"));
-    check::<A>("function", Any::type_of(function_any()), string_any("function"));
+fn typeof_<A: IVm>() {
+    check::<A>("undefined", Any::typeof_(Nullish::Undefined.to_any()), string_any("undefined"));
+    check::<A>("null", Any::typeof_(Nullish::Null.to_any()), string_any("object"));
+    check::<A>("booleanTrue", Any::typeof_(true.to_any()), string_any("boolean"));
+    check::<A>("booleanFalse", Any::typeof_(false.to_any()), string_any("boolean"));
+    check::<A>("number", Any::typeof_((2.3f64).to_any()), string_any("number"));
+    check::<A>("numberNan", Any::typeof_((f64::NAN).to_any()), string_any("number"));
+    check::<A>("string", Any::typeof_(string_any("a")), string_any("string"));
+    check::<A>("stringEmpty", Any::typeof_(string_any("")), string_any("string"));
+    check::<A>("bigint", Any::typeof_(bigint_any(5)), string_any("bigint"));
+    check::<A>("bigintZero", Any::typeof_(bigint_any(0)), string_any("bigint"));
+    check::<A>("emptyArray", Any::typeof_(Array::default().to_any()), string_any("object"));
+    check::<A>("array", Any::typeof_([(1f64).to_any(), (2f64).to_any()].to_array().to_any()), string_any("object"));
+    check::<A>("emptyObject", Any::typeof_(Object::default().to_any()), string_any("object"));
+    check::<A>("object", Any::typeof_([(string_key("a"), (1f64).to_any())].to_object().to_any()), string_any("object"));
+    check::<A>("function", Any::typeof_(function_any()), string_any("function"));
 }
 
 #[rustfmt::skip]
@@ -749,6 +749,6 @@ pub fn all<A: IVm>() {
     logical_or::<A>();
     nullish_coalescing::<A>();
     conditional::<A>();
-    type_of::<A>();
+    typeof_::<A>();
     string_coercion::<A>();
 }


### PR DESCRIPTION
## Summary

Stage 2 of the remaining `nanvm-lib` operators (see the "JS Operator Implementation Status" table in `nanvm-lib/README.md`): `typeof`.

**Based on #1867** (Stage 1: `!`, `&&`, `||`, `??`, `?:`) rather than `main`, since `typeof` reuses the `NonEdagGroup` extension `?:` introduced there (the EDAG has no `typeof` node either, so this adds a second variant alongside `'unaryPlus'` and `'ternary'`). This PR's diff is Stage 2 only — the base will need retargeting to `main` once #1867 merges.

- **`typeof`**: `Any::type_of()` ([`any/type_of.rs`](nanvm-lib/src/vm/any/type_of.rs)) — a plain method, since Rust has no unary operator to spell it with and `typeof` is itself a reserved word. A small `Dispatch` impl (`TypeOf`) maps each `Unpacked` variant to its tag: `"undefined"`, `"object"` (both `null` and the two container types), `"boolean"`, `"number"`, `"bigint"`, `"string"`, `"function"`.

Unlike Stage 1's value-selecting operators, `typeof` always returns a fresh string rather than an operand unchanged, so there's no operand/`expected` identity concern to work around in the corpus this time.

Corpus cases in `fjs/nanvm/module.f.mjs`, wired into `fjs/nanvm/proof.f.mjs` (`op1Js`) and `fjs/nanvm/rust/module.f.mjs` (`op1Rust`, `rustName` — `'type_of'` rather than `'typeof'` since the latter is reserved in Rust). `nanvm-lib/tests/test/generated.rs` regenerated via `npm run gen`, no drift beyond the new cases.

README operator table updated.

### Not in this PR

Stage 3 (bitwise `&`/`|`/`^`/`~` and shift `<<`/`>>`/`>>>`) is separate, tracked in the README table.

## Test plan

- [x] `node ./fjs/module.mjs t ./fjs/nanvm/module.f.mjs` (full `fjs test` suite, 4242 pass / 0 fail)
- [x] `node --test` (full Node suite, 4180 pass / 0 fail)
- [x] `npm run gen` — `nanvm-lib/tests/test/generated.rs` regenerated, diff limited to the new cases
- [x] `cargo test` (in `nanvm-lib`)
- [x] `cargo clippy --lib -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `tsc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016r91tf9sadPY8kgPXwfRu9

---
_Generated by [Claude Code](https://claude.ai/code/session_016r91tf9sadPY8kgPXwfRu9)_