### PR TITLE
todo: JSON's reader comes from a grammar; stage 3b is open, not blocked

### DIFF
--- a/fjs/bnf/todo/207-bnf-semantic-actions.md
+++ b/fjs/bnf/todo/207-bnf-semantic-actions.md
@@ -27,8 +27,14 @@ now has JSON's reader coming from a grammar. The reason is the module: that
 grammar runs over `fjs/ebnf/`, while `fjs/bnf` may still hold JSON and DataJS
 grammars only as proof-covered examples. This issue makes those examples produce
 values; it does not make them a codec. The capability it describes is the same
-one a codec needs, so the codec's version of it is being designed for `fjs/ebnf/`
-in [#1890](https://github.com/functionalscript/functionalscript/pull/1890).
+one a codec needs, and `fjs/ebnf/` already has it:
+[`fjs/ebnf/map`](../../ebnf/map/README.md) rewrites a rule's AST to values,
+keyed by the rules the author holds, and writing JSON's mapping over it is a
+task of [self-contained-tokenizer](../../media/json/todo/self-contained-tokenizer.md),
+not of any PR.
+[#1890](https://github.com/functionalscript/functionalscript/pull/1890) adds an
+optional metadata channel on top, which buys better errors than today's and
+cannot classify a parse failure.
 
 ### Proposal
 

--- a/fjs/bnf/todo/207-bnf-semantic-actions.md
+++ b/fjs/bnf/todo/207-bnf-semantic-actions.md
@@ -30,7 +30,8 @@ values; it does not make them a codec. The capability it describes is the same
 one a codec needs, and `fjs/ebnf/` already has it:
 [`fjs/ebnf/map`](../../ebnf/map/README.md) rewrites a rule's AST to values,
 keyed by the rules the author holds, and writing JSON's mapping over it is a
-task of [self-contained-tokenizer](../../media/json/todo/self-contained-tokenizer.md),
+task of
+[self-contained-tokenizer](../../media/json/todo/self-contained-tokenizer.md),
 not of any PR.
 [#1890](https://github.com/functionalscript/functionalscript/pull/1890) adds an
 optional metadata channel on top, which buys better errors than today's and

--- a/fjs/bnf/todo/207-bnf-semantic-actions.md
+++ b/fjs/bnf/todo/207-bnf-semantic-actions.md
@@ -20,12 +20,15 @@ value walks that tree afterwards, and each one writes the walk again:
 One cause: the AST is **mandatory**, **anonymous** (a node records the branch tag
 but not the rule that produced it), and **complete before anything else starts**.
 
-**Not in this list: `fjs/media/json`.** Its codec keeps a hand-written tokenizer
-and container-stack parser by decision —
+**Not in this list: `fjs/media/json`.** Not because its codec stays
+hand-written — that decision is withdrawn, and
 [parser-serializer-restructure](../../../todo/parser-serializer-restructure.md)
-settles that the media codecs take no runtime dependency on `fjs/bnf`. `fjs/bnf`
-may hold JSON and DataJS grammars only as proof-covered examples. This issue
-makes those examples produce values; it does not make them a codec.
+now has JSON's reader coming from a grammar. The reason is the module: that
+grammar runs over `fjs/ebnf/`, while `fjs/bnf` may still hold JSON and DataJS
+grammars only as proof-covered examples. This issue makes those examples produce
+values; it does not make them a codec. The capability it describes is the same
+one a codec needs, so the codec's version of it is being designed for `fjs/ebnf/`
+in [#1890](https://github.com/functionalscript/functionalscript/pull/1890).
 
 ### Proposal
 

--- a/fjs/bnf/todo/bnf-grammar-single-owner.md
+++ b/fjs/bnf/todo/bnf-grammar-single-owner.md
@@ -39,8 +39,8 @@ used to settle that the media codecs take **no runtime dependency** on a
 grammar module at all. **That rule is reversed**: JSON's and DataJS's readers
 will be grammars over `fjs/ebnf/` plus a mapping, which is that plan's stage 3b
 ([self-contained-tokenizer](../../media/json/todo/self-contained-tokenizer.md),
-rewritten around the reversal and blocked on
-[ebnf-migration](../../todo/ebnf-migration.md)).
+rewritten around the reversal; open, with
+[ebnf-migration](../../todo/ebnf-migration.md) related rather than blocking).
 
 What survives is the ban on a *classical* copy under `fjs/media/json`. `fjs/bnf`
 is the module being retired, so a second grammar there would recreate exactly
@@ -61,7 +61,7 @@ withdrawn** — the hand-written JSON scanner was implemented in full and
 reverted with
 [#1895](https://github.com/functionalscript/functionalscript/pull/1895), and
 [self-contained-tokenizer](../../media/json/todo/self-contained-tokenizer.md)
-is now written around a grammar instead. Until that unblocks, `fjs/bnf/lib/json`
+is now written around a grammar instead. Until that lands, `fjs/bnf/lib/json`
 stays an example rather than any codec's source, and the spec — not a shared
 module — is what keeps today's tokenizer and the BNF example in agreement.
 

--- a/fjs/bnf/todo/bnf-grammar-single-owner.md
+++ b/fjs/bnf/todo/bnf-grammar-single-owner.md
@@ -32,12 +32,21 @@ tokenizer is not pointed at any of it. None of that is alphabet work, but all of
 it is easier to land once the EBNF adapter has settled the names.
 
 **Do not create `fjs/media/json/grammar/module.f.mjs`.** That was this issue's
-original proposal and it is withdrawn.
+original proposal and it is withdrawn, and it stays withdrawn — but the reason
+has changed, and the old reason must not be quoted back.
 [parser-serializer-restructure](../../../todo/parser-serializer-restructure.md)
-settles that the media codecs take **no runtime dependency** on `fjs/bnf`: the
-canonical JSON grammar's owner is the spec text plus a proof-covered `fjs/bnf`
-example, not a runtime module under `fjs/media/json`. A module there would
-recreate exactly the duplication this issue existed to remove.
+used to settle that the media codecs take **no runtime dependency** on a
+grammar module at all. **That rule is reversed**: JSON's and DataJS's readers
+will be grammars over `fjs/ebnf/` plus a mapping, which is that plan's stage 3b
+([self-contained-tokenizer](../../media/json/todo/self-contained-tokenizer.md),
+rewritten around the reversal and blocked on
+[ebnf-migration](../../todo/ebnf-migration.md)).
+
+What survives is the ban on a *classical* copy under `fjs/media/json`. `fjs/bnf`
+is the module being retired, so a second grammar there would recreate exactly
+the duplication this issue existed to remove, and it would be written against
+the API that is going away. A runtime grammar belongs to `fjs/ebnf/` and arrives
+with stage 3b, not here.
 
 That is also why this file moved here from `fjs/media/json/todo/`. Everything it
 still describes — the two `fjs/bnf/lib` grammars and the `fjs/ebnf/unicode` API
@@ -45,11 +54,16 @@ their port moves them onto — lives under `fjs/bnf`, and it now rules out addin
 all under `fjs/media/json`, so a reader of the media codec's `todo/` would find
 nothing here to act on.
 
-That constraint is on the **media codecs**, and only them. Their scanners stay
-hand-written and take no runtime dependency on `fjs/bnf`
-([self-contained-tokenizer](../../media/json/todo/self-contained-tokenizer.md)
-covers the JSON one), so for those the spec — not a shared module — is what
-keeps them and the BNF example in agreement.
+That constraint is on the **media codecs**, and only them: no grammar of theirs
+under `fjs/bnf`. It is no longer a statement about how their scanners are
+written. This file used to say the media scanners stay hand-written; **that is
+withdrawn** — the hand-written JSON scanner was implemented in full and
+reverted with
+[#1895](https://github.com/functionalscript/functionalscript/pull/1895), and
+[self-contained-tokenizer](../../media/json/todo/self-contained-tokenizer.md)
+is now written around a grammar instead. Until that unblocks, `fjs/bnf/lib/json`
+stays an example rather than any codec's source, and the spec — not a shared
+module — is what keeps today's tokenizer and the BNF example in agreement.
 
 The compiler front end is the opposite case and keeps this issue's original
 task. `fjs/djs`'s tokenizer is already grammar-based
@@ -261,9 +275,11 @@ read them first:
   [`fjs/bnf/lib/datajs`](../lib/datajs/module.f.mjs) — the canonical
   grammars this task migrates.
 - [self-contained-tokenizer](../../media/json/todo/self-contained-tokenizer.md) — why the
-  **media** JSON scanner stays hand-written and takes no runtime dependency on
-  these grammars. It does not govern the compiler front end, whose tokenizer is
-  grammar-based and stays so.
+  **media** JSON reader takes no runtime dependency on *these* grammars: it will
+  be a grammar over `fjs/ebnf/`, not over the classical module being retired.
+  Its earlier hand-written design is withdrawn, so this file no longer rests on
+  the media scanner staying hand-written. It does not govern the compiler front
+  end, whose tokenizer is grammar-based and stays so.
 - [157](../../djs/todo/157-json-djs-shared-value-machine.md) — shares JSON/DJS
   value machinery; orthogonal to the lexical BNF grammar.
 - [group-fs-subdirectories-by-concern](../../todo/group-fs-subdirectories-by-concern.md)
@@ -271,8 +287,10 @@ read them first:
   placement is no longer one of its exports-map dependents.
 - [parser-serializer-restructure](../../../todo/parser-serializer-restructure.md)
   — the plan this task sits inside; its stage 2 deleted a third copy, and its BNF
-  rule (grammars are spec text plus proof-covered `fjs/bnf` examples, never a
-  runtime dependency of the **media codecs**) is what withdrew this issue's
-  original proposal. Its stage 5 renames the grammar-based front-end tokenizer
+  rule is what withdrew this issue's original proposal. That rule has since been
+  **partly reversed** there: a grammar module may now be a runtime dependency of
+  the media codecs, but it is `fjs/ebnf/`, and `fjs/bnf` grammars remain spec
+  text plus proof-covered examples. The withdrawal stands on the surviving half.
+  Its stage 5 renames the grammar-based front-end tokenizer
   into `fjs/fsc`, which is why this issue's tokenizer task survives with a new
   path rather than being withdrawn with the rest.

--- a/fjs/ebnf/lib/todo/widened-rule-signatures.md
+++ b/fjs/ebnf/lib/todo/widened-rule-signatures.md
@@ -66,3 +66,7 @@ the answer belongs in that issue as much as here.
   precision loss on two literals.
 - [`../datajs/module.f.mjs`](../datajs/module.f.mjs) — `statement`, the
   helper already fixed.
+- [self-contained-tokenizer](../../../media/json/todo/self-contained-tokenizer.md)
+  — stage 3b's JSON mapping keys on `value` and `string`, which `Checked`
+  refuses as annotated; the `value` row here is that stage's one prerequisite.
+  DataJS's `value` thunk is the same case.

--- a/fjs/ebnf/lib/todo/widened-rule-signatures.md
+++ b/fjs/ebnf/lib/todo/widened-rule-signatures.md
@@ -67,6 +67,7 @@ the answer belongs in that issue as much as here.
 - [`../datajs/module.f.mjs`](../datajs/module.f.mjs) — `statement`, the
   helper already fixed.
 - [self-contained-tokenizer](../../../media/json/todo/self-contained-tokenizer.md)
-  — stage 3b's JSON mapping keys on `value` and `string`, which `Checked`
-  refuses as annotated; the `value` row here is that stage's one prerequisite.
-  DataJS's `value` thunk is the same case.
+  — stage 3b's token mapping keys on `string`, which `Checked` refuses as
+  annotated; the `string` row here is that stage's one prerequisite. The
+  `value` row is stage 4's grammar route's, and DataJS's `value` thunk is the
+  same case.

--- a/fjs/ebnf/map/todo/stack-safe-rewrite.md
+++ b/fjs/ebnf/map/todo/stack-safe-rewrite.md
@@ -1,0 +1,73 @@
+## stack-safe-rewrite. The rewrite recurses per node, so nesting overflows it
+
+**Priority:** P2 — stage 3b of
+[parser-serializer-restructure](../../../../todo/parser-serializer-restructure.md)
+is P2 and its mapping cannot ship on top of this.
+**Status:** open
+
+### Problem
+
+`rewriteRule` in [`../module.f.mjs`](../module.f.mjs) rewrites a node by
+calling itself on each child — a tuple's elements, a variant's branch, a
+`const` thunk's payload, a repetition's rounds — before applying the node's
+own function. The JS call stack therefore grows with the **nesting depth of
+the input**, not with the grammar, which is exactly the shape
+[`../../ll1/module.f.mjs`](../../ll1/module.f.mjs) refuses for its matcher:
+that one loops over frames it keeps on the heap, "so a recursive matcher
+would overflow the JS stack on a few thousand nested brackets, where this
+one's stack grows on the heap."
+
+Measured over `[json, eof]`, with `json` from
+[`../../lib/json`](../../lib/json/module.f.mjs):
+
+| input | `fjs/ebnf/ll1` | `rewrite([])` on its tree | today's `fjs/media/json` |
+|---|---|---|---|
+| 1,000 nested arrays | ok | `RangeError: Maximum call stack size exceeded` | ok |
+| 5,000 nested arrays | ok | `RangeError` | ok — a proof requires it |
+| 6,000 nested arrays | ok | `RangeError` | ok |
+| 6,000 sibling `[]` | ok | ok | ok — a proof requires it |
+
+The empty map is the identity, so this is the walk itself, not any mapping.
+Siblings are fine because a repetition's rounds are mapped in a loop; only
+nesting recurses.
+
+The consequence is a contract break.
+[`../../../media/json/parser`](../../../media/json/parser/module.f.mjs)
+walks containers on its own heap stack and its proof
+([`proof.f.mjs`](../../../media/json/parser/proof.f.mjs), `siblingContainers`)
+pins 5,000 nested and 6,000 sibling containers as `ok`, after a regression that
+overflowed at that depth was fixed. A reader built on `rewrite` — the one
+stage 3b builds, and any DataJS reader that maps its grammar — throws on input
+the public `parse` accepts under a `Result` contract, whether the mapping
+builds values or tokens, since either walks the tree.
+
+### Proposal
+
+Walk the tree as `ll1` walks the input: one loop over an explicit stack of
+frames, each holding the rule, the node, and the children rewritten so far,
+applying the rule's function when its last child is done. Every assertion the
+recursive walk makes — arity, branch, symbol, bounds, a rule spelled twice —
+is made at the same point of the loop, so the refusals do not move. The
+signature and the types in [`../types.ts`](../types.ts) do not change; this is
+the walk only.
+
+### Tasks
+
+- [ ] The loop, replacing the mutual recursion of `rewriteRule`,
+      `dataChildren` and `thunkChildren`.
+- [ ] Proofs mirroring the parser's: 5,000 nested arrays and 6,000 sibling
+      containers rewritten by the empty map and by a value-building map, in
+      [`../proof.f.mjs`](../proof.f.mjs); the existing refusal proofs
+      unchanged.
+- [ ] `tsc`, `fjs test`.
+
+### Related
+
+- [`../../ll1/module.f.mjs`](../../ll1/module.f.mjs) — the heap-stack loop
+  this walk should mirror.
+- [`../../../media/json/parser/proof.f.mjs`](../../../media/json/parser/proof.f.mjs)
+  — the depth contract, and the regression note that explains it.
+- [self-contained-tokenizer](../../../media/json/todo/self-contained-tokenizer.md)
+  — stage 3b; this is one of its mapping's two prerequisites.
+- [parser-serializer](../../../media/datajs/todo/parser-serializer.md) — stage
+  4's grammar route has the same dependency.

--- a/fjs/ebnf/map/todo/stack-safe-rewrite.md
+++ b/fjs/ebnf/map/todo/stack-safe-rewrite.md
@@ -1,8 +1,10 @@
 ## stack-safe-rewrite. The rewrite recurses per node, so nesting overflows it
 
-**Priority:** P2 — stage 3b of
+**Priority:** P3 — a prerequisite of any reader that maps a nested grammar:
+the value route stage 3b of
 [parser-serializer-restructure](../../../../todo/parser-serializer-restructure.md)
-is P2 and its mapping cannot ship on top of this.
+declined, and stage 4's grammar route. Not of stage 3b's token-stream
+grammar, whose tree is flat.
 **Status:** open
 
 ### Problem
@@ -36,10 +38,12 @@ The consequence is a contract break.
 walks containers on its own heap stack and its proof
 ([`proof.f.mjs`](../../../media/json/parser/proof.f.mjs), `siblingContainers`)
 pins 5,000 nested and 6,000 sibling containers as `ok`, after a regression that
-overflowed at that depth was fixed. A reader built on `rewrite` — the one
-stage 3b builds, and any DataJS reader that maps its grammar — throws on input
-the public `parse` accepts under a `Result` contract, whether the mapping
-builds values or tokens, since either walks the tree.
+overflowed at that depth was fixed. A reader that maps a nested grammar — the
+value route stage 3b declined, or a DataJS reader that maps its grammar to
+values — throws on input the public `parse` accepts under a `Result` contract.
+A token-stream grammar's tree is flat and is not reached: 20,000 nested
+brackets lex to 40,000 tokens and rewrite without incident, which is how stage
+3b sidesteps this rather than depending on it.
 
 ### Proposal
 
@@ -68,6 +72,7 @@ the walk only.
 - [`../../../media/json/parser/proof.f.mjs`](../../../media/json/parser/proof.f.mjs)
   — the depth contract, and the regression note that explains it.
 - [self-contained-tokenizer](../../../media/json/todo/self-contained-tokenizer.md)
-  — stage 3b; this is one of its mapping's two prerequisites.
+  — stage 3b, which declined the value route partly for this; its token-stream
+  tree is flat, so this is related there, not a prerequisite.
 - [parser-serializer](../../../media/datajs/todo/parser-serializer.md) — stage
   4's grammar route has the same dependency.

--- a/fjs/media/datajs/todo/parser-serializer.md
+++ b/fjs/media/datajs/todo/parser-serializer.md
@@ -148,16 +148,19 @@ seam met from the other side, and it interacts with
 
 #### 2. Tokenizer
 
-Depends on stage 3b, and **the seam it depends on is answered in code.** Stage
-3b was to export `scanString` and `scanNumber`; that design is withdrawn, and
-JSON's reader comes from a grammar over `fjs/ebnf/` instead. What DataJS reuses
-is therefore JSON's *rules* rather than its functions, by ordinary import —
+Depends on stage 3b **on the token-machine route only**, and the seam it was
+to depend on is answered in code. Stage 3b was to export `scanString` and
+`scanNumber`; that design is withdrawn, and JSON's reader comes from a grammar
+over `fjs/ebnf/` instead. What DataJS reuses is therefore JSON's *rules*
+rather than its functions, by ordinary import —
 [`fjs/ebnf/lib/datajs`](../../../ebnf/lib/datajs/module.f.mjs) already does
 exactly that, and
 [self-contained-tokenizer](../../json/todo/self-contained-tokenizer.md) marks
-the question done. The table below states the requirement, which is unchanged.
-What is still open is §3's Layer 1: whether this codec runs that grammar or
-feeds a token machine.
+the question done — so the grammar route consumes nothing from stage 3b. The
+token-machine route does: its token-stream grammar extends JSON's and inherits
+the boundary resolution stage 3b owes. The table below states the requirement,
+which is unchanged on either. What is still open is §3's Layer 1: whether this
+codec runs that grammar or feeds a token machine.
 
 | Piece | Source |
 |---|---|
@@ -217,14 +220,22 @@ rather than widening it, and the four rows below become moot — with the same
 type prerequisite as JSON's mapping, since its `value` is a widened `Thunk`
 that `Checked` refuses as a key until
 [widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md)
-gives it a recursive type, and with two contracts stage 3b measured and took
-the token route to keep: `rewrite` recurses per node and overflows at 1,000
-nested arrays where JSON's parser is proven at 5,000
-([stack-safe-rewrite](../../../ebnf/map/todo/stack-safe-rewrite.md)), and a
-mapping straight to values loses the exact number lexeme, which here is what
-tells `1n` from `1`. Mapped only to a token stream, every row still stands as
-written, and both contracts are kept by construction — a token-stream
-grammar's tree is flat, which is how 3b sidesteps the first.
+gives it a recursive type; with the alphabet stage 3b settled, **UTF-16 code
+units** — over the `ll1` proofs' `stringToCodePointList`, `[dataJs, eof]`
+throws `['not a symbol', 16, …]` on `export default "\ud800";`, where over
+`stringToList` it accepts it, and the corpus requires that document to read
+as the one-unit string; and with one contract stage 3b measured that this
+route has to keep through the mapping: depth, since `rewrite` recurses per
+node and overflows at 1,000 nested arrays where JSON's parser is proven at
+5,000 ([stack-safe-rewrite](../../../ebnf/map/todo/stack-safe-rewrite.md)).
+The numeric contract it keeps on its own: `1` and `1n` parse to distinct
+branches, `optionFloatSuffix` and `n`, with every digit retained, so a mapping
+picks `Number` or `BigInt` from the branch before it discards the spelling.
+Nothing here needs JSON's `NumberPolicy` seam, which exists for two codecs
+over one grammar where this format has one numeric domain. Mapped only to a
+token stream, every row still stands as written; a token-stream grammar's
+tree is flat, which is how 3b sidesteps the depth contract rather than
+keeping it.
 
 The two routes are not variants of one design, and picking wrong wastes the
 prerequisite work. See stage 4 in
@@ -458,9 +469,12 @@ the spec judges them independently and this module provides all three.
       unchanged.
 - [ ] `fjs/media/datajs/types.ts` and `README.md`.
 - [ ] Tokenizer. On the grammar route this is `fjs/ebnf/lib/datajs` composed
-      with `eof`, since it is a prefix rule, and it already reuses JSON's rules
-      by import; on the token-machine route, a token-stream grammar extending
-      JSON's — not the exported scanners the withdrawn design promised.
+      with `eof`, since it is a prefix rule, run over **UTF-16 code units**,
+      since the corpus's lone surrogates throw under the code-point decoding
+      the `ll1` proofs use, and it already reuses JSON's rules by import; on
+      the token-machine route, a token-stream grammar extending JSON's, over
+      the same units — not the exported scanners the withdrawn design
+      promised.
 - [ ] Statement layer: environment, bound-once, declare-before-use.
 - [ ] Key policy: accept the computed `["__proto__"]`, and reject a plain
       string key decoding to `__proto__` in every spelling.

--- a/fjs/media/datajs/todo/parser-serializer.md
+++ b/fjs/media/datajs/todo/parser-serializer.md
@@ -205,8 +205,12 @@ may instead be the grammar at
 [`fjs/ebnf/lib/datajs`](../../../ebnf/lib/datajs/module.f.mjs), which already
 exists, already imports JSON's rules, and is proof-covered. Mapped straight to
 values through `fjs/ebnf/map`, it **retires** the token-driven container machine
-rather than widening it, and the four rows below become moot. Mapped only to a
-token stream, every row still stands as written.
+rather than widening it, and the four rows below become moot — with the same
+type prerequisite as JSON's mapping, since its `value` is a widened `Thunk`
+that `Checked` refuses as a key until
+[widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md)
+gives it a recursive type. Mapped only to a token stream, every row still
+stands as written.
 
 The two routes are not variants of one design, and picking wrong wastes the
 prerequisite work. See stage 4 in

--- a/fjs/media/datajs/todo/parser-serializer.md
+++ b/fjs/media/datajs/todo/parser-serializer.md
@@ -189,7 +189,23 @@ anything after the `export`. The environment is what makes forward and unknown
 references errors: a reference resolves by lookup, and a failed lookup is a
 parse error rather than a `null` leaf.
 
-**Layer 1 — the value machine**, which is `fjs/media/json/parser` generalized.
+**Layer 1 — the value machine.** *Which* machine is now an open question that
+this section predates, and it has to be settled before any of the widening
+below is started.
+
+The coordinating plan reversed its no-runtime-grammar rule, so DataJS's reader
+may instead be the grammar at
+[`fjs/ebnf/lib/datajs`](../../../ebnf/lib/datajs/module.f.mjs), which already
+exists, already imports JSON's rules, and is proof-covered. Mapped straight to
+values through `fjs/ebnf/map`, it **retires** the token-driven container machine
+rather than widening it, and the four rows below become moot. Mapped only to a
+token stream, every row still stands as written.
+
+The two routes are not variants of one design, and picking wrong wastes the
+prerequisite work. See stage 4 in
+[parser-serializer-restructure](../../../../todo/parser-serializer-restructure.md).
+
+What follows is the second route, which is what today's code is shaped for.
 Measured against the code as it stands, four things are too narrow:
 
 | Today | Why it does not fit |
@@ -407,10 +423,14 @@ the spec judges them independently and this module provides all three.
 
 ### Tasks
 
-- [ ] Widen `fjs/media/json/parser`'s seams: leaf policy, multi-token key
-      policy, token vocabulary, and order-preserving member accumulation in
-      place of the sorting `OrderedMap`. One PR, with proofs pinning JSON's
-      accepted language and observable key order unchanged.
+- [ ] **First: settle whether the reader is the grammar or the token machine**
+      (§3, Layer 1). Everything below assumes the token machine, and the
+      grammar route retires rather than widens it.
+- [ ] *Token-machine route only.* Widen `fjs/media/json/parser`'s seams: leaf
+      policy, multi-token key policy, token vocabulary, and order-preserving
+      member accumulation in place of the sorting `OrderedMap`. One PR, with
+      proofs pinning JSON's accepted language and observable key order
+      unchanged.
 - [ ] `fjs/media/datajs/types.ts` and `README.md`.
 - [ ] Tokenizer, reusing JSON's rules through whatever seam stage 3b settles on
       — not the exported scanners the withdrawn design promised.

--- a/fjs/media/datajs/todo/parser-serializer.md
+++ b/fjs/media/datajs/todo/parser-serializer.md
@@ -209,8 +209,13 @@ rather than widening it, and the four rows below become moot — with the same
 type prerequisite as JSON's mapping, since its `value` is a widened `Thunk`
 that `Checked` refuses as a key until
 [widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md)
-gives it a recursive type. Mapped only to a token stream, every row still
-stands as written.
+gives it a recursive type, and with two contracts stage 3b measured and took
+the token route to keep: `rewrite` recurses per node and overflows at 1,000
+nested arrays where JSON's parser is proven at 5,000
+([stack-safe-rewrite](../../../ebnf/map/todo/stack-safe-rewrite.md)), and a
+mapping straight to values loses the exact number lexeme, which here is what
+tells `1n` from `1`. Mapped only to a token stream, every row still stands as
+written, and both contracts are kept by construction.
 
 The two routes are not variants of one design, and picking wrong wastes the
 prerequisite work. See stage 4 in

--- a/fjs/media/datajs/todo/parser-serializer.md
+++ b/fjs/media/datajs/todo/parser-serializer.md
@@ -80,7 +80,14 @@ vectors as byte arrays "fed to the reader's public byte-accepting path — which
 stage 4 owes". By the time input is a JavaScript string both distinctions are
 gone, so `tryParse` alone can neither implement nor prove them. `tryParseBytes`
 decodes with [`fjs/text/utf8`](../../../text/utf8/module.f.mjs)'s
-`toCodePointList`, refuses invalid UTF-8, and **rejects** a leading `EF BB BF`.
+`toCodePointList`, refuses invalid UTF-8, **rejects** a leading `EF BB BF`, and
+then re-encodes with [`fjs/text/utf16`](../../../text/utf16/module.f.mjs)'s
+`fromCodePointList` before the reader sees a symbol, because the reader's
+symbols are UTF-16 code units (§3, Layer 1): a four-byte scalar such as `😀`
+decodes to the one code point `0x1F600`, and the grammar must receive the
+pair `0xD83D 0xDE00`, which is what the corpus's four-byte vectors require to
+succeed. The byte path and the string path share one reader over one
+alphabet; the bridge is the decoder's, not the mapping's.
 
 That last word matters, and an earlier draft of this file had it backwards.
 "A document is UTF-8. It has no BOM" is a *rejection* rule: a BOM makes the byte

--- a/fjs/media/datajs/todo/parser-serializer.md
+++ b/fjs/media/datajs/todo/parser-serializer.md
@@ -140,11 +140,18 @@ seam met from the other side, and it interacts with
 
 #### 2. Tokenizer
 
-Depends on stage 3b, which is what exports JSON's scanners for reuse.
+Depends on stage 3b, and **the seam it depends on is an open question.** Stage
+3b was to export `scanString` and `scanNumber`; that design is withdrawn, and
+JSON's reader comes from a grammar over `fjs/ebnf/` instead. What DataJS reuses
+is therefore JSON's *rules* rather than its functions, and DataJS's own grammar
+extends JSON's rather than wrapping its scanners. The table below states the
+requirement, which is unchanged; only the mechanism is undecided, and it is
+listed as open in
+[self-contained-tokenizer](../../json/todo/self-contained-tokenizer.md).
 
 | Piece | Source |
 |---|---|
-| string scanner | JSON's, **unchanged** — the spec's §Strings is "a JSON string, unchanged" |
+| string rule | JSON's, **unchanged** — the spec's §Strings is "a JSON string, unchanged" |
 | number core | JSON's, extended |
 | everything else | new here |
 
@@ -405,7 +412,8 @@ the spec judges them independently and this module provides all three.
       place of the sorting `OrderedMap`. One PR, with proofs pinning JSON's
       accepted language and observable key order unchanged.
 - [ ] `fjs/media/datajs/types.ts` and `README.md`.
-- [ ] Tokenizer, over stage 3b's exported scanners.
+- [ ] Tokenizer, reusing JSON's rules through whatever seam stage 3b settles on
+      — not the exported scanners the withdrawn design promised.
 - [ ] Statement layer: environment, bound-once, declare-before-use.
 - [ ] Key policy: accept the computed `["__proto__"]`, and reject a plain
       string key decoding to `__proto__` in every spelling.

--- a/fjs/media/datajs/todo/parser-serializer.md
+++ b/fjs/media/datajs/todo/parser-serializer.md
@@ -3,10 +3,13 @@
 **Priority:** P1 — stage 4 is P1 in the coordinating issue and in the
 conformance-vector issue, which says outright that it blocks stage 4 "which is
 P1". This file is the canonical co-located issue, so it carries the same level.
-**Status:** blocked
-**Blocked by:** [JSON's reader](../../json/todo/self-contained-tokenizer.md),
-which is open but undecided rather than blocked — so the wait here is on a
-decision, not on a dependency landing.
+**Status:** open — **the first task is actionable now**: settling whether the
+reader is the grammar or the token machine (§3, Layer 1) depends on nothing
+outside this file, and it decides what the rest waits on. Implementation then
+waits on stage 1b's corpus, its proof source, and — on the token route — on
+[JSON's reader](../../json/todo/self-contained-tokenizer.md), whose
+token-stream grammar this codec's would extend; the grammar route waits on the
+`fjs/ebnf` items §3 names instead.
 The dependency also **changed shape**: JSON's reader will be a grammar over
 `fjs/ebnf/` rather than a hand-written scanner, so what this issue reuses is
 JSON's *rules* and not the `scanString`/`scanNumber` exports the withdrawn
@@ -203,7 +206,12 @@ below is started.
 The coordinating plan reversed its no-runtime-grammar rule, so DataJS's reader
 may instead be the grammar at
 [`fjs/ebnf/lib/datajs`](../../../ebnf/lib/datajs/module.f.mjs), which already
-exists, already imports JSON's rules, and is proof-covered. Mapped straight to
+exists, already imports JSON's rules, and is proof-covered. It is a **prefix**
+rule, like JSON's: `parser(dataJs)` accepts `export default 1;garbage` at
+offset 17 and `export default 1; export default 2;` at 18, so a reader on this
+route composes `eof` or checks the end offset against the input length —
+`[dataJs, eof]` rejects both at those offsets — or it returns a plausible
+value for a document Layer 2 must reject. Mapped straight to
 values through `fjs/ebnf/map`, it **retires** the token-driven container machine
 rather than widening it, and the four rows below become moot — with the same
 type prerequisite as JSON's mapping, since its `value` is a widened `Thunk`
@@ -449,10 +457,10 @@ the spec judges them independently and this module provides all three.
       proofs pinning JSON's accepted language and observable key order
       unchanged.
 - [ ] `fjs/media/datajs/types.ts` and `README.md`.
-- [ ] Tokenizer. On the grammar route this is `fjs/ebnf/lib/datajs`, which
-      already reuses JSON's rules by import; on the token-machine route, a lexer
-      that reuses them the same way — not the exported scanners the withdrawn
-      design promised.
+- [ ] Tokenizer. On the grammar route this is `fjs/ebnf/lib/datajs` composed
+      with `eof`, since it is a prefix rule, and it already reuses JSON's rules
+      by import; on the token-machine route, a token-stream grammar extending
+      JSON's — not the exported scanners the withdrawn design promised.
 - [ ] Statement layer: environment, bound-once, declare-before-use.
 - [ ] Key policy: accept the computed `["__proto__"]`, and reject a plain
       string key decoding to `__proto__` in every spelling.

--- a/fjs/media/datajs/todo/parser-serializer.md
+++ b/fjs/media/datajs/todo/parser-serializer.md
@@ -36,7 +36,8 @@ below:
   `export default`, with names and a declare-before-use rule;
 - a document denotes a **DAG**, so a reference must read back as the same node,
   and a serializer must hoist a node reachable more than once;
-- JSON's parser seam is **not wide enough** to be reused as it stands, which is
+- JSON's parser seam is **not wide enough** to be reused as it stands, so on
+  the token-machine route — one of the two §3 leaves open — there is
   prerequisite work on `fjs/media/json/parser` rather than work here.
 
 ### Proposal
@@ -144,14 +145,16 @@ seam met from the other side, and it interacts with
 
 #### 2. Tokenizer
 
-Depends on stage 3b, and **the seam it depends on is an open question.** Stage
+Depends on stage 3b, and **the seam it depends on is answered in code.** Stage
 3b was to export `scanString` and `scanNumber`; that design is withdrawn, and
 JSON's reader comes from a grammar over `fjs/ebnf/` instead. What DataJS reuses
-is therefore JSON's *rules* rather than its functions, and DataJS's own grammar
-extends JSON's rather than wrapping its scanners. The table below states the
-requirement, which is unchanged; only the mechanism is undecided, and it is
-listed as open in
-[self-contained-tokenizer](../../json/todo/self-contained-tokenizer.md).
+is therefore JSON's *rules* rather than its functions, by ordinary import —
+[`fjs/ebnf/lib/datajs`](../../../ebnf/lib/datajs/module.f.mjs) already does
+exactly that, and
+[self-contained-tokenizer](../../json/todo/self-contained-tokenizer.md) marks
+the question done. The table below states the requirement, which is unchanged.
+What is still open is §3's Layer 1: whether this codec runs that grammar or
+feeds a token machine.
 
 | Piece | Source |
 |---|---|
@@ -436,8 +439,10 @@ the spec judges them independently and this module provides all three.
       proofs pinning JSON's accepted language and observable key order
       unchanged.
 - [ ] `fjs/media/datajs/types.ts` and `README.md`.
-- [ ] Tokenizer, reusing JSON's rules through whatever seam stage 3b settles on
-      — not the exported scanners the withdrawn design promised.
+- [ ] Tokenizer. On the grammar route this is `fjs/ebnf/lib/datajs`, which
+      already reuses JSON's rules by import; on the token-machine route, a lexer
+      that reuses them the same way — not the exported scanners the withdrawn
+      design promised.
 - [ ] Statement layer: environment, bound-once, declare-before-use.
 - [ ] Key policy: accept the computed `["__proto__"]`, and reject a plain
       string key decoding to `__proto__` in every spelling.

--- a/fjs/media/datajs/todo/parser-serializer.md
+++ b/fjs/media/datajs/todo/parser-serializer.md
@@ -3,8 +3,16 @@
 **Priority:** P1 — stage 4 is P1 in the coordinating issue and in the
 conformance-vector issue, which says outright that it blocks stage 4 "which is
 P1". This file is the canonical co-located issue, so it carries the same level.
-**Status:** open
-**Blocked by:** [JSON self-contained tokenizer](../../json/todo/self-contained-tokenizer.md)
+**Status:** blocked
+**Blocked by:** [JSON's reader](../../json/todo/self-contained-tokenizer.md),
+which is itself blocked on EBNF — so this is now two removes from actionable.
+The dependency also **changed shape**: JSON's reader will be a grammar over
+`fjs/ebnf/` rather than a hand-written scanner, so what this issue reuses is
+JSON's *rules* and not the `scanString`/`scanNumber` exports the withdrawn
+[#1895](https://github.com/functionalscript/functionalscript/pull/1895)
+provided. The requirement is unchanged — a bigint is `int 'n'` reusing JSON's
+integer part, and `NaN`/`Infinity` are words rather than number syntax — but the
+seam it arrives through is an open question, listed as such in that issue.
 
 ### Problem
 
@@ -420,6 +428,6 @@ the spec judges them independently and this module provides all three.
 - [`todo/parser-serializer-restructure.md`](../../../../todo/parser-serializer-restructure.md) — the coordinating plan; this is its stage 4.
 - [`spec/datajs/README.md`](../../../../spec/datajs/README.md) — normative. This issue implements it.
 - [`spec/datajs/todo/conformance-vectors.md`](../../../../spec/datajs/todo/conformance-vectors.md) — stage 1b, the proof source. Land it first.
-- [self-contained tokenizer](../../json/todo/self-contained-tokenizer.md) — stage 3; 3b exports the scanners this reuses.
+- [JSON's reader](../../json/todo/self-contained-tokenizer.md) — stage 3, blocked on EBNF. It no longer promises the exported scanners this issue was written to reuse; over a grammar the reuse is of rules.
 - [157](../../../djs/todo/157-json-djs-shared-value-machine.md) — the shared serializer walker and its four seams. Stage 4 is its second consumer.
 - [663](../../../djs/todo/663-json-djs-tree-type.md) — the tree type; interacts with the optional index signature in §1.

--- a/fjs/media/datajs/todo/parser-serializer.md
+++ b/fjs/media/datajs/todo/parser-serializer.md
@@ -215,7 +215,8 @@ nested arrays where JSON's parser is proven at 5,000
 ([stack-safe-rewrite](../../../ebnf/map/todo/stack-safe-rewrite.md)), and a
 mapping straight to values loses the exact number lexeme, which here is what
 tells `1n` from `1`. Mapped only to a token stream, every row still stands as
-written, and both contracts are kept by construction.
+written, and both contracts are kept by construction — a token-stream
+grammar's tree is flat, which is how 3b sidesteps the first.
 
 The two routes are not variants of one design, and picking wrong wastes the
 prerequisite work. See stage 4 in

--- a/fjs/media/datajs/todo/parser-serializer.md
+++ b/fjs/media/datajs/todo/parser-serializer.md
@@ -5,14 +5,18 @@ conformance-vector issue, which says outright that it blocks stage 4 "which is
 P1". This file is the canonical co-located issue, so it carries the same level.
 **Status:** blocked
 **Blocked by:** [JSON's reader](../../json/todo/self-contained-tokenizer.md),
-which is itself blocked on EBNF — so this is now two removes from actionable.
+which is open but undecided rather than blocked — so the wait here is on a
+decision, not on a dependency landing.
 The dependency also **changed shape**: JSON's reader will be a grammar over
 `fjs/ebnf/` rather than a hand-written scanner, so what this issue reuses is
 JSON's *rules* and not the `scanString`/`scanNumber` exports the withdrawn
 [#1895](https://github.com/functionalscript/functionalscript/pull/1895)
 provided. The requirement is unchanged — a bigint is `int 'n'` reusing JSON's
-integer part, and `NaN`/`Infinity` are words rather than number syntax — but the
-seam it arrives through is an open question, listed as such in that issue.
+integer part, and `NaN`/`Infinity` are words rather than number syntax — and the
+seam is now **answered in code**:
+[`fjs/ebnf/lib/datajs`](../../../ebnf/lib/datajs/module.f.mjs) already exists and
+imports JSON's rules directly. What is still open is §3's Layer 1 — whether this
+codec runs that grammar or the token-driven container machine.
 
 ### Problem
 
@@ -456,6 +460,6 @@ the spec judges them independently and this module provides all three.
 - [`todo/parser-serializer-restructure.md`](../../../../todo/parser-serializer-restructure.md) — the coordinating plan; this is its stage 4.
 - [`spec/datajs/README.md`](../../../../spec/datajs/README.md) — normative. This issue implements it.
 - [`spec/datajs/todo/conformance-vectors.md`](../../../../spec/datajs/todo/conformance-vectors.md) — stage 1b, the proof source. Land it first.
-- [JSON's reader](../../json/todo/self-contained-tokenizer.md) — stage 3, blocked on EBNF. It no longer promises the exported scanners this issue was written to reuse; over a grammar the reuse is of rules.
+- [JSON's reader](../../json/todo/self-contained-tokenizer.md) — stage 3, open with its error shapes undecided. It no longer promises the exported scanners this issue was written to reuse; over a grammar the reuse is of rules, which [`fjs/ebnf/lib/datajs`](../../../ebnf/lib/datajs/module.f.mjs) already does by import.
 - [157](../../../djs/todo/157-json-djs-shared-value-machine.md) — the shared serializer walker and its four seams. Stage 4 is its second consumer.
 - [663](../../../djs/todo/663-json-djs-tree-type.md) — the tree type; interacts with the optional index signature in §1.

--- a/fjs/media/json/todo/self-contained-tokenizer.md
+++ b/fjs/media/json/todo/self-contained-tokenizer.md
@@ -5,24 +5,23 @@ shapes are undecided and `fjs/ebnf/` is mid-migration, so it is not the thing
 to pick up first.
 **Status:** open — **partly startable**. Measurement retired the two blockers
 earlier drafts claimed; see [What is actually missing](#what-is-actually-missing).
-The grammar exists, the LL(1) backend parses JSON with it, and `fjs/ebnf/map`
-is the engine that rewrites the result to values. JSON's own mapping is not
-written, and its typed form has one prerequisite —
-[widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md),
-a recursive type for `value`. What is undecided is what the reader reports on
-malformed input, and what a streaming consumer gets. What the mapping builds
-is decided: **tokens** for the container machine that stays, since a value
-mapping breaks two contracts today's `parse` keeps —
-[What the reader must keep](#what-the-reader-must-keep).
-**Prerequisites of one task, not of the issue:**
+The document grammar exists, the LL(1) backend parses JSON with it, and
+`fjs/ebnf/map` is the engine that rewrites a tree. What this stage runs is
+narrower and not yet written: a **token-stream grammar** over that module's
+exported lexical rules, over **UTF-16 code units**, mapped to the tokens the
+container machine consumes — the four contracts that decide it are under
+[What the reader must keep](#what-the-reader-must-keep). What is undecided is
+what the reader reports on malformed input, how a number's boundary is made
+LL(1), and what a streaming consumer gets.
+**Prerequisite of one task, not of the issue:**
 [widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md) —
-the mapping cannot be type-checked before it — and
-[stack-safe-rewrite](../../../ebnf/map/todo/stack-safe-rewrite.md) — it
-overflows on nesting the current parser is proven to accept.
+its `string` row; the mapping cannot be type-checked before it.
 **Related, not blocking:**
-[ebnf-migration](../../../todo/ebnf-migration.md), and the metadata channel in
+[ebnf-migration](../../../todo/ebnf-migration.md); the metadata channel in
 [functionalscript/functionalscript#1890](https://github.com/functionalscript/functionalscript/pull/1890)
-— which buys *better* errors than today's, not the ones this reader owes.
+— which buys *better* errors than today's, not the ones this reader owes; and
+[stack-safe-rewrite](../../../ebnf/map/todo/stack-safe-rewrite.md), which a
+token-stream grammar's flat tree does not reach.
 
 ### The direction changed, and this issue is rewritten around it
 
@@ -68,15 +67,16 @@ direction rather than a retreat.
 ### What is actually missing
 
 Two earlier drafts of this section each named a blocker, and measurement
-retired both. The honest answer is that **the mapping has two prerequisites in
-`fjs/ebnf` and no other**, one of type and one of the engine, and what remains
-open is error reporting and one API property.
+retired both. The honest answer is that **the tokenizer has one prerequisite
+in `fjs/ebnf`, a type, and two design questions of its own** — error reporting
+and a number's boundary — plus one API property.
 
 Measured against the tree as it stands:
 
-- The **grammar already exists**, exported and proof-covered, at
-  [`fjs/ebnf/lib/json`](../../../ebnf/lib/json/module.f.mjs). It is not work
-  this issue owes.
+- The **document grammar already exists**, exported and proof-covered, at
+  [`fjs/ebnf/lib/json`](../../../ebnf/lib/json/module.f.mjs). It is not the
+  grammar this stage runs — see below — but its exported lexical rules are
+  what that grammar is built from, and they are not work this issue owes.
 - The **LL(1) backend already parses JSON with it**, as
   [`fjs/ebnf/ll1/proof.f.mjs`](../../../ebnf/ll1/proof.f.mjs) shows.
 - **The mapping engine exists; JSON's mapping does not.**
@@ -86,12 +86,17 @@ Measured against the tree as it stands:
   as `json[1]`, rewrites the parsed node. **Under `tsc` it is refused**: `value`
   is annotated `Const<Variant>` and `string` is annotated `Rule`, neither of
   which says its parts, so `Checked` rejects both as keys — measured, along
-  with `json` itself; `digit` and `uint` are accepted. A typed JSON mapping
-  therefore waits on
-  [widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md):
-  a recursive type for `value` and a `const` pin for `string`. That is
-  prerequisite type work, not a missing capability, and it is the one thing
-  the mapping task below cannot start without.
+  with `json` itself; `digit` and `uint` are accepted. A token mapping keys
+  on `string`, a number tuple and its own token variant, and never on
+  `value`, so what it waits on is the `string` pin alone —
+  [widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md)'
+  `string` row; `uint`, `optionNeg`, `optionFloatSuffix` and `ws` are
+  accepted, and the token variant is refused only for holding `string`. One
+  more measured rule of the road: a repetition built in place inside the map
+  literal is refused where the same rule held in a binding is accepted, so
+  hold the rule, then key on it, which is what the map's README says. The pin
+  is prerequisite type work, not a missing capability, and it is the one
+  thing the mapping task below cannot start without.
 - An LL(1) failure returns **an offset** — `[1,` yields `['error', 3]`.
 
 **`json` alone is a prefix parser, and a reader must not use it that way.** The
@@ -123,16 +128,17 @@ So what genuinely remains, in the order it should be done:
 1. **Error shapes.** Decide what a grammar-driven reader reports. This is design
    work, not a dependency, and it is the last item under
    [What this still needs](#what-this-still-needs).
-2. **A recursive type for `value`.** The one dependency: until
+2. **`string`'s pin.** The one dependency: until
    [widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md)
-   lands its `value` and `string` rows, the mapping can be run but not
-   type-checked. It is filed P4, which understates it now that a P2 stage
-   waits on it.
-3. **A stack-safe `rewrite`.** The other dependency: `fjs/ebnf/map` recurses
-   per node, so the empty map over 1,000 nested arrays throws `RangeError`
-   where `fjs/ebnf/ll1` parses 6,000 and today's parser is proven at 5,000 —
-   [stack-safe-rewrite](../../../ebnf/map/todo/stack-safe-rewrite.md), filed
-   P2. It holds whether the mapping builds tokens or values.
+   lands its `string` row, the mapping can be run but not type-checked. Its
+   `value` row is not needed here, since no lexical rule names `value`. It is
+   filed P4, which understates it now that a P2 stage waits on it.
+3. **The number boundary.** The token-stream grammar written naively is not
+   LL(1), because `12` is one token where `1 2` is two and a nullable
+   separator cannot decide that predictively —
+   [What the reader must keep](#what-the-reader-must-keep) has the measured
+   conflict, what today's tokenizer does at that boundary, and the two
+   resolutions. Design work, not a dependency.
 4. **The streaming seam.** `Parser<T>` takes `readonly number[]`, a
    materialized array, while `tokenize` is public and `List`-based. The public
    `parse(text)` is unaffected, since it starts from a string, but a streaming
@@ -150,17 +156,19 @@ withdrawn.
 
 ### What the reader must keep
 
-Two contracts of today's `parse` that a mapping straight to values would break.
-Each is measured, and each is held to as the two invariants below are.
+Four contracts of today's public API, each measured, and each held to as the
+two invariants below are. The first two rule out a mapping straight to values;
+the last two decide which grammar the tokenizer runs, and over what symbols.
 
 - **Depth.** [`fjs/media/json/parser`](../parser/module.f.mjs) walks containers
   on a heap stack, and its proof requires 5,000 nested arrays and 6,000
   sibling containers to return `ok`. `fjs/ebnf/ll1` keeps that — 6,000 nested
   arrays parse — but `fjs/ebnf/map` recurses per node, and `rewrite([])` over
-  the tree of 1,000 nested arrays throws `RangeError`. Anything built on
-  `rewrite` throws on input the public `parse` accepts under its `Result`
-  contract until
-  [stack-safe-rewrite](../../../ebnf/map/todo/stack-safe-rewrite.md) lands.
+  the *document* tree of 1,000 nested arrays throws `RangeError`
+  ([stack-safe-rewrite](../../../ebnf/map/todo/stack-safe-rewrite.md)). A
+  token-stream tree is flat, so it is not reached: 20,000 nested brackets lex
+  to 40,000 tokens and rewrite without incident, and depth stays where it is
+  kept today, in the container machine.
 - **The numeric policy.** A number token reaches the codec's `NumberPolicy`
   with its exact lexeme, which is the parser's stated design: `extended.parse`
   reads `123` as `123n` and `9007199254740993` without rounding, where the
@@ -169,14 +177,52 @@ Each is measured, and each is held to as the two invariants below are.
   finite range — which the machine reports once at the seam, and which a
   mapping would have to carry as a `Result` through every container above.
 
-**So the mapping builds tokens, not values.** The container machine stays,
-with both codecs and their policies untouched, and it is what keeps both
-contracts: depth on its own heap stack, numbers through the seam that already
-exists. That is also this stage's stated scope — replacing the tokenizer
-wrapper — where a value mapping would retire the parser too. The value route
-stays open to whoever can show both contracts kept through the mapping;
-nothing measured says that is impossible, only that neither piece exists. The
-token mapping still walks the tree, so the depth prerequisite holds either way.
+- **`tokenize` is public and lexical.** It accepts a stream that is no
+  document: `1 2`, `[] []` and `1,2` each tokenize with no error — two
+  numbers and EOF; four brackets and EOF; number, comma, number and EOF — and
+  `parse` then rejects each with `unexpected token`. `[json, eof]` rejects all
+  three at the first symbol after the value and yields no tree. So the
+  tokenizer cannot run the document grammar. It runs a **token-stream
+  grammar** — `[ws, repeat0([token, ws]), eof]` over the lexical rules
+  `fjs/ebnf/lib/json` exports — and the container machine is what turns a
+  stream into a document, as today. The first invariant below is stated over
+  that stream, and this is what keeps it.
+- **Strings are UTF-16 code-unit sequences.** `tokenize('"\ud800"')` is one
+  string token holding the lone surrogate and `parse` returns it, as it does
+  `"😀"`. `ll1`'s proof decodes its input with `stringToCodePointList`, which
+  tags a lone surrogate, and `parser([json, eof])` over that input throws
+  `['not a symbol', 1, -2147428352]`. Over `stringToList` — code units, which
+  is what `tokenize(List<number>)` already takes — the same parser accepts
+  both: the lone surrogate as one `c` node holding 55296, the astral character
+  as two. The grammar's string rule admits every unit, since its character
+  set is `0x20` to `0x10FFFF` less two. So **the reader's symbols are code
+  units**, not code points, and the mapping joins them back into a string,
+  which is today's semantics. Escapes, keywords and whitespace are ASCII and
+  unaffected.
+
+**So the reader is a token-stream grammar over code units, mapped to tokens.**
+The container machine stays, with both codecs and their policies untouched,
+and it is what keeps the first two contracts; the grammar and its alphabet
+keep the last two. That is also this stage's stated scope — replacing the
+tokenizer wrapper — where a value mapping would retire the parser too. The
+value route stays open to whoever can show all four kept through a mapping;
+nothing measured says that is impossible, only that the pieces do not exist.
+
+**The token-stream grammar is not written, and written naively it is not
+LL(1).** `[ws, repeat0([token, ws]), eof]`, with `token` a variant of
+`string`, `[optionNeg, uint, ...optionFloatSuffix]`, the six punctuators and
+the three words, is refused at construction — `first/follow conflict` at
+`1.item.0.number.1.onenine.1`, the optional digits after a number's first —
+because `ws` is nullable and the next token may begin with a digit. Maximal
+munch, by which `12` is one token where `1 2` is two, is not a predictive
+decision across a nullable separator. What today's tokenizer does at that
+boundary is measured, since a resolution has to reproduce it: `1-1` is two
+numbers, `1]` a number and a bracket, `1true` and `1"a"` an error and then
+the second token, `1.5.5` and `1e` one error each. Two resolutions are on the
+table, and choosing is the design question this stage owns beside error
+shapes: a boundary rule in the grammar, saying what may follow a number
+without whitespace; or an entry point that reads one token from an offset by
+prefix parse, which is the streaming seam under another name.
 
 ### What any replacement is held to
 
@@ -627,8 +673,9 @@ blocked. The first two items can be started today.
 
 - [ ] Compose EOF, or check the end offset against the input length. `json`
       alone is a **prefix** rule: `parser(json)` accepts `[1]x`. A document is
-      `[json, eof]`. Do this before anything maps an AST, or the reader silently
-      accepts trailing garbage.
+      `[json, eof]`, and the token-stream grammar composes `eof` the same way.
+      Do this before anything maps an AST, or the reader silently accepts
+      trailing garbage.
 - [ ] The `fjs/ebnf/` half of
       [ebnf-migration](../../../todo/ebnf-migration.md) settles, so the codec is
       not written against names still in motion. A sequencing concern, **not** a
@@ -649,7 +696,17 @@ blocked. The first two items can be started today.
       not under `fjs/bnf`, which is the module being retired and holds its JSON
       grammar as an example only
       ([bnf-grammar-single-owner](../../../bnf/todo/bnf-grammar-single-owner.md)).
-      **Do not write a second one.**
+      **Do not write a second one.** That is the *document* grammar; the
+      token-stream grammar below is not a second copy but a few lines over
+      the rules that module exports.
+- [ ] Write the token-stream grammar, `[ws, repeat0([token, ws]), eof]` over
+      `string`, `uint`, `optionNeg`, `optionFloatSuffix` and `ws` from
+      `fjs/ebnf/lib/json`, run over UTF-16 code units, and make it LL(1) at a
+      number's boundary —
+      [What the reader must keep](#what-the-reader-must-keep) has the conflict
+      and the two resolutions. Prove that `1 2`, `[] []` and `1,2` lex as they
+      do today, that `"\ud800"` is one string token, and that 20,000 nested
+      brackets lex.
 - [ ] Cross-check that grammar against the accepted-language probes above. It
       was written to RFC 8259 rather than against this tokenizer, so agreement
       is expected but unmeasured, and the `1n1` class is exactly where today's
@@ -659,12 +716,11 @@ blocked. The first two items can be started today.
       demonstrates on a smaller grammar, building values there where this one
       builds tokens ([What the reader must keep](#what-the-reader-must-keep)
       says why). This is the reader's substance and the part that does not
-      exist yet. **After** two `fjs/ebnf` items: `value`'s recursive type and
-      `string`'s pin, per
+      exist yet. Its keys are `string`, the number tuple and the token
+      variant, held in bindings; a string token is its code units joined.
+      **After** `string`'s pin, per
       [widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md),
-      since `Checked` refuses both as keys today; and
-      [stack-safe-rewrite](../../../ebnf/map/todo/stack-safe-rewrite.md),
-      since the walk overflows on nesting the parser's proof requires.
+      since `Checked` refuses it as a key today.
 - [x] ~~Decide what replaces the seam.~~ **Answered in code, and it is what the
       reversal predicted.**
       [`fjs/ebnf/lib/datajs`](../../../ebnf/lib/datajs/module.f.mjs) already

--- a/fjs/media/json/todo/self-contained-tokenizer.md
+++ b/fjs/media/json/todo/self-contained-tokenizer.md
@@ -196,9 +196,14 @@ the last two decide which grammar the tokenizer runs, and over what symbols.
   both: the lone surrogate as one `c` node holding 55296, the astral character
   as two. The grammar's string rule admits every unit, since its character
   set is `0x20` to `0x10FFFF` less two. So **the reader's symbols are code
-  units**, not code points, and the mapping joins them back into a string,
-  which is today's semantics. Escapes, keywords and whitespace are ASCII and
-  unaffected.
+  units**, not code points. A string token's value is then the `c` units as
+  they are and each escape **decoded**: the grammar keeps an escape as
+  spelled — `["escape", ["c", 110]]` for `\n`, the four hex digits for
+  `\u1234` — where today's tokenizer yields the newline and U+1234, and its
+  proofs pin that. A `\uXXXX` produces one unit whatever it spells, so an
+  escaped lone surrogate stays one unit and an escaped pair stays two, which
+  is what keeps this row and the previous one consistent. Keywords and
+  whitespace are ASCII and unaffected.
 
 **So the reader is a token-stream grammar over code units, mapped to tokens.**
 The container machine stays, with both codecs and their policies untouched,
@@ -723,7 +728,9 @@ blocked. The first two items can be started today.
       [What the reader must keep](#what-the-reader-must-keep) has the measured
       table and the two resolutions. Prove that `1 2`, `[] []` and `1,2` lex
       as they do today, that `12` is one number and `truetrue` an error, that
-      `"\ud800"` is one string token, and that 20,000 nested brackets lex.
+      `"\ud800"` is one string token, that `"\n"` and `"\u1234"` decode to
+      the one unit each today's proofs pin, and that 20,000 nested brackets
+      lex.
 - [ ] Cross-check that grammar against the accepted-language probes above. It
       was written to RFC 8259 rather than against this tokenizer, so agreement
       is expected but unmeasured, and the `1n1` class is exactly where today's
@@ -734,7 +741,9 @@ blocked. The first two items can be started today.
       builds tokens ([What the reader must keep](#what-the-reader-must-keep)
       says why). This is the reader's substance and the part that does not
       exist yet. Its keys are `string`, the number tuple and the token
-      variant, held in bindings; a string token is its code units joined.
+      variant, held in bindings; a string token's value is its raw units
+      kept and its escapes decoded, one unit per `\uXXXX`, as the code-unit
+      contract above says.
       **After** `string`'s pin, per
       [widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md),
       since `Checked` refuses it as a key today.

--- a/fjs/media/json/todo/self-contained-tokenizer.md
+++ b/fjs/media/json/todo/self-contained-tokenizer.md
@@ -10,10 +10,15 @@ is the engine that rewrites the result to values. JSON's own mapping is not
 written, and its typed form has one prerequisite —
 [widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md),
 a recursive type for `value`. What is undecided is what the reader reports on
-malformed input, and what a streaming consumer gets.
-**Prerequisite of one task, not of the issue:**
+malformed input, and what a streaming consumer gets. What the mapping builds
+is decided: **tokens** for the container machine that stays, since a value
+mapping breaks two contracts today's `parse` keeps —
+[What the reader must keep](#what-the-reader-must-keep).
+**Prerequisites of one task, not of the issue:**
 [widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md) —
-the mapping cannot be type-checked before it.
+the mapping cannot be type-checked before it — and
+[stack-safe-rewrite](../../../ebnf/map/todo/stack-safe-rewrite.md) — it
+overflows on nesting the current parser is proven to accept.
 **Related, not blocking:**
 [ebnf-migration](../../../todo/ebnf-migration.md), and the metadata channel in
 [functionalscript/functionalscript#1890](https://github.com/functionalscript/functionalscript/pull/1890)
@@ -37,7 +42,8 @@ is `invalid token` because it is a valid JS bigint literal.
 scanner of JSON's lexical grammar, with `scanString` and `scanNumber` exported
 as a seam for `fjs/media/datajs`. JSON's reader will instead come from an
 **EBNF grammar** over [`fjs/ebnf/`](../../../ebnf/module.f.mjs), with a mapping
-that builds the tokens or the value.
+that builds the tokens today's container machine consumes — not the value;
+[What the reader must keep](#what-the-reader-must-keep) says why.
 
 That reverses this repository's standing rule that the media codecs take no
 runtime dependency on a grammar module
@@ -62,9 +68,9 @@ direction rather than a retreat.
 ### What is actually missing
 
 Two earlier drafts of this section each named a blocker, and measurement
-retired both. The honest answer is that **the value half of this reader has one
-type prerequisite and no other**, and what remains open is error reporting and
-one API property.
+retired both. The honest answer is that **the mapping has two prerequisites in
+`fjs/ebnf` and no other**, one of type and one of the engine, and what remains
+open is error reporting and one API property.
 
 Measured against the tree as it stands:
 
@@ -122,20 +128,55 @@ So what genuinely remains, in the order it should be done:
    lands its `value` and `string` rows, the mapping can be run but not
    type-checked. It is filed P4, which understates it now that a P2 stage
    waits on it.
-3. **The streaming seam.** `Parser<T>` takes `readonly number[]`, a
+3. **A stack-safe `rewrite`.** The other dependency: `fjs/ebnf/map` recurses
+   per node, so the empty map over 1,000 nested arrays throws `RangeError`
+   where `fjs/ebnf/ll1` parses 6,000 and today's parser is proven at 5,000 —
+   [stack-safe-rewrite](../../../ebnf/map/todo/stack-safe-rewrite.md), filed
+   P2. It holds whether the mapping builds tokens or values.
+4. **The streaming seam.** `Parser<T>` takes `readonly number[]`, a
    materialized array, while `tokenize` is public and `List`-based. The public
    `parse(text)` is unaffected, since it starts from a string, but a streaming
    consumer has no grammar equivalent today. This is a real consequence of the
    direction and is why
    [streaming-recognizer](./streaming-recognizer.md) is now blocked rather than
    merely rebased.
-4. **`fjs/ebnf/` stability.** The module is mid-migration
+5. **`fjs/ebnf/` stability.** The module is mid-migration
    ([ebnf-migration](../../../todo/ebnf-migration.md)), so a codec written
    against it now is written against names still in motion. This is a reason to
    sequence carefully, not a missing capability.
 
 **Do not start a hand-written scanner in the meantime.** That is what was just
 withdrawn.
+
+### What the reader must keep
+
+Two contracts of today's `parse` that a mapping straight to values would break.
+Each is measured, and each is held to as the two invariants below are.
+
+- **Depth.** [`fjs/media/json/parser`](../parser/module.f.mjs) walks containers
+  on a heap stack, and its proof requires 5,000 nested arrays and 6,000
+  sibling containers to return `ok`. `fjs/ebnf/ll1` keeps that — 6,000 nested
+  arrays parse — but `fjs/ebnf/map` recurses per node, and `rewrite([])` over
+  the tree of 1,000 nested arrays throws `RangeError`. Anything built on
+  `rewrite` throws on input the public `parse` accepts under its `Result`
+  contract until
+  [stack-safe-rewrite](../../../ebnf/map/todo/stack-safe-rewrite.md) lands.
+- **The numeric policy.** A number token reaches the codec's `NumberPolicy`
+  with its exact lexeme, which is the parser's stated design: `extended.parse`
+  reads `123` as `123n` and `9007199254740993` without rounding, where the
+  standard codec reads `123` as the number. A mapping that turns the number
+  rule into a `number` loses both. A policy can also *fail* — out of the
+  finite range — which the machine reports once at the seam, and which a
+  mapping would have to carry as a `Result` through every container above.
+
+**So the mapping builds tokens, not values.** The container machine stays,
+with both codecs and their policies untouched, and it is what keeps both
+contracts: depth on its own heap stack, numbers through the seam that already
+exists. That is also this stage's stated scope — replacing the tokenizer
+wrapper — where a value mapping would retire the parser too. The value route
+stays open to whoever can show both contracts kept through the mapping;
+nothing measured says that is impossible, only that neither piece exists. The
+token mapping still walks the tree, so the depth prerequisite holds either way.
 
 ### What any replacement is held to
 
@@ -613,13 +654,17 @@ blocked. The first two items can be started today.
       was written to RFC 8259 rather than against this tokenizer, so agreement
       is expected but unmeasured, and the `1n1` class is exactly where today's
       wrapper is known to differ from JSON.
-- [ ] Write the mapping from its AST to JSON values, which is `fjs/ebnf/map`'s
-      `rewrite` — the shape `ll1`'s proof already demonstrates on a smaller
-      grammar. This is the reader's substance and the part that does not exist
-      yet. **After** `value` has its recursive type and `string` its pin, per
-      [widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md):
-      `Checked` refuses both as keys today, so a typed mapping cannot be
-      written before that lands.
+- [ ] Write the mapping from its AST to the **tokens** `fjs/media/json/parser`
+      consumes, which is `fjs/ebnf/map`'s `rewrite` — the shape `ll1`'s proof
+      demonstrates on a smaller grammar, building values there where this one
+      builds tokens ([What the reader must keep](#what-the-reader-must-keep)
+      says why). This is the reader's substance and the part that does not
+      exist yet. **After** two `fjs/ebnf` items: `value`'s recursive type and
+      `string`'s pin, per
+      [widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md),
+      since `Checked` refuses both as keys today; and
+      [stack-safe-rewrite](../../../ebnf/map/todo/stack-safe-rewrite.md),
+      since the walk overflows on nesting the parser's proof requires.
 - [x] ~~Decide what replaces the seam.~~ **Answered in code, and it is what the
       reversal predicted.**
       [`fjs/ebnf/lib/datajs`](../../../ebnf/lib/datajs/module.f.mjs) already

--- a/fjs/media/json/todo/self-contained-tokenizer.md
+++ b/fjs/media/json/todo/self-contained-tokenizer.md
@@ -691,7 +691,9 @@ blocked. The first two items can be started today.
 - [ebnf-migration](../../../todo/ebnf-migration.md) — `fjs/ebnf/` beside
   `fjs/bnf/`, then retire `bnf/`. The module this now depends on.
 - [#1890](https://github.com/functionalscript/functionalscript/pull/1890) —
-  `meta-ast-mapping`, the metadata channel a reader's mapping needs.
+  `meta-ast-mapping`, the metadata channel. **Optional**: it buys errors better
+  than today's, is not needed to match the current parser's contract, and
+  cannot classify an LL(1) failure, which yields no tree to annotate.
 - [#1895](https://github.com/functionalscript/functionalscript/pull/1895) —
   the withdrawn hand-written implementation. Read it for the measurements and
   for the defect classes review found, not as a plan.

--- a/fjs/media/json/todo/self-contained-tokenizer.md
+++ b/fjs/media/json/todo/self-contained-tokenizer.md
@@ -1,33 +1,79 @@
-## self-contained-tokenizer. JSON's tokenizer is a wrapper over the JS tokenizer
+## self-contained-tokenizer. JSON's reader comes from a grammar, not a wrapper
 
-**Priority:** P1 — raised, see
-[parser-serializer-restructure](../../../../todo/parser-serializer-restructure.md)'s
-priority note. EDAG needs a DataJS codec, and this stage is its prerequisite.
-**Status:** wip — 3a has landed, 3b is open. The fabricated token is gone; the
-`fjs/js/tokenizer` dependency is not.
+**Priority:** P2 — lowered from P1. Stage 4 still waits on it, but nothing can
+start until the EBNF backend can carry what a reader needs.
+**Status:** blocked
+**Blocked by:** [ebnf-migration](../../../todo/ebnf-migration.md)
+and the metadata channel filed in
+[functionalscript/functionalscript#1890](https://github.com/functionalscript/functionalscript/pull/1890)
+— `fjs/ebnf/todo/meta-ast-mapping.md`, which lands with it.
 
-### Problem
+### The direction changed, and this issue is rewritten around it
 
-`fjs/media/json/tokenizer/module.f.mjs` does not scan JSON. It calls
-`tokenize` from [`fjs/js/tokenizer`](../../../js/tokenizer/module.f.mjs) — the
-747-line JavaScript tokenizer — and post-processes the result: `mapToken`
-passes the JSON-shaped token kinds through, drops `ws`/`nl`, turns every other
-JavaScript token into `invalid token`, and a two-state scan re-attaches a
-leading `-` to the following number lexeme.
+JSON's tokenizer is a ~100-line adapter over
+[`fjs/js/tokenizer`](../../../js/tokenizer/module.f.mjs), the 747-line
+JavaScript tokenizer. That is still the problem, and the argument for fixing it
+is unchanged: JSON is frozen by
+[RFC 8259](https://www.rfc-editor.org/rfc/rfc8259) and `fjs/js/tokenizer` must
+grow with FunctionalScript, so every future JavaScript token — a new operator, a
+new numeric literal, a new escape — reaches JSON's `default` arm as an input it
+has to classify. The coupling is visible in the output: `/* c` reports
+`*/ expected`, JSON being told about an unterminated comment it has no comments
+to have; `>>>=` is one token because JavaScript lexes it as one operator; `0n`
+is `invalid token` because it is a valid JS bigint literal.
 
-JSON is frozen by its own specification; `fjs/js/tokenizer` must grow with
-FunctionalScript. A frozen format sitting downstream of a deliberately
-evolving lexer is the first of the two structural problems in
-[parser-serializer-restructure](../../../../todo/parser-serializer-restructure.md),
-and this module is where it is load-bearing: every future JavaScript token —
-a new operator, a new numeric literal form, a new escape — reaches JSON's
-tokenizer as an input its `default` arm has to classify.
+**What changed is the replacement.** This issue used to specify a hand-written
+scanner of JSON's lexical grammar, with `scanString` and `scanNumber` exported
+as a seam for `fjs/media/datajs`. JSON's reader will instead come from an
+**EBNF grammar** over [`fjs/ebnf/`](../../../ebnf/module.f.mjs), with a mapping
+that builds the tokens or the value.
 
-The dependency is not paying for itself. JSON's lexical grammar is small
-enough to scan directly, and the shared code is not shared behavior: the two
-languages agree on structural characters and disagree on nearly everything
-else, so what arrives is a JavaScript token that has to be re-judged against
-JSON's rules anyway.
+That reverses this repository's standing rule that the media codecs take no
+runtime dependency on a grammar module
+([parser-serializer-restructure](../../../../todo/parser-serializer-restructure.md)
+lists it among the decisions not to reopen; it is reopened, and that file
+records the reversal). The old rule rested on `fjs/bnf` not being stable enough
+to depend on. What changes it is not that argument but what the alternative
+costs: a hand-written tokenizer and container machine **per format** against a
+grammar of a few dozen readable lines.
+
+The evidence is on the record rather than assumed. The hand-written design was
+written, reviewed over several rounds, implemented in full and withdrawn —
+[#1895](https://github.com/functionalscript/functionalscript/pull/1895),
+reverted. It reached a working scanner with 100% proof coverage and a 5,586-row
+differential sweep, and along the way review found a fabricated-token class, a
+`\uXXXX` recovery hole that silently ate the token after a bad escape, and two
+terminator-set errors in this very document. Those are the defects a hand-written
+lexer produces, and each one had to be found by a person. **That is the cost the
+grammar is being bought to avoid**, and it is why the withdrawal is a change of
+direction rather than a retreat.
+
+### Why it is blocked rather than open
+
+`fjs/ebnf/` exists but its LL(1) backend cannot yet carry what a reader needs.
+A mapping must receive what the grammar ignored about each input symbol — a
+position, or which identifier a token was — and must be able to return
+information of its own. That channel is being designed now, in
+[#1890](https://github.com/functionalscript/functionalscript/pull/1890)
+(`meta-ast-mapping`), and the module's own migration is
+[ebnf-migration](../../../todo/ebnf-migration.md).
+
+Without it a JSON grammar can recognize a document but cannot produce a token
+stream carrying values, let alone the error positions
+[`fjs/media/json/parser`](../parser/module.f.mjs) reports. So there is nothing
+to implement here yet, and the design that *can* be written is the grammar
+itself, which is cheap and can wait for the backend it runs on.
+
+**Do not start a hand-written scanner in the meantime.** That is what was just
+withdrawn.
+
+### What any replacement is held to
+
+These are measurements of the current tokenizer, not design, so they survive the
+change of direction intact. A grammar-driven reader is judged against exactly
+the same two invariants the hand-written one was, for the same reason: they are
+what stops the accepted language moving under a consumer.
+
 
 ### The accepted language is already JSON's
 
@@ -140,7 +186,7 @@ also why 3a's suppression rule names three messages rather than "control
 characters" — the message is the class, and the character is not.
 
 Counting instances understates it — a reader sizing the change needs the class,
-since rule 1 below covers all of them at once.
+since the suppression covers all of them at once.
 
 A caller that filters errors out — or a parser that resynchronizes on the next
 value — sees a string `"x"` that no document contained. That is
@@ -164,328 +210,7 @@ carried a sign. `--` reports **once** where `---` reports twice, because the JS
 tokenizer merges `--` into a decrement operator before JSON ever sees it — a
 JavaScript fact with no JSON meaning.
 
-### Proposal
-
-Replace the wrapper with a scanner of JSON's own lexical grammar, in the same
-shape as the JS tokenizer it replaces: a `StateScan` over **UTF-16 code
-units** followed by a single `null` end-of-input sentinel, folded with
-`stateScan` and `flat`.
-No `fjs/bnf` dependency — the format's grammars are spec text plus
-proof-covered examples, never a runtime dependency of the codecs.
-
-The public signature does not change:
-
-```ts
-export const tokenize: (input: List<number>) => List<JsonToken>
-```
-
-`JsonToken`'s *shape* is unchanged — the same kinds carrying the same fields —
-so `fjs/media/json/parser`'s behavior is untouched. But it does change at the
-type level, and in a way worth deciding here rather than leaving to the
-implementation.
-
-`fjs/media/json/tokenizer/types.ts` currently builds `JsonToken` out of
-`StringToken`, `NumberToken`, `ErrorToken` and `EofToken` imported from
-`js/tokenizer/types.ts`. Those become JSON's own declarations, and
-`_ScanInput`/`_ScanState` are replaced by the new state type. `ErrorToken` is
-the one that cannot simply move: its `message` is a **closed union** of ten
-literals (`js/tokenizer/types.ts`'s `_ErrorMessage`), and the message this
-design introduces — `invalid string` — is not one of them.
-
-Define JSON's own union explicitly rather than widening `message` to `string`
-or copying JavaScript's list:
-
-```ts
-type JsonErrorMessage =
-    | 'invalid number'
-    | 'invalid string'
-    | 'invalid token'
-    | 'unexpected character'
-```
-
-Four messages, and that is the whole vocabulary — down from the ten JSON
-inherits today, of which it emits **nine** — only `eof` is unreachable, and
-`*/ expected` is not JS-only in practice: `tokenize('/* c')` emits it, which is
-JSON being told about an unterminated comment it has no comments to have. The
-narrowing is a feature: the union is
-the tokenizer's error contract, so a consumer can exhaustively switch on it, and
-a message JSON cannot produce should not typecheck.
-
-This is a public API change, additive in one direction and narrowing in the
-other, and it belongs in the `Changelog:` declaration alongside the error
-shapes.
-
-There is a second edge to repoint, easy to miss because it does not go through
-the tokenizer at all: `fjs/media/json/parser/types.ts` imports `NumberToken`
-**directly** from `../../../js/tokenizer/types.ts`. After this change JSON's
-parser takes it from `../tokenizer/types.ts` like everything else, and
-`fjs/media/json` holds no reference to `fjs/js/tokenizer` in either direction.
-
-`fjs/djs/*` keeps a `js/tokenizer` dependency, but a much smaller one than it
-looks: `fjs/djs/tokenizer/module.f.mjs:51` imports exactly `isKeywordToken` and
-`mergeTrivia`, plus token *types*, and drives its own BNF tokenizer
-`tokenizeJs` at line 544. It never consumes the JavaScript token stream.
-
-That makes this stage's reach larger than "one module stops importing another".
-`tokenize` — the public entry point of `fjs/js/tokenizer`, and the 747-line
-state machine behind it — has exactly two runtime importers today, and JSON is
-the only one that calls `tokenize`. **After this stage it has none.** What is
-still live is two helper functions and a set of token types.
-
-Stage 7 is where that gets acted on, and the plan's wording for it —
-retire `fjs/js/tokenizer` "when its last consumer is gone" — resolves to
-something more concrete than it reads: the machine is already consumerless at
-the end of stage 3, so stage 7 is a move of `isKeywordToken`, `mergeTrivia` and
-the token types to wherever `fjs/fsc` wants them, and a delete of the rest. Not
-this stage's work, but this stage is what makes it true.
-
-The grammar being scanned, which is [RFC 8259](https://www.rfc-editor.org/rfc/rfc8259)'s:
-
-```text
-ws     ::= (' ' | '\t' | '\n' | '\r')*
-token  ::= '{' | '}' | '[' | ']' | ':' | ',' | 'true' | 'false' | 'null'
-         | string | number
-string ::= '"' char* '"'
-char   ::= <any code unit except '"', '\', and U+0000–U+001F>
-         | '\' ('"' | '\' | '/' | 'b' | 'f' | 'n' | 'r' | 't' | 'u' hex hex hex hex)
-number ::= '-'? int frac? exp?
-int    ::= '0' | [1-9] [0-9]*
-frac   ::= '.' [0-9]+
-exp    ::= ('e' | 'E') ('+' | '-')? [0-9]+
-```
-
-Character constants come from
-[`fjs/text/ascii`](../../../text/ascii/module.f.mjs), as they do today at one
-remove, and the simple escapes keep coming from
-[`fjs/js/string_escape`](../../../js/string_escape/module.f.mjs). That module
-is not JavaScript's escape table — it is deliberately the eight escapes
-JavaScript and JSON share, excluding `\0`, `\v`, `\xXX` and line
-continuations, and it exists so that the serializer and both tokenizers cannot
-drift apart. Today JSON reads it at one remove through `fjs/js/tokenizer`;
-after this change it imports the table directly, which is a shorter path to
-the same single source of truth. It is frozen by the JavaScript specification
-rather than growing with the language, so it is not the dependency this stage
-is removing — stage 7 keeps it for the same reason.
-
-### The error rule, stated once
-
-Five rules replace the inherited behavior:
-
-1. **One error token per invalid lexeme.** A lexeme that cannot be completed
-   produces exactly one `{ kind: 'error' }` and no value token — never a
-   partial string or number built from the surviving characters.
-2. **A number ends at a terminator, and a malformed one runs to the next
-   terminator.** Scan JSON's number grammar; when the grammar can no longer
-   continue, look at the next character.
-
-   **The scan is maximal munch, and it reaches past the grammar.** A character
-   the grammar can consume is consumed; and a character the grammar *cannot*
-   consume is still taken — **absorbed** — when it is one that looks like
-   number syntax. Absorbing moves the scan into a **non-accepting** state from
-   which the lexeme can no longer end, so it recovers. One rule, measured
-   across every phase:
-
-   > In any number state that has already consumed a digit or the point, a
-   > character in `0-9 . e E +` that the grammar cannot consume is **absorbed**.
-   > `-` is never absorbed — it terminates. The bare-sign state absorbs nothing.
-
-   Which characters that leaves per phase, measured — every column is a fact
-   about today's tokenizer, not a choice this design makes:
-
-   | state | absorbs | so this is one error |
-   | - | - | - |
-   | after the sign — `-` | *nothing* | — |
-   | integer part — `12` | `+` | `12+1` |
-   | integer part after a leading `0` — `0` | `0`-`9` `+` | `00`, `01`, `0+1` |
-   | after the point — `1.` | `.` `e` `E` `+` | `1..1`, `1.e1`, `1.+1` |
-   | in the fraction — `1.5` | `.` `+` | `1.5.1`, `1.5+1` |
-   | after the exponent letter — `1e` | `.` `e` `E` | `1e.1`, `1ee1` |
-   | after the exponent sign — `1e+` | `.` `e` `E` `+` | `1e+.1`, `1e++1` |
-   | in the exponent — `1e5` | `.` `e` `E` `+` | `1e5.1`, `1e5+1` |
-
-   The pattern is one grammar's leftovers seen through another: `+`, a second
-   `.`, a second `e` are all *number* characters, so JavaScript's machine keeps
-   eating them and then reports the whole run invalid. Where the grammar wants
-   the character the question never arises — `1e+5` consumes its sign, `12.5`
-   its point.
-
-   Two review rounds found this rule one phase at a time, which is why it is
-   stated generatively and then measured rather than listed. `12+"]` is
-   `invalid number` then `]` today; re-dispatching the `+` hands `"` to a
-   string scan that eats the `]`. `1e."/1` is `invalid number`, an error for
-   `/`, then `number 1`; re-dispatching the `.` loses that `1` the same way.
-   Nothing here is an improvement and none of it is JSON's — it is reproduced
-   because not reproducing it destroys tokens today's tokenizer emits.
-
-   What happens at the end is decided by **how the lexeme failed**, and there
-   are three cases, not two. An earlier draft had two and would have destroyed
-   tokens in five number phases.
-
-   - **Accepting stop.** The lexeme is complete, and the character that ended it
-     is re-dispatched. It becomes a `number` token if that character is an
-     accepting terminator — JSON's set below, and the caller's in general, per
-     the seam section — and one `invalid number` if it is not — `"` in
-     `12"a"`, `;` in `12;1` — with the character re-dispatched either way, so
-     the string or the next token still scans. An absorbed character never
-     reaches this case, per the rule above.
-   - **Incomplete stop.** The grammar wanted more and met a character that
-     cannot continue: `-`, `1.`, `1e`, `1e+`, `1e-`. One `invalid number`, and
-     the character is **re-dispatched**, exactly as in the accepting case.
-     `1e"a"` is `invalid number` then the string `"a"` — which is what the
-     tokenizer does today, in all five phases. `12.]` is here rather than above,
-     since `12.` stops after the point: `error, ]`.
-   - **Absorbed character.** The table above pulled a character into the
-     lexeme, which is now invalid and cannot end. This is the **only** case
-     that enters **recovery** — consume through to the next recovery boundary
-     and emit one `invalid number`, so `00abc`, `01"a"`, `012"a"`, `12+"a"` and
-     `1e."a"` are each a single error with the rest swallowed.
-
-   Measured, that third trigger is exactly as wide as the table and no wider:
-   `01"a"`, `00"a"`, `012"a"`, `-00"a"`, `12+"a"` and `1e."a"` swallow the
-   string, while `1.2"a"`, `1e2"a"`, `-0"a"` and `-."a"` emit it. Any rule that sent every non-accepting stop to
-   recovery would swallow strings after `-`, `1.`, `1e`, `1e+` and `1e-` — five
-   phases of token loss, from one word in the rule.
-
-   The pair most easily conflated: `0abc` is an *accepting* stop (the `0`
-   completes) so it is `invalid number` then `invalid token`, while `00abc`
-   absorbed its second digit so it is one error.
-
-   A character the grammar can still consume is consumed, so the terminator
-   test never fires mid-lexeme: the `-` in `1e-5` is an exponent sign, because
-   after `e` the grammar wants one.
-
-   Requiring a terminator is why `0abc` reports `invalid number` for the `0`
-   rather than accepting it as a number. RFC 8259 does not demand that — `0` is
-   a complete `number` and the *parser* would reject what follows — but in a
-   valid document a number is always terminated, so requiring it rejects
-   nothing valid and says something far more useful about input that is wrong.
-   The `"` case is the same judgement applied consistently: a number abutting a
-   string is as malformed as a number abutting a word.
-
-   It does **not** collapse the whole run into one token. `0abc` is `invalid
-   number` and then `invalid token`, because the `a` is re-dispatched and the
-   word rule takes it — two errors, exactly as today. Only an **absorbed
-   character** — `00abc`, `01"a"`, `12+"a"`, `1e."a"` — enters recovery and
-   consumes the rest into a single error.
-
-   `-` has to be in the terminator set, and the proofs are what say so:
-   `tokenize('10-0')` asserts the two number tokens `10` and `-0`. Without `-`
-   as a terminator the whole input would scan as one `invalid number`, breaking
-   an accepted-input proof — the very bar this design sets for itself.
-
-3. **A malformed string runs to its next *unescaped* quote, which it
-   consumes.** The general terminator rule cannot apply inside a string
-   literal, where the only structure is the quote: re-dispatching the closing
-   `"` of `"\x"` would start a *second* string that then hits end of input,
-   giving two errors where one was promised. Recovery therefore ends at the
-   closing `"`, consuming it, or at end of input for an unterminated literal.
-
-   **Recovery keeps interpreting backslashes** — it is scanning for the end of
-   the literal, not for the next quote character. In `"\x\""` the quote after
-   the bad `\x` is the second half of a `\"` escape and only the final quote
-   closes the literal; stopping at the first would report one error and then
-   start an unterminated string at the last quote, which is the two-error shape
-   this rule exists to prevent.
-
-   **A raw LF or CR also ends recovery**, and is re-dispatched rather than
-   consumed. This matches what the tokenizer does today — `"a<LF>1` reports the
-   unterminated literal and then goes on to emit the number `1` — and it is
-   worth keeping on its own merits: an unterminated string should not eat the
-   rest of the file. A raw space does not end it (`"a 1` is one error today),
-   because a space is legal inside a JSON string and a newline is not.
-
-   Getting the boundary right matters beyond the error count, because it
-   decides where the rest of the input resumes. Today `"ok\x\"tail" 1` already
-   ends the literal at the final unescaped quote and goes on to tokenize the
-   `1` — it just also emits a fabricated string `okx"tail` on the way. The new
-   rule keeps that boundary and drops the fabricated token.
-4. **A word is a maximal run of `[A-Za-z0-9_$]`**, and it is a keyword only if
-   the whole run is exactly `true`, `false` or `null`. Otherwise it is one
-   `invalid token`. A character outside that set ends the word and is
-   re-dispatched.
-
-   Maximal matching rather than prefix matching is the whole content of this
-   rule, and it is what today's tokenizer already does — measured, not assumed:
-   `truefalse`, `true0`, `true_`, `true$`, `nullx` and `tru3` each give one
-   `invalid token`, while `true]`, `true,` and `true true` give the keyword and
-   then the next token. A prefix matcher would emit `true` followed by
-   something for every input in the first group, which fits the grammar just as
-   well and would silently change the public token stream. `_x` and `$x` are
-   `invalid token` too, so `_` and `$` start a word rather than being
-   unexpected characters.
-
-   The rule meshes with rule 2 in both directions: `-` is not a word character,
-   so `null-1` is `null` then the number `-1`; and a digit starts a number
-   rather than a word, so `tru3` is one `invalid token` while `0abc` is an
-   `invalid number` followed by one — the digit sends it to the number scanner
-   first, which rejects the `0` and re-dispatches the `a`.
-
-5. **The message names the lexeme that failed** — `invalid number`,
-   `invalid string`, `invalid token` for a word run that is not `true`,
-   `false` or `null`, and `unexpected character` for a code unit that can
-   start no JSON token at all (`ÿ` after `true` is one, since it is outside the
-   word-character set).
-
-Rule 2 is what makes the count stop depending on JavaScript. Today the same
-malformed number reports once or twice according to whether it carried a sign,
-and `--` reports once where `---` reports twice — the first pair being a JS
-decrement operator rather than anything JSON can see. Under one rule the count
-follows the input instead:
-
-| input | today | proposed |
-| --- | --- | --- |
-| `"\x"` | error, string `"x"` | one `invalid string` |
-| `"\uEeFg"` | error, string `"g"` | one `invalid string` |
-| `"a<TAB>b"` | error, string `"ab"` | one `invalid string` |
-| `-00` | error, error | one `invalid number` |
-| `-0.` | error, error | one `invalid number` |
-| `-` | `invalid token` | one `invalid number` |
-| `--`, `---` | one error / two errors | two / three `invalid number` — one per `-` |
-| `10-0` | number `10`, number `-0` | unchanged — `-` terminates a number |
-| `-.123` | error, error, number `123` | same count — `invalid number`, `unexpected character`, number `123` |
-| `0abc,` | error, error, `,` | unchanged — `0` completes, `abc` re-dispatched |
-| `1true` | error, `true` | unchanged — same reason |
-| `0n`, `123n` | `invalid token` — a **JS bigint literal** | `invalid number`, `invalid token` |
-| `[-123n]` | `[`, error, error, `]` | `[`, error, error, `]` — same count, JSON's messages |
-| `12"a"` | error, string `"a"` | unchanged — `"` ends without accepting |
-| `12+1` | one error — `+1` is **swallowed** | unchanged — the `+` is absorbed |
-| `12+"]` | error, `]` | unchanged — the `]` survives because the `+` is absorbed |
-| `1e."/1` | error, error, number `1` | same count — `/`'s message becomes `unexpected character` |
-| `>>>=` | one `invalid token` — a **JS operator** | four `unexpected character` |
-| `/*a*/1` | one `invalid token` — a **JS comment** — then number `1` | four `unexpected character` and one `invalid token` for the word `a`, then number `1` |
-| `/*"*/1` | one `invalid token`, then number `1` | two `unexpected character`, then one `invalid string` — **`1` is lost** |
-| `1n1` | **number `11`, no error** — the `n` is deleted | `invalid number`, `invalid token` |
-| `0n1` | **number `01`, no error** — not valid JSON | `invalid number`, `invalid token` |
-| `1n1n1` | **number `111`, no error** — both `n`s deleted | errors |
-| `00-2` | one error — `-2` is **swallowed** | unchanged — `-` is not a recovery boundary |
-| `00-` | one error | unchanged |
-| `00-"/1` | error, error, number `1` | same count — `/`'s message becomes `unexpected character` |
-| `00"a"` | one error — the string is swallowed | unchanged — `"` is not a recovery boundary |
-| `00"/1` | error, error, number `1` | same count — `/`'s message becomes `unexpected character` |
-| `00<LF>1` | error, number `1` | unchanged — LF was already a boundary |
-| `00/1` | error, error, number `1` | same count — `/`'s message becomes `unexpected character` |
-| `12/1` | number `12`, error, number `1` | same count — `/`'s message becomes `unexpected character` |
-| `00;1` | one error — `;` is not a boundary | unchanged |
-| `"a<LF>1` | error, number `1` | unchanged — LF ends string recovery |
-
-An unterminated string stays one error, and today it has **two** messages
-depending on how it ended — `" are missing` at end of input, `unterminated
-string literal` at a raw newline. Both become `invalid string`.
-
-The `00-2` and `00-` rows are a recovery class of their own, and the current
-behavior there is worse than noisy — it is lossy. Today a malformed number
-swallows a following `-` and everything after it: `00-2` reports one error and
-the well-formed number `-2` never reaches the caller at all. And it does this
-inconsistently, which is the tell that it is an accident rather than a policy —
-`0.-2` and `12.-2`, malformed in a different way, *do* emit the `-2`.
-
-This is the same defect class as the fabricated string, running the other
-direction: one invents a token the input never contained, the other discards one
-it did. **It is recorded here and not fixed here** — a draft made `-` a
-recovery boundary and lost a different token in `00-"/1`; see "Where a number
-lexeme ends" for the counterexample and why the fix belongs in its own change.
-
-#### What is preserved, and what is only recorded
+### What is preserved, and what is only recorded
 
 Five review rounds were spent trying to state a rule that preserves today's
 malformed-number behavior. Each attempt was wrong, and the reason is worth
@@ -528,7 +253,7 @@ before/after record, reviewed as data.
 That is the honest shape of this change, and it is stronger than the invariants
 the earlier drafts claimed, because these two are true.
 
-#### The accepting set, measured
+### The accepting set, measured
 
 A complete number is accepted today when followed by:
 
@@ -581,7 +306,7 @@ to the closing `*/` and emits one error there, resuming after it. That rejects
 comments as firmly as anything here — it never yields a comment token, and no
 input moves out of erroring — so "you would have to accept comments" was never
 the obstacle. It is **block** comments only: in `//"<LF>1` the LF ends
-string recovery and is re-dispatched, per rule 3, so the `number 1` still
+string recovery and is re-dispatched, so the `number 1` still
 arrives — a line comment cannot swallow a suffix, because the construct and the
 malformed string end at the same character. Reproducing today's result
 would still mean giving JSON's scanner the *extent* of a JavaScript construct —
@@ -609,21 +334,64 @@ because recovering it costs more than it returns.
 Narrowing the set to JSON's own delimiters is defensible, and is a separate,
 deliberate change with its own proofs — not something to slip into a port.
 
-#### Where a number lexeme ends
+### Maximal munch reaches past the grammar
+
+**The scan is maximal munch, and it reaches past the grammar.** A character
+the grammar can consume is consumed; and a character the grammar *cannot*
+consume is still taken — **absorbed** — when it is one that looks like
+number syntax. Absorbing moves the scan into a **non-accepting** state from
+which the lexeme can no longer end, so it recovers. One rule, measured
+across every phase:
+
+> In any number state that has already consumed a digit or the point, a
+> character in `0-9 . e E +` that the grammar cannot consume is **absorbed**.
+> `-` is never absorbed — it terminates. The bare-sign state absorbs nothing.
+
+Which characters that leaves per phase, measured — every column is a fact
+about today's tokenizer, not a choice this design makes:
+
+| state | absorbs | so this is one error |
+| - | - | - |
+| after the sign — `-` | *nothing* | — |
+| integer part — `12` | `+` | `12+1` |
+| integer part after a leading `0` — `0` | `0`-`9` `+` | `00`, `01`, `0+1` |
+| after the point — `1.` | `.` `e` `E` `+` | `1..1`, `1.e1`, `1.+1` |
+| in the fraction — `1.5` | `.` `+` | `1.5.1`, `1.5+1` |
+| after the exponent letter — `1e` | `.` `e` `E` | `1e.1`, `1ee1` |
+| after the exponent sign — `1e+` | `.` `e` `E` `+` | `1e+.1`, `1e++1` |
+| in the exponent — `1e5` | `.` `e` `E` `+` | `1e5.1`, `1e5+1` |
+
+The pattern is one grammar's leftovers seen through another: `+`, a second
+`.`, a second `e` are all *number* characters, so JavaScript's machine keeps
+eating them and then reports the whole run invalid. Where the grammar wants
+the character the question never arises — `1e+5` consumes its sign, `12.5`
+its point.
+
+Two review rounds found this rule one phase at a time, which is why it is
+stated generatively and then measured rather than listed. `12+"]` is
+`invalid number` then `]` today; re-dispatching the `+` hands `"` to a
+string scan that eats the `]`. `1e."/1` is `invalid number`, an error for
+
+That table is what the two references below mean by "absorbed", and it is a fact
+about today's tokenizer rather than a choice: `+`, a second `.` and a second `e`
+are all *number* characters, so JavaScript's machine keeps eating them and then
+reports the whole run invalid.
+
+### Where a number lexeme ends
 
 Three failure states, which earlier drafts conflated into two:
 
 - **A complete number followed by a character outside the accepting set** emits
   one `invalid number` and **re-dispatches** that character. `1true` is
   `invalid number` then `true`; `12"a"` is `invalid number` then the string.
-  `+` is not such a character — it is absorbed, below.
+  `+` is not such a character — it is absorbed, per the table above.
 - **An incomplete number** — the grammar wanted more and met a character that
   cannot continue — does the same: one `invalid number`, character
   **re-dispatched**. `1e"a"` is `invalid number` then the string, and so are
   `-"a"`, `1."a"`, `1e+"a"` and `1e-"a"`. This is the case a two-state rule
   swallowed, destroying a string in all five phases.
 - **An absorbed character** — a number-syntax character the grammar cannot
-  consume, per the table in rule 2 — is the **only** state that enters
+  consume, per the table above — is the **only** state that enters
   recovery, consuming until a boundary and emitting one `invalid number`.
   `00abc`, `01"a"`, `012"a"`, `12+"a"` and `1e."a"` are each one error.
 
@@ -664,322 +432,10 @@ recovery-policy changes with proofs of their own, and neither is something to
 slip into a port. Whoever takes it should start from `00-"/1`, which is the case
 that makes the obvious fix wrong.
 
-### The string and number scanners are the seam DataJS reuses
+### Stage 3a — the fabricated token — **landed**
 
-The plan promises this module exports its string and number scanners so
-`fjs/media/datajs` can reuse them, and that consumer is **real and immediate**:
-DataJS's tokenizer reuses parts of JSON's rather than restating them, and stage
-4 follows soon after — with stage 1b, the conformance corpus, between them.
-
-What DataJS needs is known precisely enough to shape the seam:
-
-- **Strings are JSON's, unchanged** — same grammar, same escapes, same
-  rejection of raw control characters. `scanString` is reused as-is.
-- **Numbers are JSON's, unchanged.** The spec is explicit
-  ([`spec/datajs/README.md`](../../../../spec/datajs/README.md)): a DataJS
-  number *is* a JSON number, same production. What DataJS adds sits beside it,
-  not inside it — a **bigint is its own production**, `'-'? int 'n'`, reusing
-  JSON's integer part, and deliberately not "a number followed by `n`", since
-  that would accept `1.5n` and `1e2n`, which JavaScript rejects. And `NaN`,
-  `Infinity` and `-Infinity` are **words**, not number syntax at all; the `-`
-  folds into a following `Infinity` *word*.
-
-  So the reuse is of JSON's number *scanner*, not an extension of its number
-  *rule*. What stage 4 needs is to reach into the middle of that scanner —
-  hence the phase clause below.
-
-So the two are exported, and this stage owes their **entry contract** in
-writing, not just their signatures — that was the gap in an earlier draft, where
-a bare `(input, state) => [tokens, state]` named no state type, no initial
-value, and no convention for which character the caller had already consumed. An
-export a second implementation could satisfy incompatibly is not a contract.
-Each scanner therefore ships with:
-
-- a named state type in `types.ts`;
-- an exported initial state, with the convention that **the scanner consumes
-  its own opening character** — the `"` for a string, the `-` or first digit
-  for a number — so there is no "already consumed" ambiguity at the boundary;
-- a stated rule for how the caller learns the lexeme ended, and whether the
-  terminating character was consumed or must be re-dispatched;
-- **the signature itself**, below. Naming the states and the conventions is not
-  enough: "consumes the stopping character and emits a token" and "reports a
-  stop and emits nothing" both satisfy the prose above, and stage 4 can only
-  use the second.
-
-#### The signature, so the seam has one shape rather than two
-
-```ts
-export type ScanResult<S> =
-    { readonly kind: 'consumed', readonly state: S } |
-    { readonly kind: 'stopped',  readonly state: S }
-
-export type Scan<S> = (state: S) => (input: U16 | null) => ScanResult<S>
-```
-
-Both scanners are that shape — `Scan<StringState>` and `Scan<NumberState>` —
-and each ships its initial state as a named export, spelled out here because
-the paragraph above rules that "an export a second implementation could satisfy
-incompatibly is not a contract" and then, in an earlier draft, said only *that*
-there was an initial state:
-
-```ts
-export const scanString: Scan<StringState>
-export const scanNumber: Scan<NumberState>
-
-export const stringStart: StringState   // { kind: 'start' }
-export const numberStart: NumberState   // { kind: 'start', lexeme: [] }
-```
-
-The **values** are part of the contract, not just the types. `numberStart`'s
-`lexeme` is empty, and both kinds are `'start'` rather than a phase an input
-could also reach — which is the property the state task already requires proved,
-and it is unprovable against an initial state the design never named.
-
-Three properties, and each is load-bearing for something already argued above:
-
-- **A scanner emits no tokens.** It advances a state, and the state carries the
-  lexeme accumulated so far. Building a `JsonToken` is the caller's, which is
-  what lets JSON build one and DataJS build a different one from the same scan.
-- **`stopped` does not consume the character.** The caller sees the state and
-  the character it stopped at, and decides: terminate, re-dispatch, or take
-  over. That is the whole of "the terminator sets are the caller's", expressed
-  as a return type rather than a promise — and it is where `n`, `Infinity` and
-  `;` are intercepted, all three before any accept-or-reject.
-- **Absorption stays inside `consumed`.** A character the grammar rejects but
-  maximal munch takes — rule 2's table — is a `consumed` that moves to the
-  recovery variant, never a `stopped`. Absorption decides what the lexeme *is*,
-  so it is the scanner's; termination decides what to *do* with it, so it is
-  the caller's. Stating both on one return type is what keeps that boundary
-  from drifting.
-
-`input` is `null` at end of input, so a scanner never needs a separate
-finish call, and the caller's terminator policy handles EOF as one more
-non-continuing character.
-
-And the two state types, since `Scan<S>` without `S` is still two APIs:
-
-```ts
-export type NumberState = {
-    readonly kind:
-        'start' | 'sign' | 'int' | 'point' | 'frac' |
-        'exp' | 'expSign' | 'expDigits' | 'recovery',
-    readonly lexeme: readonly U16[],
-}
-
-export type StringState =
-    { readonly kind: 'start' } |
-    { readonly kind: 'body' | 'escape', readonly value: readonly U16[] } |
-    { readonly kind: 'hex', readonly value: readonly U16[], readonly digits: readonly U16[] } |
-    { readonly kind: 'recovery' | 'recoveryEscape' } |
-    { readonly kind: 'done', readonly value: readonly U16[] } |
-    { readonly kind: 'failed' }
-```
-
-**Every one of those `U16`s is a UTF-16 code unit, not a code point**, and
-that is load-bearing rather than a naming preference. The public entry point is
-`tokenize(stringToList(text))` and `stringToList` is `charCodeAt` — code units
-— so the choice is already made by the code this design replaces; an earlier
-draft of this document said "code points" and would have sent an implementer
-to build something the caller cannot feed. Two consequences, both measured
-against today's tokenizer:
-
-```text
-"😀"             → [0xd83d, 0xde00]
-"\ud83d\ude00"  → [0xd83d, 0xde00]      the same value, as JSON requires
-"\ud800"        → [0xd800]              a lone surrogate, preserved
-```
-
-A code-point scan breaks both: the raw astral character would decode to
-`[0x1f600]` while its escaped spelling stayed two units, so two JSON documents
-that denote the same string would decode differently — and a lone surrogate,
-which `\uXXXX` can spell and JSON permits, has no code point to be. The escape
-grammar is `\uXXXX`, a *code unit* escape, so a JSON string simply is a
-sequence of code units; scanning it as anything else re-opens a question JSON
-already answered.
-
-This is also why the scanner never decodes: every non-ASCII code unit,
-surrogate or not, is just "any character except the three excluded classes" in
-the `char` production above, so the string rules never inspect one.
-
-**Recovery is two states, and it carries no value.** `recoveryEscape` is
-required by rule 3: recovery keeps interpreting backslashes, which is why
-`"\x\""` is one error rather than two, so after a backslash the scanner must
-know that the next quote is escaped rather than closing. One `recovery` variant
-cannot answer that without smuggling the distinction into another field, and
-the sweep's `"\x\` prefix exists to exercise exactly this state.
-
-Carrying no value is the second half: a malformed string has no value to
-report, and a variant with nowhere to put one **cannot** produce the fabricated
-token 3a removes. The defect becomes unrepresentable rather than merely
-forbidden.
-
-`NumberState`'s nine kinds are the seven grammar phases plus `start` and
-`recovery`, as argued above — `int` is the bigint interception point, `sign`
-the `-Infinity` one, and `recovery` is closed to the wrapper.
-
-**A number state carries its `lexeme`; a string state carries its decoded
-`value`.** The asymmetry is deliberate and both halves are already required
-elsewhere: a number must reach `value` as its *exact* lexeme with no numeric
-value built while scanning, and a string's value simply *is* its decoding, with
-the escapes resolved by the shared table. Carrying raw text for a string would
-make every consumer re-decode it, and carrying a decoded number would lose the
-spelling the losslessness proofs pin.
-
-**`recovery` is terminal for the number scanner too, and for a reason worth
-stating.** Recovery ends at a *boundary*, and the boundary set is the caller's
-— `00;1` must consume the `;` under JSON's set and stop before it under
-DataJS's. A scanner that consumed during recovery would have to know one set or
-the other, which is the delimiter knowledge this design just moved out of it.
-So on entering `recovery` the scanner returns `stopped` for every input, and
-the caller runs to its own boundary and emits one `invalid number`. Review
-found the hole: the `Scan` signature took only a state and a character, so
-without this the same recovery state could not serve both languages.
-
-The string scanner is different **because its recovery ends at string syntax,
-not at delimiters**: the closing quote, a raw LF, a raw CR — the same in both
-languages, since DataJS's strings are JSON's unchanged. Nothing there is
-policy, so `recovery` and `recoveryEscape` consume as normal and reach
-`failed`. The asymmetry tracks exactly where a caller could disagree.
-
-`done` and `failed` are **terminal**: every input returns `stopped` without
-consuming, so a caller that keeps feeding them gets a stable answer rather than
-an error. A well-formed string reaches `done` by *consuming* its closing quote
-— the quote is part of the lexeme, so it is a `consumed`, and the `stopped`
-comes on the character after. `failed` is where rule 3's recovery ends, whether
-at a consumed closing quote or a re-dispatched LF or CR.
-
-#### The number state exposes its phase, because that is what stage 4 wraps
-
-That list is not sufficient on its own, and saying so is the difference between
-a seam and a signature. Work through what DataJS actually has to do:
-
-- **`1n`.** The bigint production is JSON's *integer* part followed by `n` —
-  with no fraction and no exponent, since JS rejects `1.5n` and `1e2n`. So the
-  wrapper must be able to tell that scanning stopped **after a well-formed
-  `int` with nothing else consumed**, and it must see that before JSON's own
-  recovery treats `n` as a non-terminator and swallows it into an `invalid
-  number`. *Well-formed* is load-bearing: JS rejects `00n` exactly as it
-  rejects `00`, so "stopped in the integer part" must not be a state an
-  absorbed character can also reach — a digit in `00n`, a `+` in `12+n`.
-- **`-Infinity`.** The wrapper must intervene immediately **after the leading
-  minus**, where JSON would otherwise see `I` as a non-terminator and consume
-  the whole run as a malformed number.
-- **`const $0=1;`.** DataJS's statement separator is `;`, which is not in
-  JSON's accepting-terminator set — `12;1` is an `invalid number` today. A
-  DataJS document with a numeric `const` ends that number exactly that way, so
-  the seam is useless to stage 4 unless `;` can terminate an accepting number.
-  The export needs it too, and for the same reason: DataJS terminates every
-  statement with `;`, `export default <value>;` included, so a bare-number root
-  also stops at a `;` rather than at end of input. Both statement kinds put a
-  numeric lexeme in front of one, which makes the requirement a single rule
-  rather than a `const`-only exception — an earlier draft of this paragraph had
-  the export ending at end of input, from a spec revision that briefly dropped
-  the final `;`. Review found the underlying issue, and it is the finding that
-  shapes the clause below: two enumerated interceptions were never going to be
-  enough.
-
-A contract of "named state, initial value, terminator rule" can be satisfied by
-an implementation whose state is opaque — and then neither interception is
-possible. So the contract has one more clause, and it is the load-bearing one:
-
-**`scanNumber`'s state is a public discriminated union.** Its variants are:
-
-- **start** — the exported initial value, nothing consumed yet. It exists
-  because the entry contract says the scanner consumes its own opening
-  character, so a caller holds this state before feeding the `-` or the first
-  digit. It is **closed to interception**: a wrapper reading it has been told
-  nothing, and treating it as the sign or integer variant would let an empty
-  scan pose as a `-Infinity` or bigint site.
-- **the grammar's phases** — after the sign, in the integer part, after the
-  decimal point, in the fraction, after the exponent letter, after the exponent
-  sign, in the exponent.
-- **recovery** — not a phase: the state the error rule above gives a lexeme
-  that absorbed a character the grammar rejects, per rule 2's table.
-
-Each carries the lexeme accumulated so far, empty in **start**. A wrapper
-inspects the state at the moment the scanner meets a character it cannot
-consume, and decides whether to take over *before* the accept-or-reject
-decision is made.
-
-The recovery variant is what keeps the seam honest, and it is why the union is
-listed here rather than left as "the grammar's phases". Without it, the scanner
-after `00` and the scanner after `10` would be the same variant — a wrapper
-reading "in the integer part" would intercept the `n` in `00n` and mint a
-bigint out of a literal JavaScript rejects, and stage 3 would have handed stage
-4 a way to accept something neither language accepts. Hiding the run behind an
-unspecified or opaque state is the same bug wearing a different hat.
-
-So the interception rule is stated on the **state**, not on the character:
-
-- **A wrapper may take over an `n` only from the integer variant**, which is
-  reachable only by a well-formed `int` and is therefore an accepting state.
-  From every other variant — **start** and recovery included — an `n` is JSON's
-  to reject.
-- **The recovery variant is closed to the wrapper**, and JSON's own
-  recovery runs unchanged underneath it — the two are different statements and
-  only the first is about DataJS. The wrapper cannot intercept from this
-  variant at all; recovery then consumes to a **boundary**, exactly as the rule
-  above says, not to the end of the input. So `00n` is one `invalid number`
-  because `n` is not a boundary, while `00/1` is one `invalid number`, an
-  `unexpected character` and `number 1` because `/` is — the token DataJS must
-  not lose any more than JSON must.
-- **`-Infinity` is intercepted from the sign variant**, and only from it, by
-  the same discipline: a non-accepting state a wrapper is allowed to claim
-  before JSON rejects it, named rather than inferred.
-
-And one clause that is not about interception at all, because `;` showed the
-enumeration was the wrong shape:
-
-- **The accepting-terminator set is the caller's, not the scanner's.**
-  `scanNumber` scans the lexeme — absorption included, since that decides what
-  the lexeme *is* — and reports where it stopped and in which state. Whether
-  the stopping character *terminates* is policy applied afterwards, by whoever
-  called it. JSON's tokenizer applies the measured set above and nothing
-  changes for it; DataJS applies that set plus `;`, so both `const $0=1;` and
-  `export default 1;` yield `number 1` at the `;`. Every other character DataJS
-  can put after a number —
-  `,` `]` `}` and whitespace — is already in JSON's set, so `;` is the whole
-  difference.
-
-  The **recovery boundary set travels with it**, for the same reason and by the
-  same argument — it is delimiters, not grammar — so DataJS recovers a
-  malformed number at its own `;` rather than swallowing the statement end.
-  JSON's stays today's, exactly.
-
-  This is not parameterizing the grammar, the thing this stage refuses to do.
-  Neither set was ever lexical: both are JavaScript operator tables reproduced
-  for compatibility, sitting where a language's own delimiters belong. Moving
-  them to the caller puts each language's delimiters in that language's module,
-  and is the reason `;` needs no special case.
-
-That is what makes `-Infinity` and `1n` expressible without stage 3 knowing
-anything about them — and `00n` inexpressible, which matters just as much.
-
-Note what this is not: stage 3 still does not add DataJS's productions. There is
-no bigint branch and no `Infinity` branch in JSON's scanner, and no
-configuration parameter that switches them on. Exposing which phase the machine
-is in is not the same as parameterizing it — the first is making the existing
-machine observable, the second is putting someone else's grammar inside it. An
-earlier draft of this section said "do not parameterize" and left it there,
-which read as forbidding both; only the second is forbidden.
-
-One honest caveat remains: a seam designed one stage before its caller can still
-come out the wrong shape. Stage 4 may need to adjust it, and that is cheap
-precisely because these exports are new here and unreleased, so changing them
-breaks nobody.
-
-### The stage lands as two changes: the fix, then the port
-
-Review raised that this stage did two things at once — removed a dependency and
-changed error recovery — and that a PR should do one. Earlier drafts argued the
-split was unavailable. **That was wrong**, on the repo's own rule and on the
-facts, and the design now splits.
-
-[`DESIGN.md`](../../../../doc/DESIGN.md) settles the question and even settles the
-order. It forbids *the combination*, not a fixed order, and it names this exact
-case: when the idea is the **premise** — decided before any port and provable in
-the existing context — the separation runs idea first, then the port, "which
-then carries no idea of its own beyond what the shared code already does".
+Independent of everything above, and still correct under the new direction: it
+fixes the wrapper that remains in place until the grammar replaces it.
 
 #### Stage 3a — the fabricated token, fixed where it lives — **landed**
 
@@ -1018,97 +474,6 @@ without JSON's own machine knowing about it. Either way the port deletes it,
 which is the point rather than a cost: it is what makes 3b carry no idea of its
 own.
 
-#### Stage 3b — the port, carrying only what the removal forces
-
-Everything else in this design belongs to the port, because it **is** the
-removal showing through rather than a policy this stage chose:
-
-- the `n`-deletion acceptance fix, which the wrapper *cannot* make — it sees the
-  token value `11`, never the `1n1` that produced it, so nothing in the existing
-  context can tell the two apart;
-- `JsonToken`'s error `message` narrowing to JSON's own four literals, since the
-  ten-message union is the JavaScript tokenizer's;
-- the three-case failure rule, absorption, and the terminator sets as caller
-  policy — all statements about a scanner that does not exist until 3b;
-- `--` reporting once today because the JavaScript tokenizer merges it into a
-  decrement operator, and the `-00`/`00` sign asymmetry beside it;
-- `>>>=` as one `invalid token`, and the block-comment suffix loss.
-
-Reproducing any of these in a new scanner would mean writing new code to
-implement JavaScript's lexical structure inside JSON — which is the coupling
-being removed.
-
-Attribution then has both halves: 3a is one small change with its own proofs,
-and 3b is judged as a port. Every accepted-input proof must pass
-**byte-identically**, so any failure among them is the port — that half is a
-closed set, because the proofs are enumerated. Error-shape differences are
-judged against the **two invariants and the stated rules**: a difference is
-**3b's** if it follows from them, and a defect in the port if it does not. The
-split does not change that test, because after it the error rules *are* the
-port's — 3a carries none of them. The generated sweep tables are how such
-differences are *surfaced*; they do not decide which ones may exist, and the
-next section says why they cannot.
-
-**No finite sweep is exhaustive**, and this design has now claimed otherwise
-four times — first over two number prefixes, then over the number scanner
-alone, then over the new scanner's states while the *old* one has states the new
-one deliberately lacks, and then over a prefix list that announced one prefix per
-state and delivered neither: it gave none for three of `StringState`'s eight
-kinds, and none for the leading zero, whose behavior `NumberState` keeps in the
-`lexeme` rather than the `kind`. That last round is the sharpest, because the
-rule above the list was right both times and the list under it had simply never
-been re-derived. `>>>=` is one `invalid token` today, because the
-JavaScript tokenizer knows it as a single operator; the replacement emits four
-`unexpected character` errors, and no prefix derived from the new scanner
-reaches that.
-
-So the sweep is **coverage, not a proof**, and attribution rests on the two
-invariants plus the stated rules: a difference is expected if it follows from
-the rules, and a bug if it does not — including a difference no table contains,
-which is why the paragraph above cannot make absence from the tables a verdict. The tables make violations likely to be
-*found*; they do not make the set of differences finite. Their prefixes should
-be derived from the union of both machines — including the old one's operator
-runs — because that is where the differences the new machine cannot predict
-come from.
-
-The changed-shapes table above is narrower still: illustrative, and known
-incomplete. `+1` and `.5`
-are `invalid token` today and become `unexpected character`, and neither has a
-row — the table lists the cases worth explaining to a reader, while the sweep
-lists all of them. An earlier draft rested the attribution rule on the manual
-table, which would have misclassified a correct implementation as a
-regression.
-
-### Edits owed to existing issues
-
-Two open issues are written against the dependency this stage removes, and both
-would otherwise send someone to build something stage 3 deletes. **666 is
-already rewritten, in this PR; only `streaming-recognizer` is still owed.**
-
-- [666-js-tokenizer-position-layer](../../../js/todo/666-js-tokenizer-position-layer.md)
-  — proposes exporting a raw, metadata-free `tokenizeRaw` entry point from
-  `fjs/js/tokenizer`, with a task to "switch `fjs/media/json/tokenizer` to
-  consume it". JSON is that export's **only** proposed consumer, and no other
-  exists: DJS imports two helpers and drives its own tokenizer. So after stage
-  3 the export would be dead public API, against the issue's own
-  defer-until-a-second-consumer rule. **Done in this PR**, and more firmly than
-  an earlier draft of this paragraph claimed: the export and the JSON task are
-  *deleted* from the proposal and the task list, not struck through, and the
-  file records "removed, not deferred". What survives there is the internal
-  `tokenizeOp` re-extraction, which needs no consumer to justify it.
-- [streaming-recognizer](./streaming-recognizer.md) — requires the recognizer
-  to reuse "the tokenizer's *transition structure*" and to inherit the
-  raw-control-in-string rejection from `fjs/js`'s `parseStringStateOp`. Its
-  design survives intact and improves: the scanner it factors over a no-op
-  builder becomes JSON's own string and number scanning, so "one grammar, two
-  builders" stops meaning "one *JavaScript* grammar". A pointer note is in place;
-  the citations are repointed in the implementation PR, where the premise
-  actually becomes true.
-
-### Tasks
-
-Two PRs, in this order. Everything from "Stage 3b" down is the second.
-
 #### Stage 3a — drop the fabricated string
 
 **Done.** `dropFabricatedString` in
@@ -1142,253 +507,49 @@ Two PRs, in this order. Everything from "Stage 3b" down is the second.
       the tree, not to the diff, and "not affected by this change" is a
       prediction where a green run is a fact.
 
-#### Stage 3b — the port
+### What unblocks this
 
-- [ ] Write the scanner in `fjs/media/json/tokenizer/module.f.mjs`; delete the
-      `fjs/js/tokenizer` import, the `mapToken`/`parseMinusState` wrapper, and
-      3a's fabricated-token suppression, which the scanner makes unreachable.
-- [ ] Move `StringToken`, `NumberToken`, `ErrorToken`, `EofToken` into
-      `fjs/media/json/tokenizer/types.ts`; drop the `js/tokenizer` imports.
-      Give `ErrorToken` JSON's own four-literal `message` union rather than
-      widening it to `string` or copying JavaScript's ten.
-- [ ] Repoint `fjs/media/json/parser/types.ts`'s direct `NumberToken` import at
-      `../tokenizer/types.ts`, so no file under `fjs/media/json` names
-      `js/tokenizer`.
-- [ ] Keep every accepted-input proof unchanged; rewrite only the error-shape
-      cases, each with the reason it changed.
-- [ ] Add string-recovery proofs for the escape cases, which today's suite does
-      not cover: `"\x\""` is one `invalid string`, and `"ok\x\"tail" 1` is one
-      `invalid string` followed by the number `1` — the second pins the
-      resumption point, not just the count. Pin at least one *other* invalid
-      escape (`"\v"`) and one raw control character, so the proof holds the
-      class rather than three instances of it.
-- [ ] Add word-boundary proofs, which today's suite does not cover: `true0`,
-      `true_`, `true$`, `nullx`, `tru3` and `_x` are each one `invalid token`;
-      `null-1` is `null` then `-1`; `trueÿ` is `true` then
-      `unexpected character`.
-- [ ] Keep the losslessness proofs — a valid number reaches `value` as its
-      exact lexeme, with no derived numeric value built while scanning.
-- [ ] 100% proof coverage, including `scanString` and `scanNumber` called
-      directly from their exported initial states — not only through
-      `tokenize`. A seam proved only via its own module's entry point is not
-      proved as a seam, and stage 4 is about to be its second caller.
-- [ ] Prove the terminator policy is the caller's: `scanNumber` reports the
-      stop, `fjs/media/json/tokenizer` applies JSON's set, and a proof feeds
-      the scanner `1;` with a set containing `;` and gets `number 1` — the
-      case stage 4 needs for `const $0=1;`, the terminal export's bare number
-      being covered by the end-of-input member the set already carries. JSON's own tokens must not
-      move: `12;1` stays `invalid number`, `unexpected character`, `number 1`.
-- [ ] Export `Scan<S>`, `ScanResult<S>`, `StringState` and `NumberState` from
-      `types.ts`, and `scanString`, `scanNumber`, `stringStart` and
-      `numberStart` from the module, **as declared above** — the initial states
-      by those names and with those values, since stage 4 imports them — the kinds and fields, not a shape of
-      the implementer's choosing, with `U16` imported from
-      [`fjs/text/utf16/types.ts`](../../../text/utf16/types.ts) rather than
-      spelled `number`. It is an alias, so this buys no checking; it buys the
-      reader the one fact a bare `number` hides, and this document has already
-      lost that fact once — and prove the properties stage 4 rests on:
-      a scan emits no token; a `stopped` leaves the character unconsumed so the
-      caller can terminate, re-dispatch or take over; `done` and `failed` are
-      terminal; and a number's `lexeme` is its exact source text while a
-      string's `value` is decoded.
-- [ ] Prove the state is observable the way stage 4 needs: from the exported
-      state alone, a caller can distinguish "stopped after a well-formed `int`"
-      (the bigint interception point) from "stopped after the sign" (the
-      `-Infinity` one), from **start**, from **recovery**, and from every other
-      variant, before the accept-or-reject decision. Pin the ways into recovery
-      explicitly — after `00`, after `12+`, after `1e.` — since that is the
-      single distinction standing between stage 4 and a bigint built from
-      `00n`, `12+n` or `1e.n`; and pin that the initial state is **start** and
-      not the sign or integer variant, so an untouched scanner cannot pose as
-      an interception site.
-- [ ] Confirm afterwards that no runtime importer of `fjs/js/tokenizer` calls
-      `tokenize`, and that `fjs/djs/tokenizer`'s `isKeywordToken`/`mergeTrivia`
-      import is all that is left. The machine is retired in stage 7, not here.
-- [ ] Repoint `streaming-recognizer`'s scanner citations at JSON's own string
-      and number scanners. (666's edit is **already done** — it was rewritten in
-      the PR that filed this design, so nothing is owed there.)
-- [ ] Add the `Changelog:` section to the PR description. The implementation
-      changes observable behavior of the public `tokenize` — the error tokens it
-      emits — so the declaration is
-      required, with an additive half for the newly exported `scanString`,
-      `scanNumber`, their initial states `stringStart` and `numberStart`, and
-      their state types, and a note that `JsonToken`'s error
-      `message` narrows to JSON's own four-literal union. Prefix the error-shape half with
-      `**BREAKING CHANGES:**`: a
-      direct consumer matching on today's messages (`" are missing` and
-      `unterminated string literal`, which both become `invalid string`,
-      `unescaped character`, `invalid token` for `0n`) sees different tokens,
-      and `1n1` starts erroring where it was a number. The fabricated value
-      token is **3a's** entry, not this one — it is gone before the port
-      begins, and claiming it here would credit the port with a change it did
-      not make. Valid JSON is unaffected, and the entry should say so.
-- [ ] **Derive the sweep's prefixes from the scanners' own behavior** — rule
-      2's absorption table for numbers, `StringState`'s kinds for strings —
-      rather than listing the ones that came to mind. This requirement is
-      the point: the prefix set has now been too narrow in three review rounds
-      — first covering only `12` and `00`, which cannot see that `1e"a"` emits
-      a string today; then covering only the number scanner, which cannot see
-      that `"\x"` changes at all; then, in one round, both listing five of
-      `StringState`'s eight kinds under a heading promising all of them **and**
-      omitting the leading zero. The first two called the sweep exhaustive
-      while being exhaustive over one axis. The third is why the last sentence
-      of this task exists — a list that loses to the state set is only useful
-      if someone runs the comparison, and for one round nobody did — and why
-      the derivation below names its two sources instead of saying "the
-      states".
-
-      Every state of every scanner needs a prefix — but "state" here is
-      **behavior, not `kind`**, and the two do not coincide. Derive the number
-      prefixes from rule 2's absorption table, which enumerates eight phases,
-      and the string prefixes from `StringState`'s kinds; the union is the
-      list. Review found this the hard way, having first written a list off the
-      kind unions alone and lost the leading zero: `0` and `12` are both `int`,
-      and they diverge on the very next character — `120` is `number 120` and
-      `00` is an error. The split lives in the `lexeme`, not in the `kind`.
-
-      The kinds are still right, and should *not* grow a `zero` variant to make
-      the derivation tidier. No caller wants the distinction: `0n` is as valid
-      a bigint as `12n`, so stage 4's interception point is exactly `int`, and
-      splitting it would make the wrapper match two kinds to ask one question.
-      The state set is the API; the prefix list is a test obligation. It is the
-      list that owes the finer grain.
-
-      A **text** prefix also reaches a scanner state only through the
-      tokenizer's own dispatch, so it pins that state against the characters the
-      tokenizer can deliver, not against every character the now-public API
-      admits. Two states are therefore not prefixes of their own, and the list
-      has to say so, because each is a place where a mechanically
-      complete-looking list would be **false** coverage: `start` shares the
-      empty prefix, and the two terminal states cannot be any prefix's resting
-      state at all.
-
-      So enumerated:
-
-      - **top level** — the empty prefix, so a bare `c` is swept. This one
-        prefix is also **`start`** for both scanners: `c` is where the
-        dispatcher hands `"` to a fresh string scan and a digit or `-` to a
-        fresh number scan, and inside the tokenizer neither scanner has any
-        other way in;
-      - **number** — one per row of the absorption table: `12` in the integer
-        part, **`0` after a leading zero**, `1.5` in the fraction and `1e5` in
-        the exponent, all accepting; `00`, `12+` and `1e.` for recovery; and
-        `-`, `1.`, `1e`, `1e+`, `1e-` incomplete. `12` cannot stand in for `0`:
-        the two share the `+` that both absorb, and differ on every digit,
-        which is the character that separates them;
-      - **string** — inside a literal (`"a`), after a backslash (`"\`), each
-        `\u` hex position (`"\u`, `"\uA`, `"\uAB`, `"\uABC`), and — since
-        rule 3 gives malformed strings a recovery of their own — **inside
-        recovery** after an invalid escape (`"\x`) and its post-backslash
-        substate (`"\x\`). Without those two, a mishandled quote, backslash,
-        LF or CR *after* an invalid escape is reachable only by the handful of
-        cases pinned individually, which is what this task exists to stop
-        relying on;
-      - **after a literal, both ways** — `""` and `"\x"`. These are *not*
-        prefixes for `done` and `failed`, and listing them under those names
-        would be the false coverage just described: both states are terminal,
-        so the tokenizer emits its token and returns to top level rather than
-        resting in either, and a prefix ending in a closed literal sweeps
-        top-level dispatch. What they pin is the **resumption point** after
-        each kind of string — that a well-formed and a malformed literal hand
-        the next character back to the same place — and `"\x"` is where 3a
-        changes the emitted token, so its rows are the ones a reviewer diffs
-        that change against;
-      - **word** — a keyword prefix (`tru`), a complete keyword (`true`), and a
-        non-keyword run (`x`).
-
-      `done` and `failed` are reached by the sweep, then, but never held, and
-      their contract — every input `stopped`, nothing consumed — is proved
-      directly on the scanner by the export task above. So is the number
-      scanner's terminal `recovery`, for the same reason and with the same
-      division of labour: a caller may feed a terminal state where the
-      tokenizer never would, and only a direct proof sees that.
-
-      For each prefix, and every ASCII character `c`, record `prefix` + `c` +
-      `1`. If the implementation's state set does not match this list, the list
-      is wrong and the state set wins — subject to the two exemptions named
-      above, which are claims about what a text sweep can reach, not licence to
-      leave a state unpinned. A kind carrying two behaviors owes **two**
-      prefixes, as `int` does; matching the list against the kind union alone is
-      how the leading zero went missing.
-
-      Add the **old** machine's states too, since it has states the replacement
-      deliberately lacks: JavaScript operator runs (`>>`, `>>>`, `>>>=`, `===`,
-      `!==`, `&&`, `??`, `=>`, `**=`), each one `invalid token` today and one
-      `unexpected character` per character after; and its **comment** states
-      (`/*`, `//`). `/*` is the only old state that can swallow a suffix —
-      `/*"*/1` loses its `number 1`, per the exception above — but sweep `//`
-      as well, since "it cannot" is the kind of claim this review has
-      falsified repeatedly and the prefix costs nothing. A prefix set
-      derived only from the new scanner cannot reach any of them, which is how
-      this was missed.
-- [ ] Commit **two** tables from the sweep, not one: the old tokenizer's output
-      (recorded once during implementation, for review) and the new scanner's
-      expected output. The proof asserts against the *new* table — asserting
-      against the old one cannot pass, since the `n` class changes deliberately
-      and 14 rows change their message — and the old table is what a reviewer
-      diffs it against. Neither may import
-      `fjs/js/tokenizer`: a permanent dependency would contradict this stage's
-      own "no runtime importer calls `tokenize`" task and leave stage 7 unable
-      to delete the machine without rewriting the proof.
-- [ ] Check the recorded diff against the two invariants, which is the whole
-      point of recording it: no row where the old output has no error and the
-      new one does (or vice versa), and no row where a valid JSON document
-      tokenizes differently — **with the one exception**, an `n` the old
-      tokenizer deletes from inside a number, which the sweep reaches at
-      `c = 'n'`. Test it by inspecting the *old* output: a row crossing the
-      erroring boundary is the fix if its old token is a number that swallowed
-      an `n`, and a bug otherwise. Do not test it by matching input shapes —
-      the class includes `1n1n1`, `0n01` and `-1n1` but excludes `1n0`, and
-      three attempts in this document to write that shape down were all wrong.
-- [ ] Sweep **mixed boundaries** too, not only single characters: `00"/1` and
-      `12+"]` are both invisible to `prefix` + `c` + `1`, because the damage
-      comes from what the re-dispatched character's *own* scanner then
-      consumes — in `12+"]` a re-dispatched `+` would hand `"` to a string scan
-      that eats the `]`. Generate the table from two-character suffixes as
-      well; that is how both absorbed characters were found, one review round
-      apart.
-- [ ] Pin the individual cases, since they are what a reader reads: **no input
-      in the `00` + `c` + `1` family changes its token kinds or counts** — that
-      is the point of reproducing today's recovery set rather than improving it.
-      Messages are a separate matter and do change, so the two groups are pinned
-      apart: `00-2`, `00-`, `00"a"`, `00;1`, `00 1`, `00]`, `00,` and `00<LF>1`
-      are unchanged token for token, while `00"/1`, `00-"/1`, `00/1` and `12/1`
-      keep their kinds and counts with `/`'s message becoming `unexpected
-      character`. `message` is part of `JsonToken`, so a committed table that
-      claimed the whole family unchanged could not be satisfied.
-- [ ] Prove string recovery ends at an unescaped quote, a raw LF and a raw CR
-      but not a space — `"a<LF>1` emits the number `1`, `"a 1` is one error.
-- [ ] Pin the **comment** cases, since they are the one place a suffix token is
-      lost: `/*a*/1` is four `unexpected character` and an `invalid token` for
-      the word `a`, then `number 1`; `/*"*/1` is two `unexpected character`
-      then one `invalid string`, with the `number 1` gone; and `//"<LF>1`
-      keeps its `number 1`, since LF ends string recovery. Assert the loss rather than leaving it to be
-      discovered — it is the exception the no-suffix-loss claim carries, and a
-      proof that states it is what stops the next reader from "fixing" it by
-      teaching JSON's scanner about comments.
-- [ ] `npm run gen`, then `tsc`, `fjs test`, `cargo clippy` and
-      `cargo fmt -- --check`. The check set lists the last two unconditionally —
-      only `cargo test` is scoped to having touched Rust — and they are quick
-      no-ops for a change that touches none. The `gen` step is not
-      optional bookkeeping here: it regenerates the CI workflows, and this
-      stage adds no dependency so no lockfile needs `lock-update`, but it does
-      change the module's exports and types, and the generated declaration
-      output moves with them.
+- [ ] **#1890 lands**, so a mapping can receive and return metadata.
+- [ ] The EBNF backend reaches the point where a grammar can emit a token
+      stream carrying values and positions — the `fjs/ebnf/` half of
+      [ebnf-migration](../../../todo/ebnf-migration.md).
+- [ ] Write JSON's grammar in EBNF, cross-checked against the accepted-language
+      probes above, and decide where it lives: a codec that *runs* a grammar is
+      a different arrangement from one that keeps the grammar as a
+      proof-covered example, which is what
+      [bnf-grammar-single-owner](../../../bnf/todo/bnf-grammar-single-owner.md)
+      assumes today.
+- [ ] Decide what replaces the seam. `fjs/media/datajs` was to reuse JSON's
+      string and number scanners; over a grammar the reuse is of *rules*, and
+      DataJS's own grammar extends rather than wraps. The requirement is
+      unchanged and is stated in
+      [`fjs/media/datajs/todo/parser-serializer.md`](../../datajs/todo/parser-serializer.md):
+      a bigint is `int 'n'` reusing JSON's integer part, and `NaN`/`Infinity`
+      are words rather than number syntax.
+- [ ] Re-derive the error-shape decisions. The measured tables above say what
+      today's tokenizer does; what a grammar-driven reader *should* do with
+      malformed input is an open question, and the answer will not be the
+      hand-written recovery rules, which existed to reproduce a JavaScript
+      lexer's accidents.
 
 ### Related
 
 - [parser-serializer-restructure](../../../../todo/parser-serializer-restructure.md)
-  — this is its stage 3; stage 4 (`fjs/media/datajs`) is the second caller of
-  the string and number scanners this stage exports, and may refine their
-  contract while it is still unreleased.
+  — this is its stage 3, and the file that carries the reversed no-runtime-BNF
+  rule.
+- [ebnf-migration](../../../todo/ebnf-migration.md) — `fjs/ebnf/` beside
+  `fjs/bnf/`, then retire `bnf/`. The module this now depends on.
+- [#1890](https://github.com/functionalscript/functionalscript/pull/1890) —
+  `meta-ast-mapping`, the metadata channel a reader's mapping needs.
+- [#1895](https://github.com/functionalscript/functionalscript/pull/1895) —
+  the withdrawn hand-written implementation. Read it for the measurements and
+  for the defect classes review found, not as a plan.
 - [`spec/datajs/README.md`](../../../../spec/datajs/README.md) — DataJS's
-  grammar. Its string rule is JSON's, and its number rule is JSON's
-  *unchanged* — the bigint is a separate production reusing JSON's integer
-  part, and `NaN`/`Infinity` are words rather than number syntax. Stage 4
-  reuses JSON's scanners; it does not widen JSON's grammar.
-- [bnf-grammar-single-owner](../../../bnf/todo/bnf-grammar-single-owner.md) — the BNF copy of
-  this grammar; spec text and proof-covered example, never a runtime
-  dependency of this scanner.
-- [number-edge-cases](./number-edge-cases.md),
-  [standard-parse-serialize](./standard-parse-serialize.md) — behavior
-  downstream of this tokenizer, unchanged by the swap.
+  grammar. Its string rule is JSON's and its number rule is JSON's unchanged.
+- [bnf-grammar-single-owner](../../../bnf/todo/bnf-grammar-single-owner.md) —
+  written when a codec grammar was an example rather than a runtime
+  dependency; owed an edit once this direction is settled.
+- [streaming-recognizer](./streaming-recognizer.md),
+  [number-edge-cases](./number-edge-cases.md),
+  [standard-parse-serialize](./standard-parse-serialize.md) — behavior around
+  this tokenizer; the first names scanners this issue no longer promises.

--- a/fjs/media/json/todo/self-contained-tokenizer.md
+++ b/fjs/media/json/todo/self-contained-tokenizer.md
@@ -1,13 +1,17 @@
 ## self-contained-tokenizer. JSON's reader comes from a grammar, not a wrapper
 
-**Priority:** P2 — lowered from P1. Stage 4 still waits on it, but the reader
-cannot report errors until a mapping can carry metadata, so it cannot hold the
-front of a queue.
-**Status:** blocked
-**Blocked by:** [ebnf-migration](../../../todo/ebnf-migration.md)
-and the metadata channel filed in
+**Priority:** P2 — lowered from P1. Stage 4 still waits on it, but the error
+shapes are undecided and `fjs/ebnf/` is mid-migration, so it is not the thing
+to pick up first.
+**Status:** open — **partly startable**. Measurement retired the two blockers
+earlier drafts claimed; see [What is actually missing](#what-is-actually-missing).
+The grammar exists, the LL(1) backend parses JSON with it, and `fjs/ebnf/map`
+can already rewrite the result to values. What is undecided is what the reader
+reports on malformed input, and what a streaming consumer gets.
+**Related, not blocking:**
+[ebnf-migration](../../../todo/ebnf-migration.md), and the metadata channel in
 [functionalscript/functionalscript#1890](https://github.com/functionalscript/functionalscript/pull/1890)
-— `fjs/ebnf/todo/meta-ast-mapping.md`, which lands with it.
+— which buys *better* errors than today's, not the ones this reader owes.
 
 ### The direction changed, and this issue is rewritten around it
 
@@ -49,46 +53,66 @@ lexer produces, and each one had to be found by a person. **That is the cost the
 grammar is being bought to avoid**, and it is why the withdrawal is a change of
 direction rather than a retreat.
 
-### Why it is blocked rather than open
+### What is actually missing
 
-**Less is missing than an earlier draft of this section claimed**, and the
-difference matters, because it says what to build rather than what to wait for.
+Two earlier drafts of this section each named a blocker, and measurement
+retired both. The honest answer is that **the value half of this reader can be
+built now**, and what remains open is error reporting and one API property.
+
 Measured against the tree as it stands:
 
 - The **grammar already exists**, exported and proof-covered, at
   [`fjs/ebnf/lib/json`](../../../ebnf/lib/json/module.f.mjs). It is not work
   this issue owes.
-- The **LL(1) backend already parses JSON with it.**
-  [`fjs/ebnf/ll1/proof.f.mjs`](../../../ebnf/ll1/proof.f.mjs) builds
-  `parser(json)`, and running it on `[1]` returns a full typed `Ast<typeof
-  json>`.
+- The **LL(1) backend already parses JSON with it**, as
+  [`fjs/ebnf/ll1/proof.f.mjs`](../../../ebnf/ll1/proof.f.mjs) shows.
 - **Values are already mappable.** [`fjs/ebnf/map`](../../../ebnf/map/README.md)
-  rewrites an AST bottom-up, and `ll1`'s own proof does exactly that over the
-  LL(1) backend to turn `[-12,3]` into integers.
-- An LL(1) failure already returns **an offset** — `[1,` yields `['error', 3]`.
+  rewrites an AST bottom-up, keyed by the rules the grammar exports. The
+  recursive `value` thunk is reachable as `json[1]`, and a `rewrite` keyed on it
+  rewrites the parsed node — so nothing about JSON's self-reference blocks a
+  mapping.
+- An LL(1) failure returns **an offset** — `[1,` yields `['error', 3]`.
 
-So a grammar-driven reader is closer than "nothing to implement". Two gaps are
-real, and they are about the *mapping*, not the grammar:
+**`json` alone is a prefix parser, and a reader must not use it that way.** The
+rule ends where its own syntax ends, so `parser(json)` accepts `[1]x`,
+returning a plausible `[1]` and an end offset of 3; `1 2` likewise stops at 2.
+A document is `[json, eof]`, which the `ll1` proof spells out and which
+correctly rejects both. **Any reader built here composes EOF or checks that the
+end offset equals the input length**; mapping the AST from a bare `parser(json)`
+would silently accept malformed JSON.
 
-1. **A mapping receives no metadata.** Per `map`'s own table a function sees
-   only its children already rewritten — never a position, never which symbol
-   it matched — and it cannot return information alongside its value. So a
-   mapping cannot attach source locations or classify a failure. That channel
-   is [#1890](https://github.com/functionalscript/functionalscript/pull/1890)
-   (`meta-ast-mapping`), and the module's own migration is
-   [ebnf-migration](../../../todo/ebnf-migration.md).
-2. **An offset is not an error message.** The backend says *where* a parse
-   failed, not *what* was wrong. Today's tokenizer emits classified messages
-   (`invalid number`, `invalid token`), and the error shapes a grammar-driven
-   reader should emit are an open question either way — see the last item under
-   [What unblocks this](#what-unblocks-this).
+**Metadata is not a prerequisite, and an earlier draft was wrong to call it
+one.** [#1890](https://github.com/functionalscript/functionalscript/pull/1890)
+adds a channel so a mapping can receive a position and return information of its
+own. That would let this reader report *better* errors than today's. It is not
+needed to match today's, and it cannot help with the failure case at all: when
+LL(1) fails there is no AST, so there are no mapped nodes to carry metadata.
+Classifying a failure is the backend's job, not the mapping's.
 
-**The bar is not position preservation.**
-[`fjs/media/json/parser`](../parser/module.f.mjs) says so in its own source:
-its single error "carries no position or metadata". An earlier draft here
-claimed the replacement had to preserve error positions the parser reports; it
-reports none, and the LL(1) backend already gives more location information
-than the current API exposes.
+**The bar for errors is low, which is what makes the work startable.**
+[`fjs/media/json/parser`](../parser/module.f.mjs) says in its own source that
+its single error "carries no position or metadata". So the public parser's
+contract is met by discarding the offset the backend already gives. The
+tokenizer's classified messages (`invalid number`, `invalid token`) are the
+harder half, and this issue already accepts that error shapes change once in
+the swap.
+
+So what genuinely remains, in the order it should be done:
+
+1. **Error shapes.** Decide what a grammar-driven reader reports. This is design
+   work, not a dependency, and it is the last item under
+   [What this still needs](#what-this-still-needs).
+2. **The streaming seam.** `Parser<T>` takes `readonly number[]`, a
+   materialized array, while `tokenize` is public and `List`-based. The public
+   `parse(text)` is unaffected, since it starts from a string, but a streaming
+   consumer has no grammar equivalent today. This is a real consequence of the
+   direction and is why
+   [streaming-recognizer](./streaming-recognizer.md) is now blocked rather than
+   merely rebased.
+3. **`fjs/ebnf/` stability.** The module is mid-migration
+   ([ebnf-migration](../../../todo/ebnf-migration.md)), so a codec written
+   against it now is written against names still in motion. This is a reason to
+   sequence carefully, not a missing capability.
 
 **Do not start a hand-written scanner in the meantime.** That is what was just
 withdrawn.
@@ -535,15 +559,28 @@ own.
       the tree, not to the diff, and "not affected by this change" is a
       prediction where a green run is a fact.
 
-### What unblocks this
+### What this still needs
 
-- [ ] **#1890 lands**, so a mapping can receive and return metadata. This is
-      the one true blocker: without it a mapping sees only its rewritten
-      children, so no reader built on it can locate or classify a failure.
+Renamed from "What unblocks this", because measurement showed most of it is not
+blocked. The first two items can be started today.
+
+- [ ] Compose EOF, or check the end offset against the input length. `json`
+      alone is a **prefix** rule: `parser(json)` accepts `[1]x`. A document is
+      `[json, eof]`. Do this before anything maps an AST, or the reader silently
+      accepts trailing garbage.
 - [ ] The `fjs/ebnf/` half of
       [ebnf-migration](../../../todo/ebnf-migration.md) settles, so the codec is
-      not written against names still in motion. **Not** a claim that parsing is
-      missing — `ll1` parses JSON today.
+      not written against names still in motion. A sequencing concern, **not** a
+      missing capability — `ll1` parses JSON today.
+- [ ] Decide whether the reader must keep a streaming entry point. `Parser<T>`
+      takes a materialized `readonly number[]` while `tokenize` is `List`-based.
+      `parse(text)` is unaffected; a streaming consumer has no grammar
+      equivalent yet.
+- [ ] *Optional, and not a prerequisite.*
+      [#1890](https://github.com/functionalscript/functionalscript/pull/1890)
+      lands, letting a mapping receive and return metadata. It buys errors
+      better than today's. It cannot classify a parse **failure**, since a
+      failure produces no AST and so no mapped nodes.
 - [x] ~~Write JSON's grammar in EBNF.~~ **It already exists**, exported and
       proof-covered, at
       [`fjs/ebnf/lib/json`](../../../ebnf/lib/json/module.f.mjs), and

--- a/fjs/media/json/todo/self-contained-tokenizer.md
+++ b/fjs/media/json/todo/self-contained-tokenizer.md
@@ -514,11 +514,14 @@ own.
       stream carrying values and positions — the `fjs/ebnf/` half of
       [ebnf-migration](../../../todo/ebnf-migration.md).
 - [ ] Write JSON's grammar in EBNF, cross-checked against the accepted-language
-      probes above, and decide where it lives: a codec that *runs* a grammar is
+      probes above, and decide where it lives. A codec that *runs* a grammar is
       a different arrangement from one that keeps the grammar as a
-      proof-covered example, which is what
-      [bnf-grammar-single-owner](../../../bnf/todo/bnf-grammar-single-owner.md)
-      assumes today.
+      proof-covered example. What is settled is that it is **not** under
+      `fjs/bnf`, which is the module being retired and still holds its JSON
+      grammar as an example only
+      ([bnf-grammar-single-owner](../../../bnf/todo/bnf-grammar-single-owner.md));
+      the open part is where under `fjs/ebnf/` or `fjs/media/json` the runtime
+      grammar sits, and whether DataJS extends it by import or by restatement.
 - [ ] Decide what replaces the seam. `fjs/media/datajs` was to reuse JSON's
       string and number scanners; over a grammar the reuse is of *rules*, and
       DataJS's own grammar extends rather than wraps. The requirement is
@@ -547,8 +550,9 @@ own.
 - [`spec/datajs/README.md`](../../../../spec/datajs/README.md) — DataJS's
   grammar. Its string rule is JSON's and its number rule is JSON's unchanged.
 - [bnf-grammar-single-owner](../../../bnf/todo/bnf-grammar-single-owner.md) —
-  written when a codec grammar was an example rather than a runtime
-  dependency; owed an edit once this direction is settled.
+  written when a codec grammar was an example rather than a runtime dependency;
+  edited for this direction. Its `fjs/media/json/grammar` ban survives on the
+  narrower ground that `fjs/bnf` is the module being retired.
 - [streaming-recognizer](./streaming-recognizer.md),
   [number-edge-cases](./number-edge-cases.md),
   [standard-parse-serialize](./standard-parse-serialize.md) — behavior around

--- a/fjs/media/json/todo/self-contained-tokenizer.md
+++ b/fjs/media/json/todo/self-contained-tokenizer.md
@@ -6,8 +6,14 @@ to pick up first.
 **Status:** open — **partly startable**. Measurement retired the two blockers
 earlier drafts claimed; see [What is actually missing](#what-is-actually-missing).
 The grammar exists, the LL(1) backend parses JSON with it, and `fjs/ebnf/map`
-can already rewrite the result to values. What is undecided is what the reader
-reports on malformed input, and what a streaming consumer gets.
+is the engine that rewrites the result to values. JSON's own mapping is not
+written, and its typed form has one prerequisite —
+[widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md),
+a recursive type for `value`. What is undecided is what the reader reports on
+malformed input, and what a streaming consumer gets.
+**Prerequisite of one task, not of the issue:**
+[widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md) —
+the mapping cannot be type-checked before it.
 **Related, not blocking:**
 [ebnf-migration](../../../todo/ebnf-migration.md), and the metadata channel in
 [functionalscript/functionalscript#1890](https://github.com/functionalscript/functionalscript/pull/1890)
@@ -56,8 +62,9 @@ direction rather than a retreat.
 ### What is actually missing
 
 Two earlier drafts of this section each named a blocker, and measurement
-retired both. The honest answer is that **the value half of this reader can be
-built now**, and what remains open is error reporting and one API property.
+retired both. The honest answer is that **the value half of this reader has one
+type prerequisite and no other**, and what remains open is error reporting and
+one API property.
 
 Measured against the tree as it stands:
 
@@ -66,11 +73,19 @@ Measured against the tree as it stands:
   this issue owes.
 - The **LL(1) backend already parses JSON with it**, as
   [`fjs/ebnf/ll1/proof.f.mjs`](../../../ebnf/ll1/proof.f.mjs) shows.
-- **Values are already mappable.** [`fjs/ebnf/map`](../../../ebnf/map/README.md)
-  rewrites an AST bottom-up, keyed by the rules the grammar exports. The
-  recursive `value` thunk is reachable as `json[1]`, and a `rewrite` keyed on it
-  rewrites the parsed node — so nothing about JSON's self-reference blocks a
-  mapping.
+- **The mapping engine exists; JSON's mapping does not.**
+  [`fjs/ebnf/map`](../../../ebnf/map/README.md) rewrites an AST bottom-up,
+  keyed by the rules the grammar exports, and `ll1`'s proof does it on a
+  smaller grammar. At runtime a `rewrite` keyed on the `value` thunk, reachable
+  as `json[1]`, rewrites the parsed node. **Under `tsc` it is refused**: `value`
+  is annotated `Const<Variant>` and `string` is annotated `Rule`, neither of
+  which says its parts, so `Checked` rejects both as keys — measured, along
+  with `json` itself; `digit` and `uint` are accepted. A typed JSON mapping
+  therefore waits on
+  [widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md):
+  a recursive type for `value` and a `const` pin for `string`. That is
+  prerequisite type work, not a missing capability, and it is the one thing
+  the mapping task below cannot start without.
 - An LL(1) failure returns **an offset** — `[1,` yields `['error', 3]`.
 
 **`json` alone is a prefix parser, and a reader must not use it that way.** The
@@ -102,14 +117,19 @@ So what genuinely remains, in the order it should be done:
 1. **Error shapes.** Decide what a grammar-driven reader reports. This is design
    work, not a dependency, and it is the last item under
    [What this still needs](#what-this-still-needs).
-2. **The streaming seam.** `Parser<T>` takes `readonly number[]`, a
+2. **A recursive type for `value`.** The one dependency: until
+   [widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md)
+   lands its `value` and `string` rows, the mapping can be run but not
+   type-checked. It is filed P4, which understates it now that a P2 stage
+   waits on it.
+3. **The streaming seam.** `Parser<T>` takes `readonly number[]`, a
    materialized array, while `tokenize` is public and `List`-based. The public
    `parse(text)` is unaffected, since it starts from a string, but a streaming
    consumer has no grammar equivalent today. This is a real consequence of the
    direction and is why
    [streaming-recognizer](./streaming-recognizer.md) is now blocked rather than
    merely rebased.
-3. **`fjs/ebnf/` stability.** The module is mid-migration
+4. **`fjs/ebnf/` stability.** The module is mid-migration
    ([ebnf-migration](../../../todo/ebnf-migration.md)), so a codec written
    against it now is written against names still in motion. This is a reason to
    sequence carefully, not a missing capability.
@@ -596,7 +616,10 @@ blocked. The first two items can be started today.
 - [ ] Write the mapping from its AST to JSON values, which is `fjs/ebnf/map`'s
       `rewrite` — the shape `ll1`'s proof already demonstrates on a smaller
       grammar. This is the reader's substance and the part that does not exist
-      yet.
+      yet. **After** `value` has its recursive type and `string` its pin, per
+      [widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md):
+      `Checked` refuses both as keys today, so a typed mapping cannot be
+      written before that lands.
 - [x] ~~Decide what replaces the seam.~~ **Answered in code, and it is what the
       reversal predicted.**
       [`fjs/ebnf/lib/datajs`](../../../ebnf/lib/datajs/module.f.mjs) already

--- a/fjs/media/json/todo/self-contained-tokenizer.md
+++ b/fjs/media/json/todo/self-contained-tokenizer.md
@@ -1,7 +1,8 @@
 ## self-contained-tokenizer. JSON's reader comes from a grammar, not a wrapper
 
-**Priority:** P2 — lowered from P1. Stage 4 still waits on it, but nothing can
-start until the EBNF backend can carry what a reader needs.
+**Priority:** P2 — lowered from P1. Stage 4 still waits on it, but the reader
+cannot report errors until a mapping can carry metadata, so it cannot hold the
+front of a queue.
 **Status:** blocked
 **Blocked by:** [ebnf-migration](../../../todo/ebnf-migration.md)
 and the metadata channel filed in
@@ -50,19 +51,44 @@ direction rather than a retreat.
 
 ### Why it is blocked rather than open
 
-`fjs/ebnf/` exists but its LL(1) backend cannot yet carry what a reader needs.
-A mapping must receive what the grammar ignored about each input symbol — a
-position, or which identifier a token was — and must be able to return
-information of its own. That channel is being designed now, in
-[#1890](https://github.com/functionalscript/functionalscript/pull/1890)
-(`meta-ast-mapping`), and the module's own migration is
-[ebnf-migration](../../../todo/ebnf-migration.md).
+**Less is missing than an earlier draft of this section claimed**, and the
+difference matters, because it says what to build rather than what to wait for.
+Measured against the tree as it stands:
 
-Without it a JSON grammar can recognize a document but cannot produce a token
-stream carrying values, let alone the error positions
-[`fjs/media/json/parser`](../parser/module.f.mjs) reports. So there is nothing
-to implement here yet, and the design that *can* be written is the grammar
-itself, which is cheap and can wait for the backend it runs on.
+- The **grammar already exists**, exported and proof-covered, at
+  [`fjs/ebnf/lib/json`](../../../ebnf/lib/json/module.f.mjs). It is not work
+  this issue owes.
+- The **LL(1) backend already parses JSON with it.**
+  [`fjs/ebnf/ll1/proof.f.mjs`](../../../ebnf/ll1/proof.f.mjs) builds
+  `parser(json)`, and running it on `[1]` returns a full typed `Ast<typeof
+  json>`.
+- **Values are already mappable.** [`fjs/ebnf/map`](../../../ebnf/map/README.md)
+  rewrites an AST bottom-up, and `ll1`'s own proof does exactly that over the
+  LL(1) backend to turn `[-12,3]` into integers.
+- An LL(1) failure already returns **an offset** — `[1,` yields `['error', 3]`.
+
+So a grammar-driven reader is closer than "nothing to implement". Two gaps are
+real, and they are about the *mapping*, not the grammar:
+
+1. **A mapping receives no metadata.** Per `map`'s own table a function sees
+   only its children already rewritten — never a position, never which symbol
+   it matched — and it cannot return information alongside its value. So a
+   mapping cannot attach source locations or classify a failure. That channel
+   is [#1890](https://github.com/functionalscript/functionalscript/pull/1890)
+   (`meta-ast-mapping`), and the module's own migration is
+   [ebnf-migration](../../../todo/ebnf-migration.md).
+2. **An offset is not an error message.** The backend says *where* a parse
+   failed, not *what* was wrong. Today's tokenizer emits classified messages
+   (`invalid number`, `invalid token`), and the error shapes a grammar-driven
+   reader should emit are an open question either way — see the last item under
+   [What unblocks this](#what-unblocks-this).
+
+**The bar is not position preservation.**
+[`fjs/media/json/parser`](../parser/module.f.mjs) says so in its own source:
+its single error "carries no position or metadata". An earlier draft here
+claimed the replacement had to preserve error positions the parser reports; it
+reports none, and the LL(1) backend already gives more location information
+than the current API exposes.
 
 **Do not start a hand-written scanner in the meantime.** That is what was just
 withdrawn.
@@ -511,29 +537,44 @@ own.
 
 ### What unblocks this
 
-- [ ] **#1890 lands**, so a mapping can receive and return metadata.
-- [ ] The EBNF backend reaches the point where a grammar can emit a token
-      stream carrying values and positions — the `fjs/ebnf/` half of
-      [ebnf-migration](../../../todo/ebnf-migration.md).
-- [ ] Write JSON's grammar in EBNF, cross-checked against the accepted-language
-      probes above, and decide where it lives. A codec that *runs* a grammar is
-      a different arrangement from one that keeps the grammar as a
-      proof-covered example. What is settled is that it is **not** under
-      `fjs/bnf`, which is the module being retired and still holds its JSON
+- [ ] **#1890 lands**, so a mapping can receive and return metadata. This is
+      the one true blocker: without it a mapping sees only its rewritten
+      children, so no reader built on it can locate or classify a failure.
+- [ ] The `fjs/ebnf/` half of
+      [ebnf-migration](../../../todo/ebnf-migration.md) settles, so the codec is
+      not written against names still in motion. **Not** a claim that parsing is
+      missing — `ll1` parses JSON today.
+- [x] ~~Write JSON's grammar in EBNF.~~ **It already exists**, exported and
+      proof-covered, at
+      [`fjs/ebnf/lib/json`](../../../ebnf/lib/json/module.f.mjs), and
+      `fjs/ebnf/ll1` already parses JSON with it. Placement is settled with it:
+      not under `fjs/bnf`, which is the module being retired and holds its JSON
       grammar as an example only
-      ([bnf-grammar-single-owner](../../../bnf/todo/bnf-grammar-single-owner.md));
-      the open part is where under `fjs/ebnf/` or `fjs/media/json` the runtime
-      grammar sits, and whether DataJS extends it by import or by restatement.
-- [ ] Decide what replaces the seam. `fjs/media/datajs` was to reuse JSON's
-      string and number scanners; over a grammar the reuse is of *rules*, and
-      DataJS's own grammar extends rather than wraps. The requirement is
-      unchanged and is stated in
-      [`fjs/media/datajs/todo/parser-serializer.md`](../../datajs/todo/parser-serializer.md):
-      a bigint is `int 'n'` reusing JSON's integer part, and `NaN`/`Infinity`
-      are words rather than number syntax.
-- [ ] Re-derive the error-shape decisions. The measured tables above say what
-      today's tokenizer does; what a grammar-driven reader *should* do with
-      malformed input is an open question, and the answer will not be the
+      ([bnf-grammar-single-owner](../../../bnf/todo/bnf-grammar-single-owner.md)).
+      **Do not write a second one.**
+- [ ] Cross-check that grammar against the accepted-language probes above. It
+      was written to RFC 8259 rather than against this tokenizer, so agreement
+      is expected but unmeasured, and the `1n1` class is exactly where today's
+      wrapper is known to differ from JSON.
+- [ ] Write the mapping from its AST to JSON values, which is `fjs/ebnf/map`'s
+      `rewrite` — the shape `ll1`'s proof already demonstrates on a smaller
+      grammar. This is the reader's substance and the part that does not exist
+      yet.
+- [x] ~~Decide what replaces the seam.~~ **Answered in code, and it is what the
+      reversal predicted.**
+      [`fjs/ebnf/lib/datajs`](../../../ebnf/lib/datajs/module.f.mjs) already
+      imports JSON's exported rules — `string`, `uint`, `optionNeg`,
+      `optionFloatSuffix`, `digit`, `ws` — so the reuse is of *rules*, by
+      ordinary import, and DataJS's grammar extends rather than wraps. The
+      requirement in
+      [`fjs/media/datajs/todo/parser-serializer.md`](../../datajs/todo/parser-serializer.md)
+      is met by it: a bigint is `uint` plus `'n'`, and `Infinity` is a word in
+      the number variant rather than number syntax.
+- [ ] Re-derive the error-shape decisions — the last genuinely open design
+      question. The measured tables above say what today's tokenizer does; an
+      LL(1) failure is instead a bare offset, and today's tokenizer emits
+      classified messages. What a grammar-driven reader *should* do with
+      malformed input is settled by neither, and the answer will not be the
       hand-written recovery rules, which existed to reproduce a JavaScript
       lexer's accidents.
 
@@ -555,7 +596,16 @@ own.
   written when a codec grammar was an example rather than a runtime dependency;
   edited for this direction. Its `fjs/media/json/grammar` ban survives on the
   narrower ground that `fjs/bnf` is the module being retired.
-- [streaming-recognizer](./streaming-recognizer.md),
-  [number-edge-cases](./number-edge-cases.md),
+- [streaming-recognizer](./streaming-recognizer.md) — built on the `Scan<S>`
+  seam this issue no longer promises, so it is now **blocked on this one** and
+  its tasks are marked not to be started. Its requirement survives the rebase;
+  its lexer plan does not.
+- [number-edge-cases](./number-edge-cases.md),
   [standard-parse-serialize](./standard-parse-serialize.md) — behavior around
-  this tokenizer; the first names scanners this issue no longer promises.
+  this tokenizer.
+- [`fjs/ebnf/lib/json`](../../../ebnf/lib/json/module.f.mjs) and
+  [`fjs/ebnf/lib/datajs`](../../../ebnf/lib/datajs/module.f.mjs) — the grammars
+  this reader is to run, both already written and proof-covered, the second
+  importing the first's rules.
+- [`fjs/ebnf/map`](../../../ebnf/map/README.md) — the AST-to-value rewrite a
+  reader's mapping is written in, and the layer the metadata channel extends.

--- a/fjs/media/json/todo/self-contained-tokenizer.md
+++ b/fjs/media/json/todo/self-contained-tokenizer.md
@@ -69,7 +69,7 @@ direction rather than a retreat.
 Two earlier drafts of this section each named a blocker, and measurement
 retired both. The honest answer is that **the tokenizer has one prerequisite
 in `fjs/ebnf`, a type, and two design questions of its own** — error reporting
-and a number's boundary — plus one API property.
+and token boundaries — plus one API property.
 
 Measured against the tree as it stands:
 

--- a/fjs/media/json/todo/self-contained-tokenizer.md
+++ b/fjs/media/json/todo/self-contained-tokenizer.md
@@ -11,8 +11,8 @@ narrower and not yet written: a **token-stream grammar** over that module's
 exported lexical rules, over **UTF-16 code units**, mapped to the tokens the
 container machine consumes — the four contracts that decide it are under
 [What the reader must keep](#what-the-reader-must-keep). What is undecided is
-what the reader reports on malformed input, how a number's boundary is made
-LL(1), and what a streaming consumer gets.
+what the reader reports on malformed input, how a number's and a word's
+boundaries are made to match today's, and what a streaming consumer gets.
 **Prerequisite of one task, not of the issue:**
 [widened-rule-signatures](../../../ebnf/lib/todo/widened-rule-signatures.md) —
 its `string` row; the mapping cannot be type-checked before it.
@@ -133,12 +133,12 @@ So what genuinely remains, in the order it should be done:
    lands its `string` row, the mapping can be run but not type-checked. Its
    `value` row is not needed here, since no lexical rule names `value`. It is
    filed P4, which understates it now that a P2 stage waits on it.
-3. **The number boundary.** The token-stream grammar written naively is not
-   LL(1), because `12` is one token where `1 2` is two and a nullable
-   separator cannot decide that predictively —
+3. **Token boundaries.** The token-stream grammar written naively is not
+   LL(1) at a number, because `12` is one token where `1 2` is two and a
+   nullable separator cannot decide that predictively, and it accepts
+   `truetrue` at a word where today's tokenizer refuses it —
    [What the reader must keep](#what-the-reader-must-keep) has the measured
-   conflict, what today's tokenizer does at that boundary, and the two
-   resolutions. Design work, not a dependency.
+   table and the two resolutions. Design work, not a dependency.
 4. **The streaming seam.** `Parser<T>` takes `readonly number[]`, a
    materialized array, while `tokenize` is public and `List`-based. The public
    `parse(text)` is unaffected, since it starts from a string, but a streaming
@@ -208,21 +208,38 @@ tokenizer wrapper — where a value mapping would retire the parser too. The
 value route stays open to whoever can show all four kept through a mapping;
 nothing measured says that is impossible, only that the pieces do not exist.
 
-**The token-stream grammar is not written, and written naively it is not
-LL(1).** `[ws, repeat0([token, ws]), eof]`, with `token` a variant of
-`string`, `[optionNeg, uint, ...optionFloatSuffix]`, the six punctuators and
-the three words, is refused at construction — `first/follow conflict` at
+**The token-stream grammar is not written, and written naively it gets two
+boundaries wrong.** `[ws, repeat0([token, ws]), eof]`, with `token` a variant
+of `string`, `[optionNeg, uint, ...optionFloatSuffix]`, the six punctuators
+and the three words, is refused at construction — `first/follow conflict` at
 `1.item.0.number.1.onenine.1`, the optional digits after a number's first —
 because `ws` is nullable and the next token may begin with a digit. Maximal
 munch, by which `12` is one token where `1 2` is two, is not a predictive
-decision across a nullable separator. What today's tokenizer does at that
-boundary is measured, since a resolution has to reproduce it: `1-1` is two
-numbers, `1]` a number and a bracket, `1true` and `1"a"` an error and then
-the second token, `1.5.5` and `1e` one error each. Two resolutions are on the
-table, and choosing is the design question this stage owns beside error
-shapes: a boundary rule in the grammar, saying what may follow a number
-without whitespace; or an entry point that reads one token from an offset by
-prefix parse, which is the streaming seam under another name.
+decision across a nullable separator. And with the number left out so that
+the grammar builds, it accepts what today's tokenizer refuses: `truetrue`,
+`truefalse` and `nulltrue` lex as two words each where `tokenize` returns one
+error, so a word's boundary is a second case of the same thing. What today's
+tokenizer does at both boundaries is measured, since a resolution has to
+reproduce the accepted rows and keep the refused ones refused — the first
+invariant below lets nothing but the `n` class cross:
+
+| after | followed by | today |
+| --- | --- | --- |
+| a number | a digit | munched: `12` is one number |
+| a number | `.`, `e`, `E` | munched into the lexeme, or an error: `1.5.5`, `1e` |
+| a number | `-` | two numbers: `1-1` |
+| a number | a punctuator | two tokens: `1[` |
+| a number | a letter or `"` | an error, then the second token: `1true`, `1"a"` |
+| a word | a letter or a digit | one error: `truetrue`, `true1`, `nulltrue` |
+| a word | `-`, `"` or a punctuator | two tokens: `true-1`, `true"a"`, `true[` |
+| a string or a punctuator | anything | two tokens: `"a"true`, `"a""b"`, `]true` |
+
+Two resolutions are on the table, and choosing is the design question this
+stage owns beside error shapes: a boundary rule in the grammar, saying what
+may follow a number or a word without whitespace; or an entry point that reads
+one token from an offset by prefix parse, which is the streaming seam under
+another name and still owes the word rows. Nothing here is settled, and
+nothing here has to be before the cross-check task starts.
 
 ### What any replacement is held to
 
@@ -701,12 +718,12 @@ blocked. The first two items can be started today.
       the rules that module exports.
 - [ ] Write the token-stream grammar, `[ws, repeat0([token, ws]), eof]` over
       `string`, `uint`, `optionNeg`, `optionFloatSuffix` and `ws` from
-      `fjs/ebnf/lib/json`, run over UTF-16 code units, and make it LL(1) at a
-      number's boundary —
-      [What the reader must keep](#what-the-reader-must-keep) has the conflict
-      and the two resolutions. Prove that `1 2`, `[] []` and `1,2` lex as they
-      do today, that `"\ud800"` is one string token, and that 20,000 nested
-      brackets lex.
+      `fjs/ebnf/lib/json`, run over UTF-16 code units, and make its number
+      and word boundaries match today's —
+      [What the reader must keep](#what-the-reader-must-keep) has the measured
+      table and the two resolutions. Prove that `1 2`, `[] []` and `1,2` lex
+      as they do today, that `12` is one number and `truetrue` an error, that
+      `"\ud800"` is one string token, and that 20,000 nested brackets lex.
 - [ ] Cross-check that grammar against the accepted-language probes above. It
       was written to RFC 8259 rather than against this tokenizer, so agreement
       is expected but unmeasured, and the `1n1` class is exactly where today's

--- a/fjs/media/json/todo/self-contained-tokenizer.md
+++ b/fjs/media/json/todo/self-contained-tokenizer.md
@@ -365,17 +365,19 @@ The pattern is one grammar's leftovers seen through another: `+`, a second
 `.`, a second `e` are all *number* characters, so JavaScript's machine keeps
 eating them and then reports the whole run invalid. Where the grammar wants
 the character the question never arises — `1e+5` consumes its sign, `12.5`
-its point.
+its point. That table is also what the two references below mean by
+"absorbed", and every row of it is a fact about today's tokenizer rather than
+a choice.
 
 Two review rounds found this rule one phase at a time, which is why it is
 stated generatively and then measured rather than listed. `12+"]` is
 `invalid number` then `]` today; re-dispatching the `+` hands `"` to a
 string scan that eats the `]`. `1e."/1` is `invalid number`, an error for
+`/`, then `number 1`; re-dispatching the `.` loses that `1` the same way.
 
-That table is what the two references below mean by "absorbed", and it is a fact
-about today's tokenizer rather than a choice: `+`, a second `.` and a second `e`
-are all *number* characters, so JavaScript's machine keeps eating them and then
-reports the whole run invalid.
+Both were re-measured against the wrapper as it stands and still hold. What a
+grammar-driven reader *should* do with them is open: the withdrawn design
+reproduced these accidents on purpose, and that rationale went with it.
 
 ### Where a number lexeme ends
 
@@ -437,7 +439,7 @@ that makes the obvious fix wrong.
 Independent of everything above, and still correct under the new direction: it
 fixes the wrapper that remains in place until the grammar replaces it.
 
-#### Stage 3a — the fabricated token, fixed where it lives — **landed**
+#### Why it landed on its own
 
 The fabricated `string` after `"\x"` was a doc/DESIGN.md §10 violation that
 existed before any port was designed, and was provable against the wrapper as it
@@ -474,7 +476,7 @@ without JSON's own machine knowing about it. Either way the port deletes it,
 which is the point rather than a cost: it is what makes 3b carry no idea of its
 own.
 
-#### Stage 3a — drop the fabricated string
+#### The change, and its proofs
 
 **Done.** `dropFabricatedString` in
 [`../tokenizer/module.f.mjs`](../tokenizer/module.f.mjs), with the

--- a/fjs/media/json/todo/streaming-recognizer.md
+++ b/fjs/media/json/todo/streaming-recognizer.md
@@ -1,7 +1,29 @@
 ## streaming-recognizer. A payload-free, O(depth) JSON validity recognizer
 
 **Priority:** P3
-**Status:** open
+**Status:** blocked — the reader it reuses is being redesigned.
+**Blocked by:** [self-contained-tokenizer](./self-contained-tokenizer.md)
+
+> **The seam this design is built on no longer exists.** It reuses the
+> hand-written `Scan<S>` scanners that
+> [self-contained-tokenizer](./self-contained-tokenizer.md) used to promise, and
+> that design was implemented, reverted
+> ([#1895](https://github.com/functionalscript/functionalscript/pull/1895)) and
+> replaced by a reader generated from JSON's EBNF grammar. Nothing exports
+> `Scan<S>`, and nothing will.
+>
+> **Do not start the tasks below.** The `U16` signature, the scanner-transition
+> factoring and the "one state machine serves both instantiations" plan are all
+> statements about the withdrawn scanner. What survives is the *requirement* —
+> answer "is this a valid JSON document?" in O(depth) without building the
+> value — and the depth-cap design, which is about the container stack rather
+> than the lexer.
+>
+> Rebasing it means asking what a grammar-driven reader offers instead: a
+> recognizer is a parse that discards its mapping, so this may reduce to running
+> the existing grammar with no value-building map, which is closer to free than
+> the factoring below. That is the question to answer before writing any code
+> here.
 
 ### Problem
 
@@ -201,6 +223,10 @@ property, scoped to make it actually hold:
   there too, that is its own change, not this recognizer's contract.)
 
 ### Tasks
+
+**Blocked, and the first three are written against the withdrawn scanner** —
+see the note at the top. Rebase them on the grammar-driven reader before
+starting; do not follow them as they stand.
 
 - [ ] Factor the `fjs/js` string/number token ops and the `fjs/media/json` parser fold
       over their builders so one state machine serves both instantiations — the

--- a/spec/datajs/todo/conformance-vectors.md
+++ b/spec/datajs/todo/conformance-vectors.md
@@ -31,10 +31,12 @@ DataJS corpus has nothing to say about any of it.
 the only ordering constraint it carries. Landing stage 4 without it would mean
 writing stage 4's proofs twice.
 
-The coordinating plan sequenced it 3, then 1b, then 4. Stage 3b is open but
-P2, with its error shapes undecided, where this is P1 and gates stage 4 — so
-**1b goes first**, and the plan's task list says so too. Nothing is lost by the
-swap, because 1b never depended on stage 3: the corpus bootstraps in JSON
+The coordinating plan's dependencies are 3 before 4 and 1b before 4; an
+earlier draft wrote that as a sequence, 3, then 1b, then 4, and it is not one.
+Stage 3b is open but P2, with its error shapes undecided, where this is P1 and
+gates stage 4 — so the execution order is **1b first**, then 3b, then 4, and
+the plan's priority section and task list say so too. Nothing is lost by
+that, because 1b never depended on stage 3: the corpus bootstraps in JSON
 precisely so it can exist before any DataJS reader does, and it is indifferent
 to whether that reader ends up hand-written or generated from a grammar.
 

--- a/spec/datajs/todo/conformance-vectors.md
+++ b/spec/datajs/todo/conformance-vectors.md
@@ -3,8 +3,8 @@
 **Priority:** P1 — it blocks stage 4, which is P1. Raised with the stages it
 sits between; see
 [parser-serializer-restructure](../../../todo/parser-serializer-restructure.md).
-**Status:** open — and **next**, since stage 3b is blocked on EBNF while this is
-not blocked on anything.
+**Status:** open — and **next**. It is P1 and gates stage 4, where stage 3b is
+P2 with an undecided design, and this is blocked on nothing.
 
 ### Problem
 

--- a/spec/datajs/todo/conformance-vectors.md
+++ b/spec/datajs/todo/conformance-vectors.md
@@ -31,15 +31,16 @@ DataJS corpus has nothing to say about any of it.
 the only ordering constraint it carries. Landing stage 4 without it would mean
 writing stage 4's proofs twice.
 
-The coordinating plan's dependencies are 1b before 4, and 3b before 4 on
-stage 4's token-machine route only; an earlier draft wrote that as a sequence,
-3, then 1b, then 4, and it is not one. Stage 3b is open but P2, with its error
+The coordinating plan's dependencies are 1b before 4, and 3b before 4 on stage
+4's token-machine route only; an earlier draft wrote that as a sequence, 3,
+then 1b, then 4, and it is not one. Stage 3b is open but P2, with its error
 shapes undecided, where this is P1 and gates stage 4 on either route — so the
 execution order is **1b first**, with 3b and 4 following as stage 4's route
-decides, and the plan's priority section and task list say so too. Nothing is lost by
-that, because 1b never depended on stage 3: the corpus bootstraps in JSON
-precisely so it can exist before any DataJS reader does, and it is indifferent
-to whether that reader ends up hand-written or generated from a grammar.
+decides, and the plan's priority section and task list say so too. Nothing is
+lost by that, because 1b never depended on stage 3: the corpus bootstraps in
+JSON precisely so it can exist before any DataJS reader does, and it is
+indifferent to whether that reader ends up hand-written or generated from a
+grammar.
 
 ### Proposal
 

--- a/spec/datajs/todo/conformance-vectors.md
+++ b/spec/datajs/todo/conformance-vectors.md
@@ -23,9 +23,9 @@ stays JSON's, but for the one enumerated `n`-deletion defect its invariants
 name — is a property of JSON, established by JSON's own
 accepted-input proofs and by those two invariants
 [self-contained-tokenizer](../../../fjs/media/json/todo/self-contained-tokenizer.md)
-states, with its character sweeps as coverage rather than proof: that design is
-explicit that no finite sweep is exhaustive. A DataJS corpus has nothing to say
-about any of it.
+states, with its character sweeps as coverage rather than proof: that file marks
+them **recorded, not promised** — a before/after record reviewed as data. A
+DataJS corpus has nothing to say about any of it.
 
 **This corpus must therefore land before or together with stage 4**, and that is
 the only ordering constraint it carries. Landing stage 4 without it would mean

--- a/spec/datajs/todo/conformance-vectors.md
+++ b/spec/datajs/todo/conformance-vectors.md
@@ -3,7 +3,8 @@
 **Priority:** P1 — it blocks stage 4, which is P1. Raised with the stages it
 sits between; see
 [parser-serializer-restructure](../../../todo/parser-serializer-restructure.md).
-**Status:** open
+**Status:** open — and **next**, since stage 3b is blocked on EBNF while this is
+not blocked on anything.
 
 ### Problem
 
@@ -26,12 +27,16 @@ states, with its character sweeps as coverage rather than proof: that design is
 explicit that no finite sweep is exhaustive. A DataJS corpus has nothing to say
 about any of it.
 
-**This corpus must therefore land before or together with stage 4.** The
-sequence was 3, then 1b, then 4; stage 3 is now blocked on EBNF, so this corpus
-is the one piece of it that can proceed — it bootstraps in JSON precisely so it
-can exist before any DataJS reader does, and it is indifferent to whether that
-reader is hand-written or generated from a grammar.
-Landing stage 4 without it would mean writing stage 4's proofs twice.
+**This corpus must therefore land before or together with stage 4**, and that is
+the only ordering constraint it carries. Landing stage 4 without it would mean
+writing stage 4's proofs twice.
+
+The coordinating plan sequenced it 3, then 1b, then 4. Stage 3b is now blocked
+on EBNF, so **1b goes first** — the plan's task list says so too. Nothing is
+lost by the swap, because 1b never depended on stage 3: the corpus bootstraps in
+JSON precisely so it can exist before any DataJS reader does, and it is
+indifferent to whether that reader ends up hand-written or generated from a
+grammar. That makes this the one piece of the plan that is actionable today.
 
 ### Proposal
 

--- a/spec/datajs/todo/conformance-vectors.md
+++ b/spec/datajs/todo/conformance-vectors.md
@@ -31,12 +31,12 @@ DataJS corpus has nothing to say about any of it.
 the only ordering constraint it carries. Landing stage 4 without it would mean
 writing stage 4's proofs twice.
 
-The coordinating plan sequenced it 3, then 1b, then 4. Stage 3b is now blocked
-on EBNF, so **1b goes first** — the plan's task list says so too. Nothing is
-lost by the swap, because 1b never depended on stage 3: the corpus bootstraps in
-JSON precisely so it can exist before any DataJS reader does, and it is
-indifferent to whether that reader ends up hand-written or generated from a
-grammar. That makes this the one piece of the plan that is actionable today.
+The coordinating plan sequenced it 3, then 1b, then 4. Stage 3b is open but
+P2, with its error shapes undecided, where this is P1 and gates stage 4 — so
+**1b goes first**, and the plan's task list says so too. Nothing is lost by the
+swap, because 1b never depended on stage 3: the corpus bootstraps in JSON
+precisely so it can exist before any DataJS reader does, and it is indifferent
+to whether that reader ends up hand-written or generated from a grammar.
 
 ### Proposal
 

--- a/spec/datajs/todo/conformance-vectors.md
+++ b/spec/datajs/todo/conformance-vectors.md
@@ -31,11 +31,12 @@ DataJS corpus has nothing to say about any of it.
 the only ordering constraint it carries. Landing stage 4 without it would mean
 writing stage 4's proofs twice.
 
-The coordinating plan's dependencies are 3 before 4 and 1b before 4; an
-earlier draft wrote that as a sequence, 3, then 1b, then 4, and it is not one.
-Stage 3b is open but P2, with its error shapes undecided, where this is P1 and
-gates stage 4 — so the execution order is **1b first**, then 3b, then 4, and
-the plan's priority section and task list say so too. Nothing is lost by
+The coordinating plan's dependencies are 1b before 4, and 3b before 4 on
+stage 4's token-machine route only; an earlier draft wrote that as a sequence,
+3, then 1b, then 4, and it is not one. Stage 3b is open but P2, with its error
+shapes undecided, where this is P1 and gates stage 4 on either route — so the
+execution order is **1b first**, with 3b and 4 following as stage 4's route
+decides, and the plan's priority section and task list say so too. Nothing is lost by
 that, because 1b never depended on stage 3: the corpus bootstraps in JSON
 precisely so it can exist before any DataJS reader does, and it is indifferent
 to whether that reader ends up hand-written or generated from a grammar.

--- a/spec/datajs/todo/conformance-vectors.md
+++ b/spec/datajs/todo/conformance-vectors.md
@@ -26,8 +26,11 @@ states, with its character sweeps as coverage rather than proof: that design is
 explicit that no finite sweep is exhaustive. A DataJS corpus has nothing to say
 about any of it.
 
-**This corpus must therefore land before or together with stage 4**, which is
-compatible with running stage 3 first: the sequence is 3, then 1b, then 4.
+**This corpus must therefore land before or together with stage 4.** The
+sequence was 3, then 1b, then 4; stage 3 is now blocked on EBNF, so this corpus
+is the one piece of it that can proceed — it bootstraps in JSON precisely so it
+can exist before any DataJS reader does, and it is indifferent to whether that
+reader is hand-written or generated from a grammar.
 Landing stage 4 without it would mean writing stage 4's proofs twice.
 
 ### Proposal

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -24,18 +24,23 @@ Item 1 is context rather than work. **Item 2 is what to start.**
    below is reversed.
 
    **It is not blocked, though two earlier drafts of this plan said so.**
-   Measurement retired that claim: the grammar exists at `fjs/ebnf/lib/json`,
-   the LL(1) backend parses JSON with it, and `fjs/ebnf/map` is the engine that
-   rewrites a parsed tree to values. JSON's own mapping is **not written**, and
-   its typed form has one prerequisite: `value` and `string` are annotated
-   widened, so `rewrite` refuses them as keys until
-   [widened-rule-signatures](../fjs/ebnf/lib/todo/widened-rule-signatures.md)
-   gives `value` its recursive type, and `rewrite` recurses per node, so it
-   overflows at 1,000 nested arrays where today's parser is proven at 5,000 —
-   [stack-safe-rewrite](../fjs/ebnf/map/todo/stack-safe-rewrite.md). The
-   mapping builds **tokens** for the container machine, which stays: a value
-   mapping would also lose the `NumberPolicy` seam the extended codec's
-   `123n` comes from. The metadata channel in
+   Measurement retired that claim: the document grammar exists at
+   `fjs/ebnf/lib/json`, the LL(1) backend parses JSON with it, and
+   `fjs/ebnf/map` is the engine that rewrites a parsed tree. What 3b runs is
+   narrower and **not written**: a token-stream grammar over that module's
+   exported lexical rules, over UTF-16 code units, mapped to the tokens the
+   container machine consumes — the machine stays, with both codecs and
+   their `NumberPolicy` untouched. Four measured contracts decide that, in
+   the stage's issue: a value mapping would lose the seam the extended
+   codec's `123n` comes from and, through `rewrite`'s per-node recursion
+   ([stack-safe-rewrite](../fjs/ebnf/map/todo/stack-safe-rewrite.md)), the
+   depth today's parser is proven at; the public `tokenize` accepts streams
+   that are no document, which the document grammar rejects; and strings are
+   code-unit sequences, which the `ll1` proof's code-point decoding throws
+   on. Its typed mapping has one prerequisite, `string`'s pin in
+   [widened-rule-signatures](../fjs/ebnf/lib/todo/widened-rule-signatures.md),
+   and one design question of its own: the naive token grammar is not LL(1)
+   at a number's boundary. The metadata channel in
    [#1890](https://github.com/functionalscript/functionalscript/pull/1890) buys
    errors *better* than today's rather than the ones this reader owes, and it
    cannot classify a parse failure at all, since a failure yields no tree to
@@ -506,11 +511,12 @@ two — it is stage 4's proof source.
 
 **Urgency is not the same as readiness, and stage 3b now separates them.** The
 change of direction lowered its own issue to **P2**. It is still what stage 4
-waits on, and it is startable — the grammar and the mapping engine exist,
-though JSON's own mapping is not written and waits on a recursive type for
-`value` and a stack-safe `rewrite` — but what it reports on malformed input is
-undecided, and `fjs/ebnf/` is mid-migration. Design work, one type
-prerequisite and a moving dependency are poor reasons to hold the
+waits on, and it is startable — the lexical rules and the mapping engine
+exist, though its token-stream grammar is not written, must be made LL(1) at
+a number's boundary, and its mapping waits on `string`'s pin — but what it
+reports on malformed input is undecided, and `fjs/ebnf/` is mid-migration.
+Design work, one type prerequisite and a moving dependency are poor reasons
+to hold the
 front of a queue, so the P1 urgency of this plan rests on stages 1b and 4.
 
 An EDAG is an expression DAG whose sharing is *semantics*, not an encoding
@@ -698,15 +704,14 @@ throughout.
       [`self-contained-tokenizer`](../fjs/media/json/todo/self-contained-tokenizer.md),
       the defect that predates the replacement and is provable without it.
 - [ ] Stage 3b: the reader comes from a grammar over `fjs/ebnf/`, not from a
-      hand-written scanner. **Startable but not first**: the grammar exists at
-      `fjs/ebnf/lib/json` and `fjs/ebnf/map` is the engine that rewrites its
-      AST — JSON's own mapping is still to be written, builds **tokens** for
-      the container machine that stays, and needs two `fjs/ebnf` items first:
-      `value`'s recursive type from
+      hand-written scanner. **Startable but not first**: the lexical rules
+      exist at `fjs/ebnf/lib/json` and `fjs/ebnf/map` is the engine that
+      rewrites a tree — the token-stream grammar 3b runs, over UTF-16 code
+      units, is still to be written and made LL(1) at a number's boundary;
+      its mapping builds **tokens** for the container machine that stays and
+      needs `string`'s pin from
       [widened-rule-signatures](../fjs/ebnf/lib/todo/widened-rule-signatures.md)
-      and a `rewrite` that does not recurse per node,
-      [stack-safe-rewrite](../fjs/ebnf/map/todo/stack-safe-rewrite.md) — so
-      this is no longer blocked on
+      first — so this is no longer blocked on
       [#1890](https://github.com/functionalscript/functionalscript/pull/1890) —
       that channel buys better errors than today's, not the ones owed. What is
       undecided is the error shapes, and `fjs/ebnf/` is mid-migration.

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -542,10 +542,9 @@ picked up in is the next paragraph's.
 **The execution order is 1b, then 3b, then 4.** 1b never depended on stage 3:
 the corpus bootstraps in JSON, and it is indifferent to whether the DataJS
 reader that eventually consumes it is hand-written or generated from a
-grammar. It is P1 where 3b is
-P2, it needs no decision that has not been made, and running it early costs
-nothing — it still lands before stage 4, which is the only ordering constraint
-it ever carried.
+grammar. It is P1 where 3b is P2, it needs no decision that has not been made,
+and running it early costs nothing — it still lands before stage 4, which is
+the only ordering constraint it ever carried.
 
 ### Stages
 

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -25,8 +25,12 @@ Item 1 is context rather than work. **Item 2 is what to start.**
 
    **It is not blocked, though two earlier drafts of this plan said so.**
    Measurement retired that claim: the grammar exists at `fjs/ebnf/lib/json`,
-   the LL(1) backend parses JSON with it, and `fjs/ebnf/map` already rewrites
-   the result to values. The metadata channel in
+   the LL(1) backend parses JSON with it, and `fjs/ebnf/map` is the engine that
+   rewrites a parsed tree to values. JSON's own mapping is **not written**, and
+   its typed form has one prerequisite: `value` and `string` are annotated
+   widened, so `rewrite` refuses them as keys until
+   [widened-rule-signatures](../fjs/ebnf/lib/todo/widened-rule-signatures.md)
+   gives `value` its recursive type. The metadata channel in
    [#1890](https://github.com/functionalscript/functionalscript/pull/1890) buys
    errors *better* than today's rather than the ones this reader owes, and it
    cannot classify a parse failure at all, since a failure yields no tree to
@@ -170,11 +174,16 @@ fjs/fsc            JS tokenizer (comments, all     evolves with the language
   tokenizer being replaced rather than about its replacement.
 - **DataJS** (the format known in this repository as DJS): a new, minimal,
   spec'd format — JSON extended from a tree to a DAG, nothing else. Its reader
-  runs a grammar extending JSON's rather than a hand-written parser layered on
-  JSON's exported scanners. That grammar is already written, at
+  is built on a grammar extending JSON's rather than on JSON's exported
+  scanners, which the withdrawn design promised and nothing now provides. That
+  grammar is already written, at
   [`fjs/ebnf/lib/datajs`](../fjs/ebnf/lib/datajs/module.f.mjs) beside JSON's and
-  importing its rules — not under `fjs/media/datajs`, which holds the codec. The
-  serializer stays hand-written, since nothing generates one from a grammar.
+  importing its rules — not under `fjs/media/datajs`, which holds the codec.
+  **Whether that grammar maps straight to values or only feeds the token-driven
+  container machine is not decided here**: it is stage 4's first task, below,
+  and the container machine is retired on the first route and widened on the
+  second. The serializer stays hand-written either way, since nothing generates
+  one from a grammar.
   Everything that is not needed for the DAG property moves to FunctionalScript.
 - **FunctionalScript**: the current `fjs/djs` front end (grammar-based
   tokenizer, BNF parser, AST, transpiler) moves to `fjs/fsc` and continues to
@@ -492,9 +501,11 @@ two — it is stage 4's proof source.
 
 **Urgency is not the same as readiness, and stage 3b now separates them.** The
 change of direction lowered its own issue to **P2**. It is still what stage 4
-waits on, and it is startable — the grammar and the value mapping both exist —
-but what it reports on malformed input is undecided, and `fjs/ebnf/` is
-mid-migration. Design work and a moving dependency are poor reasons to hold the
+waits on, and it is startable — the grammar and the mapping engine exist,
+though JSON's own mapping is not written and its typed form waits on a
+recursive type for `value` — but what it reports on malformed input is
+undecided, and `fjs/ebnf/` is mid-migration. Design work, one type
+prerequisite and a moving dependency are poor reasons to hold the
 front of a queue, so the P1 urgency of this plan rests on stages 1b and 4.
 
 An EDAG is an expression DAG whose sharing is *semantics*, not an encoding
@@ -590,7 +601,9 @@ throughout.
    quoted work is wasted; if the grammar only produces tokens for it, the
    widening is still owed exactly as written. Nothing measured so far decides
    it — `fjs/ebnf/map` can rewrite an AST to values, which makes the first
-   route real, while the second is what today's code is shaped for. Whoever
+   route real, though DataJS's `value` is a widened thunk like JSON's and
+   needs the same recursive type before a typed mapping can key on it — while
+   the second is what today's code is shaped for. Whoever
    starts stage 4 settles this first and records it here and in
    [its own issue](../fjs/media/datajs/todo/parser-serializer.md), which says
    the same and makes the decision its first task.
@@ -669,8 +682,11 @@ throughout.
       the defect that predates the replacement and is provable without it.
 - [ ] Stage 3b: the reader comes from a grammar over `fjs/ebnf/`, not from a
       hand-written scanner. **Startable but not first**: the grammar exists at
-      `fjs/ebnf/lib/json` and `fjs/ebnf/map` already rewrites its AST to
-      values, so this is no longer blocked on
+      `fjs/ebnf/lib/json` and `fjs/ebnf/map` is the engine that rewrites its
+      AST to values — JSON's own mapping is still to be written, and its typed
+      form needs `value`'s recursive type from
+      [widened-rule-signatures](../fjs/ebnf/lib/todo/widened-rule-signatures.md)
+      first — so this is no longer blocked on
       [#1890](https://github.com/functionalscript/functionalscript/pull/1890) —
       that channel buys better errors than today's, not the ones owed. What is
       undecided is the error shapes, and `fjs/ebnf/` is mid-migration.

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -1,8 +1,9 @@
 ## Restructure JSON, DataJS, and FunctionalScript parsers/serializers
 
 **Priority:** P1 — stage 4 is urgent and stage 1b feeds it; see
-[Priority](#priority-stages-3-and-4-come-first). **Stage 3b is P2 while it is
-blocked**, which is the level its own issue now carries.
+[Priority](#priority-stages-3-and-4-come-first). **Stage 3b is P2**: open,
+partly startable, and not first, which is the level and status its own issue
+carries.
 **Status:** wip — stages 1a, 2 and 3a done. **Stage 1b is what to pick up
 next**: it is P1 and gates stage 4, while stage 3b is P2 with its error shapes
 still undecided.
@@ -54,8 +55,10 @@ Item 1 is context rather than work. **Item 2 is what to start.**
    record reviewed as data, not a rule a replacement inherits. The two
    invariants are the part an implementation is actually held to.
    *Why it still matters:* stage 4 needs it. DataJS's reader reuses JSON's, and
-   over a grammar the reuse is of rules rather than of exported scanners —
-   which is one of the open questions the rewritten issue lists.
+   over a grammar the reuse is of rules rather than of exported scanners.
+   That is answered in code —
+   [`fjs/ebnf/lib/datajs`](../fjs/ebnf/lib/datajs/module.f.mjs) already
+   imports JSON's rules — and the rewritten issue marks it done.
 2. **Start here: stage 1b, the conformance vectors**
    ([`spec/datajs/todo/conformance-vectors.md`](../spec/datajs/todo/conformance-vectors.md)).
    *Why here:* it is stage 4's proof source, so landing stage 4 first means
@@ -65,17 +68,19 @@ Item 1 is context rather than work. **Item 2 is what to start.**
    own proofs — unchanged but for one enumerated defect, an `n` today's
    tokenizer deletes from inside a number.
    *Why it moved:* it was listed after stage 3 for convenience, not dependency.
-   With 3b blocked it is the only actionable piece of this plan, and it is
-   blocked on nothing — it needs no DataJS reader, and it does not care whether
-   that reader is eventually hand-written or generated.
+   It is P1 and gates stage 4, where 3b is P2 with its error shapes undecided,
+   and it is blocked on nothing — it needs no DataJS reader, and it does not
+   care whether that reader is eventually hand-written or generated.
 3. **Then: stage 4, `fjs/media/datajs`.** Design is filed:
    [`fjs/media/datajs/todo/parser-serializer.md`](../fjs/media/datajs/todo/parser-serializer.md).
    The normative
    behavior is already settled in
    [`spec/datajs/README.md`](../spec/datajs/README.md); stage 4 implements that
-   spec, it does not redesign it. Known prerequisite work is named in the stage
-   list below: JSON's parser seam is **not** wide enough today and has to be
-   generalized first.
+   spec, it does not redesign it. Its first task is a decision the stage list
+   below states: whether the reader is the grammar at `fjs/ebnf/lib/datajs`
+   mapped to values, or the token-driven container machine. Only on the second
+   route is JSON's parser seam — **not** wide enough today — prerequisite
+   work; on the first it is retired instead.
    *Why:* this is the deliverable everything else is waiting for — see
    [Priority](#priority-stages-3-and-4-come-first).
 4. **Then stages 5–7**, in order, as listed below.
@@ -547,14 +552,16 @@ throughout.
    design this plan replaces with `;`, so keeping it would have preserved a
    grammar contradicting the decision record above. Git history holds them if
    a future stage wants the `id`/`alpha`/comment rules.
-3. **JSON's reader — 3a done, 3b blocked; see above.** Two PRs: **3a** drops
-   the fabricated `string` token that follows a malformed-literal error, in the
-   existing wrapper, since that defect predates the replacement and is provable
-   without it; **3b** replaces the `fjs/js/tokenizer` wrapper in
+3. **JSON's reader — 3a done, 3b open but not first; see above.** Two PRs:
+   **3a** drops the fabricated `string` token that follows a malformed-literal
+   error, in the existing wrapper, since that defect predates the replacement
+   and is provable without it; **3b** replaces the `fjs/js/tokenizer` wrapper in
    `fjs/media/json/tokenizer` with a reader generated from JSON's own grammar
    over `fjs/ebnf/`. **3b exports no scanners.** That seam belonged to the
-   withdrawn hand-written design, and what replaces it is one of the open
-   questions the stage-3 issue lists. Accepted-input proofs unchanged in both,
+   withdrawn hand-written design, and what replaces it is answered in code:
+   rule reuse by ordinary import, as
+   [`fjs/ebnf/lib/datajs`](../fjs/ebnf/lib/datajs/module.f.mjs) already does.
+   Accepted-input proofs unchanged in both,
    but for one enumerated defect — the `n` an old number swallowed — which only
    3b can fix; error-shape proofs rewritten once, to shapes 3b has still to
    decide.
@@ -585,8 +592,8 @@ throughout.
    it — `fjs/ebnf/map` can rewrite an AST to values, which makes the first
    route real, while the second is what today's code is shaped for. Whoever
    starts stage 4 settles this first and records it here and in
-   [its own issue](../fjs/media/datajs/todo/parser-serializer.md), which
-   currently states the second route as settled.
+   [its own issue](../fjs/media/datajs/todo/parser-serializer.md), which says
+   the same and makes the decision its first task.
 
    The serializer is unaffected either way, since nothing generates one from a
    grammar. It is the shared walker of
@@ -651,8 +658,9 @@ throughout.
       **Next, and actionable now**: the only constraint it carries is landing
       **before stage 4**, which consumes it, since landing stage 4 first means
       writing its proofs twice. It was sequenced after stage 3 for convenience
-      rather than dependency, and with 3b blocked it goes first. The corpus
-      bootstraps in JSON so it needs no DataJS reader to exist.
+      rather than dependency, and it goes first because it is P1 where 3b is
+      P2 with its error shapes undecided. The corpus bootstraps in JSON so it
+      needs no DataJS reader to exist.
 - [x] Stage 2: dead `fjs/fsc` grammar deleted; its todo file removed and the
       citations in [207](../fjs/bnf/todo/207-bnf-semantic-actions.md)
       repointed at `fjs/bnf/testlib.f.mjs`.
@@ -671,8 +679,10 @@ throughout.
       language is JSON's already, but for one defect — `1n1` and its class,
       accepted today by deleting an `n` from inside a number, which only 3b can
       fix — so beyond that only error shapes change. What replaces the
-      hand-written seam, and what error shapes a grammar-driven reader should
-      produce, are open questions listed in that issue.
+      hand-written seam is answered in code — rule reuse by import, as
+      `fjs/ebnf/lib/datajs` already does — and what error shapes a
+      grammar-driven reader should produce is the open question that issue
+      lists.
 - [ ] Stage 4: `fjs/media/datajs`; file its todo. Needs stage 1b's corpus in
       place as its proof source.
 - [ ] Stage 5: front-end move to `fjs/fsc`; file its todo.
@@ -699,7 +709,7 @@ throughout.
   no longer "a media codec may not depend on a grammar module at runtime",
   which is reversed. It is that `fjs/bnf` is the classical module being
   retired, so a runtime grammar belongs to `fjs/ebnf/` and arrives with stage
-  3b. Until 3b is unblocked the `fjs/bnf/lib/json` grammar remains an example
+  3b. Until 3b lands the `fjs/bnf/lib/json` grammar remains an example
   rather than the codec's source, so nothing in that issue's current work
   changes — but its statement that **the media scanners stay hand-written** is
   withdrawn and must not be built on. Lowering the example onto

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -152,10 +152,12 @@ fjs/fsc            JS tokenizer (comments, all     evolves with the language
   tokenizer being replaced rather than about its replacement.
 - **DataJS** (the format known in this repository as DJS): a new, minimal,
   spec'd format — JSON extended from a tree to a DAG, nothing else. Its reader
-  is a grammar in `fjs/media/datajs` extending JSON's rather than a hand-written
-  parser layered on JSON's exported scanners; the serializer stays
-  hand-written, since nothing generates one from a grammar. Everything that is
-  not needed for the DAG property moves to FunctionalScript.
+  runs a grammar extending JSON's rather than a hand-written parser layered on
+  JSON's exported scanners. That grammar is already written, at
+  [`fjs/ebnf/lib/datajs`](../fjs/ebnf/lib/datajs/module.f.mjs) beside JSON's and
+  importing its rules — not under `fjs/media/datajs`, which holds the codec. The
+  serializer stays hand-written, since nothing generates one from a grammar.
+  Everything that is not needed for the DAG property moves to FunctionalScript.
 - **FunctionalScript**: the current `fjs/djs` front end (grammar-based
   tokenizer, BNF parser, AST, transpiler) moves to `fjs/fsc` and continues to
   grow there — comments, imports, identifier keys, and the staged EDAG work.
@@ -543,15 +545,37 @@ throughout.
    3b can fix; error-shape proofs rewritten once, to shapes 3b has still to
    decide.
 4. **`fjs/media/datajs` — urgent, see above; this is what EDAG needs.** Parser
-   and serializer, proofs over the spec vectors. The parser reuses JSON's container machine, and today's seam is
-   **not wide enough for that**: `NumberPolicy` receives number tokens only,
-   `JsonToken` has no identifier/bigint/`=` tokens, and the object states
-   accept string keys only. Generalizing the seam is therefore explicit
-   stage-4 prerequisite work on `fjs/media/json/parser`: extend the token
-   vocabulary the machine can be fed, add the leaf/identifier policy hook
-   (JSON's instantiation: error) and the key-form hook (JSON's: string keys
-   only), and pin JSON's accepted language and behavior unchanged by proofs
-   across the API change. The serializer is the shared walker of
+   and serializer, proofs over the spec vectors.
+
+   **Which reader stage 4 builds is an open question, and it must be settled
+   before its prerequisite work starts.** The reversal above puts DataJS's
+   reader on a grammar, and
+   [`fjs/ebnf/lib/datajs`](../fjs/ebnf/lib/datajs/module.f.mjs) already exists
+   and already imports JSON's rules. The paragraph below describes the *other*
+   route, written when a hand-written token-driven parser was the plan:
+
+   > The parser reuses JSON's container machine, and today's seam is
+   > **not wide enough for that**: `NumberPolicy` receives number tokens only,
+   > `JsonToken` has no identifier/bigint/`=` tokens, and the object states
+   > accept string keys only. Generalizing the seam is therefore explicit
+   > stage-4 prerequisite work on `fjs/media/json/parser`: extend the token
+   > vocabulary the machine can be fed, add the leaf/identifier policy hook
+   > (JSON's instantiation: error) and the key-form hook (JSON's: string keys
+   > only), and pin JSON's accepted language and behavior unchanged by proofs
+   > across the API change.
+
+   The two are not variants of one design. If the grammar maps straight to
+   values, the container machine is not widened but **retired**, and that
+   quoted work is wasted; if the grammar only produces tokens for it, the
+   widening is still owed exactly as written. Nothing measured so far decides
+   it — `fjs/ebnf/map` can rewrite an AST to values, which makes the first
+   route real, while the second is what today's code is shaped for. Whoever
+   starts stage 4 settles this first and records it here and in
+   [its own issue](../fjs/media/datajs/todo/parser-serializer.md), which
+   currently states the second route as settled.
+
+   The serializer is unaffected either way, since nothing generates one from a
+   grammar. It is the shared walker of
    [157](../fjs/djs/todo/157-json-djs-shared-value-machine.md) §2 with a
    ref-lookup hook and DataJS's own number writer.
 5. **Front-end move** — `fjs/djs/{tokenizer,parser,ast,transpiler}` →

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -3,8 +3,9 @@
 **Priority:** P1 — stage 4 is urgent and stage 1b feeds it; see
 [Priority](#priority-stages-3-and-4-come-first). **Stage 3b is P2 while it is
 blocked**, which is the level its own issue now carries.
-**Status:** wip — stages 1a, 2 and 3a done; **stage 3b is blocked on EBNF**, so
-**stage 1b is what to pick up next**.
+**Status:** wip — stages 1a, 2 and 3a done. **Stage 1b is what to pick up
+next**: it is P1 and gates stage 4, while stage 3b is P2 with its error shapes
+still undecided.
 
 This is a coordinating issue: it records the design decided in discussion,
 sequences the stages, and names the edits owed to existing issues. Each stage
@@ -14,16 +15,28 @@ not here.
 ### Pick up here
 
 Read in this order; each line says what to do and why it comes when it does.
-Item 1 is context rather than work — it is blocked. **Item 2 is what to start.**
+Item 1 is context rather than work. **Item 2 is what to start.**
 
-1. **Stage 3b is blocked, and the reason changes this plan.** JSON's reader
+1. **Stage 3b changed direction, and that changes this plan.** JSON's reader
    will come from an **EBNF grammar** over `fjs/ebnf/` rather than the
    hand-written scanner this issue specified, so the no-runtime-grammar rule
-   below is reversed. Nothing can start until the EBNF LL(1) backend can carry
-   a mapping's metadata, which is being designed in
-   [#1890](https://github.com/functionalscript/functionalscript/pull/1890);
-   the module's own migration is
+   below is reversed.
+
+   **It is not blocked, though two earlier drafts of this plan said so.**
+   Measurement retired that claim: the grammar exists at `fjs/ebnf/lib/json`,
+   the LL(1) backend parses JSON with it, and `fjs/ebnf/map` already rewrites
+   the result to values. The metadata channel in
+   [#1890](https://github.com/functionalscript/functionalscript/pull/1890) buys
+   errors *better* than today's rather than the ones this reader owes, and it
+   cannot classify a parse failure at all, since a failure yields no tree to
+   annotate. What genuinely remains is a design decision — what the reader
+   reports on malformed input — plus the module's own migration,
    [`fjs/todo/ebnf-migration.md`](../fjs/todo/ebnf-migration.md).
+
+   It still is not what to pick up first. It is P2, its error shapes are
+   undecided, and `fjs/ebnf/` is mid-migration, so writing a codec against it
+   now means writing against names still moving. Stage 1b is P1 and gates
+   stage 4, which is the ordering that matters.
 
    The hand-written design was written, reviewed, implemented in full and
    **withdrawn** —
@@ -170,7 +183,7 @@ fjs/fsc            JS tokenizer (comments, all     evolves with the language
 
   The old rule rested on the grammar module not being stable enough to depend
   on, and that argument has not changed — `fjs/ebnf/` is mid-migration, which is
-  why stage 3b is *blocked* rather than open. What changed is what the
+  why stage 3b is not the thing to start first. What changed is what the
   alternative costs: a hand-written tokenizer and container machine per format,
   whose defects have to be found one at a time by review, against a grammar of a
   few dozen readable lines.
@@ -472,11 +485,12 @@ Stages 3 and 4 are the urgent ones, ahead of the rest of this plan. They are
 what [EDAG](./edag-spec.md) is waiting on. Stage 1b comes with them, between the
 two — it is stage 4's proof source.
 
-**Urgency is not the same as actionability, and stage 3b now separates them.**
-Being blocked on EBNF lowered its own issue to **P2**: it is still what stage 4
-waits on, but no amount of priority makes it startable, so it cannot hold the
-front of a queue. The P1 urgency of this plan therefore rests on stages 1b and
-4 until the EBNF backend unblocks 3b, at which point it returns to the front.
+**Urgency is not the same as readiness, and stage 3b now separates them.** The
+change of direction lowered its own issue to **P2**. It is still what stage 4
+waits on, and it is startable — the grammar and the value mapping both exist —
+but what it reports on malformed input is undecided, and `fjs/ebnf/` is
+mid-migration. Design work and a moving dependency are poor reasons to hold the
+front of a queue, so the P1 urgency of this plan rests on stages 1b and 4.
 
 An EDAG is an expression DAG whose sharing is *semantics*, not an encoding
 detail: one node referenced from two operand positions is one value, and `{} ===
@@ -501,12 +515,12 @@ Stage 1b (the conformance vectors) sits **between** them: it is stage 4's proof
 source, not stage 3's, and its corpus is stored in JSON exactly so it can exist
 before a DataJS reader does. So the intended order is 3, 1b, 4.
 
-**With 3b blocked, 1b runs first.** Only 3b is blocked, and 1b never depended
-on it: the corpus bootstraps in JSON, and it is indifferent to whether the
-DataJS reader that eventually consumes it is hand-written or generated from a
-grammar. It is therefore the one piece of this plan that is actionable today,
-and running it early costs nothing — it still lands before stage 4, which is
-the only ordering constraint it ever carried.
+**1b runs first anyway.** It never depended on stage 3: the corpus bootstraps in
+JSON, and it is indifferent to whether the DataJS reader that eventually
+consumes it is hand-written or generated from a grammar. It is P1 where 3b is
+P2, it needs no decision that has not been made, and running it early costs
+nothing — it still lands before stage 4, which is the only ordering constraint
+it ever carried.
 
 ### Stages
 
@@ -645,10 +659,14 @@ throughout.
 - [x] Stage 3a: drop the fabricated `string` token in the existing wrapper —
       [`self-contained-tokenizer`](../fjs/media/json/todo/self-contained-tokenizer.md),
       the defect that predates the replacement and is provable without it.
-- [ ] Stage 3b: **blocked on EBNF, do not start.** The reader comes from a
-      grammar over `fjs/ebnf/`, not from a hand-written scanner, and it waits
-      on the metadata channel in
-      [#1890](https://github.com/functionalscript/functionalscript/pull/1890).
+- [ ] Stage 3b: the reader comes from a grammar over `fjs/ebnf/`, not from a
+      hand-written scanner. **Startable but not first**: the grammar exists at
+      `fjs/ebnf/lib/json` and `fjs/ebnf/map` already rewrites its AST to
+      values, so this is no longer blocked on
+      [#1890](https://github.com/functionalscript/functionalscript/pull/1890) —
+      that channel buys better errors than today's, not the ones owed. What is
+      undecided is the error shapes, and `fjs/ebnf/` is mid-migration.
+      A reader must compose EOF: `json` alone accepts `[1]x`.
       What is measured and still holds is the swap's blast radius: the accepted
       language is JSON's already, but for one defect — `1n1` and its class,
       accepted today by deleting an `n` from inside a number, which only 3b can

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -622,11 +622,16 @@ throughout.
    value mapping breaks two contracts today's parser keeps: depth, since
    `rewrite` recurses per node and overflows at 1,000 nested arrays where the
    parser is proven at 5,000, and the `NumberPolicy` seam that gives the
-   extended codec its `bigint`. DataJS owes both too — its values nest as
-   JSON's do, and its bigint is the same lexeme-preserving requirement. The
-   grammar route has to keep both through the mapping, on top of the
-   recursive type DataJS's widened `value` thunk needs like JSON's; the token
-   route keeps both by construction and is what today's code is shaped for.
+   extended codec its `bigint`. DataJS owes the first — its values nest as
+   JSON's do — and not the second: its grammar parses `1` and `1n` to
+   distinct branches with every digit retained, so a mapping picks `Number`
+   or `BigInt` from the branch, and the format has one numeric domain where
+   the seam exists for two codecs over one grammar. What it does share with
+   3b is the alphabet, UTF-16 code units, since its corpus carries lone
+   surrogates that code-point decoding throws on. The grammar route has to
+   keep depth through the mapping, on top of the recursive type DataJS's
+   widened `value` thunk needs like JSON's; the token route keeps it by
+   construction and is what today's code is shaped for.
    Whoever
    starts stage 4 settles this first and records it here and in
    [its own issue](../fjs/media/datajs/todo/parser-serializer.md), which says

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -39,8 +39,8 @@ Item 1 is context rather than work. **Item 2 is what to start.**
    code-unit sequences, which the `ll1` proof's code-point decoding throws
    on. Its typed mapping has one prerequisite, `string`'s pin in
    [widened-rule-signatures](../fjs/ebnf/lib/todo/widened-rule-signatures.md),
-   and one design question of its own: the naive token grammar is not LL(1)
-   at a number's boundary. The metadata channel in
+   and one design question of its own: the naive token grammar gets a
+   number's and a word's boundaries wrong. The metadata channel in
    [#1890](https://github.com/functionalscript/functionalscript/pull/1890) buys
    errors *better* than today's rather than the ones this reader owes, and it
    cannot classify a parse failure at all, since a failure yields no tree to
@@ -512,8 +512,9 @@ two — it is stage 4's proof source.
 **Urgency is not the same as readiness, and stage 3b now separates them.** The
 change of direction lowered its own issue to **P2**. It is still what stage 4
 waits on, and it is startable — the lexical rules and the mapping engine
-exist, though its token-stream grammar is not written, must be made LL(1) at
-a number's boundary, and its mapping waits on `string`'s pin — but what it
+exist, though its token-stream grammar is not written, must match today's
+tokenizer at a number's and a word's boundaries, and its mapping waits on
+`string`'s pin — but what it
 reports on malformed input is undecided, and `fjs/ebnf/` is mid-migration.
 Design work, one type prerequisite and a moving dependency are poor reasons
 to hold the
@@ -707,8 +708,9 @@ throughout.
       hand-written scanner. **Startable but not first**: the lexical rules
       exist at `fjs/ebnf/lib/json` and `fjs/ebnf/map` is the engine that
       rewrites a tree — the token-stream grammar 3b runs, over UTF-16 code
-      units, is still to be written and made LL(1) at a number's boundary;
-      its mapping builds **tokens** for the container machine that stays and
+      units, is still to be written and made to match today's at a number's
+      and a word's boundaries; its mapping builds **tokens** for the container
+      machine that stays and
       needs `string`'s pin from
       [widened-rule-signatures](../fjs/ebnf/lib/todo/widened-rule-signatures.md)
       first — so this is no longer blocked on

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -30,7 +30,12 @@ Item 1 is context rather than work. **Item 2 is what to start.**
    its typed form has one prerequisite: `value` and `string` are annotated
    widened, so `rewrite` refuses them as keys until
    [widened-rule-signatures](../fjs/ebnf/lib/todo/widened-rule-signatures.md)
-   gives `value` its recursive type. The metadata channel in
+   gives `value` its recursive type, and `rewrite` recurses per node, so it
+   overflows at 1,000 nested arrays where today's parser is proven at 5,000 —
+   [stack-safe-rewrite](../fjs/ebnf/map/todo/stack-safe-rewrite.md). The
+   mapping builds **tokens** for the container machine, which stays: a value
+   mapping would also lose the `NumberPolicy` seam the extended codec's
+   `123n` comes from. The metadata channel in
    [#1890](https://github.com/functionalscript/functionalscript/pull/1890) buys
    errors *better* than today's rather than the ones this reader owes, and it
    cannot classify a parse failure at all, since a failure yields no tree to
@@ -502,8 +507,8 @@ two — it is stage 4's proof source.
 **Urgency is not the same as readiness, and stage 3b now separates them.** The
 change of direction lowered its own issue to **P2**. It is still what stage 4
 waits on, and it is startable — the grammar and the mapping engine exist,
-though JSON's own mapping is not written and its typed form waits on a
-recursive type for `value` — but what it reports on malformed input is
+though JSON's own mapping is not written and waits on a recursive type for
+`value` and a stack-safe `rewrite` — but what it reports on malformed input is
 undecided, and `fjs/ebnf/` is mid-migration. Design work, one type
 prerequisite and a moving dependency are poor reasons to hold the
 front of a queue, so the P1 urgency of this plan rests on stages 1b and 4.
@@ -568,8 +573,11 @@ throughout.
    error, in the existing wrapper, since that defect predates the replacement
    and is provable without it; **3b** replaces the `fjs/js/tokenizer` wrapper in
    `fjs/media/json/tokenizer` with a reader generated from JSON's own grammar
-   over `fjs/ebnf/`. **3b exports no scanners.** That seam belonged to the
-   withdrawn hand-written design, and what replaces it is answered in code:
+   over `fjs/ebnf/`, whose mapping builds **tokens** for the container machine
+   in `fjs/media/json/parser`, which stays with both codecs and their
+   `NumberPolicy` unchanged. **3b exports no scanners.** That seam belonged
+   to the withdrawn hand-written design, and what replaces it is answered in
+   code:
    rule reuse by ordinary import, as
    [`fjs/ebnf/lib/datajs`](../fjs/ebnf/lib/datajs/module.f.mjs) already does.
    Accepted-input proofs unchanged in both,
@@ -599,11 +607,17 @@ throughout.
    The two are not variants of one design. If the grammar maps straight to
    values, the container machine is not widened but **retired**, and that
    quoted work is wasted; if the grammar only produces tokens for it, the
-   widening is still owed exactly as written. Nothing measured so far decides
-   it — `fjs/ebnf/map` can rewrite an AST to values, which makes the first
-   route real, though DataJS's `value` is a widened thunk like JSON's and
-   needs the same recursive type before a typed mapping can key on it — while
-   the second is what today's code is shaped for. Whoever
+   widening is still owed exactly as written. What is measured bears on it
+   without settling it. Stage 3b took the token route for JSON because a
+   value mapping breaks two contracts today's parser keeps: depth, since
+   `rewrite` recurses per node and overflows at 1,000 nested arrays where the
+   parser is proven at 5,000, and the `NumberPolicy` seam that gives the
+   extended codec its `bigint`. DataJS owes both too — its values nest as
+   JSON's do, and its bigint is the same lexeme-preserving requirement. The
+   grammar route has to keep both through the mapping, on top of the
+   recursive type DataJS's widened `value` thunk needs like JSON's; the token
+   route keeps both by construction and is what today's code is shaped for.
+   Whoever
    starts stage 4 settles this first and records it here and in
    [its own issue](../fjs/media/datajs/todo/parser-serializer.md), which says
    the same and makes the decision its first task.
@@ -683,10 +697,13 @@ throughout.
 - [ ] Stage 3b: the reader comes from a grammar over `fjs/ebnf/`, not from a
       hand-written scanner. **Startable but not first**: the grammar exists at
       `fjs/ebnf/lib/json` and `fjs/ebnf/map` is the engine that rewrites its
-      AST to values — JSON's own mapping is still to be written, and its typed
-      form needs `value`'s recursive type from
+      AST — JSON's own mapping is still to be written, builds **tokens** for
+      the container machine that stays, and needs two `fjs/ebnf` items first:
+      `value`'s recursive type from
       [widened-rule-signatures](../fjs/ebnf/lib/todo/widened-rule-signatures.md)
-      first — so this is no longer blocked on
+      and a `rewrite` that does not recurse per node,
+      [stack-safe-rewrite](../fjs/ebnf/map/todo/stack-safe-rewrite.md) — so
+      this is no longer blocked on
       [#1890](https://github.com/functionalscript/functionalscript/pull/1890) —
       that channel buys better errors than today's, not the ones owed. What is
       undecided is the error shapes, and `fjs/ebnf/` is mid-migration.

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -532,21 +532,28 @@ not marginally: it has no way to express sharing at all, and it also lacks the
 cache reads `.f.js` back, and the property that matters is that parsing a
 serialized EDAG reproduces the same EDAG.
 
-**Stage 3 is a dependency of stage 4**, because DataJS's reader reuses parts
-of JSON's rather than restating them: strings are JSON's unchanged, and
-DataJS's numbers are JSON's int/frac/exp core plus a bigint suffix and
-`-Infinity` folding. Over a grammar that reuse is of *rules* rather than of
-exported scanners, so what stage 4 inherits is a grammar to extend, and stage
-4 stays close behind to keep the shared rules honest.
+**Stage 3 is a dependency of stage 4 on the token-machine route only.**
+DataJS's reader reuses parts of JSON's rather than restating them: strings
+are JSON's unchanged, and DataJS's numbers are JSON's int/frac/exp core plus
+a bigint suffix and `-Infinity` folding. Over a grammar that reuse is of
+*rules* rather than of exported scanners, and the rules are already imported
+— `fjs/ebnf/lib/datajs` exists — so the grammar route consumes nothing from
+stage 3b. The token-machine route does: its token-stream grammar extends
+JSON's and inherits the boundary resolution 3b owes. Either way stage 4 stays
+close behind 3b, to keep the shared rules honest.
 
 Stage 1b (the conformance vectors) is stage 4's other dependency, and not
 stage 3's: it is stage 4's proof source, and its corpus is stored in JSON
-exactly so it can exist before a DataJS reader does. So the dependencies are 3
-before 4 and 1b before 4 — a relationship, not a queue. An earlier draft wrote
-it as an intended order of 3, 1b, 4; that is withdrawn, and the order work is
-picked up in is the next paragraph's.
+exactly so it can exist before a DataJS reader does. So the dependencies are
+1b before 4, and 3b before 4 on the token route — a relationship, not a queue.
+An earlier draft wrote it as an intended order of 3, 1b, 4; that is withdrawn,
+and the order work is picked up in is the next paragraph's.
 
-**The execution order is 1b, then 3b, then 4.** 1b never depended on stage 3:
+**The execution order is 1b first, then 3b and 4 as stage 4's route decides.**
+Stage 4's first task — choosing that route — waits on nothing and can run
+beside 1b. On the token route stage 4's implementation follows 3b; on the
+grammar route it needs only 1b's corpus and the `fjs/ebnf` items its issue
+names, and 3b proceeds on its own P2 schedule. 1b never depended on stage 3:
 the corpus bootstraps in JSON, and it is indifferent to whether the DataJS
 reader that eventually consumes it is hand-written or generated from a
 grammar. It is P1 where 3b is P2, it needs no decision that has not been made,

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -1,7 +1,7 @@
 ## Restructure JSON, DataJS, and FunctionalScript parsers/serializers
 
 **Priority:** P1 — stages 3 and 4 are urgent; see [Priority](#priority-stages-3-and-4-come-first).
-**Status:** wip — stages 1a, 2 and 3a done.
+**Status:** wip — stages 1a, 2 and 3a done; **stage 3b is blocked on EBNF**.
 
 This is a coordinating issue: it records the design decided in discussion,
 sequences the stages, and names the edits owed to existing issues. Each stage
@@ -12,10 +12,20 @@ not here.
 
 Read in this order; each line says what to do and why it comes when it does.
 
-1. **Next: stage 3b, the port.** Stage 3a — the fabricated string token — has
-   landed, so what is left of stage 3 is the JSON self-contained tokenizer
-   itself. Design is written and
-   reviewed:
+1. **Stage 3b is blocked, and the reason changes this plan.** JSON's reader
+   will come from an **EBNF grammar** over `fjs/ebnf/` rather than the
+   hand-written scanner this issue specified, so the no-runtime-grammar rule
+   below is reversed. Nothing can start until the EBNF LL(1) backend can carry
+   a mapping's metadata, which is being designed in
+   [#1890](https://github.com/functionalscript/functionalscript/pull/1890);
+   the module's own migration is
+   [`fjs/todo/ebnf-migration.md`](../fjs/todo/ebnf-migration.md).
+
+   The hand-written design was written, reviewed, implemented in full and
+   **withdrawn** —
+   [#1895](https://github.com/functionalscript/functionalscript/pull/1895),
+   reverted. Read it for its measurements, not as a plan. The rewritten issue
+   carries what survives:
    [`fjs/media/json/todo/self-contained-tokenizer.md`](../fjs/media/json/todo/self-contained-tokenizer.md).
    It has the grammar, the error rule and the two invariants that decide
    whether a difference is expected, an illustrative table of error shapes that
@@ -24,13 +34,11 @@ Read in this order; each line says what to do and why it comes when it does.
    generated sweeps are coverage rather than an enumeration — the design is
    explicit that no finite sweep is exhaustive, so the rules plus the
    invariants are what an implementation is held to. Implementable without
-   reading anything else here. It lands as **two PRs**: 3a dropped the
-   fabricated string token in the existing wrapper, and 3b is the port, which
-   then carries only what removing the dependency forces — the order
-   [`DESIGN.md`](../doc/DESIGN.md) prescribes when the idea is the premise.
-   *Why first:* stage 4 needs it. DataJS's tokenizer reuses JSON's string
-   scanner unchanged and its number core extended, so JSON has to own those
-   scanners before DataJS can borrow them.
+   the two invariants any replacement is held to, the accepted-language
+   probes, the measured terminator sets, and what still has to be decided.
+   *Why it still matters:* stage 4 needs it. DataJS's reader reuses JSON's, and
+   over a grammar the reuse is of rules rather than of exported scanners —
+   which is one of the open questions the rewritten issue lists.
 2. **Then: stage 1b, the conformance vectors**
    ([`spec/datajs/todo/conformance-vectors.md`](../spec/datajs/todo/conformance-vectors.md)).
    *Why here:* it is stage 4's proof source, so landing stage 4 first means
@@ -55,11 +63,16 @@ Read in this order; each line says what to do and why it comes when it does.
 (the dead `fjs/fsc` grammars, deleted), and stage 3a (the fabricated string
 token, dropped). All three are on `main`.
 
+**Do not start a hand-written JSON scanner.** That is what #1895 was, and it is
+withdrawn — not because it failed, but because the defects review had to find in
+it one at a time are the cost the grammar is being bought to avoid.
+
 **Three things are decided and should not be reopened without a reason:**
 DataJS is frozen at "JSON extended from a tree to a DAG, plus the leaves JSON
 cannot spell" — new syntax belongs in FunctionalScript, not here; the media
-codecs take no runtime dependency on `fjs/bnf` or on `fjs/js/tokenizer`, which
-is the whole point of the restructure; and the mandatory identifier prefix is
+codecs take no runtime dependency on `fjs/js/tokenizer`, which is the whole
+point of the restructure — **the half of that rule about grammar modules is
+reversed, see below**; and the mandatory identifier prefix is
 **`$`**, not `_` or any other character. The prefix itself is what carries the
 design — it retires the exclusion list — and the grammar does not force which
 character does it, so the choice was made once and is closed. The objection on
@@ -119,27 +132,51 @@ fjs/fsc            JS tokenizer (comments, all     evolves with the language
                    operators) → parser → AST → EDAG
 ```
 
-- **JSON**: accepted language and value semantics are frozen; the tokenizer
-  becomes self-contained (the `fjs/js/tokenizer` wrapper is replaced by a
-  small scanner of JSON's own lexical grammar). Error shapes may change once
-  in that swap; accepted-input behavior does not, with one enumerated
-  exception — inputs like `1n1`, which today's tokenizer accepts as a number
-  by deleting the `n`, start erroring. No existing proof is in that class.
+- **JSON**: accepted language and value semantics are frozen; the
+  `fjs/js/tokenizer` wrapper is replaced by a reader generated from JSON's own
+  grammar over `fjs/ebnf/`. Error shapes may change once in that swap;
+  accepted-input behavior does not, with one enumerated exception — inputs like
+  `1n1`, which today's tokenizer accepts as a number by deleting the `n`, start
+  erroring. No existing proof is in that class. Both halves are measured and
+  the invariants stated in
+  [self-contained-tokenizer](../fjs/media/json/todo/self-contained-tokenizer.md),
+  which survives the change of direction because they are facts about the
+  tokenizer being replaced rather than about its replacement.
 - **DataJS** (the format known in this repository as DJS): a new, minimal,
-  spec'd format — JSON extended from a tree to a DAG, nothing else. New
-  hand-written parser and serializer in `fjs/media/datajs`, layered on JSON's
-  exported pieces. Everything that is not needed for the DAG property moves to
-  FunctionalScript.
+  spec'd format — JSON extended from a tree to a DAG, nothing else. Its reader
+  is a grammar in `fjs/media/datajs` extending JSON's rather than a hand-written
+  parser layered on JSON's exported scanners; the serializer stays
+  hand-written, since nothing generates one from a grammar. Everything that is
+  not needed for the DAG property moves to FunctionalScript.
 - **FunctionalScript**: the current `fjs/djs` front end (grammar-based
   tokenizer, BNF parser, AST, transpiler) moves to `fjs/fsc` and continues to
   grow there — comments, imports, identifier keys, and the staged EDAG work.
   The compiler can emit DataJS (normalized) or JSON.
-- **BNF is not a runtime dependency of the media codecs.** The spec carries
+- **A grammar module *is* a runtime dependency of the media codecs — reversed.**
+  This bullet used to read "BNF is not a runtime dependency of the media
+  codecs", with the grammars kept as proof-covered examples. JSON's and DataJS's
+  readers are instead a grammar over [`fjs/ebnf/`](../fjs/ebnf/module.f.mjs)
+  plus a mapping.
+
+  The old rule rested on the grammar module not being stable enough to depend
+  on, and that argument has not changed — `fjs/ebnf/` is mid-migration, which is
+  why stage 3b is *blocked* rather than open. What changed is what the
+  alternative costs: a hand-written tokenizer and container machine per format,
+  whose defects have to be found one at a time by review, against a grammar of a
+  few dozen readable lines.
+
+  The rule's other half survives, and binds harder now: an example grammar
+  without proof coverage is how the dead `fjs/fsc` copy happened, so none may be
+  added without proofs. The paragraph below is what the old rule said, kept
+  because [bnf-grammar-single-owner](../fjs/bnf/todo/bnf-grammar-single-owner.md)
+  is still written against it and is owed an edit.
+
+  ~~The spec carries
   the grammars as BNF text; `fjs/bnf/**` may hold the JSON and DataJS grammars
   as *proof-covered examples* cross-checked against the spec's test vectors.
   An example grammar without proof coverage is how the dead `fjs/fsc` copy
   happened — nothing imported or proved it, so it silently drifted from the
-  other two; none may be added without proofs.
+  other two; none may be added without proofs.~~
 
 ### The DataJS format (decision record)
 

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -1,6 +1,8 @@
 ## Restructure JSON, DataJS, and FunctionalScript parsers/serializers
 
-**Priority:** P1 — stages 3 and 4 are urgent; see [Priority](#priority-stages-3-and-4-come-first).
+**Priority:** P1 — stage 4 is urgent and stage 1b feeds it; see
+[Priority](#priority-stages-3-and-4-come-first). **Stage 3b is P2 while it is
+blocked**, which is the level its own issue now carries.
 **Status:** wip — stages 1a, 2 and 3a done; **stage 3b is blocked on EBNF**, so
 **stage 1b is what to pick up next**.
 
@@ -34,11 +36,10 @@ Item 1 is context rather than work — it is blocked. **Item 2 is what to start.
    accepting and terminator sets, the error shapes today's wrapper produces,
    and a checklist of what has to be decided before an implementation can
    start. Those survive the reversal because they are facts about the
-   tokenizer being replaced rather than about its replacement. The tables are
-   illustrative and known incomplete, and even the generated sweeps are
-   coverage rather than an enumeration — the design is explicit that no finite
-   sweep is exhaustive, so the rules plus the invariants are what an
-   implementation is held to.
+   tokenizer being replaced rather than about its replacement. Read the tables
+   as what that file calls them — **recorded, not promised**: a before/after
+   record reviewed as data, not a rule a replacement inherits. The two
+   invariants are the part an implementation is actually held to.
    *Why it still matters:* stage 4 needs it. DataJS's reader reuses JSON's, and
    over a grammar the reuse is of rules rather than of exported scanners —
    which is one of the open questions the rewritten issue lists.
@@ -468,6 +469,12 @@ combined marker would encode a redundant fact.
 Stages 3 and 4 are the urgent ones, ahead of the rest of this plan. They are
 what [EDAG](./edag-spec.md) is waiting on. Stage 1b comes with them, between the
 two — it is stage 4's proof source.
+
+**Urgency is not the same as actionability, and stage 3b now separates them.**
+Being blocked on EBNF lowered its own issue to **P2**: it is still what stage 4
+waits on, but no amount of priority makes it startable, so it cannot hold the
+front of a queue. The P1 urgency of this plan therefore rests on stages 1b and
+4 until the EBNF backend unblocks 3b, at which point it returns to the front.
 
 An EDAG is an expression DAG whose sharing is *semantics*, not an encoding
 detail: one node referenced from two operand positions is one value, and `{} ===

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -525,20 +525,24 @@ not marginally: it has no way to express sharing at all, and it also lacks the
 cache reads `.f.js` back, and the property that matters is that parsing a
 serialized EDAG reproduces the same EDAG.
 
-The order stays **3 then 4**, because DataJS's reader reuses parts of JSON's
-rather than restating them: strings are JSON's unchanged, and DataJS's numbers
-are JSON's int/frac/exp core plus a bigint suffix and `-Infinity` folding.
-Stage 3 is therefore the prerequisite. Over a grammar that reuse is of *rules*
-rather than of exported scanners, so what stage 4 inherits is a grammar to
-extend, and stage 4 stays close behind to keep the shared rules honest.
+**Stage 3 is a dependency of stage 4**, because DataJS's reader reuses parts
+of JSON's rather than restating them: strings are JSON's unchanged, and
+DataJS's numbers are JSON's int/frac/exp core plus a bigint suffix and
+`-Infinity` folding. Over a grammar that reuse is of *rules* rather than of
+exported scanners, so what stage 4 inherits is a grammar to extend, and stage
+4 stays close behind to keep the shared rules honest.
 
-Stage 1b (the conformance vectors) sits **between** them: it is stage 4's proof
-source, not stage 3's, and its corpus is stored in JSON exactly so it can exist
-before a DataJS reader does. So the intended order is 3, 1b, 4.
+Stage 1b (the conformance vectors) is stage 4's other dependency, and not
+stage 3's: it is stage 4's proof source, and its corpus is stored in JSON
+exactly so it can exist before a DataJS reader does. So the dependencies are 3
+before 4 and 1b before 4 — a relationship, not a queue. An earlier draft wrote
+it as an intended order of 3, 1b, 4; that is withdrawn, and the order work is
+picked up in is the next paragraph's.
 
-**1b runs first anyway.** It never depended on stage 3: the corpus bootstraps in
-JSON, and it is indifferent to whether the DataJS reader that eventually
-consumes it is hand-written or generated from a grammar. It is P1 where 3b is
+**The execution order is 1b, then 3b, then 4.** 1b never depended on stage 3:
+the corpus bootstraps in JSON, and it is indifferent to whether the DataJS
+reader that eventually consumes it is hand-written or generated from a
+grammar. It is P1 where 3b is
 P2, it needs no decision that has not been made, and running it early costs
 nothing — it still lands before stage 4, which is the only ordering constraint
 it ever carried.

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -1,7 +1,8 @@
 ## Restructure JSON, DataJS, and FunctionalScript parsers/serializers
 
 **Priority:** P1 — stages 3 and 4 are urgent; see [Priority](#priority-stages-3-and-4-come-first).
-**Status:** wip — stages 1a, 2 and 3a done; **stage 3b is blocked on EBNF**.
+**Status:** wip — stages 1a, 2 and 3a done; **stage 3b is blocked on EBNF**, so
+**stage 1b is what to pick up next**.
 
 This is a coordinating issue: it records the design decided in discussion,
 sequences the stages, and names the edits owed to existing issues. Each stage
@@ -11,6 +12,7 @@ not here.
 ### Pick up here
 
 Read in this order; each line says what to do and why it comes when it does.
+Item 1 is context rather than work — it is blocked. **Item 2 is what to start.**
 
 1. **Stage 3b is blocked, and the reason changes this plan.** JSON's reader
    will come from an **EBNF grammar** over `fjs/ebnf/` rather than the
@@ -27,19 +29,20 @@ Read in this order; each line says what to do and why it comes when it does.
    reverted. Read it for its measurements, not as a plan. The rewritten issue
    carries what survives:
    [`fjs/media/json/todo/self-contained-tokenizer.md`](../fjs/media/json/todo/self-contained-tokenizer.md).
-   It has the grammar, the error rule and the two invariants that decide
-   whether a difference is expected, an illustrative table of error shapes that
-   change, the seam DataJS will reuse, the edits owed to two other issues, and
-   the task list. That table is illustrative and known incomplete, and even the
-   generated sweeps are coverage rather than an enumeration — the design is
-   explicit that no finite sweep is exhaustive, so the rules plus the
-   invariants are what an implementation is held to. Implementable without
-   the two invariants any replacement is held to, the accepted-language
-   probes, the measured terminator sets, and what still has to be decided.
+   What it carries is now measurement rather than design: the two invariants
+   any replacement is held to, the accepted-language probes, the measured
+   accepting and terminator sets, the error shapes today's wrapper produces,
+   and a checklist of what has to be decided before an implementation can
+   start. Those survive the reversal because they are facts about the
+   tokenizer being replaced rather than about its replacement. The tables are
+   illustrative and known incomplete, and even the generated sweeps are
+   coverage rather than an enumeration — the design is explicit that no finite
+   sweep is exhaustive, so the rules plus the invariants are what an
+   implementation is held to.
    *Why it still matters:* stage 4 needs it. DataJS's reader reuses JSON's, and
    over a grammar the reuse is of rules rather than of exported scanners —
    which is one of the open questions the rewritten issue lists.
-2. **Then: stage 1b, the conformance vectors**
+2. **Start here: stage 1b, the conformance vectors**
    ([`spec/datajs/todo/conformance-vectors.md`](../spec/datajs/todo/conformance-vectors.md)).
    *Why here:* it is stage 4's proof source, so landing stage 4 first means
    writing its proofs twice. The corpus bootstraps in JSON precisely so it can
@@ -47,6 +50,10 @@ Read in this order; each line says what to do and why it comes when it does.
    which is JSON's own tokenizer and settles its own accepted set with JSON's
    own proofs — unchanged but for one enumerated defect, an `n` today's
    tokenizer deletes from inside a number.
+   *Why it moved:* it was listed after stage 3 for convenience, not dependency.
+   With 3b blocked it is the only actionable piece of this plan, and it is
+   blocked on nothing — it needs no DataJS reader, and it does not care whether
+   that reader is eventually hand-written or generated.
 3. **Then: stage 4, `fjs/media/datajs`.** Design is filed:
    [`fjs/media/datajs/todo/parser-serializer.md`](../fjs/media/datajs/todo/parser-serializer.md).
    The normative
@@ -165,18 +172,23 @@ fjs/fsc            JS tokenizer (comments, all     evolves with the language
   whose defects have to be found one at a time by review, against a grammar of a
   few dozen readable lines.
 
-  The rule's other half survives, and binds harder now: an example grammar
-  without proof coverage is how the dead `fjs/fsc` copy happened, so none may be
-  added without proofs. The paragraph below is what the old rule said, kept
-  because [bnf-grammar-single-owner](../fjs/bnf/todo/bnf-grammar-single-owner.md)
-  is still written against it and is owed an edit.
+  The reversal is also narrower than it looks: it names `fjs/ebnf/`, and
+  **`fjs/bnf` is not what a codec may depend on.** That module is the classical
+  one being retired ([ebnf-migration](../fjs/todo/ebnf-migration.md)), so the
+  old rule survives verbatim with respect to it:
 
-  ~~The spec carries
-  the grammars as BNF text; `fjs/bnf/**` may hold the JSON and DataJS grammars
-  as *proof-covered examples* cross-checked against the spec's test vectors.
-  An example grammar without proof coverage is how the dead `fjs/fsc` copy
-  happened — nothing imported or proved it, so it silently drifted from the
-  other two; none may be added without proofs.~~
+  > The spec carries the grammars as BNF text; `fjs/bnf/**` may hold the JSON
+  > and DataJS grammars as *proof-covered examples* cross-checked against the
+  > spec's test vectors. An example grammar without proof coverage is how the
+  > dead `fjs/fsc` copy happened — nothing imported or proved it, so it
+  > silently drifted from the other two; none may be added without proofs.
+
+  The proof-coverage half binds harder now, and binds `fjs/ebnf/` too. The
+  three issues written against the withdrawn rule —
+  [bnf-grammar-single-owner](../fjs/bnf/todo/bnf-grammar-single-owner.md),
+  [207-bnf-semantic-actions](../fjs/bnf/todo/207-bnf-semantic-actions.md) and
+  [`fjs/media/datajs`](../fjs/media/datajs/todo/parser-serializer.md) — are
+  edited to match rather than left to be read as live instructions.
 
 ### The DataJS format (decision record)
 
@@ -469,16 +481,23 @@ not marginally: it has no way to express sharing at all, and it also lacks the
 cache reads `.f.js` back, and the property that matters is that parsing a
 serialized EDAG reproduces the same EDAG.
 
-The order stays **3 then 4**, because DataJS's tokenizer reuses parts of JSON's
+The order stays **3 then 4**, because DataJS's reader reuses parts of JSON's
 rather than restating them: strings are JSON's unchanged, and DataJS's numbers
 are JSON's int/frac/exp core plus a bigint suffix and `-Infinity` folding.
-Stage 3 is therefore the prerequisite, and it exports that shared core as a
-seam — with stage 4 as its second caller, close enough behind to keep the seam
-honest, and stage 1b between them.
+Stage 3 is therefore the prerequisite. Over a grammar that reuse is of *rules*
+rather than of exported scanners, so what stage 4 inherits is a grammar to
+extend, and stage 4 stays close behind to keep the shared rules honest.
 
 Stage 1b (the conformance vectors) sits **between** them: it is stage 4's proof
 source, not stage 3's, and its corpus is stored in JSON exactly so it can exist
-before a DataJS reader does. So the order is 3, 1b, 4.
+before a DataJS reader does. So the intended order is 3, 1b, 4.
+
+**With 3b blocked, 1b runs first.** Only 3b is blocked, and 1b never depended
+on it: the corpus bootstraps in JSON, and it is indifferent to whether the
+DataJS reader that eventually consumes it is hand-written or generated from a
+grammar. It is therefore the one piece of this plan that is actionable today,
+and running it early costs nothing — it still lands before stage 4, which is
+the only ordering constraint it ever carried.
 
 ### Stages
 
@@ -505,14 +524,17 @@ throughout.
    design this plan replaces with `;`, so keeping it would have preserved a
    grammar contradicting the decision record above. Git history holds them if
    a future stage wants the `id`/`alpha`/comment rules.
-3. **JSON self-contained tokenizer — urgent, see above.** Two PRs: **3a** drops
+3. **JSON's reader — 3a done, 3b blocked; see above.** Two PRs: **3a** drops
    the fabricated `string` token that follows a malformed-literal error, in the
-   existing wrapper, since that defect predates the port and is provable
+   existing wrapper, since that defect predates the replacement and is provable
    without it; **3b** replaces the `fjs/js/tokenizer` wrapper in
-   `fjs/media/json/tokenizer` with a scanner of JSON's own lexical grammar,
-   exporting the string and number scanners for reuse. Accepted-input proofs
-   unchanged in both, but for one enumerated defect — the `n` an old number
-   swallowed — which only 3b can fix; error-shape proofs rewritten once.
+   `fjs/media/json/tokenizer` with a reader generated from JSON's own grammar
+   over `fjs/ebnf/`. **3b exports no scanners.** That seam belonged to the
+   withdrawn hand-written design, and what replaces it is one of the open
+   questions the stage-3 issue lists. Accepted-input proofs unchanged in both,
+   but for one enumerated defect — the `n` an old number swallowed — which only
+   3b can fix; error-shape proofs rewritten once, to shapes 3b has still to
+   decide.
 4. **`fjs/media/datajs` — urgent, see above; this is what EDAG needs.** Parser
    and serializer, proofs over the spec vectors. The parser reuses JSON's container machine, and today's seam is
    **not wide enough for that**: `NumberPolicy` receives number tokens only,
@@ -581,20 +603,27 @@ throughout.
       the compiler accepts today.
 - [ ] Stage 1b: the conformance vectors —
       [`conformance-vectors`](../spec/datajs/todo/conformance-vectors.md).
-      After stage 3 and **before stage 4**, which consumes it: landing stage 4
-      first means writing its proofs twice. The corpus bootstraps in JSON so it
-      needs no DataJS reader to exist.
+      **Next, and actionable now**: the only constraint it carries is landing
+      **before stage 4**, which consumes it, since landing stage 4 first means
+      writing its proofs twice. It was sequenced after stage 3 for convenience
+      rather than dependency, and with 3b blocked it goes first. The corpus
+      bootstraps in JSON so it needs no DataJS reader to exist.
 - [x] Stage 2: dead `fjs/fsc` grammar deleted; its todo file removed and the
       citations in [207](../fjs/bnf/todo/207-bnf-semantic-actions.md)
       repointed at `fjs/bnf/testlib.f.mjs`.
-- [ ] Stage 3a: drop the fabricated `string` token in the existing wrapper —
+- [x] Stage 3a: drop the fabricated `string` token in the existing wrapper —
       [`self-contained-tokenizer`](../fjs/media/json/todo/self-contained-tokenizer.md),
-      the defect that predates the port and is provable without it.
-- [ ] Stage 3b: the port itself, same design, carrying only what removing the
-      dependency forces. It measured the swap's blast radius: the accepted
+      the defect that predates the replacement and is provable without it.
+- [ ] Stage 3b: **blocked on EBNF, do not start.** The reader comes from a
+      grammar over `fjs/ebnf/`, not from a hand-written scanner, and it waits
+      on the metadata channel in
+      [#1890](https://github.com/functionalscript/functionalscript/pull/1890).
+      What is measured and still holds is the swap's blast radius: the accepted
       language is JSON's already, but for one defect — `1n1` and its class,
-      accepted today by deleting an `n` from inside a number, which only the
-      port can fix — so beyond that only error shapes change.
+      accepted today by deleting an `n` from inside a number, which only 3b can
+      fix — so beyond that only error shapes change. What replaces the
+      hand-written seam, and what error shapes a grammar-driven reader should
+      produce, are open questions listed in that issue.
 - [ ] Stage 4: `fjs/media/datajs`; file its todo. Needs stage 1b's corpus in
       place as its proof source.
 - [ ] Stage 5: front-end move to `fjs/fsc`; file its todo.
@@ -615,19 +644,24 @@ throughout.
 - [663-json-djs-tree-type](../fjs/djs/todo/663-json-djs-tree-type.md) — the
   shared `Tree<P>` instantiation targets `fjs/media/datajs`; rename paths.
 - [bnf-grammar-single-owner](../fjs/bnf/todo/bnf-grammar-single-owner.md)
-  — **re-scoped**: the canonical JSON grammar's owner is the spec (text) plus a
-  proof-covered `fjs/bnf` example, not a runtime module, so its
-  `fjs/media/json/grammar` proposal is withdrawn and the grammar ships at
-  `fjs/bnf/lib/json`. Lowering that example onto `fjs/ebnf/unicode/` is **not** open
-  there: it happens when the grammar is ported to `fjs/ebnf/lib`
-  ([ebnf-migration](../fjs/todo/ebnf-migration.md)'s consumer port), and the
-  classical original stays as it is until `bnf/` is deleted. What remains
-  open is the shared lexical API
+  — **re-scoped, and owed a second edit by the reversal above.** Its
+  `fjs/media/json/grammar` proposal stays withdrawn and the `fjs/bnf` grammar
+  still ships at `fjs/bnf/lib/json`, but the reason has changed: that path is
+  no longer "a media codec may not depend on a grammar module at runtime",
+  which is reversed. It is that `fjs/bnf` is the classical module being
+  retired, so a runtime grammar belongs to `fjs/ebnf/` and arrives with stage
+  3b. Until 3b is unblocked the `fjs/bnf/lib/json` grammar remains an example
+  rather than the codec's source, so nothing in that issue's current work
+  changes — but its statement that **the media scanners stay hand-written** is
+  withdrawn and must not be built on. Lowering the example onto
+  `fjs/ebnf/unicode/` is **not** open there: it happens when the grammar is
+  ported to `fjs/ebnf/lib` ([ebnf-migration](../fjs/todo/ebnf-migration.md)'s
+  consumer port), and the classical original stays as it is until `bnf/` is
+  deleted. What remains open is the shared lexical API
   #1817 shipped only partly — parameterizing `string` over its simple escapes,
   exporting the digit rules, and pointing the tokenizer at them. The
   `fjs/djs/tokenizer` pointer becomes the `fsc` tokenizer,
-  which stays grammar-based across the stage-5 rename; the no-runtime-BNF rule
-  binds the media codecs, not the front end.
+  which stays grammar-based across the stage-5 rename.
 - [compile-modules-to-edag](../fjs/djs/todo/compile-modules-to-edag.md) — its
   front-end paths move `djs` → `fsc` in stage 5, while its serializer
   citation (`../serializer/module.f.mjs`) follows the serializer into


### PR DESCRIPTION
> Stacked on #1894, whose branch this is cut from. Docs only — no code changes.

JSON's reader will come from an **EBNF grammar** over `fjs/ebnf/` with a
mapping, not the hand-written scanner
`fjs/media/json/todo/self-contained-tokenizer.md` specified. #1895, which
implemented that scanner in full, is withdrawn.

## The rule this reverses

`todo/parser-serializer-restructure.md` lists "the media codecs take no runtime
dependency on `fjs/bnf`" among the decisions **not to reopen**. It is reopened,
and that file records the reversal rather than quietly dropping it — the
superseded paragraph is kept struck through, because
[bnf-grammar-single-owner](fjs/bnf/todo/bnf-grammar-single-owner.md) is still
written against it and is owed an edit.

The old rule rested on the grammar module not being stable enough to depend on.
`fjs/ebnf/` is still mid-migration
([`fjs/todo/ebnf-migration.md`](fjs/todo/ebnf-migration.md)), which is a reason
to sequence 3b carefully, not a missing capability.

## Why open, not blocked

Two drafts of this PR called stage 3b blocked, first on EBNF generally and then
on the metadata channel in #1890. Review asked for the blocker to be measured
rather than asserted, and measuring it retired both:

- `fjs/ebnf/lib/json` exists and is proof-covered; `fjs/ebnf/ll1` parses JSON
  with it and returns an offset on failure; `fjs/ebnf/map` is the engine that
  rewrites an AST to values, which `ll1`'s own proof shows on a smaller
  grammar. JSON's own mapping is **not** written, and a typed one has one
  prerequisite: under `tsc`, `Checked` refuses `value`, `json` and `string`
  as keys because they are annotated widened — the `value` row of
  `fjs/ebnf/lib/todo/widened-rule-signatures.md`, which every touched file
  names as one of the mapping task's two dependencies.
- Four contracts of today's public API decide the reader's shape, all
  measured. A mapping straight to values loses two: `rewrite` recurses per
  node and throws `RangeError` on 1,000 nested arrays, where `fjs/ebnf/ll1`
  parses 6,000 and the current parser is proven at 5,000 (filed as
  `fjs/ebnf/map/todo/stack-safe-rewrite.md`); and the extended codec's `123n`
  comes from the `NumberPolicy` seam receiving the exact lexeme. The document
  grammar loses a third: the public `tokenize` accepts `1 2`, `[] []` and
  `1,2`, which `[json, eof]` rejects. Decoding to code points loses the
  fourth: `"\ud800"` parses today, the `ll1` proof's `stringToCodePointList`
  makes the same parser throw on it, and code units — what `tokenize` already
  takes — parse. So **3b runs a token-stream grammar over UTF-16 code units
  and maps it to tokens** for the container machine, which stays with both
  codecs unchanged — that was 3b's scope all along. That grammar is not
  written, and written naively it gets a number's boundary wrong (`12` against
  `1 2`, a first/follow conflict) and a word's (`truetrue` lexes as two words
  where today's tokenizer refuses it), which is the stage's second design
  question beside error shapes. Its tree is flat, so the recursion is not
  reached there.
- The public parser's only error "carries no position or metadata" per its own
  source, so parity needs nothing #1890 adds. And a parse failure produces no
  AST, so a metadata channel could never have classified that case anyway.
- `json` alone is a **prefix** rule — `parser(json)("[1]x")` succeeds at offset
  3 — so a reader composes EOF or checks the end offset; that is now stated
  before mapping is discussed.

What remains is two design decisions (error shapes, token boundaries), one
`fjs/ebnf` prerequisite for the mapping (`string`'s pin), a streaming seam
`Parser<T>` has no equivalent for, and the migration above. So 3b is **P2, open, partly
startable, and not first**: stage 1b is P1 and gates stage 4.

## What changed the decision

Not that the hand-written approach failed. #1895 reached a working scanner with
100% coverage, matched all 50 rows of the design's expected-output table, and
its 5,586-row differential sweep crossed the erroring boundary in exactly the
two sanctioned rows — independently replayed against the pre-port tokenizer by
a reviewer, 0 mismatches.

What it cost is the point. Over its rounds, review found:

- a fabricated-token class (fixed separately in #1894)
- a `\uXXXX` recovery hole that silently ate the token after a bad escape —
  invisible to both invariants, in a sweep row that passed
- two terminator-set errors in the design document, found only by measuring the
  old tokenizer rather than transcribing it
- a proof whose only case for its load-bearing claim exercised everything
  except that claim

Each found by a person, one at a time. That is what a hand-written lexer per
format costs, against a grammar of a few dozen readable lines — and DataJS would
have paid it again.

## What the rewrite keeps

1,394 lines to 550. What survives is **measurement, not design**, so it is
indifferent to which implementation lands:

- the two invariants any replacement is held to
- the accepted-language probes
- the `n`-deletion defect — `1n1` is `number 11` today, with no error
- the absorption table, measured per phase
- both terminator sets, measured out of the running tokenizer including the `;`
  the design had wrong

What goes is the scanner's own design: its error rules, its
`Scan`/`StringState`/`NumberState` seam, its sweep obligations.

Stage 3a stays as landed — it fixes the wrapper that remains in place until the
grammar replaces it.

## Dependents

- `fjs/media/datajs/todo/parser-serializer.md` → `open`, its first task — the
  route decision — actionable now, and records that its reuse **changed
  shape**: not JSON's
  exported `scanString` / `scanNumber` but its rules, by import — which
  `fjs/ebnf/lib/datajs` already does. What it must settle first is whether its
  reader is that grammar mapped to values or the token-driven container
  machine; only the second route owes the widening of JSON's parser seam, and
  the plan's decision record no longer pre-empts that choice. Its grammar is a
  prefix rule like JSON's, so the grammar route composes EOF, and it runs over
  code units for the same reason JSON's does, with the byte path re-encoding
  decoded code points to units; it keeps `1n` against `1` on its own, since
  they are distinct branches with every digit retained. Stage 3b is a
  dependency of stage 4 on the token route only, and the plan's order says so.
- `spec/datajs/todo/conformance-vectors.md` → runs first: it is P1, gates
  stage 4, bootstraps in JSON, and does not care how JSON is read.
- `fjs/media/json/todo/streaming-recognizer.md` → `blocked` on 3b; its plan
  was written against the withdrawn `Scan<S>` seam.

Every relative link in the touched files resolves. `tsc` 0, `node --test`
5495/0, `npm run gen` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







