### PR TITLE
nanvm-lib: implement &, |, ^, ~ — bitwise operators

### DIFF
--- a/fjs/nanvm/module.f.mjs
+++ b/fjs/nanvm/module.f.mjs
@@ -36,7 +36,7 @@
  * ```js
  * import { data } from './module.f.mjs'
  *
- * data.groups.length // 19
+ * data.groups.length // 23
  * ```
  */
 
@@ -1108,6 +1108,163 @@ const stringCoercionCases = [
     { name: 'object', args: [{ a: 1 }], expected: '[object Object]' },
 ]
 
+/**
+ * `&`/`|`/`^` all coerce both operands with `ToNumeric` like `*`, then — for
+ * two `Number`s — apply `ToInt32` to each side before the bitwise op, so a
+ * fraction truncates toward zero, a non-finite value becomes `+0`, and a
+ * magnitude beyond 32 bits wraps. Two `BigInt`s use the operator's exact
+ * infinite-precision two's-complement meaning instead, and mixed
+ * number/bigint operands throw, the same as every other arithmetic operator
+ * above.
+ *
+ * @type {readonly Case<2>[]}
+ */
+const bitAndCases = [
+    { name: 'nullBitAndSix', args: [null, 6], expected: 0 },
+    { name: 'undefinedBitAndSix', args: [undefined, 6], expected: 0 },
+    { name: 'trueBitAndSix', args: [true, 6], expected: 0 },
+    { name: 'falseBitAndSix', args: [false, 6], expected: 0 },
+    { name: 'stringTenBitAndSix', args: ['10', 6], expected: 2 },
+    { name: 'stringLetterBitAndSix', args: ['a', 6], expected: 0 },
+    { name: 'emptyArrayBitAndSix', args: [[], 6], expected: 0 },
+    { name: 'arrayTenBitAndSix', args: [[10], 6], expected: 2 },
+    { name: 'arrayStringTenBitAndSix', args: [['10'], 6], expected: 2 },
+    { name: 'arrayPairBitAndSix', args: [[0, 0], 6], expected: 0 },
+    { name: 'emptyObjectBitAndSix', args: [{}, 6], expected: 0 },
+    // The one binary case that escapes: `functionValue` has no expression,
+    // so both consumers take the direct path with two operands rather than
+    // one.
+    { name: 'functionBitAndSix', args: [functionValue, 6], expected: 0 },
+    { name: 'truncatesTowardZero', args: [3.9, 6], expected: 2 },
+    { name: 'negativeTruncatesTowardZero', args: [-3.9, 6], expected: 4 },
+    { name: 'nanBitAndSix', args: [NaN, 6], expected: 0 },
+    { name: 'infinityBitAndSix', args: [Infinity, 6], expected: 0 },
+    { name: 'negativeInfinityBitAndSix', args: [-Infinity, 6], expected: 0 },
+    { name: 'wrapsAt32Bits', args: [2 ** 32 + 5, 6], expected: 4 },
+    { name: 'negativeOneBitAndSix', args: [-1, 6], expected: 6 },
+    { name: 'bigTwelveBitAndTen', args: [12n, 10n], expected: 8n },
+    { name: 'bigNegativeOneBitAndNegativeOne', args: [-1n, -1n], expected: -1n },
+    { name: 'bigNegativeTwoBitAndNegativeThree', args: [-2n, -3n], expected: -4n },
+    { name: 'bigFiveBitAndNegativeOne', args: [5n, -1n], expected: 5n },
+    { name: 'bigZeroBitAndZero', args: [0n, 0n], expected: 0n },
+    { name: 'bigPositiveBitAndZero', args: [12345n, 0n], expected: 0n },
+    { name: 'bigNegativeBitAndZero', args: [-12345n, 0n], expected: 0n },
+    // A magnitude near the largest value the corpus can print (`i64::MAX`),
+    // where `-1`'s all-ones pattern makes AND an identity.
+    { name: 'bigLargeMagnitude', args: [-(2n ** 62n), -1n], expected: -(2n ** 62n) },
+    { name: 'numberBitAndBigint', args: [1, 1n], expected: throws },
+]
+
+/** @type {readonly Case<2>[]} */
+const bitOrCases = [
+    { name: 'nullBitOrSix', args: [null, 6], expected: 6 },
+    { name: 'undefinedBitOrSix', args: [undefined, 6], expected: 6 },
+    { name: 'trueBitOrSix', args: [true, 6], expected: 7 },
+    { name: 'falseBitOrSix', args: [false, 6], expected: 6 },
+    { name: 'stringTenBitOrSix', args: ['10', 6], expected: 14 },
+    { name: 'stringLetterBitOrSix', args: ['a', 6], expected: 6 },
+    { name: 'emptyArrayBitOrSix', args: [[], 6], expected: 6 },
+    { name: 'arrayTenBitOrSix', args: [[10], 6], expected: 14 },
+    { name: 'arrayStringTenBitOrSix', args: [['10'], 6], expected: 14 },
+    { name: 'arrayPairBitOrSix', args: [[0, 0], 6], expected: 6 },
+    { name: 'emptyObjectBitOrSix', args: [{}, 6], expected: 6 },
+    // The one binary case that escapes: `functionValue` has no expression,
+    // so both consumers take the direct path with two operands rather than
+    // one.
+    { name: 'functionBitOrSix', args: [functionValue, 6], expected: 6 },
+    { name: 'truncatesTowardZero', args: [3.9, 6], expected: 7 },
+    { name: 'negativeTruncatesTowardZero', args: [-3.9, 6], expected: -1 },
+    { name: 'nanBitOrSix', args: [NaN, 6], expected: 6 },
+    { name: 'infinityBitOrSix', args: [Infinity, 6], expected: 6 },
+    { name: 'negativeInfinityBitOrSix', args: [-Infinity, 6], expected: 6 },
+    { name: 'wrapsAt32Bits', args: [2 ** 32 + 5, 6], expected: 7 },
+    { name: 'negativeOneBitOrSix', args: [-1, 6], expected: -1 },
+    { name: 'bigTwelveBitOrTen', args: [12n, 10n], expected: 14n },
+    { name: 'bigNegativeTwoBitOrNegativeThree', args: [-2n, -3n], expected: -1n },
+    { name: 'bigFiveBitOrNegativeOne', args: [5n, -1n], expected: -1n },
+    { name: 'bigZeroBitOrZero', args: [0n, 0n], expected: 0n },
+    { name: 'bigPositiveBitOrZero', args: [12345n, 0n], expected: 12345n },
+    { name: 'bigNegativeBitOrZero', args: [-12345n, 0n], expected: -12345n },
+    // A magnitude near the largest value the corpus can print (`i64::MAX`):
+    // `-1`'s all-ones two's-complement pattern absorbs anything it meets, so
+    // the result is `-1` regardless of the other operand's magnitude.
+    { name: 'bigLargeMagnitude', args: [-(2n ** 62n), -1n], expected: -1n },
+    { name: 'numberBitOrBigint', args: [1, 1n], expected: throws },
+]
+
+/** @type {readonly Case<2>[]} */
+const bitXorCases = [
+    { name: 'nullBitXorSix', args: [null, 6], expected: 6 },
+    { name: 'undefinedBitXorSix', args: [undefined, 6], expected: 6 },
+    { name: 'trueBitXorSix', args: [true, 6], expected: 7 },
+    { name: 'falseBitXorSix', args: [false, 6], expected: 6 },
+    { name: 'stringTenBitXorSix', args: ['10', 6], expected: 12 },
+    { name: 'stringLetterBitXorSix', args: ['a', 6], expected: 6 },
+    { name: 'emptyArrayBitXorSix', args: [[], 6], expected: 6 },
+    { name: 'arrayTenBitXorSix', args: [[10], 6], expected: 12 },
+    { name: 'arrayStringTenBitXorSix', args: [['10'], 6], expected: 12 },
+    { name: 'arrayPairBitXorSix', args: [[0, 0], 6], expected: 6 },
+    { name: 'emptyObjectBitXorSix', args: [{}, 6], expected: 6 },
+    // The one binary case that escapes: `functionValue` has no expression,
+    // so both consumers take the direct path with two operands rather than
+    // one.
+    { name: 'functionBitXorSix', args: [functionValue, 6], expected: 6 },
+    { name: 'truncatesTowardZero', args: [3.9, 6], expected: 5 },
+    { name: 'negativeTruncatesTowardZero', args: [-3.9, 6], expected: -5 },
+    { name: 'nanBitXorSix', args: [NaN, 6], expected: 6 },
+    { name: 'infinityBitXorSix', args: [Infinity, 6], expected: 6 },
+    { name: 'negativeInfinityBitXorSix', args: [-Infinity, 6], expected: 6 },
+    { name: 'wrapsAt32Bits', args: [2 ** 32 + 5, 6], expected: 3 },
+    { name: 'negativeOneBitXorSix', args: [-1, 6], expected: -7 },
+    { name: 'bigTwelveBitXorTen', args: [12n, 10n], expected: 6n },
+    { name: 'bigNegativeOneBitXorNegativeOne', args: [-1n, -1n], expected: 0n },
+    { name: 'bigNegativeTwoBitXorNegativeThree', args: [-2n, -3n], expected: 3n },
+    { name: 'bigFiveBitXorNegativeOne', args: [5n, -1n], expected: -6n },
+    { name: 'bigZeroBitXorZero', args: [0n, 0n], expected: 0n },
+    { name: 'bigPositiveBitXorZero', args: [12345n, 0n], expected: 12345n },
+    { name: 'bigNegativeBitXorZero', args: [-12345n, 0n], expected: -12345n },
+    // A magnitude near the largest value the corpus can print (`i64::MAX`):
+    // `x ^ -1` is `~x`, the identity `bitwiseNotCases` below checks
+    // directly, exercised here at a large magnitude instead of a small one.
+    { name: 'bigLargeMagnitude', args: [-(2n ** 62n), -1n], expected: 2n ** 62n - 1n },
+    { name: 'numberBitXorBigint', args: [1, 1n], expected: throws },
+]
+
+/**
+ * `~` coerces its operand with `ToNumeric` like the unary `+`/`-` groups
+ * above, then — for a `Number` — applies `ToInt32` before negating the bits.
+ * For a `BigInt`, `~x` is exactly `-x - 1` (`BigInt::unaryMinus` composed
+ * with `BigInt::subtract`), not a bitwise algorithm of its own.
+ *
+ * @type {readonly Case<1>[]}
+ */
+const bitwiseNotCases = [
+    { name: 'null', args: [null], expected: -1 },
+    { name: 'undefined', args: [undefined], expected: -1 },
+    { name: 'booleanFalse', args: [false], expected: -1 },
+    { name: 'booleanTrue', args: [true], expected: -2 },
+    { name: 'stringTen', args: ['10'], expected: -11 },
+    { name: 'stringLetter', args: ['a'], expected: -1 },
+    { name: 'emptyArray', args: [[]], expected: -1 },
+    { name: 'arrayTen', args: [[10]], expected: -11 },
+    { name: 'arrayStringTen', args: [['10']], expected: -11 },
+    { name: 'arrayPair', args: [[0, 0]], expected: -1 },
+    { name: 'emptyObject', args: [{}], expected: -1 },
+    { name: 'function', args: [functionValue], expected: -1 },
+    { name: 'truncatesTowardZero', args: [3.9], expected: -4 },
+    { name: 'negativeTruncatesTowardZero', args: [-3.9], expected: 2 },
+    { name: 'nan', args: [NaN], expected: -1 },
+    { name: 'infinity', args: [Infinity], expected: -1 },
+    { name: 'negativeInfinity', args: [-Infinity], expected: -1 },
+    { name: 'wrapsAt32Bits', args: [2 ** 32 + 5], expected: -6 },
+    { name: 'negativeOne', args: [-1], expected: 0 },
+    { name: 'bigZero', args: [0n], expected: -1n },
+    { name: 'bigPositive', args: [5n], expected: -6n },
+    { name: 'bigNegative', args: [-5n], expected: 4n },
+    { name: 'bigOne', args: [1n], expected: -2n },
+    { name: 'bigNegativeOne', args: [-1n], expected: 0n },
+]
+
 /** @type {Data} */
 export const data = {
     eq: {
@@ -1172,12 +1329,16 @@ export const data = {
                 { name: 'bigintNegative', args: [-1n], expected: 1n },
             ],
         },
+        { op: '~', cases: bitwiseNotCases },
         { op: '*', commutative: true, cases: mulCases },
         { op: '/', cases: divCases },
         { op: '**', cases: expCases },
         { op: '-', cases: subCases },
         { op: '+', cases: addCases },
         { op: '%', cases: remCases },
+        { op: '&', commutative: true, cases: bitAndCases },
+        { op: '|', commutative: true, cases: bitOrCases },
+        { op: '^', commutative: true, cases: bitXorCases },
         { op: '<', cases: lessThanCases },
         { op: '<=', cases: lessOrEqualCases },
         { op: '>', cases: greaterThanCases },

--- a/fjs/nanvm/proof.f.mjs
+++ b/fjs/nanvm/proof.f.mjs
@@ -60,6 +60,7 @@ const op1Js = {
     neg: a => -a,
     unaryPlus: a => +a,
     '!': a => !a,
+    '~': a => ~a,
     typeof: a => typeof a,
 }
 
@@ -71,6 +72,9 @@ const op2Js = {
     '-': (a, b) => a - b,
     '+': (a, b) => a + b,
     '%': (a, b) => a % b,
+    '&': (a, b) => a & b,
+    '|': (a, b) => a | b,
+    '^': (a, b) => a ^ b,
     '<': (a, b) => a < b,
     '<=': (a, b) => a <= b,
     '>': (a, b) => a > b,
@@ -353,7 +357,7 @@ const jsOnly = {
         forwardSharedRef: () =>
             lowerEq({ shared: { a: [ref('b')], b: [] }, cases: [] }),
         /** An id the corpus does not exercise has no JavaScript here. */
-        unusedOperation: () => op1('~'),
+        unusedOperation: () => op1('Number'),
         /**
          * A count the operation does not take. `Case<N>` cannot carry one,
          * but `caseExp` is exported and its `args` are a plain array, so the

--- a/fjs/nanvm/rust/module.f.mjs
+++ b/fjs/nanvm/rust/module.f.mjs
@@ -82,12 +82,16 @@ export const path = `${directory}/generated.rs`
 export const rustName = {
     unaryPlus: 'unary_plus',
     neg: 'neg',
+    '~': 'bitwise_not',
     '*': 'mul',
     '/': 'div',
     '**': 'pow',
     '-': 'sub',
     '+': 'add',
     '%': 'rem',
+    '&': 'bitand',
+    '|': 'bitor',
+    '^': 'bitxor',
     '<': 'lt',
     '<=': 'le',
     '>': 'gt',
@@ -110,6 +114,7 @@ const op1Rust = {
     unaryPlus: a => `Any::unary_plus(${a})`,
     neg: a => `-(${a})`,
     '!': a => `!(${a})`,
+    '~': a => `Any::bitwise_not(${a})`,
     typeof: a => `Any::typeof_(${a})`,
     String: a => `${a}.to_string().map(|v| v.to_any())`,
 }
@@ -117,7 +122,7 @@ const op1Rust = {
 /**
  * The same, for the binary operations.
  *
- * An operator not yet implemented in `nanvm-lib` (such as `&`) has every one
+ * An operator not yet implemented in `nanvm-lib` (such as `<<`) has every one
  * of its cases carry a `rust` reason, and `emit` prints this text as a
  * comment rather than a statement — this entry only has to read as the
  * operation, not compile.
@@ -143,6 +148,9 @@ const op2Rust = {
     '-': (a, b) => `${a} - ${b}`,
     '+': (a, b) => `${a} + ${b}`,
     '%': (a, b) => `${a} % ${b}`,
+    '&': (a, b) => `${a} & ${b}`,
+    '|': (a, b) => `${a} | ${b}`,
+    '^': (a, b) => `${a} ^ ${b}`,
     '<': (a, b) => `Any::lt(${a}, ${b})`,
     '<=': (a, b) => `Any::le(${a}, ${b})`,
     '>': (a, b) => `Any::gt(${a}, ${b})`,

--- a/fjs/nanvm/rust/proof.f.mjs
+++ b/fjs/nanvm/rust/proof.f.mjs
@@ -192,7 +192,7 @@ export const proof = {
          * generated file would otherwise carry a statement that does not
          * compile, or worse, one that does and means something else.
          */
-        unknownOperation: () => nodeExpr(['&', 1, 2]),
+        unknownOperation: () => nodeExpr(['<<', 1, 2]),
         /** An object key the corpus cannot produce and Rust cannot spell. */
         computedKey: () => nodeExpr(['{}', [[':', ['undefined'], 1]]]),
         /**

--- a/nanvm-lib/README.md
+++ b/nanvm-lib/README.md
@@ -24,7 +24,7 @@ Operators on [`Any<A>`](src/vm/any/mod.rs) (the top-level VM value type).
 | `-`      | Unary minus         | [x]      | [`any/neg.rs`](src/vm/any/neg.rs) — `Neg for Any<A>` |
 | `+`      | Unary plus          | [x]      | `Any::unary_plus()` method (coerces to number) |
 | `!`      | Logical NOT         | [x]      | [`any/not.rs`](src/vm/any/not.rs) — `Not for Any<A>`, via the new `ToBoolean` coercion ([`boolean_coercion.rs`](src/vm/boolean_coercion.rs)) |
-| `~`      | Bitwise NOT         | [ ]      | |
+| `~`      | Bitwise NOT         | [x]      | `Numeric::bitwise_not()`/`Any::bitwise_not()` methods (no Rust operator to spell it with — `Not` is already `!`'s); `Number`: `ToInt32` then bitwise-negate; `BigInt`: `-x - 1`, the exact spec identity, reusing `Neg`/`Sub` rather than a new algorithm |
 | `typeof` | Type of             | [x]      | [`any/typeof_.rs`](src/vm/any/typeof_.rs) — `Any::typeof_()` method (no Rust operator to spell it with; the trailing underscore resolves the collision with Rust's own reserved `typeof`, the same convention FJS and JS use); returns `"undefined"`, `"object"` (`null` and both container types), `"boolean"`, `"number"`, `"bigint"`, `"string"`, or `"function"` |
 
 ### Comparison
@@ -42,9 +42,9 @@ Operators on [`Any<A>`](src/vm/any/mod.rs) (the top-level VM value type).
 
 | Operator | Description         | `Any<A>` | Notes |
 |----------|---------------------|----------|-------|
-| `&`      | AND                 | [ ]      | |
-| `\|`     | OR                  | [ ]      | |
-| `^`      | XOR                 | [ ]      | |
+| `&`      | AND                 | [x]      | [`any/bitand.rs`](src/vm/any/bitand.rs) — `BitAnd for Any<A>`; `Number`: `ToInt32` each side, then native `&`; `BigInt`: [`bigint/bitand.rs`](src/vm/bigint/bitand.rs) — infinite-precision two's-complement `AND` over words (see [`bigint/mod.rs`](src/vm/bigint/mod.rs)'s `bitwise_op`); rejects mixed `number`/`bigint` |
+| `\|`     | OR                  | [x]      | [`any/bitor.rs`](src/vm/any/bitor.rs) — `BitOr for Any<A>`; same coercion as `&`; `BigInt`: [`bigint/bitor.rs`](src/vm/bigint/bitor.rs) |
+| `^`      | XOR                 | [x]      | [`any/bitxor.rs`](src/vm/any/bitxor.rs) — `BitXor for Any<A>`; same coercion as `&`; `BigInt`: [`bigint/bitxor.rs`](src/vm/bigint/bitxor.rs) |
 | `<<`     | Left shift          | [ ]      | `Shl for BigInt` exists; no `Any`-level impl |
 | `>>`     | Signed right shift  | [ ]      | `Shr for BigInt` exists; no `Any`-level impl |
 | `>>>`    | Unsigned right shift| [ ]      | |
@@ -75,3 +75,4 @@ Operators on [`Any<A>`](src/vm/any/mod.rs) (the top-level VM value type).
 | To boolean     | [x]    | [`boolean_coercion.rs`](src/vm/boolean_coercion.rs) — never throws, unlike the others |
 | To primitive   | [x]    | [`primitive_coercion.rs`](src/vm/primitive_coercion.rs) |
 | To numeric     | [x]    | `Any::to_numeric()` |
+| To int32       | [x]    | [`int32_coercion.rs`](src/vm/int32_coercion.rs) — `ToInt32`, operating on the already-coerced `f64` a `Number::` bitwise op needs (`ToUint32` not yet needed — only `>>>` uses it) |

--- a/nanvm-lib/src/vm/any/bitand.rs
+++ b/nanvm-lib/src/vm/any/bitand.rs
@@ -1,0 +1,11 @@
+use core::ops::BitAnd;
+
+use crate::vm::{Any, IVm, Unpacked};
+
+impl<A: IVm> BitAnd for Any<A> {
+    type Output = Result<Any<A>, Any<A>>;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Ok(Unpacked::from((self.to_numeric()? & rhs.to_numeric()?)?).into())
+    }
+}

--- a/nanvm-lib/src/vm/any/bitor.rs
+++ b/nanvm-lib/src/vm/any/bitor.rs
@@ -1,0 +1,11 @@
+use core::ops::BitOr;
+
+use crate::vm::{Any, IVm, Unpacked};
+
+impl<A: IVm> BitOr for Any<A> {
+    type Output = Result<Any<A>, Any<A>>;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Ok(Unpacked::from((self.to_numeric()? | rhs.to_numeric()?)?).into())
+    }
+}

--- a/nanvm-lib/src/vm/any/bitxor.rs
+++ b/nanvm-lib/src/vm/any/bitxor.rs
@@ -1,0 +1,11 @@
+use core::ops::BitXor;
+
+use crate::vm::{Any, IVm, Unpacked};
+
+impl<A: IVm> BitXor for Any<A> {
+    type Output = Result<Any<A>, Any<A>>;
+
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        Ok(Unpacked::from((self.to_numeric()? ^ rhs.to_numeric()?)?).into())
+    }
+}

--- a/nanvm-lib/src/vm/any/mod.rs
+++ b/nanvm-lib/src/vm/any/mod.rs
@@ -1,5 +1,8 @@
 mod add;
 mod and;
+mod bitand;
+mod bitor;
+mod bitxor;
 mod conditional;
 mod div;
 mod from;
@@ -68,6 +71,14 @@ impl<A: IVm> Any<A> {
         Ok(Unpacked::from(self.to_numeric()?.pow(rhs.to_numeric()?)?).into())
     }
 
+    /// `~`. Not a `core::ops` trait — `Not` is already claimed by this
+    /// type's own logical `!` (`any/not.rs`) — so this is a plain method,
+    /// the same as `unary_plus`/`pow`.
+    /// <https://tc39.es/ecma262/#sec-bitwise-not-operator>
+    pub fn bitwise_not(self) -> Result<Self, Self> {
+        Ok(Unpacked::from(self.to_numeric()?.bitwise_not()).into())
+    }
+
     /// Same as `Number.isNaN` in ECMAScript.
     /// TODO: check and test.
     pub fn is_nan(self) -> bool {
@@ -116,6 +127,4 @@ impl<A: IVm> Any<A> {
     }
 }
 
-// TODO implement other operators like &, |, ^, <<, >>, >>>, ~, etc using Rust standard traits -
-// similarly to Neg above. Implement operators that do not have corresponding Rust standard traits
-// via adding methods to Any<A> - similarly to unary_plus.
+// TODO implement <<, >>, >>> using Rust standard traits - similarly to Neg above.

--- a/nanvm-lib/src/vm/bigint/bitand.rs
+++ b/nanvm-lib/src/vm/bigint/bitand.rs
@@ -1,0 +1,64 @@
+use core::ops::BitAnd;
+
+use crate::vm::{BigInt, IVm};
+
+impl<A: IVm> BitAnd for BigInt<A> {
+    type Output = Self;
+    fn bitand(self, rhs: Self) -> Self::Output {
+        self.bitwise_op(rhs, |a, b| a & b, |a_neg, b_neg| a_neg && b_neg)
+    }
+}
+
+// TODO: The unit tests should not use `naive` or other VM implementations.
+//       We should move these tests into integration tests.
+#[cfg(test)]
+mod tests {
+    use crate::{naive::Naive, sign::Sign, vm::bigint::BigInt};
+
+    type T = BigInt<Naive>;
+
+    fn int(value: i64) -> T {
+        value.into()
+    }
+
+    #[test]
+    fn both_positive() {
+        assert_eq!(int(0b1100) & int(0b1010), int(0b1000));
+    }
+
+    #[test]
+    fn both_negative() {
+        // -1 & -1 == -1 (all-ones AND all-ones).
+        assert_eq!(int(-1) & int(-1), int(-1));
+        // -2 & -3 == -4: 0b...110 & 0b...101 == 0b...100.
+        assert_eq!(int(-2) & int(-3), int(-4));
+    }
+
+    #[test]
+    fn mixed_signs() {
+        // 5 & -1 == 5 (AND with all-ones is identity).
+        assert_eq!(int(5) & int(-1), int(5));
+        // -1 & 5 == 5.
+        assert_eq!(int(-1) & int(5), int(5));
+    }
+
+    #[test]
+    fn with_zero() {
+        assert_eq!(int(0) & int(0), int(0));
+        assert_eq!(int(12345) & int(0), int(0));
+        assert_eq!(int(-12345) & int(0), int(0));
+    }
+
+    #[test]
+    fn multi_word_carry_on_decode() {
+        // x = -(0xFFFFFFFF00000001), y = -(0x100000000). Both single-word
+        // magnitudes, so L=1: x's two's-complement word is 0x00000000FFFFFFFF
+        // and y's is 0xFFFFFFFF00000000, which AND to all-zero across that
+        // single word — so decoding the negative result must carry a
+        // brand-new second word into existence, giving -(2^64).
+        let x = T::unchecked_new(Sign::Negative, [0xFFFF_FFFF_0000_0001u64]);
+        let y = T::unchecked_new(Sign::Negative, [0x1_0000_0000u64]);
+        let expected = T::unchecked_new(Sign::Negative, [0u64, 1u64]);
+        assert_eq!(x & y, expected);
+    }
+}

--- a/nanvm-lib/src/vm/bigint/bitor.rs
+++ b/nanvm-lib/src/vm/bigint/bitor.rs
@@ -1,0 +1,59 @@
+use core::ops::BitOr;
+
+use crate::vm::{BigInt, IVm};
+
+impl<A: IVm> BitOr for BigInt<A> {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self::Output {
+        self.bitwise_op(rhs, |a, b| a | b, |a_neg, b_neg| a_neg || b_neg)
+    }
+}
+
+// TODO: The unit tests should not use `naive` or other VM implementations.
+//       We should move these tests into integration tests.
+#[cfg(test)]
+mod tests {
+    use crate::{naive::Naive, sign::Sign, vm::bigint::BigInt};
+
+    type T = BigInt<Naive>;
+
+    fn int(value: i64) -> T {
+        value.into()
+    }
+
+    #[test]
+    fn both_positive() {
+        assert_eq!(int(0b1100) | int(0b1010), int(0b1110));
+    }
+
+    #[test]
+    fn both_negative() {
+        // -2 | -3 == -1: 0b...110 | 0b...101 == 0b...111.
+        assert_eq!(int(-2) | int(-3), int(-1));
+    }
+
+    #[test]
+    fn mixed_signs() {
+        // 5 | -1 == -1 (OR with all-ones is all-ones).
+        assert_eq!(int(5) | int(-1), int(-1));
+        assert_eq!(int(-1) | int(5), int(-1));
+    }
+
+    #[test]
+    fn with_zero() {
+        assert_eq!(int(0) | int(0), int(0));
+        assert_eq!(int(12345) | int(0), int(12345));
+        assert_eq!(int(-12345) | int(0), int(-12345));
+    }
+
+    #[test]
+    fn different_word_lengths() {
+        // x = -(2^64), a two-word magnitude; y = -1, a one-word magnitude
+        // zero-extended to match. -1's all-ones two's-complement word ORs
+        // with anything to stay all-ones, so the result is -1.
+        let x = T::unchecked_new(Sign::Negative, [0u64, 1u64]);
+        let y = int(-1);
+        let expected = int(-1);
+        assert_eq!(x | y, expected);
+    }
+}

--- a/nanvm-lib/src/vm/bigint/bitxor.rs
+++ b/nanvm-lib/src/vm/bigint/bitxor.rs
@@ -1,0 +1,63 @@
+use core::ops::BitXor;
+
+use crate::vm::{BigInt, IVm};
+
+impl<A: IVm> BitXor for BigInt<A> {
+    type Output = Self;
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        self.bitwise_op(rhs, |a, b| a ^ b, |a_neg, b_neg| a_neg != b_neg)
+    }
+}
+
+// TODO: The unit tests should not use `naive` or other VM implementations.
+//       We should move these tests into integration tests.
+#[cfg(test)]
+mod tests {
+    use crate::{naive::Naive, sign::Sign, vm::bigint::BigInt};
+
+    type T = BigInt<Naive>;
+
+    fn int(value: i64) -> T {
+        value.into()
+    }
+
+    #[test]
+    fn both_positive() {
+        assert_eq!(int(0b1100) ^ int(0b1010), int(0b0110));
+    }
+
+    #[test]
+    fn both_negative() {
+        // -1 ^ -1 == 0 (all-ones XOR all-ones cancels out).
+        assert_eq!(int(-1) ^ int(-1), int(0));
+        // -2 ^ -3 == 3: 0b...110 ^ 0b...101 == 0b...011.
+        assert_eq!(int(-2) ^ int(-3), int(3));
+    }
+
+    #[test]
+    fn mixed_signs() {
+        // 5 ^ -1 == -6 (XOR with all-ones flips every bit, i.e. bitwise NOT).
+        assert_eq!(int(5) ^ int(-1), int(-6));
+        assert_eq!(int(-1) ^ int(5), int(-6));
+    }
+
+    #[test]
+    fn with_zero() {
+        assert_eq!(int(0) ^ int(0), int(0));
+        assert_eq!(int(12345) ^ int(0), int(12345));
+        assert_eq!(int(-12345) ^ int(0), int(-12345));
+    }
+
+    #[test]
+    fn multi_word_carry_on_decode() {
+        // x = -(0xFFFFFFFF00000001), whose two's-complement word is
+        // 0x00000000FFFFFFFF; y = 0x00000000FFFFFFFF (positive, so its
+        // pattern is its own value). XORing equal words gives an all-zero
+        // pattern, so decoding the negative result must carry a brand-new
+        // second word into existence, giving -(2^64).
+        let x = T::unchecked_new(Sign::Negative, [0xFFFF_FFFF_0000_0001u64]);
+        let y = T::unchecked_new(Sign::Positive, [0x0000_0000_FFFF_FFFFu64]);
+        let expected = T::unchecked_new(Sign::Negative, [0u64, 1u64]);
+        assert_eq!(x ^ y, expected);
+    }
+}

--- a/nanvm-lib/src/vm/bigint/mod.rs
+++ b/nanvm-lib/src/vm/bigint/mod.rs
@@ -1,4 +1,7 @@
 mod add;
+mod bitand;
+mod bitor;
+mod bitxor;
 mod cmp;
 mod debug;
 mod default;
@@ -55,6 +58,32 @@ fn cmp_words(a: &[u64], b: &[u64]) -> Ordering {
         }
     }
     Ordering::Equal
+}
+
+/// The positive magnitude a negative `bitwise_op` result's two's-complement
+/// word pattern decodes to: flip every bit, then add one — the standard
+/// two's-complement negation, over words instead of a single machine
+/// integer. The `+ 1` can carry a new word into existence (`!x` all-ones
+/// becomes all-zeros, and `+ 1` then carries out past the last word) —
+/// tracked explicitly here since `words` isn't pre-sized for it the way
+/// [`BigInt::add_to_vec`]'s caller in `mul.rs` pre-sizes its target.
+fn magnitude_from_twos_complement(mut words: Vec<u64>) -> Vec<u64> {
+    for word in words.iter_mut() {
+        *word = !*word;
+    }
+    let mut carry = 1u64;
+    for word in words.iter_mut() {
+        let (sum, overflow) = word.overflowing_add(carry);
+        *word = sum;
+        carry = overflow as u64;
+        if carry == 0 {
+            break;
+        }
+    }
+    if carry != 0 {
+        words.push(carry);
+    }
+    normalize(&words).to_vec()
 }
 
 /// `a -= b`, in place, trimming any leading zero words the subtraction
@@ -298,6 +327,65 @@ impl<A: IVm> BigInt<A> {
         }
 
         (normalize(&quotient).to_vec(), remainder)
+    }
+
+    /// This BigInt's infinite-precision two's-complement bit pattern, sliced
+    /// to `len` words (the caller passes the larger of the two operand
+    /// lengths, so no significant bit is cut off). Non-negative: the
+    /// magnitude, zero-padded. Negative: `NOT(|self| - 1)` — the standard
+    /// two's-complement encoding, chosen (over flip-then-subtract) because
+    /// the sign bit implicitly repeats forever above the magnitude, and
+    /// subtracting first keeps that repetition free instead of needing it
+    /// threaded through the padding words too.
+    fn twos_complement_words(self, len: u32) -> Vec<u64> {
+        let sign = self.sign();
+        let mut words: Vec<u64> = self.index_iter().collect();
+        words.resize(len as usize, 0);
+        if sign == Sign::Negative {
+            let mut borrow = 1u64;
+            for word in words.iter_mut() {
+                let (diff, overflow) = word.overflowing_sub(borrow);
+                *word = diff;
+                borrow = overflow as u64;
+                if borrow == 0 {
+                    break;
+                }
+            }
+            for word in words.iter_mut() {
+                *word = !*word;
+            }
+        }
+        words
+    }
+
+    /// Shared `&`/`|`/`^` dispatch (ECMA-262's `BigInt::bitwiseOp`): decode
+    /// both operands to same-length two's-complement word patterns, apply
+    /// `word_op` word-by-word, then decode the outcome — `result_negative`
+    /// gives the result's sign from whether each operand was negative (AND:
+    /// both; OR: either; XOR: exactly one), and a negative outcome's word
+    /// pattern is turned back into a magnitude via
+    /// [`magnitude_from_twos_complement`].
+    fn bitwise_op(
+        self,
+        rhs: Self,
+        word_op: impl Fn(u64, u64) -> u64,
+        result_negative: impl Fn(bool, bool) -> bool,
+    ) -> Self {
+        let self_negative = self.sign() == Sign::Negative;
+        let rhs_negative = rhs.sign() == Sign::Negative;
+        let len = self.length().max(rhs.length());
+        let a = self.twos_complement_words(len);
+        let b = rhs.twos_complement_words(len);
+        let out: Vec<u64> = a
+            .iter()
+            .zip(b.iter())
+            .map(|(&x, &y)| word_op(x, y))
+            .collect();
+        if result_negative(self_negative, rhs_negative) {
+            Self::normalize_new(Sign::Negative, magnitude_from_twos_complement(out))
+        } else {
+            Self::normalize_new(Sign::Positive, out)
+        }
     }
 }
 

--- a/nanvm-lib/src/vm/int32_coercion.rs
+++ b/nanvm-lib/src/vm/int32_coercion.rs
@@ -3,10 +3,12 @@
 /// the latter not yet implemented — no operator needs it until `>>>`):
 /// non-finite (`NaN`, `±Infinity`) becomes `+0`, otherwise the number is
 /// truncated toward zero and reduced to its non-negative remainder modulo
-/// `2^32`. `%` on `f64` (unlike integer `%`) is exact — no precision is lost
-/// reducing even a huge truncated magnitude down to 32 bits — so the only
-/// rounding in this whole pipeline already happened when `argument` first
-/// became an `f64` via `ToNumber`.
+/// `2^32`. Unlike integer `%`, `f64`'s `%` (IEEE 754 remainder, C's `fmod`)
+/// never rounds: for any two finite operands the true mathematical
+/// remainder is itself exactly representable in the same format, so this
+/// step introduces no error of its own even when `number.trunc()` is a huge
+/// magnitude — whatever rounding happened is already baked into `number`
+/// from when it became an `f64` via `ToNumber`, upstream of this function.
 fn modulo_2_32(number: f64) -> u32 {
     if !number.is_finite() {
         return 0;

--- a/nanvm-lib/src/vm/int32_coercion.rs
+++ b/nanvm-lib/src/vm/int32_coercion.rs
@@ -1,0 +1,75 @@
+/// The `modulo 2^32` step `ToInt32` shares with `ToUint32`
+/// (<https://tc39.es/ecma262/#sec-toint32> / <https://tc39.es/ecma262/#sec-touint32>,
+/// the latter not yet implemented — no operator needs it until `>>>`):
+/// non-finite (`NaN`, `±Infinity`) becomes `+0`, otherwise the number is
+/// truncated toward zero and reduced to its non-negative remainder modulo
+/// `2^32`. `%` on `f64` (unlike integer `%`) is exact — no precision is lost
+/// reducing even a huge truncated magnitude down to 32 bits — so the only
+/// rounding in this whole pipeline already happened when `argument` first
+/// became an `f64` via `ToNumber`.
+fn modulo_2_32(number: f64) -> u32 {
+    if !number.is_finite() {
+        return 0;
+    }
+    const TWO_POW_32: f64 = 4294967296.0;
+    let remainder = number.trunc() % TWO_POW_32;
+    let non_negative = if remainder < 0.0 {
+        remainder + TWO_POW_32
+    } else {
+        remainder
+    };
+    non_negative as u32
+}
+
+/// `ToInt32`. <https://tc39.es/ecma262/#sec-toint32>
+pub(crate) fn to_int32(number: f64) -> i32 {
+    modulo_2_32(number) as i32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::to_int32;
+
+    #[test]
+    fn non_finite_and_zero() {
+        for n in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY, 0.0, -0.0] {
+            assert_eq!(to_int32(n), 0);
+        }
+    }
+
+    #[test]
+    fn truncates_toward_zero() {
+        assert_eq!(to_int32(3.9), 3);
+        assert_eq!(to_int32(-3.9), -3);
+    }
+
+    #[test]
+    fn in_range_round_trips() {
+        assert_eq!(to_int32(42.0), 42);
+        assert_eq!(to_int32(-42.0), -42);
+    }
+
+    #[test]
+    fn wraps_at_32_bit_boundary() {
+        // 2^31 is the first value ToInt32 reinterprets as negative.
+        assert_eq!(to_int32(2147483648.0), i32::MIN);
+        // 2^32 - 1 wraps to -1 as a signed 32-bit value.
+        assert_eq!(to_int32(4294967295.0), -1);
+        // 2^32 itself reduces to 0.
+        assert_eq!(to_int32(4294967296.0), 0);
+    }
+
+    #[test]
+    fn negative_wraps_up() {
+        // -1 reduces (mod 2^32) to 2^32 - 1, which ToInt32 then reinterprets
+        // back down to -1 — round-tripping through the unsigned domain.
+        assert_eq!(to_int32(-1.0), -1);
+    }
+
+    #[test]
+    fn huge_magnitude() {
+        // Far beyond f64's 53-bit integer precision: an exact multiple of a
+        // power of two well past 2^32, so it reduces to 0.
+        assert_eq!(to_int32(1.0e30), 0);
+    }
+}

--- a/nanvm-lib/src/vm/mod.rs
+++ b/nanvm-lib/src/vm/mod.rs
@@ -7,6 +7,7 @@ mod dispatch;
 mod ecma_whitespace;
 mod function;
 mod impls;
+mod int32_coercion;
 mod internal;
 mod join;
 mod nullish;

--- a/nanvm-lib/src/vm/numeric.rs
+++ b/nanvm-lib/src/vm/numeric.rs
@@ -1,6 +1,6 @@
-use std::ops::{Add, Div, Mul, Neg, Rem, Sub};
+use std::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Rem, Sub};
 
-use crate::vm::{Any, BigInt, IVm, Unpacked};
+use crate::vm::{Any, BigInt, IVm, Unpacked, int32_coercion::to_int32};
 
 const CANNOT_MIX_NUMBER_AND_BIGINT: &str =
     "TypeError: Cannot mix BigInt and other types, use explicit conversions";
@@ -94,6 +94,48 @@ impl<A: IVm> Div for Numeric<A> {
     }
 }
 
+impl<A: IVm> BitAnd for Numeric<A> {
+    type Output = Result<Self, Any<A>>;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Ok(match (self, rhs) {
+            (Numeric::Number(a), Numeric::Number(b)) => {
+                Numeric::Number((to_int32(a) & to_int32(b)) as f64)
+            }
+            (Numeric::BigInt(a), Numeric::BigInt(b)) => Numeric::BigInt(a & b),
+            _ => return Err(CANNOT_MIX_NUMBER_AND_BIGINT.into()),
+        })
+    }
+}
+
+impl<A: IVm> BitOr for Numeric<A> {
+    type Output = Result<Self, Any<A>>;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Ok(match (self, rhs) {
+            (Numeric::Number(a), Numeric::Number(b)) => {
+                Numeric::Number((to_int32(a) | to_int32(b)) as f64)
+            }
+            (Numeric::BigInt(a), Numeric::BigInt(b)) => Numeric::BigInt(a | b),
+            _ => return Err(CANNOT_MIX_NUMBER_AND_BIGINT.into()),
+        })
+    }
+}
+
+impl<A: IVm> BitXor for Numeric<A> {
+    type Output = Result<Self, Any<A>>;
+
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        Ok(match (self, rhs) {
+            (Numeric::Number(a), Numeric::Number(b)) => {
+                Numeric::Number((to_int32(a) ^ to_int32(b)) as f64)
+            }
+            (Numeric::BigInt(a), Numeric::BigInt(b)) => Numeric::BigInt(a ^ b),
+            _ => return Err(CANNOT_MIX_NUMBER_AND_BIGINT.into()),
+        })
+    }
+}
+
 /// `Number::exponentiate`. Diverges from `f64::powf` (and C99's `pow`, which
 /// `powf` follows) in exactly two spots: a `NaN` exponent is `NaN`
 /// regardless of the base (C99 special-cases `pow(1, y) = 1` even for a
@@ -120,6 +162,19 @@ impl<A: IVm> Numeric<A> {
             }
             (Numeric::BigInt(a), Numeric::BigInt(b)) => Ok(Numeric::BigInt(a.pow(b)?)),
             _ => Err(CANNOT_MIX_NUMBER_AND_BIGINT.into()),
+        }
+    }
+
+    /// `~`. Not a `core::ops` trait — `Not` is already claimed by `Any`'s
+    /// logical `!` one level up — so this is a plain method, the same as
+    /// `pow`. Number: `ToInt32` then bitwise-negate. BigInt: `-x - 1`, the
+    /// exact spec identity (`BigInt::unaryMinus`/`Number::subtract` on the
+    /// existing `Neg`/`Sub` impls), reusing them instead of a new
+    /// two's-complement algorithm.
+    pub fn bitwise_not(self) -> Self {
+        match self {
+            Numeric::Number(v) => Numeric::Number(!to_int32(v) as f64),
+            Numeric::BigInt(v) => Numeric::BigInt(-v - BigInt::from(1u64)),
         }
     }
 }

--- a/nanvm-lib/tests/test/generated.rs
+++ b/nanvm-lib/tests/test/generated.rs
@@ -101,6 +101,34 @@ fn neg<A: IVm>() {
 }
 
 #[rustfmt::skip]
+fn bitwise_not<A: IVm>() {
+    check::<A>("null", Any::bitwise_not(Nullish::Null.to_any()), (-1f64).to_any());
+    check::<A>("undefined", Any::bitwise_not(Nullish::Undefined.to_any()), (-1f64).to_any());
+    check::<A>("booleanFalse", Any::bitwise_not(false.to_any()), (-1f64).to_any());
+    check::<A>("booleanTrue", Any::bitwise_not(true.to_any()), (-2f64).to_any());
+    check::<A>("stringTen", Any::bitwise_not(string_any("10")), (-11f64).to_any());
+    check::<A>("stringLetter", Any::bitwise_not(string_any("a")), (-1f64).to_any());
+    check::<A>("emptyArray", Any::bitwise_not(Array::default().to_any()), (-1f64).to_any());
+    check::<A>("arrayTen", Any::bitwise_not([(10f64).to_any()].to_array().to_any()), (-11f64).to_any());
+    check::<A>("arrayStringTen", Any::bitwise_not([string_any("10")].to_array().to_any()), (-11f64).to_any());
+    check::<A>("arrayPair", Any::bitwise_not([(0f64).to_any(), (0f64).to_any()].to_array().to_any()), (-1f64).to_any());
+    check::<A>("emptyObject", Any::bitwise_not(Object::default().to_any()), (-1f64).to_any());
+    check::<A>("function", Any::bitwise_not(function_any()), (-1f64).to_any());
+    check::<A>("truncatesTowardZero", Any::bitwise_not((3.9f64).to_any()), (-4f64).to_any());
+    check::<A>("negativeTruncatesTowardZero", Any::bitwise_not((-3.9f64).to_any()), (2f64).to_any());
+    check::<A>("nan", Any::bitwise_not((f64::NAN).to_any()), (-1f64).to_any());
+    check::<A>("infinity", Any::bitwise_not((f64::INFINITY).to_any()), (-1f64).to_any());
+    check::<A>("negativeInfinity", Any::bitwise_not((f64::NEG_INFINITY).to_any()), (-1f64).to_any());
+    check::<A>("wrapsAt32Bits", Any::bitwise_not((4294967301f64).to_any()), (-6f64).to_any());
+    check::<A>("negativeOne", Any::bitwise_not((-1f64).to_any()), (0f64).to_any());
+    check::<A>("bigZero", Any::bitwise_not(bigint_any(0)), bigint_any(-1));
+    check::<A>("bigPositive", Any::bitwise_not(bigint_any(5)), bigint_any(-6));
+    check::<A>("bigNegative", Any::bitwise_not(bigint_any(-5)), bigint_any(4));
+    check::<A>("bigOne", Any::bitwise_not(bigint_any(1)), bigint_any(-2));
+    check::<A>("bigNegativeOne", Any::bitwise_not(bigint_any(-1)), bigint_any(0));
+}
+
+#[rustfmt::skip]
 fn mul<A: IVm>() {
     check::<A>("nullByNull", Nullish::Null.to_any() * Nullish::Null.to_any(), (0f64).to_any());
     check::<A>("nullByNullSwapped", Nullish::Null.to_any() * Nullish::Null.to_any(), (0f64).to_any());
@@ -372,6 +400,184 @@ fn rem<A: IVm>() {
     check_throws::<A>("bigTenModZero", bigint_any(10) % bigint_any(0));
     check_throws::<A>("numberModBigint", (1f64).to_any() % bigint_any(1));
     check_throws::<A>("bigintModNumber", bigint_any(1) % (1f64).to_any());
+}
+
+#[rustfmt::skip]
+fn bitand<A: IVm>() {
+    check::<A>("nullBitAndSix", Nullish::Null.to_any() & (6f64).to_any(), (0f64).to_any());
+    check::<A>("nullBitAndSixSwapped", (6f64).to_any() & Nullish::Null.to_any(), (0f64).to_any());
+    check::<A>("undefinedBitAndSix", Nullish::Undefined.to_any() & (6f64).to_any(), (0f64).to_any());
+    check::<A>("undefinedBitAndSixSwapped", (6f64).to_any() & Nullish::Undefined.to_any(), (0f64).to_any());
+    check::<A>("trueBitAndSix", true.to_any() & (6f64).to_any(), (0f64).to_any());
+    check::<A>("trueBitAndSixSwapped", (6f64).to_any() & true.to_any(), (0f64).to_any());
+    check::<A>("falseBitAndSix", false.to_any() & (6f64).to_any(), (0f64).to_any());
+    check::<A>("falseBitAndSixSwapped", (6f64).to_any() & false.to_any(), (0f64).to_any());
+    check::<A>("stringTenBitAndSix", string_any("10") & (6f64).to_any(), (2f64).to_any());
+    check::<A>("stringTenBitAndSixSwapped", (6f64).to_any() & string_any("10"), (2f64).to_any());
+    check::<A>("stringLetterBitAndSix", string_any("a") & (6f64).to_any(), (0f64).to_any());
+    check::<A>("stringLetterBitAndSixSwapped", (6f64).to_any() & string_any("a"), (0f64).to_any());
+    check::<A>("emptyArrayBitAndSix", Array::default().to_any() & (6f64).to_any(), (0f64).to_any());
+    check::<A>("emptyArrayBitAndSixSwapped", (6f64).to_any() & Array::default().to_any(), (0f64).to_any());
+    check::<A>("arrayTenBitAndSix", [(10f64).to_any()].to_array().to_any() & (6f64).to_any(), (2f64).to_any());
+    check::<A>("arrayTenBitAndSixSwapped", (6f64).to_any() & [(10f64).to_any()].to_array().to_any(), (2f64).to_any());
+    check::<A>("arrayStringTenBitAndSix", [string_any("10")].to_array().to_any() & (6f64).to_any(), (2f64).to_any());
+    check::<A>("arrayStringTenBitAndSixSwapped", (6f64).to_any() & [string_any("10")].to_array().to_any(), (2f64).to_any());
+    check::<A>("arrayPairBitAndSix", [(0f64).to_any(), (0f64).to_any()].to_array().to_any() & (6f64).to_any(), (0f64).to_any());
+    check::<A>("arrayPairBitAndSixSwapped", (6f64).to_any() & [(0f64).to_any(), (0f64).to_any()].to_array().to_any(), (0f64).to_any());
+    check::<A>("emptyObjectBitAndSix", Object::default().to_any() & (6f64).to_any(), (0f64).to_any());
+    check::<A>("emptyObjectBitAndSixSwapped", (6f64).to_any() & Object::default().to_any(), (0f64).to_any());
+    check::<A>("functionBitAndSix", function_any() & (6f64).to_any(), (0f64).to_any());
+    check::<A>("functionBitAndSixSwapped", (6f64).to_any() & function_any(), (0f64).to_any());
+    check::<A>("truncatesTowardZero", (3.9f64).to_any() & (6f64).to_any(), (2f64).to_any());
+    check::<A>("truncatesTowardZeroSwapped", (6f64).to_any() & (3.9f64).to_any(), (2f64).to_any());
+    check::<A>("negativeTruncatesTowardZero", (-3.9f64).to_any() & (6f64).to_any(), (4f64).to_any());
+    check::<A>("negativeTruncatesTowardZeroSwapped", (6f64).to_any() & (-3.9f64).to_any(), (4f64).to_any());
+    check::<A>("nanBitAndSix", (f64::NAN).to_any() & (6f64).to_any(), (0f64).to_any());
+    check::<A>("nanBitAndSixSwapped", (6f64).to_any() & (f64::NAN).to_any(), (0f64).to_any());
+    check::<A>("infinityBitAndSix", (f64::INFINITY).to_any() & (6f64).to_any(), (0f64).to_any());
+    check::<A>("infinityBitAndSixSwapped", (6f64).to_any() & (f64::INFINITY).to_any(), (0f64).to_any());
+    check::<A>("negativeInfinityBitAndSix", (f64::NEG_INFINITY).to_any() & (6f64).to_any(), (0f64).to_any());
+    check::<A>("negativeInfinityBitAndSixSwapped", (6f64).to_any() & (f64::NEG_INFINITY).to_any(), (0f64).to_any());
+    check::<A>("wrapsAt32Bits", (4294967301f64).to_any() & (6f64).to_any(), (4f64).to_any());
+    check::<A>("wrapsAt32BitsSwapped", (6f64).to_any() & (4294967301f64).to_any(), (4f64).to_any());
+    check::<A>("negativeOneBitAndSix", (-1f64).to_any() & (6f64).to_any(), (6f64).to_any());
+    check::<A>("negativeOneBitAndSixSwapped", (6f64).to_any() & (-1f64).to_any(), (6f64).to_any());
+    check::<A>("bigTwelveBitAndTen", bigint_any(12) & bigint_any(10), bigint_any(8));
+    check::<A>("bigTwelveBitAndTenSwapped", bigint_any(10) & bigint_any(12), bigint_any(8));
+    check::<A>("bigNegativeOneBitAndNegativeOne", bigint_any(-1) & bigint_any(-1), bigint_any(-1));
+    check::<A>("bigNegativeOneBitAndNegativeOneSwapped", bigint_any(-1) & bigint_any(-1), bigint_any(-1));
+    check::<A>("bigNegativeTwoBitAndNegativeThree", bigint_any(-2) & bigint_any(-3), bigint_any(-4));
+    check::<A>("bigNegativeTwoBitAndNegativeThreeSwapped", bigint_any(-3) & bigint_any(-2), bigint_any(-4));
+    check::<A>("bigFiveBitAndNegativeOne", bigint_any(5) & bigint_any(-1), bigint_any(5));
+    check::<A>("bigFiveBitAndNegativeOneSwapped", bigint_any(-1) & bigint_any(5), bigint_any(5));
+    check::<A>("bigZeroBitAndZero", bigint_any(0) & bigint_any(0), bigint_any(0));
+    check::<A>("bigZeroBitAndZeroSwapped", bigint_any(0) & bigint_any(0), bigint_any(0));
+    check::<A>("bigPositiveBitAndZero", bigint_any(12345) & bigint_any(0), bigint_any(0));
+    check::<A>("bigPositiveBitAndZeroSwapped", bigint_any(0) & bigint_any(12345), bigint_any(0));
+    check::<A>("bigNegativeBitAndZero", bigint_any(-12345) & bigint_any(0), bigint_any(0));
+    check::<A>("bigNegativeBitAndZeroSwapped", bigint_any(0) & bigint_any(-12345), bigint_any(0));
+    check::<A>("bigLargeMagnitude", bigint_any(-4611686018427387904) & bigint_any(-1), bigint_any(-4611686018427387904));
+    check::<A>("bigLargeMagnitudeSwapped", bigint_any(-1) & bigint_any(-4611686018427387904), bigint_any(-4611686018427387904));
+    check_throws::<A>("numberBitAndBigint", (1f64).to_any() & bigint_any(1));
+    check_throws::<A>("numberBitAndBigintSwapped", bigint_any(1) & (1f64).to_any());
+}
+
+#[rustfmt::skip]
+fn bitor<A: IVm>() {
+    check::<A>("nullBitOrSix", Nullish::Null.to_any() | (6f64).to_any(), (6f64).to_any());
+    check::<A>("nullBitOrSixSwapped", (6f64).to_any() | Nullish::Null.to_any(), (6f64).to_any());
+    check::<A>("undefinedBitOrSix", Nullish::Undefined.to_any() | (6f64).to_any(), (6f64).to_any());
+    check::<A>("undefinedBitOrSixSwapped", (6f64).to_any() | Nullish::Undefined.to_any(), (6f64).to_any());
+    check::<A>("trueBitOrSix", true.to_any() | (6f64).to_any(), (7f64).to_any());
+    check::<A>("trueBitOrSixSwapped", (6f64).to_any() | true.to_any(), (7f64).to_any());
+    check::<A>("falseBitOrSix", false.to_any() | (6f64).to_any(), (6f64).to_any());
+    check::<A>("falseBitOrSixSwapped", (6f64).to_any() | false.to_any(), (6f64).to_any());
+    check::<A>("stringTenBitOrSix", string_any("10") | (6f64).to_any(), (14f64).to_any());
+    check::<A>("stringTenBitOrSixSwapped", (6f64).to_any() | string_any("10"), (14f64).to_any());
+    check::<A>("stringLetterBitOrSix", string_any("a") | (6f64).to_any(), (6f64).to_any());
+    check::<A>("stringLetterBitOrSixSwapped", (6f64).to_any() | string_any("a"), (6f64).to_any());
+    check::<A>("emptyArrayBitOrSix", Array::default().to_any() | (6f64).to_any(), (6f64).to_any());
+    check::<A>("emptyArrayBitOrSixSwapped", (6f64).to_any() | Array::default().to_any(), (6f64).to_any());
+    check::<A>("arrayTenBitOrSix", [(10f64).to_any()].to_array().to_any() | (6f64).to_any(), (14f64).to_any());
+    check::<A>("arrayTenBitOrSixSwapped", (6f64).to_any() | [(10f64).to_any()].to_array().to_any(), (14f64).to_any());
+    check::<A>("arrayStringTenBitOrSix", [string_any("10")].to_array().to_any() | (6f64).to_any(), (14f64).to_any());
+    check::<A>("arrayStringTenBitOrSixSwapped", (6f64).to_any() | [string_any("10")].to_array().to_any(), (14f64).to_any());
+    check::<A>("arrayPairBitOrSix", [(0f64).to_any(), (0f64).to_any()].to_array().to_any() | (6f64).to_any(), (6f64).to_any());
+    check::<A>("arrayPairBitOrSixSwapped", (6f64).to_any() | [(0f64).to_any(), (0f64).to_any()].to_array().to_any(), (6f64).to_any());
+    check::<A>("emptyObjectBitOrSix", Object::default().to_any() | (6f64).to_any(), (6f64).to_any());
+    check::<A>("emptyObjectBitOrSixSwapped", (6f64).to_any() | Object::default().to_any(), (6f64).to_any());
+    check::<A>("functionBitOrSix", function_any() | (6f64).to_any(), (6f64).to_any());
+    check::<A>("functionBitOrSixSwapped", (6f64).to_any() | function_any(), (6f64).to_any());
+    check::<A>("truncatesTowardZero", (3.9f64).to_any() | (6f64).to_any(), (7f64).to_any());
+    check::<A>("truncatesTowardZeroSwapped", (6f64).to_any() | (3.9f64).to_any(), (7f64).to_any());
+    check::<A>("negativeTruncatesTowardZero", (-3.9f64).to_any() | (6f64).to_any(), (-1f64).to_any());
+    check::<A>("negativeTruncatesTowardZeroSwapped", (6f64).to_any() | (-3.9f64).to_any(), (-1f64).to_any());
+    check::<A>("nanBitOrSix", (f64::NAN).to_any() | (6f64).to_any(), (6f64).to_any());
+    check::<A>("nanBitOrSixSwapped", (6f64).to_any() | (f64::NAN).to_any(), (6f64).to_any());
+    check::<A>("infinityBitOrSix", (f64::INFINITY).to_any() | (6f64).to_any(), (6f64).to_any());
+    check::<A>("infinityBitOrSixSwapped", (6f64).to_any() | (f64::INFINITY).to_any(), (6f64).to_any());
+    check::<A>("negativeInfinityBitOrSix", (f64::NEG_INFINITY).to_any() | (6f64).to_any(), (6f64).to_any());
+    check::<A>("negativeInfinityBitOrSixSwapped", (6f64).to_any() | (f64::NEG_INFINITY).to_any(), (6f64).to_any());
+    check::<A>("wrapsAt32Bits", (4294967301f64).to_any() | (6f64).to_any(), (7f64).to_any());
+    check::<A>("wrapsAt32BitsSwapped", (6f64).to_any() | (4294967301f64).to_any(), (7f64).to_any());
+    check::<A>("negativeOneBitOrSix", (-1f64).to_any() | (6f64).to_any(), (-1f64).to_any());
+    check::<A>("negativeOneBitOrSixSwapped", (6f64).to_any() | (-1f64).to_any(), (-1f64).to_any());
+    check::<A>("bigTwelveBitOrTen", bigint_any(12) | bigint_any(10), bigint_any(14));
+    check::<A>("bigTwelveBitOrTenSwapped", bigint_any(10) | bigint_any(12), bigint_any(14));
+    check::<A>("bigNegativeTwoBitOrNegativeThree", bigint_any(-2) | bigint_any(-3), bigint_any(-1));
+    check::<A>("bigNegativeTwoBitOrNegativeThreeSwapped", bigint_any(-3) | bigint_any(-2), bigint_any(-1));
+    check::<A>("bigFiveBitOrNegativeOne", bigint_any(5) | bigint_any(-1), bigint_any(-1));
+    check::<A>("bigFiveBitOrNegativeOneSwapped", bigint_any(-1) | bigint_any(5), bigint_any(-1));
+    check::<A>("bigZeroBitOrZero", bigint_any(0) | bigint_any(0), bigint_any(0));
+    check::<A>("bigZeroBitOrZeroSwapped", bigint_any(0) | bigint_any(0), bigint_any(0));
+    check::<A>("bigPositiveBitOrZero", bigint_any(12345) | bigint_any(0), bigint_any(12345));
+    check::<A>("bigPositiveBitOrZeroSwapped", bigint_any(0) | bigint_any(12345), bigint_any(12345));
+    check::<A>("bigNegativeBitOrZero", bigint_any(-12345) | bigint_any(0), bigint_any(-12345));
+    check::<A>("bigNegativeBitOrZeroSwapped", bigint_any(0) | bigint_any(-12345), bigint_any(-12345));
+    check::<A>("bigLargeMagnitude", bigint_any(-4611686018427387904) | bigint_any(-1), bigint_any(-1));
+    check::<A>("bigLargeMagnitudeSwapped", bigint_any(-1) | bigint_any(-4611686018427387904), bigint_any(-1));
+    check_throws::<A>("numberBitOrBigint", (1f64).to_any() | bigint_any(1));
+    check_throws::<A>("numberBitOrBigintSwapped", bigint_any(1) | (1f64).to_any());
+}
+
+#[rustfmt::skip]
+fn bitxor<A: IVm>() {
+    check::<A>("nullBitXorSix", Nullish::Null.to_any() ^ (6f64).to_any(), (6f64).to_any());
+    check::<A>("nullBitXorSixSwapped", (6f64).to_any() ^ Nullish::Null.to_any(), (6f64).to_any());
+    check::<A>("undefinedBitXorSix", Nullish::Undefined.to_any() ^ (6f64).to_any(), (6f64).to_any());
+    check::<A>("undefinedBitXorSixSwapped", (6f64).to_any() ^ Nullish::Undefined.to_any(), (6f64).to_any());
+    check::<A>("trueBitXorSix", true.to_any() ^ (6f64).to_any(), (7f64).to_any());
+    check::<A>("trueBitXorSixSwapped", (6f64).to_any() ^ true.to_any(), (7f64).to_any());
+    check::<A>("falseBitXorSix", false.to_any() ^ (6f64).to_any(), (6f64).to_any());
+    check::<A>("falseBitXorSixSwapped", (6f64).to_any() ^ false.to_any(), (6f64).to_any());
+    check::<A>("stringTenBitXorSix", string_any("10") ^ (6f64).to_any(), (12f64).to_any());
+    check::<A>("stringTenBitXorSixSwapped", (6f64).to_any() ^ string_any("10"), (12f64).to_any());
+    check::<A>("stringLetterBitXorSix", string_any("a") ^ (6f64).to_any(), (6f64).to_any());
+    check::<A>("stringLetterBitXorSixSwapped", (6f64).to_any() ^ string_any("a"), (6f64).to_any());
+    check::<A>("emptyArrayBitXorSix", Array::default().to_any() ^ (6f64).to_any(), (6f64).to_any());
+    check::<A>("emptyArrayBitXorSixSwapped", (6f64).to_any() ^ Array::default().to_any(), (6f64).to_any());
+    check::<A>("arrayTenBitXorSix", [(10f64).to_any()].to_array().to_any() ^ (6f64).to_any(), (12f64).to_any());
+    check::<A>("arrayTenBitXorSixSwapped", (6f64).to_any() ^ [(10f64).to_any()].to_array().to_any(), (12f64).to_any());
+    check::<A>("arrayStringTenBitXorSix", [string_any("10")].to_array().to_any() ^ (6f64).to_any(), (12f64).to_any());
+    check::<A>("arrayStringTenBitXorSixSwapped", (6f64).to_any() ^ [string_any("10")].to_array().to_any(), (12f64).to_any());
+    check::<A>("arrayPairBitXorSix", [(0f64).to_any(), (0f64).to_any()].to_array().to_any() ^ (6f64).to_any(), (6f64).to_any());
+    check::<A>("arrayPairBitXorSixSwapped", (6f64).to_any() ^ [(0f64).to_any(), (0f64).to_any()].to_array().to_any(), (6f64).to_any());
+    check::<A>("emptyObjectBitXorSix", Object::default().to_any() ^ (6f64).to_any(), (6f64).to_any());
+    check::<A>("emptyObjectBitXorSixSwapped", (6f64).to_any() ^ Object::default().to_any(), (6f64).to_any());
+    check::<A>("functionBitXorSix", function_any() ^ (6f64).to_any(), (6f64).to_any());
+    check::<A>("functionBitXorSixSwapped", (6f64).to_any() ^ function_any(), (6f64).to_any());
+    check::<A>("truncatesTowardZero", (3.9f64).to_any() ^ (6f64).to_any(), (5f64).to_any());
+    check::<A>("truncatesTowardZeroSwapped", (6f64).to_any() ^ (3.9f64).to_any(), (5f64).to_any());
+    check::<A>("negativeTruncatesTowardZero", (-3.9f64).to_any() ^ (6f64).to_any(), (-5f64).to_any());
+    check::<A>("negativeTruncatesTowardZeroSwapped", (6f64).to_any() ^ (-3.9f64).to_any(), (-5f64).to_any());
+    check::<A>("nanBitXorSix", (f64::NAN).to_any() ^ (6f64).to_any(), (6f64).to_any());
+    check::<A>("nanBitXorSixSwapped", (6f64).to_any() ^ (f64::NAN).to_any(), (6f64).to_any());
+    check::<A>("infinityBitXorSix", (f64::INFINITY).to_any() ^ (6f64).to_any(), (6f64).to_any());
+    check::<A>("infinityBitXorSixSwapped", (6f64).to_any() ^ (f64::INFINITY).to_any(), (6f64).to_any());
+    check::<A>("negativeInfinityBitXorSix", (f64::NEG_INFINITY).to_any() ^ (6f64).to_any(), (6f64).to_any());
+    check::<A>("negativeInfinityBitXorSixSwapped", (6f64).to_any() ^ (f64::NEG_INFINITY).to_any(), (6f64).to_any());
+    check::<A>("wrapsAt32Bits", (4294967301f64).to_any() ^ (6f64).to_any(), (3f64).to_any());
+    check::<A>("wrapsAt32BitsSwapped", (6f64).to_any() ^ (4294967301f64).to_any(), (3f64).to_any());
+    check::<A>("negativeOneBitXorSix", (-1f64).to_any() ^ (6f64).to_any(), (-7f64).to_any());
+    check::<A>("negativeOneBitXorSixSwapped", (6f64).to_any() ^ (-1f64).to_any(), (-7f64).to_any());
+    check::<A>("bigTwelveBitXorTen", bigint_any(12) ^ bigint_any(10), bigint_any(6));
+    check::<A>("bigTwelveBitXorTenSwapped", bigint_any(10) ^ bigint_any(12), bigint_any(6));
+    check::<A>("bigNegativeOneBitXorNegativeOne", bigint_any(-1) ^ bigint_any(-1), bigint_any(0));
+    check::<A>("bigNegativeOneBitXorNegativeOneSwapped", bigint_any(-1) ^ bigint_any(-1), bigint_any(0));
+    check::<A>("bigNegativeTwoBitXorNegativeThree", bigint_any(-2) ^ bigint_any(-3), bigint_any(3));
+    check::<A>("bigNegativeTwoBitXorNegativeThreeSwapped", bigint_any(-3) ^ bigint_any(-2), bigint_any(3));
+    check::<A>("bigFiveBitXorNegativeOne", bigint_any(5) ^ bigint_any(-1), bigint_any(-6));
+    check::<A>("bigFiveBitXorNegativeOneSwapped", bigint_any(-1) ^ bigint_any(5), bigint_any(-6));
+    check::<A>("bigZeroBitXorZero", bigint_any(0) ^ bigint_any(0), bigint_any(0));
+    check::<A>("bigZeroBitXorZeroSwapped", bigint_any(0) ^ bigint_any(0), bigint_any(0));
+    check::<A>("bigPositiveBitXorZero", bigint_any(12345) ^ bigint_any(0), bigint_any(12345));
+    check::<A>("bigPositiveBitXorZeroSwapped", bigint_any(0) ^ bigint_any(12345), bigint_any(12345));
+    check::<A>("bigNegativeBitXorZero", bigint_any(-12345) ^ bigint_any(0), bigint_any(-12345));
+    check::<A>("bigNegativeBitXorZeroSwapped", bigint_any(0) ^ bigint_any(-12345), bigint_any(-12345));
+    check::<A>("bigLargeMagnitude", bigint_any(-4611686018427387904) ^ bigint_any(-1), bigint_any(4611686018427387903));
+    check::<A>("bigLargeMagnitudeSwapped", bigint_any(-1) ^ bigint_any(-4611686018427387904), bigint_any(4611686018427387903));
+    check_throws::<A>("numberBitXorBigint", (1f64).to_any() ^ bigint_any(1));
+    check_throws::<A>("numberBitXorBigintSwapped", bigint_any(1) ^ (1f64).to_any());
 }
 
 #[rustfmt::skip]
@@ -734,12 +940,16 @@ pub fn all<A: IVm>() {
     eq::<A>();
     unary_plus::<A>();
     neg::<A>();
+    bitwise_not::<A>();
     mul::<A>();
     div::<A>();
     pow::<A>();
     sub::<A>();
     add::<A>();
     rem::<A>();
+    bitand::<A>();
+    bitor::<A>();
+    bitxor::<A>();
     lt::<A>();
     le::<A>();
     gt::<A>();


### PR DESCRIPTION
## Summary

Stage 3a of the `nanvm-lib` JS operator rollout (after `!`/`&&`/`||`/`??`/`?:` in #1867 and `typeof` in #1868): implements the bitwise operators `&`, `|`, `^`, `~`.

- **BigInt `&`/`|`/`^`** ([`bigint/bitand.rs`](../blob/claude/nanvm-lib-bitwise-ops/nanvm-lib/src/vm/bigint/bitand.rs), `bitor.rs`, `bitxor.rs`): decode both operands to same-length two's-complement word patterns, apply the word-level op, then re-encode sign and magnitude via the shared `bitwise_op`/`twos_complement_words`/`magnitude_from_twos_complement` helpers added to `bigint/mod.rs`. Covers the edge case where decoding a negative result carries a brand-new word into existence.
- **Number `&`/`|`/`^`**: apply `ToInt32` (new [`int32_coercion.rs`](../blob/claude/nanvm-lib-bitwise-ops/nanvm-lib/src/vm/int32_coercion.rs)) to each side before the native Rust op.
- **`~`**: needs no new BigInt algorithm — `-x - 1` is the exact spec identity, reusing the existing `Neg`/`Sub` impls. For `Number`, `ToInt32` then bitwise-negate.
- **`Any<A>`**: gains `BitAnd`/`BitOr`/`BitXor` (`any/bitand.rs`, `any/bitor.rs`, `any/bitxor.rs`) and a `bitwise_not()` method — `Not` is already claimed by logical `!`.
- Corpus cases, the JS proof, and the Rust printer are wired in `fjs/nanvm/`, and `nanvm-lib/tests/test/generated.rs` is regenerated (`npm run gen`).
- `nanvm-lib/README.md`'s operator table updated.

## Test plan

- [x] `cargo test` (nanvm-lib, including generated corpus tests + new BigInt/int32 unit tests)
- [x] `cargo clippy --lib -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `tsc`
- [x] `node ./fjs/module.mjs t` (full fjs test suite, 4408/4408 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016r91tf9sadPY8kgPXwfRu9

---
_Generated by [Claude Code](https://claude.ai/code/session_016r91tf9sadPY8kgPXwfRu9)_