### PR TITLE
docs: add REVIEWING.md, the reviewer's side of REVIEW.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,11 +65,15 @@ actually touches its subject.
 
 ## 1. Workflow
 
-Find or file the issue in `todo/` first, next to the code it describes; for
-anything non-trivial make sure it contains a concrete design before writing
-code. Deviating from that design later is fine; deviating silently is not, and
-a design that cannot be built as written is rewritten rather than forced
-through ([DESIGN.md §3](./doc/DESIGN.md#3-design-before-implementation)). Write the
+Check `todo/` for existing work before starting, and file an issue there, next
+to the code it describes, when the work is worth tracking — a problem statement
+is enough. A design is not a gate: it grows one pull request at a time — an
+underspecified `todo/`, then details and ideas, then an implementation — and
+none of them waits on the document being complete. What every step owes is
+direction and consistency: a `todo/` that contradicts the code or another
+`todo/` is corrected, not built on, and deviating from a design is fine where
+deviating silently is not
+([DESIGN.md §3](./doc/DESIGN.md#3-design-before-implementation)). Write the
 code plus its proof, run `npm run gen` after changing source, run the check
 set above, and delete the `todo/` issue file in the same PR that fixes it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,9 +65,8 @@ actually touches its subject.
 
 ## 1. Workflow
 
-Check `todo/` for existing work before starting, and file an issue there, next
-to the code it describes, when the work is worth tracking — a problem statement
-is enough. A design is not a gate: it grows one pull request at a time — an
+File an issue in `todo/`, next to the code it describes, when the work is worth
+tracking — a problem statement is enough. A design is not a gate: it grows one pull request at a time — an
 underspecified `todo/`, then details and ideas, then an implementation — and
 none of them waits on the document being complete. What every step owes is
 direction and consistency: a `todo/` that contradicts the code or another
@@ -75,7 +74,7 @@ direction and consistency: a `todo/` that contradicts the code or another
 deviating silently is not
 ([DESIGN.md §3](./doc/DESIGN.md#3-design-before-implementation)). Write the
 code plus its proof, run `npm run gen` after changing source, run the check
-set above, and delete the `todo/` issue file in the same PR that fixes it.
+set above, and delete the `todo/` issue file the PR fixes, if there is one.
 
 Format, priorities, where each issue file belongs, and how GitHub-reported bugs
 become `todo/` files: [todo/README.md](./todo/README.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,8 @@ unsupported input is refused, never answered with a plausible wrong value
 ([DESIGN.md §10](./doc/DESIGN.md#10-refuse-what-you-cannot-handle)).
 
 Which comments to fix, which to push back on, and what a push-back leaves
-behind: [REVIEW.md](./doc/REVIEW.md).
+behind: [REVIEW.md](./doc/REVIEW.md). What to raise when reviewing, what to ask
+for, and when to approve: [REVIEWING.md](./doc/REVIEWING.md).
 Commit-message format and the PR checklist:
 [CONTRIBUTING.md](./CONTRIBUTING.md#opening-a-pull-request).
 Changelog entry rules, breaking changes, and versioning:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,7 @@ real Nix — see [`nix/README.md`](./nix/README.md).
 
 A pull request implements only one feature or improvement, with minimal code
 changes. Before submitting, ensure every check above passes and delete the
-`todo/` issue file in the same pull request. It adds **no changelog file**: the
+`todo/` issue file it fixes, if there is one. It adds **no changelog file**: the
 changelog is written once per release from the pull requests that shipped in it
 ([changelog/RELEASE.md](./changelog/RELEASE.md)). What a pull request owes
 instead is a declaration in its description, below. The everyday workflow around

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@ repository-wide design principles are in [DESIGN.md](./doc/DESIGN.md), the
 FunctionalScript and TypeScript rules in [fjs/AGENTS.md](./fjs/AGENTS.md), the
 Rust ones in [nanvm-lib/AGENTS.md](./nanvm-lib/AGENTS.md), and what to do with
 the comments a review leaves on your pull request in
-[REVIEW.md](./doc/REVIEW.md). This file covers getting a working environment and
+[REVIEW.md](./doc/REVIEW.md), and how to review someone else's in
+[REVIEWING.md](./doc/REVIEWING.md). This file covers getting a working environment and
 opening a pull request; every document links to the others rather than
 restating them, so they cannot drift apart.
 
@@ -260,6 +261,7 @@ messages are not working notes: write each one for a reader who meets it on
 
 Once the pull request is open, which comments to fix, which to push back on,
 and what a push-back has to leave behind: [REVIEW.md](./doc/REVIEW.md).
+Reviewing someone else's pull request: [REVIEWING.md](./doc/REVIEWING.md).
 
 ## OpenAI Codex environment
 

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -346,7 +346,10 @@ input, and crashing there is better than continuing: the caller was supposed to
 have validated, and a program that goes on past a broken assumption produces
 the silent corruption this section exists to prevent. So a `try*` belongs at
 the boundary, and an assert is the right answer inside it — an asserting API is
-not unusable, it is used after prevalidation.
+not unusable, it is used after prevalidation. That is not a reason to assert
+everything: an assert guards an assumption the code would otherwise answer
+wrongly on, and one that guards nothing the code relies on is noise
+([§9](#9-maximize-signal-to-noise)).
 
 A documented implementation limit ([§1](#1-simplicity-first)) is acceptable only
 under this rule: the limit has to be enforced where it is crossed. "Handles up

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -73,8 +73,9 @@ on top of the weaker design.
 
 ## 3. Design before implementation
 
-- A non-trivial feature's design lives in its `todo/` issue, and the issue may
-  be as thin as a problem statement. The design is not a gate: it grows through
+- Design before implementation is an order of work, not a gate. A non-trivial
+  feature's design lives in its `todo/` issue, and the issue may be as thin as
+  a problem statement. The design grows through
   pull requests — an underspecified issue, then details and ideas, then an
   implementation, with a prototype wherever nobody yet knows — and none of them
   waits on the document being complete. What it owes is direction and

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -65,18 +65,21 @@ same change; the work isn't done until that issue is deleted.
 
 **If you see a way to improve an API — or a new API that would make consuming
 modules simpler and more readable — propose it as soon as you notice it.** Don't
-defer or silently work around it. File a `todo/` issue with a concrete design
-(see [todo/README.md](../todo/README.md)) so it can be reviewed promptly; if the
+defer or silently work around it. File a `todo/` issue — a problem statement
+is enough to start, the design can grow later
+(see [todo/README.md](../todo/README.md)) — so it can be reviewed promptly; if the
 improvement is in scope for what you're already doing, raise it before building
 on top of the weaker design.
 
 ## 3. Design before implementation
 
-- Before implementing a non-trivial feature, ensure the corresponding issue
-  document in `todo/` contains a concrete design. If the issue exists but the
-  design is absent, vague, or contradicts the codebase or runtime behavior,
-  update the issue first and wait for review — do not write code against an
-  incomplete or incorrect design.
+- A non-trivial feature's design lives in its `todo/` issue, and the issue may
+  be as thin as a problem statement. The design is not a gate: it grows through
+  pull requests — an underspecified issue, then details and ideas, then an
+  implementation, with a prototype wherever nobody yet knows — and none of them
+  waits on the document being complete. What it owes is direction and
+  consistency: a design that contradicts the codebase, the runtime, or another
+  issue is corrected rather than built on.
 - When a discrepancy is found between an issue's design and reality (a missing
   API, a wrong environment variable, an incompatible type), correct the design
   document and surface the problem rather than silently working around it.

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -339,6 +339,15 @@ There are two ways to refuse, and the choice between them is the one drawn in
   supposed to guarantee, so there is nothing sensible for it to do with a
   `null` anyway.
 
+Where the line falls follows from where validation happens. A value is
+validated once, where it enters from IO — a file, a socket, a command line —
+and is trusted from then on. Inside, an assert that fires means a bug, not a bad
+input, and crashing there is better than continuing: the caller was supposed to
+have validated, and a program that goes on past a broken assumption produces
+the silent corruption this section exists to prevent. So a `try*` belongs at
+the boundary, and an assert is the right answer inside it — an asserting API is
+not unusable, it is used after prevalidation.
+
 A documented implementation limit ([§1](#1-simplicity-first)) is acceptable only
 under this rule: the limit has to be enforced where it is crossed. "Handles up
 to 128 KB" is a limit when the 129th kilobyte is refused, and a latent

--- a/doc/REVIEW.md
+++ b/doc/REVIEW.md
@@ -18,6 +18,7 @@ is wrong: it is the one place the answer will not survive.
 | One case is generalized into a rule | Answer with the case that breaks it, and record what the decision depends on |
 | A defect is reported | Fix it, or defer it behind a `todo/` naming the input that breaks it |
 | A corner case is raised | File a `todo/` naming the input, and reply with the link — not a fix. If the case answers wrong, refuse it first: that is silence |
+| A bot finds "fresh evidence" in your last fix | After the second round: a `todo/` or an answer, not a push — unless it [blocks](./REVIEWING.md#what-to-raise) |
 | A tighter type is asked for on a valid input | Keep the type simple: depth is a budget ([REVIEWING.md](./REVIEWING.md#type-level-computation)); a `todo/` if the check is wanted |
 
 A pull request implements one feature, so "while you're here" is a second one.

--- a/doc/REVIEW.md
+++ b/doc/REVIEW.md
@@ -2,7 +2,7 @@
 
 For the author of a pull request under review. Opening one is
 [CONTRIBUTING.md](../CONTRIBUTING.md#opening-a-pull-request); the principles are
-[DESIGN.md](./DESIGN.md).
+[DESIGN.md](./DESIGN.md); the reviewer's side is [REVIEWING.md](./REVIEWING.md).
 
 **Merge the knowledge.** A small step merged with what was learned written down
 beats two hundred iterations of a pull request that never lands. Most comments
@@ -17,6 +17,7 @@ is wrong: it is the one place the answer will not survive.
 | An implementation is asked for another feature | Find or file a `todo/`, and reply with the link |
 | One case is generalized into a rule | Answer with the case that breaks it, and record what the decision depends on |
 | A defect is reported | Fix it, or defer it behind a `todo/` naming the input that breaks it |
+| A corner case is raised | File a `todo/` naming the input, and reply with the link — not a fix |
 
 A pull request implements one feature, so "while you're here" is a second one.
 And a rule generalized from one real case fails on the case the reviewer did not
@@ -58,8 +59,14 @@ that cannot read a file above 128 KB is a documented limit and a `todo/` — the
 only people who can hand it a file are the people who maintain it, no such file
 exists, and the day one does is the day the issue is picked up
 ([DESIGN.md §1](./DESIGN.md#1-simplicity-first)). A module in the published
-package is the opposite: the input belongs to someone we have never met, so it
-is fixed before it lands.
+package hands its input to someone we have never met: that raises the `todo/`'s
+priority and is the reason to refuse the input now (below) — it is not a reason
+to fix it in this pull request.
+
+A corner case — a case the change did not set out to handle, which no real
+input reaches today — is a `todo/` by default, not a fix. Whether it is needed
+is decided later, on its own; the alternative is a pull request that answers
+every "what if" and never lands.
 
 Never deferrable: a **regression**, and **silence**.
 

--- a/doc/REVIEW.md
+++ b/doc/REVIEW.md
@@ -70,7 +70,8 @@ input reaches today — is a `todo/` by default, not a fix. Whether it is needed
 is decided later, on its own; the alternative is a pull request that answers
 every "what if" and never lands.
 
-Never deferrable: a **regression**, and **silence**.
+Never deferrable: what [blocks](./REVIEWING.md#what-to-raise) — a
+**regression**, **silence**, an undeclared break, a broken code rule.
 
 ## Refusing loudly
 

--- a/doc/REVIEW.md
+++ b/doc/REVIEW.md
@@ -18,6 +18,7 @@ is wrong: it is the one place the answer will not survive.
 | One case is generalized into a rule | Answer with the case that breaks it, and record what the decision depends on |
 | A defect is reported | Fix it, or defer it behind a `todo/` naming the input that breaks it |
 | A corner case is raised | File a `todo/` naming the input, and reply with the link — not a fix |
+| A tighter type is asked for on a valid input | Keep the type simple: depth is a budget ([REVIEWING.md](./REVIEWING.md#type-level-computation)); a `todo/` if the check is wanted |
 
 A pull request implements one feature, so "while you're here" is a second one.
 And a rule generalized from one real case fails on the case the reviewer did not

--- a/doc/REVIEW.md
+++ b/doc/REVIEW.md
@@ -78,10 +78,10 @@ Never deferrable: what [blocks](./REVIEWING.md#what-to-raise) — a
 An unsupported input is refused, never answered with a plausible wrong value —
 **rejected** as a `try*` returning `Nullable<T>` where a caller may legitimately
 supply it, **panicked** on where it violates a precondition
-([DESIGN.md §10](./DESIGN.md#10-refuse-what-you-cannot-handle)). New code gets
-that right before it lands. A defect found late may be staged behind an assert,
-which stops the wrong answers today, as long as the `todo/` says the rejection
-is what it still owes. Refuse fast, file, then fix.
+([DESIGN.md §10](./DESIGN.md#10-refuse-what-you-cannot-handle)). An assert is
+the fast form of either, in new code or in a defect found late: it stops the
+wrong answers today, as long as the `todo/` says the rejection it still owes.
+Refuse fast, file, then fix.
 
 ## When it cannot land
 

--- a/doc/REVIEW.md
+++ b/doc/REVIEW.md
@@ -17,7 +17,7 @@ is wrong: it is the one place the answer will not survive.
 | An implementation is asked for another feature | Find or file a `todo/`, and reply with the link |
 | One case is generalized into a rule | Answer with the case that breaks it, and record what the decision depends on |
 | A defect is reported | Fix it, or defer it behind a `todo/` naming the input that breaks it |
-| A corner case is raised | File a `todo/` naming the input, and reply with the link — not a fix |
+| A corner case is raised | File a `todo/` naming the input, and reply with the link — not a fix. If the case answers wrong, refuse it first: that is silence |
 | A tighter type is asked for on a valid input | Keep the type simple: depth is a budget ([REVIEWING.md](./REVIEWING.md#type-level-computation)); a `todo/` if the check is wanted |
 
 A pull request implements one feature, so "while you're here" is a second one.
@@ -34,11 +34,11 @@ differs is what comes next.
 - **Overspecified.** The implementer is not bound by it. Deviating is fine,
   deviating silently is not: the reason goes into the document.
 - **Underspecified.** The next person adds what is missing, in a pull request
-  that need not implement anything — an increment like any other, and what
-  [DESIGN.md §3](./DESIGN.md#3-design-before-implementation) means by updating
-  the issue before writing code against it. Detail is missing where two
-  implementers working from the design would not produce the same observable
-  behavior and the same API.
+  that need not implement anything — an increment like any other
+  ([DESIGN.md §3](./DESIGN.md#3-design-before-implementation)). Nobody waits on
+  it: an implementation may land against a thin design and say what it
+  decided. Detail is missing where two implementers working from the design
+  would not produce the same observable behavior and the same API.
 
 Either way, prefer to land the design change and the implementation as separate
 pull requests ([DESIGN.md §3](./DESIGN.md#3-design-before-implementation)).

--- a/doc/REVIEWING.md
+++ b/doc/REVIEWING.md
@@ -40,8 +40,8 @@ finding with the rule as its link. "An implementer following this task builds
 against a module the proposal above it retired" is a finding. "This could be
 more precise" is not.
 
-**What blocks.** A regression, silence, an undeclared break, and a broken rule
-are fixed before approval. Everything else in this document is a `todo/` or an
+**What blocks.** A regression, silence, an undeclared break, and a broken code
+rule — the ones held by review, above — are fixed before approval. Everything else in this document is a `todo/` or an
 answer, and never a reason to hold the pull request.
 
 ## What to ask for

--- a/doc/REVIEWING.md
+++ b/doc/REVIEWING.md
@@ -44,7 +44,7 @@ more precise" is not.
 
 | You found | Ask for |
 | --------- | ------- |
-| A corner case the change does not handle | A `todo/` naming the input — not a fix |
+| A corner case the change does not handle | A `todo/` naming the input — not a fix. If the case answers wrong, the refusal first: that is silence |
 | A design that leaves a decision open | Nothing, unless two implementers would produce different observable behavior or API; then one sentence in the document, or a `todo/` |
 | A plan that prescribes no order or method | Nothing; that is deliberate |
 | An improvement that would be nice while here | A `todo/` |
@@ -71,6 +71,11 @@ answered every "settle X before stage 1" and "fix the order of Y" by removing
 a prescription rather than adding one: the stages are numbered for reference,
 not for order, and each open question is answered by whoever needs the answer,
 when they need it, where they make it.
+
+A pull request that only files a `todo/`, or only grows one, is a change like
+any other. Review it for direction and consistency, not for completeness: a
+problem statement with no proposal is a valid increment, and so is a proposal
+that leaves most of its decisions to the implementation.
 
 What a design review does check: the document does not contradict the code it
 describes — a path that does not exist, an importer that does not import — and

--- a/doc/REVIEWING.md
+++ b/doc/REVIEWING.md
@@ -46,6 +46,7 @@ retired" is a finding. "This could be more precise" is not.
 | An improvement that would be nice while here | A `todo/` |
 | A rule a tool already enforces (`tsc`, coverage, `clippy`, `fmt`) | Nothing; CI has it |
 | A "what if" nobody has asked for, untested | Nothing; a test for it is noise, not proof |
+| A type that could reject more at compile time | Nothing on an input the code already accepts; see [below](#type-level-computation) |
 
 A corner case is a case the change did not set out to handle and no real input
 reaches today. The answer is a `todo/`, and whether it is ever picked up is
@@ -72,6 +73,20 @@ describes — a path that does not exist, an importer that does not import — a
 it does not contradict itself — a task list still building what the proposal
 above it retired. Both are checked against the tree, not against what the
 reviewer expects the tree to hold.
+
+## Type-level computation
+
+TypeScript evaluates conditional and recursive types against a hard depth, and a
+type that walks a value's shape reaches it: `Ts<T>`, `parse` and `validate` in
+`fjs/rtti` all hit TS2589 and pay for it with fast paths, phantom annotations and
+boundary casts ([`fjs/rtti/ts/README.md`](../fjs/rtti/ts/README.md#the-problem-ts2589)).
+That depth is a budget the whole module shares. An additional type-level check
+on an input the code already accepts spends it and changes nothing observable —
+the runtime already refuses the invalid value, and the valid one was valid
+before — so do not ask for one. Ask for the simplest type that states the
+contract, an `Assert<Equal<…>>` in the proof where the inference matters
+([fjs/AGENTS.md §1.4](../fjs/AGENTS.md#14-assert-type-level-facts-with-assertequal)),
+and a `todo/` for anything tighter.
 
 ## Bots
 

--- a/doc/REVIEWING.md
+++ b/doc/REVIEWING.md
@@ -17,8 +17,8 @@ later, one `todo/` at a time.
 
 Four things are always worth a comment, because nothing else catches them:
 
-- **A regression.** Something that worked before the change and does not
-  after.
+- **A regression.** Something that worked before the change, was meant to
+  keep working, and does not after. A declared breaking change is not one.
 - **Silence.** An unsupported input answered with a plausible wrong value
   instead of a refusal
   ([DESIGN.md §10](./DESIGN.md#10-refuse-what-you-cannot-handle)). Ask for the
@@ -39,6 +39,10 @@ regular expressions, no file-scope `@typedef`
 finding with the rule as its link. "An implementer following this task builds
 against a module the proposal above it retired" is a finding. "This could be
 more precise" is not.
+
+**What blocks.** A regression, silence, an undeclared break, and a broken rule
+are fixed before approval. Everything else in this document is a `todo/` or an
+answer, and never a reason to hold the pull request.
 
 ## What to ask for
 
@@ -103,12 +107,12 @@ and a `todo/` for anything tighter.
 
 Bot reviews re-run on every push, and each round finds "fresh evidence" in the
 previous round's fix. A bot finding is a bug report: verify it, then treat it
-like any other — a regression, silence or an undeclared break is fixed, the
-rest is a `todo/` —
-answer it once when it names no real input, and leave it when the answer is
-already in a document or a `todo/`. A human reviewer forwards a bot
-finding only when they would have raised it themselves, and does not hold
-approval on an open bot thread.
+like any other — what [blocks](#what-to-raise) is fixed, the rest is a `todo/`
+or an answer, given once — and leave it when the answer is already in a
+document or a `todo/`. After the second round, a finding that does not block
+gets no push: a `todo/` or an answer, and the pull request lands. A human
+reviewer forwards a bot finding only when they would have raised it
+themselves, and does not hold approval on an open bot thread.
 
 ## Writing the comment
 
@@ -121,14 +125,12 @@ approval on an open bot thread.
 
 ## When to approve
 
-Approve when what remains is `todo/` work, or the answer is in a document. A
-regression, silence or an undeclared break is never `todo/` work
-([REVIEW.md](./REVIEW.md#deferring-a-defect)): those are fixed before approval.
-Open `todo/` files are not a reason to hold a pull request, and neither is a `todo/`
+Approve when what remains is `todo/` work, or the answer is in a document, and
+what [blocks](#what-to-raise) is fixed. Open `todo/` files are not a reason to hold a pull request, and neither is a `todo/`
 that says less than you would have written: the next person adds what is
 missing, in a pull request that need not implement anything
 ([REVIEW.md](./REVIEW.md#designs)).
 
 Two rounds is normal. A third round of design feedback on the same file means
 the review has become design work, and that belongs in a pull request of its
-own. A regression, silence or an undeclared break blocks in any round.
+own. What blocks, blocks in any round.

--- a/doc/REVIEWING.md
+++ b/doc/REVIEWING.md
@@ -89,10 +89,12 @@ TypeScript evaluates conditional and recursive types against a hard depth, and a
 type that walks a value's shape reaches it: `Ts<T>`, `parse` and `validate` in
 `fjs/rtti` all hit TS2589 and pay for it with fast paths, phantom annotations and
 boundary casts ([`fjs/rtti/ts/README.md`](../fjs/rtti/ts/README.md#the-problem-ts2589)).
-That depth is a budget the whole module shares. An additional type-level check
-on an input the code already accepts spends it and changes nothing observable —
-the runtime already refuses the invalid value, and the valid one was valid
-before — so do not ask for one. Ask for the simplest type that states the
+Every check added to a type that walks a value is one more step toward that
+depth, and a step spent on an input the code already accepts changes nothing
+observable — the runtime already refuses the invalid value, and the valid one
+was valid before — so do not ask for one; the simplest type that holds is the
+right one whether or not a walk is near the limit
+([DESIGN.md §1](./DESIGN.md#1-simplicity-first)). Ask for the simplest type that states the
 contract, an `Assert<Equal<…>>` in the proof where the inference matters
 ([fjs/AGENTS.md §1.4](../fjs/AGENTS.md#14-assert-type-level-facts-with-assertequal)),
 and a `todo/` for anything tighter.
@@ -100,9 +102,10 @@ and a `todo/` for anything tighter.
 ## Bots
 
 Bot reviews re-run on every push, and each round finds "fresh evidence" in the
-previous round's fix. A bot finding is a bug report: verify it, fix it when it
-names a real input, answer it once when it does not — and leave it when the
-answer is already in a document or a `todo/`. A human reviewer forwards a bot
+previous round's fix. A bot finding is a bug report: verify it, then treat it
+like any other — a regression or silence is fixed, the rest is a `todo/` —
+answer it once when it names no real input, and leave it when the answer is
+already in a document or a `todo/`. A human reviewer forwards a bot
 finding only when they would have raised it themselves, and does not hold
 approval on an open bot thread.
 
@@ -125,5 +128,6 @@ that says less than you would have written: the next person adds what is
 missing, in a pull request that need not implement anything
 ([REVIEW.md](./REVIEW.md#designs)).
 
-Two rounds is normal. A third round on the same file means the review has
-become design work, and that belongs in a pull request of its own.
+Two rounds is normal. A third round of design feedback on the same file means
+the review has become design work, and that belongs in a pull request of its
+own. A regression or silence blocks in any round.

--- a/doc/REVIEWING.md
+++ b/doc/REVIEWING.md
@@ -1,0 +1,103 @@
+# Reviewing a pull request
+
+For the reviewer of a pull request, human or bot. The author's side is
+[REVIEW.md](./REVIEW.md); the principles are [DESIGN.md](./DESIGN.md); what a
+pull request owes on arrival is
+[CONTRIBUTING.md](../CONTRIBUTING.md#opening-a-pull-request).
+
+**A review's job is to land the pull request** — small, simple, with what it
+taught written down. It is not to make the change complete, and not to complete
+the design the change builds on. A pull request that grows a fix for every case
+a reviewer can name stops converging, and everything it learned goes with it:
+the rule [REVIEW.md](./REVIEW.md#deferring-a-defect) gives the author, seen
+from the other chair. Deliver fast and simple; the corner cases are decided
+later, one `todo/` at a time.
+
+## What to raise
+
+Four things are always worth a comment, because nothing else catches them:
+
+- **A regression.** Something that worked before the change and does not
+  after.
+- **Silence.** An unsupported input answered with a plausible wrong value
+  instead of a refusal
+  ([DESIGN.md §10](./DESIGN.md#10-refuse-what-you-cannot-handle)). Ask for the
+  refusal — an assert is minutes of work — and a `todo/` for the rest.
+- **An undeclared breaking change.** Nothing derives one from a diff
+  ([CONTRIBUTING.md](../CONTRIBUTING.md#commit-messages)); the release reads the
+  declaration to pick a version number.
+- **A second feature.** A pull request implements one; the second is a
+  `todo/`. Whether an already-combined pull request is split is the
+  repository owner's call, and once made it is not reopened on a bot's finding
+  ([#1844](https://github.com/functionalscript/functionalscript/pull/1844)).
+
+Beyond those, a comment is worth writing when it names the input that breaks
+the code, or the sentence a reader would follow to a wrong place. "An
+implementer following this task builds against a module the proposal above it
+retired" is a finding. "This could be more precise" is not.
+
+## What to ask for
+
+| You found | Ask for |
+| --------- | ------- |
+| A corner case the change does not handle | A `todo/` naming the input — not a fix |
+| A design that leaves a decision open | Nothing, unless two implementers would produce different observable behavior or API; then one sentence in the document, or a `todo/` |
+| A plan that prescribes no order or method | Nothing; that is deliberate |
+| An improvement that would be nice while here | A `todo/` |
+| A rule a tool already enforces (`tsc`, coverage, `clippy`, `fmt`) | Nothing; CI has it |
+| A "what if" nobody has asked for, untested | Nothing; a test for it is noise, not proof |
+
+A corner case is a case the change did not set out to handle and no real input
+reaches today. The answer is a `todo/`, and whether it is ever picked up is
+decided later, on its own — not by the pull request that happened to be open
+when someone thought of it. A fix for what is not broken is code that has to be
+proved, read and kept, for a case that may never arrive
+([DESIGN.md §1](./DESIGN.md#1-simplicity-first)).
+
+## Designs and `todo/` files
+
+A design document is allowed to be incomplete. Detail is missing only where two
+implementers working from it would not produce the same observable behavior and
+the same API ([REVIEW.md](./REVIEW.md#designs)); everything else is the
+implementer's room, and a review that fills it is designing in the thread — the
+one place the answer will not survive. The migration plan in
+[#1870](https://github.com/functionalscript/functionalscript/pull/1870)
+answered every "settle X before stage 1" and "fix the order of Y" by removing
+a prescription rather than adding one: the stages are numbered for reference,
+not for order, and each open question is answered by whoever needs the answer,
+when they need it, where they make it.
+
+What a design review does check: the document does not contradict the code it
+describes — a path that does not exist, an importer that does not import — and
+it does not contradict itself — a task list still building what the proposal
+above it retired. Both are checked against the tree, not against what the
+reviewer expects the tree to hold.
+
+## Bots
+
+Bot reviews re-run on every push, and each round finds "fresh evidence" in the
+previous round's fix. A bot finding is a bug report: verify it, fix it when it
+names a real input, answer it once when it does not — and leave it when the
+answer is already in a document or a `todo/`. A human reviewer forwards a bot
+finding only when they would have raised it themselves, and does not hold
+approval on an open bot thread.
+
+## Writing the comment
+
+- Lead with the input that breaks it, or the rule it violates, with a link.
+- Say what resolves it — a fix, a `todo/`, or a sentence in the document. When
+  a `todo/` resolves it, say so, so the author does not guess that a fix was
+  wanted.
+- One comment per finding. On the next round, check whether it was answered
+  rather than restating it.
+
+## When to approve
+
+Approve when what remains is `todo/` work, or the answer is in a document. Open
+`todo/` files are not a reason to hold a pull request, and neither is a `todo/`
+that says less than you would have written: the next person adds what is
+missing, in a pull request that need not implement anything
+([REVIEW.md](./REVIEW.md#designs)).
+
+Two rounds is normal. A third round on the same file means the review has
+become design work, and that belongs in a pull request of its own.

--- a/doc/REVIEWING.md
+++ b/doc/REVIEWING.md
@@ -32,9 +32,13 @@ Four things are always worth a comment, because nothing else catches them:
   ([#1844](https://github.com/functionalscript/functionalscript/pull/1844)).
 
 Beyond those, a comment is worth writing when it names the input that breaks
-the code, or the sentence a reader would follow to a wrong place. "An
-implementer following this task builds against a module the proposal above it
-retired" is a finding. "This could be more precise" is not.
+the code, the rule the change breaks, or the sentence a reader would follow to
+a wrong place. The rules no tool enforces — immutability, no `try`/`catch`, no
+regular expressions, no file-scope `@typedef`
+([fjs/AGENTS.md](../fjs/AGENTS.md)) — are held by review, so a violation is a
+finding with the rule as its link. "An implementer following this task builds
+against a module the proposal above it retired" is a finding. "This could be
+more precise" is not.
 
 ## What to ask for
 
@@ -108,8 +112,10 @@ approval on an open bot thread.
 
 ## When to approve
 
-Approve when what remains is `todo/` work, or the answer is in a document. Open
-`todo/` files are not a reason to hold a pull request, and neither is a `todo/`
+Approve when what remains is `todo/` work, or the answer is in a document. A
+regression or silence is never `todo/` work
+([REVIEW.md](./REVIEW.md#deferring-a-defect)): those are fixed before approval.
+Open `todo/` files are not a reason to hold a pull request, and neither is a `todo/`
 that says less than you would have written: the next person adds what is
 missing, in a pull request that need not implement anything
 ([REVIEW.md](./REVIEW.md#designs)).

--- a/doc/REVIEWING.md
+++ b/doc/REVIEWING.md
@@ -103,7 +103,8 @@ and a `todo/` for anything tighter.
 
 Bot reviews re-run on every push, and each round finds "fresh evidence" in the
 previous round's fix. A bot finding is a bug report: verify it, then treat it
-like any other — a regression or silence is fixed, the rest is a `todo/` —
+like any other — a regression, silence or an undeclared break is fixed, the
+rest is a `todo/` —
 answer it once when it names no real input, and leave it when the answer is
 already in a document or a `todo/`. A human reviewer forwards a bot
 finding only when they would have raised it themselves, and does not hold
@@ -121,7 +122,7 @@ approval on an open bot thread.
 ## When to approve
 
 Approve when what remains is `todo/` work, or the answer is in a document. A
-regression or silence is never `todo/` work
+regression, silence or an undeclared break is never `todo/` work
 ([REVIEW.md](./REVIEW.md#deferring-a-defect)): those are fixed before approval.
 Open `todo/` files are not a reason to hold a pull request, and neither is a `todo/`
 that says less than you would have written: the next person adds what is
@@ -130,4 +131,4 @@ missing, in a pull request that need not implement anything
 
 Two rounds is normal. A third round of design feedback on the same file means
 the review has become design work, and that belongs in a pull request of its
-own. A regression or silence blocks in any round.
+own. A regression, silence or an undeclared break blocks in any round.


### PR DESCRIPTION
`REVIEW.md` tells the author which comments to fix and which to push back on. Nothing told the reviewer what to raise, what to ask for, and when to stop, so review rounds kept growing: every corner case became a fix request, every open decision in a design became a demand for detail, and bot reviews found "fresh evidence" in each round's fix.

`doc/REVIEWING.md` writes down what the last weeks of pull requests decided:

- Four things are always worth raising: a regression, silence, an undeclared breaking change, a second feature. Beyond those, a finding names the input that breaks the code, the rule the change breaks (the ones only review enforces), or the sentence that misleads a reader.
- A corner case the change did not set out to handle is a `todo/` naming the input, not a fix; one that answers wrong is silence and is refused first. Whether the rest is needed is decided later, on its own.
- A design may leave decisions open; a review fills a gap only where two implementers would diverge on observable behavior or API, and even then with one sentence or a `todo/`. Plans prescribe no order or method on purpose — the ebnf-migration plan in [#1870](https://github.com/functionalscript/functionalscript/pull/1870) answered every such finding by removing a prescription. A pull request that only files or grows a `todo/` is reviewed for direction and consistency, not completeness.
- Whether a combined pull request is split is the owner's call ([#1844](https://github.com/functionalscript/functionalscript/pull/1844)).
- Type-level computation is a depth budget: `Ts<T>`, `parse` and `validate` in `fjs/rtti` all hit TS2589. An additional compile-time check on an input the code already accepts spends it for no observable change, so a review does not ask for one.
- A bot finding is a bug report to verify, fix once when real, answer once when not, and leave when the answer is already written down.
- Approve when what remains is `todo/` work — a regression or silence never is; a third round on one file is design work for its own pull request.

**The design gate is relaxed.** `AGENTS.md` §1 and `DESIGN.md` §3 required a concrete design in `todo/` before any non-trivial code, and told the author to update the issue and wait for review otherwise. Read literally that blocks the work it was meant to guide — a review on this branch asked for a `todo/` to be filed and deleted in the branch history so a documentation change would carry "provenance". Both now say a `todo/` may be a problem statement and the design grows one pull request at a time: an underspecified issue, then details and ideas, then an implementation, with a prototype wherever nobody yet knows, none of them waiting on the document being complete. What every step owes is direction and consistency: a `todo/` that contradicts the code or another `todo/` is corrected, not built on, and deviating silently stays forbidden.

`REVIEW.md` gets the matching author-side lines: a corner case raised in review is a `todo/` by default, a published module's wider audience raises that todo's priority and justifies refusing the input now but is not a reason to fix it in the same pull request, a tighter type asked for on a valid input is declined the same way, and an implementation may land against a thin design and say what it decided. `AGENTS.md` §5 and `CONTRIBUTING.md` link the new file beside `REVIEW.md`.

Documentation only: nothing a generator reads changes, and no observable behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6Q7akeuRUu7Ytuo3m4X3H