### PR TITLE
todo: define Git names and relative resolution

### DIFF
--- a/todo/git-name-resolution.md
+++ b/todo/git-name-resolution.md
@@ -15,28 +15,20 @@ other content**. Git is only an immutable history/transport container. DISOT
 semantics must not depend on JavaScript, Python, HTML, a package manager, a Git
 branch name, or a particular Git hosting service.
 
-The DISOT architecture already describes paths such as:
-
-```text
-~/Alice/Bob/plan.md
-/<identity>/Alice/Bob/plan.md
-```
-
-where every hop is authenticated and `~` is relative to a trust context.
-
 Keep these concepts separate:
 
 1. **DISOT name** — a human-readable path identifying an evolving entity;
 2. **hash** — an immutable revision/content address;
-3. **signature/trust** — who is allowed to establish, advance, rename, or
-   archive a name;
+3. **authority attestation / trust** — who is allowed to establish, advance,
+   rename, or relinquish a name;
 4. **trusted timestamp evidence** — when an authenticated revision/history is
    proven to have existed;
-5. **Git ancestry** — evolution, forks, merges, renames, and archival markers;
+5. **Git ancestry** — causal evolution, forks, merges, renames, and archival
+   markers;
 6. **Git refs** — reachability roots used only to keep Git objects from becoming
    unreachable and eligible for garbage collection.
 
-### Put DISOT metadata in the tree, not custom Git headers
+### Put DISOT metadata in the tree, not custom Git naming headers
 
 Do **not** put the DISOT name in a custom Git commit header.
 
@@ -46,9 +38,9 @@ cherry-pick, squash, or a normal `git commit` — do not know that an unknown
 header must be copied. The metadata can therefore disappear when a user works
 with standard Git tooling.
 
-Instead, keep it as an ordinary file in the commit tree. Standard Git tooling
-then treats it like the source/content it describes and normally carries it
-forward when creating a descendant commit.
+Instead, keep naming/resolution metadata as an ordinary file in the commit tree.
+Standard Git tooling then treats it like the source/content it describes and
+normally carries it forward when creating a descendant commit.
 
 The initial canonical filenames are:
 
@@ -76,19 +68,12 @@ src/.disot.json             # ordinary content
 vendor/x/.disot.data.js     # ordinary content
 ```
 
-This keeps one Git commit history from accidentally acquiring several DISOT
-entities merely because vendored, generated, archived, or arbitrary content
-contains a file with a recognized basename. A nested subtree can be treated as a
-separate DISOT entity only when it is independently committed/resolved as such.
+A nested subtree can be treated as a separate DISOT entity only when it is
+independently committed/resolved as such.
 
 The commit root SHOULD contain at most one recognized `.disot.*` metadata file.
 If more than one recognized encoding is present at the root, a resolver MUST
-reject the ambiguity rather than choose one by filename priority or assume that
-equivalent-looking files have the same semantics.
-
-The leading dot marks infrastructure metadata, while the `disot` namespace
-makes accidental collision much less likely than generic names such as
-`manifest.json`, `.meta.json`, or `package.json`.
+reject the ambiguity rather than choose one by filename priority.
 
 ### One path-valued `name`
 
@@ -105,27 +90,10 @@ Preferred form:
 The namespace is already part of the absolute path, so a separate field would
 only split a value that the resolver immediately recombines.
 
-The same DISOT name type can then be used consistently in metadata, redirects,
-resolver APIs, logs, indexes, and user interfaces.
-
-The initial P3 schema keeps `name` singular. Supporting several names for the
-same entity is a useful possible extension, for example:
-
-```json
-{
-  "name": [
-    "/secp256k1:23a/coolJsModule",
-    "/secp256k2:456/alsoCool"
-  ]
-}
-```
-
-but this is deliberately **not** part of the initial format. Names in different
-namespaces may require independent authority, and multiple names need an
-unambiguous rule for which namespace supplies the base for relative references.
-Aliases/redirects can provide additional names without making the entity itself
-multi-named. Revisit a `name` array only after those authority and resolution
-rules are specified.
+The initial P3 schema keeps `name` singular. Multiple names may be added later,
+but only after authority and relative-resolution semantics are defined for that
+case. Aliases/redirects can provide additional names without making the entity
+itself multi-named.
 
 ### Relative self-names
 
@@ -137,119 +105,45 @@ A DISOT metadata file MAY use a relative self-name:
 }
 ```
 
-When an authorized commit first establishes such a relative self-name, the
-relative name is expanded using the cryptographically authenticated DID of the
-trusted author/controller accepted for that operation. It is **not** the textual
-name or email in Git's `author` header.
+A relative self-name is a convenience for a personal namespace. When the entity
+is first established, `./name` expands using the **unique distinct DID that is
+accepted as the authority establishing that revision**. It is never derived from
+the textual Git `author` name/email.
 
 Conceptually:
 
 ```text
-trusted establishing author = secp256k1:23a
-name                        = ./coolJsModule
+unique establishing authority = secp256k1:23a
+name                          = ./coolJsModule
 
 => /secp256k1:23a/coolJsModule
 ```
 
-The resulting effective absolute name belongs to the trusted history. A later
-commit by another signer that merely carries the unchanged `.disot.*` file MUST
-NOT reinterpret `./coolJsModule` relative to the later signer. Otherwise an
-ordinary contribution would silently rename the entity.
+If more than one distinct DID is accepted as an establishing authority on the
+same first authoritative revision, `./name` is ambiguous and MUST NOT establish
+a name. The author must use an explicit absolute name instead:
 
-Relative self-names SHOULD be discouraged. They couple initial naming to the
-identity that happened to establish the entity and become especially awkward
-for shared, organizational, transferable, or multi-controller entities.
-Shared entities SHOULD use an explicit absolute name whose namespace represents
-the shared entity/project rather than one contributor:
+```text
+accepted establishing DIDs = Alice, Bob
+name                        = ./parser
+
+=> ERROR: ambiguous relative self-name
+```
+
+Multiple later attestations may accumulate trust for an already-established
+revision without reinterpreting the effective name. An unchanged `./name` is
+resolved from its original effective absolute name, not from later signers.
+
+Relative self-names SHOULD be discouraged, especially for shared,
+organizational, transferable, or multi-controller entities. Shared entities
+SHOULD use an explicit absolute name whose namespace represents the shared
+entity/project rather than one contributor:
 
 ```json
 {
   "name": "/<project-or-shared-DID>/coolJsModule"
 }
 ```
-
-Tools MAY make `./name` convenient for personal entities while warning before
-using it for an entity intended to have shared or transferable control.
-
-### Trust establishes metadata; presence does not
-
-A root `.disot.*` file is only bytes in a Git tree until authenticated trust
-adopts it. Its presence MUST NOT by itself establish a name, lock, or any other
-DISOT semantics.
-
-A commit that introduces `.disot.*` is eligible to establish the claimed name
-only when its cryptographic signature is accepted by the resolver's trust policy
-as authorized for that operation.
-
-For example, an unsigned or untrusted commit cannot claim Alice's namespace by
-writing:
-
-```json
-{
-  "name": "/DID:Alice/parser"
-}
-```
-
-The same principle applies to later metadata changes. Changing `name` or lock
-data does not become authoritative merely because Git accepted the commit. The
-resolver evaluates signatures and trust policy before accepting the change into
-the trusted named history.
-
-An untrusted commit may introduce `.disot.*`, and a later trusted descendant may
-leave the file unchanged and sign the new commit. Because the later signature
-covers the complete tree, that trusted descendant **adopts** the metadata at
-that point. The earlier untrusted commit does not become trusted retroactively.
-
-```text
-C0  no .disot.*
- |
-C1  adds .disot.json     unsigned / untrusted   -> not authoritative
- |
-C2  same .disot.json     authorized signature   -> metadata adopted here
-```
-
-Trust is subjective and policy-driven. A trusted party does not necessarily
-mean one hard-coded signer equal to the namespace DID: delegation, key rotation,
-multiple controllers, or community trust rules may authorize signatures.
-
-### Trusted timestamps are required for shared authoritative history
-
-This proposal follows the DISOT architecture rule that content shared outside
-its author's process must be **both signed and timestamped** before it is
-trusted.
-
-A locally created signed commit MAY be treated as provisional/local state by its
-author before timestamp evidence exists. It MUST NOT become an authoritative
-shared DISOT revision for another process merely because its signature verifies.
-
-For externally shared resolution, accepting a commit as an authoritative
-semantic revision therefore requires both:
-
-1. an accepted signature authorizing the relevant operation; and
-2. accepted trusted-timestamp evidence proving the authenticated commit/history
-   existed no later than the trusted time.
-
-Timestamp evidence may be **direct** (for example, a valid `tstsig` on the
-commit) or **ancestral** when the trusted-timestamp specification allows a later
-trusted timestamped descendant/merge to anchor the exact ancestor through Git
-parent hashes. A descendant can anchor an ancestor only when its cryptographic
-ancestry commits to that exact ancestor object; timestamp policy remains defined
-by the companion trusted-timestamp specification.
-
-Thus:
-
-```text
-valid authorized signature only
-    -> authenticated/provisional revision
-
-valid authorized signature + accepted timestamp evidence
-    -> eligible authoritative shared revision
-```
-
-The timestamp rule applies equally to establishment, advancement, rename,
-relinquishment/archive, and trusted merges. Synthetic retention-only commits are
-not semantic DISOT revisions and therefore do not need semantic signatures or
-timestamps.
 
 ### Shape
 
@@ -273,45 +167,168 @@ The important semantics are:
   including nested/scoped choices where one flat map is insufficient.
 
 The Git repository containing the commit and every Git ref pointing at it are
-not part of the entity identity. Copying the exact history to another repository
-or changing the ref layout changes no DISOT semantics.
+not part of the entity identity.
+
+### Authority attestations are representation-independent
+
+A root `.disot.*` file is only bytes in a Git tree until accepted authority
+attestation(s) adopt it. Its presence MUST NOT by itself establish a name, lock,
+or any other DISOT semantics.
+
+The naming layer MUST NOT require one particular signature encoding. It consumes
+verified **authority attestations**: evidence that an identity cryptographically
+authenticated the semantic Git revision and is authorized by the resolver's
+trust policy for the relevant operation.
+
+At least two encodings can provide such evidence:
+
+1. **detached DISOT provenance/signature blocks**, for example a CAS object that
+   references the exact stored object hash and carries a signature + signer DID;
+2. **Git-native embedded signatures**, such as the companion `gpgsig2`
+   prototype, whose own specification defines the signed projection/payload.
+
+These forms are interoperable at the naming layer but are not required to have
+the same wire representation or target hash. The signature verifier for each
+encoding decides whether the attestation authenticates the semantic revision;
+this naming design only consumes the verified result.
+
+Detached attestations remain important because independent parties can add
+trust later without rewriting the Git commit. Embedded `gpgsig2` is therefore a
+Git-native attestation encoding, not a replacement for detached DISOT
+provenance.
+
+The same representation-independence applies to timestamp evidence: an embedded
+`tstsig` may be one encoding, while detached DISOT timestamp/provenance blocks
+may provide another. Naming semantics depend on accepted evidence, not the
+container used to carry it.
+
+An untrusted commit may introduce `.disot.*`, and a later authoritative
+revision may leave the metadata unchanged and adopt it. The earlier untrusted
+commit does not become trusted retroactively.
+
+```text
+C0  no .disot.*
+ |
+C1  adds .disot.json     no accepted authority attestation
+ |                       -> not authoritative
+C2  same .disot.json     accepted authority attestation
+                         -> metadata adopted here
+```
+
+Trust is subjective and policy-driven. Delegation, key rotation, multiple
+controllers, or community trust rules may authorize attestations.
+
+### Trusted timestamps are required for shared authoritative history
+
+This proposal follows the DISOT architecture rule that content shared outside
+its author's process must be **both authenticated and timestamped** before it is
+trusted.
+
+A locally authenticated revision MAY be provisional/local state before trusted
+timestamp evidence exists. It MUST NOT become an authoritative shared DISOT
+revision for another process merely because an authority attestation verifies.
+
+For externally shared resolution, accepting a semantic revision therefore
+requires both:
+
+1. accepted authority attestation(s) for the relevant operation; and
+2. accepted trusted-timestamp evidence.
+
+Timestamp evidence may be direct or may come from an accepted timestamped
+descendant/merge that cryptographically commits to the exact ancestor through
+Git parent hashes, when allowed by the timestamp specification.
+
+Thus:
+
+```text
+accepted authority attestation only
+    -> authenticated/provisional revision
+
+accepted authority attestation + accepted timestamp evidence
+    -> eligible authoritative shared revision
+```
+
+The rule applies to establishment, advancement, rename, relinquishment/archive,
+and semantic merges. Synthetic retention-only commits are not DISOT semantic
+revisions and do not need semantic authority/timestamp evidence.
+
+### Git-backed names vs signed DISOT directories
+
+The older DISOT architecture describes names as signed directory mappings from a
+path segment to a hash. This Git-backed naming model deliberately changes the
+**final binding rule for Git-backed named entities**.
+
+For a Git-backed entity, an authoritative revision is established by:
+
+```text
+root .disot.* self-name
++ accepted authority attestation(s)
++ required trusted timestamp evidence
++ Git ancestry
+```
+
+A signed DISOT directory MUST NOT independently override that Git history by
+mapping the same final name to some other commit hash.
+
+Signed directories remain useful for:
+
+- trust-path traversal such as `~/Alice/...`;
+- aliases and redirects;
+- discovering candidate Git histories/commits;
+- non-Git DISOT objects that still use the directory-to-hash model.
+
+For a Git-backed final entity name, a directory mapping is therefore a discovery
+hint/index, not the authoritative revision selector. A candidate discovered
+through a directory MUST still be validated against its root `.disot.*`,
+authority evidence, timestamp evidence, and ancestry. If the directory points to
+a commit that does not validate for the requested name, the mapping does not win.
+
+This proposal therefore supersedes the old directory-to-hash final-binding rule
+**only for Git-backed named entities**. `todo/plan/architecture.md` should be
+updated when this design is adopted so both documents describe the same model.
 
 ### Relative references
 
 The namespace portion of the entity's **effective absolute name** supplies the
 default namespace for otherwise-unlocked relative references in its content.
-For example:
 
 ```text
-entity = /DID:Alice/parser
+entity              = /DID:Alice/parser
 relative dependency = ./json
 
 => /DID:Alice/json
 ```
 
-If the metadata used `./parser`, the trusted establishment step first expands it
-to `/DID:Alice/parser`; subsequent dependency resolution uses that effective
-absolute name rather than the signer of each later commit.
+If metadata used `./parser`, establishment first expands it to an effective
+absolute name. Later signers do not change that base.
 
-The resolver does not need to understand whether a relative reference was
-spelled as an ECMAScript `import`, Python import, HTML URL, CSS URL, Markdown
-link, or a reference in some future language. Language/hypertext-specific
-tooling discovers the relative reference; DISOT resolves the DISOT name.
+The resolver does not need to know whether the source spelling is an ECMAScript
+`import`, Python import, HTML URL, CSS URL, Markdown link, or a reference in a
+future language. Language/hypertext-specific tooling discovers the relative
+reference; DISOT resolves the DISOT name.
 
-The human-facing namespace syntax may also include trust-context paths such as:
+### Lock semantics
+
+The lock is a reproducibility record, not merely a cache.
 
 ```text
-~/Alice/parser
-/<identity>/Alice/parser
+relative name
+    -> effective DISOT name
+    -> exact immutable hash
 ```
 
-Discovery may use local indexes, signed directories, CAS/DISOT indexes, or
-network services. Git branch names are not a naming or discovery primitive in
-the DISOT model defined here.
+An exact applicable lock binding wins over mutable name resolution. A locked
+hash is terminal for resolution and is not reinterpreted as another mutable
+name.
+
+Changing the namespace component of an entity name may change the fallback
+meaning of relative references that are not pinned by `lock`. Tools performing
+an authorized rename/transfer should resolve/update the lock explicitly so the
+semantic effect is reviewable.
 
 ### Forks and contributions
 
-Signing a descendant does not rename the entity.
+Attesting to a descendant does not automatically rename the entity.
 
 Suppose Alice has an authoritative history whose metadata says:
 
@@ -321,26 +338,20 @@ Suppose Alice has an authoritative history whose metadata says:
 }
 ```
 
-Bob checks it out, changes source, and creates a commit signed by Bob. Unless an
-authorized operation changes `.disot.*`, the new tree still describes
-`/DID:Alice/parser`. Bob's signature authenticates Bob's revision; whether Bob
-is trusted to advance Alice's authoritative named history is a separate trust
-policy decision. For shared authoritative use, the timestamp requirement above
-also applies.
+Bob changes the source and creates/attests a descendant. Unless an authorized
+operation changes `.disot.*`, the tree still describes `/DID:Alice/parser`.
+Bob's attestation says who authenticated Bob's revision; whether Bob is trusted
+to advance Alice's authoritative history is a separate policy decision.
 
 ### A name change is two independent operations
 
-Changing `.disot.*` from one effective name to another is not automatically a
-single privileged "rename" operation. Semantically it contains two independent
+Changing `.disot.*` from one effective name to another contains two independent
 assertions:
 
 1. **relinquish/archive the old name**; and
 2. **establish the new name**.
 
-Each assertion is evaluated under the authority/trust policy of the name it
-affects.
-
-For example:
+Each assertion is evaluated under the authority policy of the name it affects.
 
 ```text
 C1  name = /DID:Alice/parser
@@ -348,66 +359,22 @@ C1  name = /DID:Alice/parser
 C2  name = /DID:Bob/my-parser
 ```
 
-The effects are:
+Effects:
 
-- if C2 is authorized for both Alice's old name and Bob's new name, C2 is a
-  rename/transfer: `/DID:Alice/parser` becomes archived and
-  `/DID:Bob/my-parser` becomes active;
-- if C2 is authorized only for Bob's new name, it establishes a new/forked
-  entity at `/DID:Bob/my-parser`, while `/DID:Alice/parser` remains active at
-  its last authoritative head;
-- if C2 is authorized only to relinquish Alice's old name, the old name becomes
-  archived but the new Bob name is not authoritatively established;
-- if C2 is authorized for neither assertion, it has no authoritative naming
-  effect.
+- authorized for both old and new names -> rename/transfer;
+- authorized only for the new name -> new/forked entity; old name remains
+  active on any unrelinquished lineage;
+- authorized only for the old name -> old lineage is relinquished; new name is
+  not established;
+- authorized for neither -> no authoritative naming effect.
 
-For shared authoritative resolution, each accepted assertion also requires the
-trusted timestamp evidence described above.
+There is **no implicit redirect**. Redirects/aliases require an explicit
+authorized representation in the namespace that owns the alias.
 
-There is **no implicit redirect** from the old name to the new name. If a
-redirect/alias is desired, it must be established explicitly under the authority
-of the namespace that owns the alias.
+### Removing `.disot.*` relinquishes the inherited name
 
-A same-namespace rename follows the same rule; it is simply common for one
-controller to be authorized for both names.
-
-Changing the namespace component may change the fallback meaning of relative
-references that are not pinned by `lock`. A tool performing an authorized rename
-or transfer should resolve/update the lock explicitly so the semantic effect is
-visible.
-
-This model also prevents a fork signer from retiring somebody else's name by
-merely editing `.disot.*` in a descendant commit.
-
-### Lock semantics
-
-The lock is a reproducibility record, not merely a cache.
-
-For each applicable relative dependency:
-
-```text
-relative name
-    -> effective DISOT name
-    -> exact immutable hash
-```
-
-an exact lock binding wins over mutable name resolution. A locked hash is
-terminal for resolution: it is not reinterpreted as another mutable name.
-
-If a tree already has `.disot.*`, standard Git normally carries the naming and
-lock context forward. If a tree has no DISOT metadata and a DISOT-aware tool
-wants to turn it into a named entity, the tool creates `.disot.*` before signing
-and timestamping/adopting the resulting commit according to trust policy.
-
-### Removing `.disot.*` archives the entity
-
-Removing the recognized root `.disot.*` file from an established semantic
-history is the special case of a name transition with **no new name**.
-
-Once a trusted history has established a DISOT name, a later authorized semantic
-descendant whose root no longer contains recognized `.disot.*` relinquishes and
-archives that old name when the required trust and timestamp evidence are
-accepted.
+Removing the recognized root `.disot.*` from an established semantic lineage is
+the no-new-name form of relinquishment.
 
 ```text
 C1  .disot.json = { name: /DID:Alice/parser }   authoritative
@@ -415,45 +382,78 @@ C1  .disot.json = { name: /DID:Alice/parser }   authoritative
 C2  .disot.json unchanged                      authoritative
  |
 C3  root .disot.* removed                      authorized + timestamped
-     -> /DID:Alice/parser is archived
 ```
 
-The archived identity comes from trusted ancestry. An unsigned/untrusted removal
-or a removal lacking the required shared timestamp evidence has no authoritative
-archival effect.
+`C3` relinquishes the inherited name **only for the lineage(s) it causally
+descends from**.
 
-Here "author" means a cryptographically authenticated identity accepted by the
-trust policy to control/advance/relinquish the entity, not the textual Git
-`author` field.
+An unauthenticated, unauthorized, or insufficiently timestamped removal has no
+authoritative archival effect.
 
 Archiving does not delete history. Earlier revisions remain immutable and
-addressable by hash. Archival only means that mutable name resolution has no
-active authoritative head after the tombstone unless a later authorized
-operation explicitly re-establishes the entity.
+addressable by hash.
+
+### Archival is ancestry-scoped, not global
+
+Relinquishment/tombstones are causal. They do not globally erase incomparable
+authoritative forks merely because they use the same DISOT name.
+
+Example:
+
+```text
+      H1 ---- T      # T relinquishes .disot.*
+     /
+A ---
+     \
+      H2             # incomparable authoritative head
+```
+
+`T` archives/relinquishes the lineage through `H1`, but it does **not** archive
+`H2`. `H2` remains an active authoritative head.
+
+To relinquish all currently known authoritative heads with one tombstone, the
+tombstone must causally descend from all of them, normally through a semantic
+merge:
+
+```text
+H1 ---\
+       M --- T
+H2 ---/
+```
+
+Alternatively each fork can be relinquished independently.
+
+Therefore the correct rule is:
+
+> A relinquishment terminates only the active head(s) in its ancestry. It has no
+> semantic effect on incomparable authoritative heads.
+
+If a previously unknown incomparable authoritative fork is discovered later, it
+may make the name active/ambiguous again under the resolver's trust policy. DISOT
+does not invent a total order from timestamps, ref names, or arrival order to
+hide that causal fact.
+
+The same ancestry scope applies to the old-name side of a rename. A rename
+commit descending from only one of several old-name heads cannot retire the
+other incomparable heads.
 
 ### Heads, forks, renames, and archival
 
-For one effective DISOT name, consider known authoritative semantic revisions,
-name-transition assertions, and tombstones by ancestry rather than commit
-timestamps, ref names, or arrival order:
+For one effective DISOT name, consider accepted semantic revisions and
+relinquishment markers by ancestry:
 
 - an ancestor is an older revision, not a competing head;
 - one maximal active descendant is an unambiguous active head;
 - several incomparable maximal active commits are forks/concurrent heads;
-- an authorized trusted merge descending from those heads may restore one
+- an authorized semantic merge descending from those heads may restore one
   unambiguous head;
-- an accepted relinquishment caused by either a name change or `.disot.*`
-  removal terminates the old name and acts as an archive marker for it.
+- an accepted relinquishment makes only the active heads in its ancestry
+  inactive for that name.
 
 A resolver MUST NOT choose among incomparable heads merely by commit time,
 lexicographic hash order, Git branch name, network arrival order, or which
-server answered first. It either applies an explicit trust/policy rule or
-reports ambiguity. An exact lock binding removes ambiguity for that dependency.
-
-An unauthenticated, unauthorized, or insufficiently timestamped shared
-descendant is not automatically an authoritative head, rename, or archive
-marker. It may be retained as a contribution/candidate but has no authoritative
-shared DISOT semantic effect until adopted according to policy.
+server answered first. It either applies explicit caller trust/policy or reports
+ambiguity. An exact lock binding removes ambiguity for that dependency.
 
 ### Git refs exist only for reachability / GC protection
 
@@ -462,48 +462,29 @@ rename signals, archive signals, discovery semantics, or semantic head
 selection.
 
 Their sole role in this Git-backed design is pragmatic: ordinary Git may prune
-unreachable objects. A DISOT implementation therefore keeps commits that must
-remain available reachable from persistent Git refs so they are not merely
-detached/unreachable objects eligible for garbage collection.
-
-Conceptually:
+unreachable objects. Commits that must remain available therefore need to stay
+reachable from persistent refs unless another storage layer guarantees
+retention.
 
 ```text
-.disot.* + trusted signed/timestamped ancestry  = DISOT semantics
-Git refs                                        = Git object retention roots only
+.disot.* + authority/timestamp evidence + ancestry = DISOT semantics
+Git refs                                            = retention roots only
 ```
 
 A ref name may be arbitrary. Renaming a ref changes nothing. Deleting a ref does
-not archive an entity; it is safe only when the commits that must be retained
-remain reachable through another ref or another storage layer provides the
-retention guarantee.
+not archive an entity; it is safe only when required commits remain reachable
+elsewhere.
 
-Reflogs are not the DISOT retention mechanism because they are temporary and may
-expire. Persistent refs provide the ordinary Git-native reachability roots.
+Reflogs are not sufficient because they expire.
 
-Live incomparable heads that must all remain available may temporarily require
-multiple reachability refs. These refs still have no naming semantics.
+Live incomparable heads may temporarily require multiple reachability refs.
+Those refs still have no naming semantics.
 
-### One archive ref for many archived entities
+### One archive ref for many archived lineages
 
-Keeping one branch/ref forever for every archived entity would accumulate
-unnecessary refs. Once an entity has a valid authoritative tombstone or other
-accepted relinquishment marker, DISOT may merge that terminal commit into a
-single synthetic **archive retention branch**.
-
-For example:
-
-```text
-Alice/foo --- A4        # A4: trusted tombstone / relinquishment
-                \
-archive-0 ------ R1
-                  \
-Bob/bar ------- B7 \
-                   R2  -> refs/heads/archive
-```
-
-A simpler implementation can extend the archive branch one terminal history at
-a time:
+Keeping one branch forever for every archived lineage would accumulate needless
+refs. Once a lineage has a valid terminal relinquishment/tombstone, DISOT may
+merge that terminal commit into a single synthetic archive-retention branch.
 
 ```text
 R0
@@ -517,67 +498,25 @@ R3 ---- archived-C-terminal
  refs/heads/archive
 ```
 
-Each synthetic archive commit uses the previous archive commit and one archived
-entity's terminal commit as parents. Its tree contains **no recognized root
-`.disot.*`**. After the merge, the individual archived-entity ref may be deleted
-because the terminal commit and its full ancestry remain reachable from the
-common archive ref.
+Each synthetic archive commit uses the previous archive commit and one terminal
+entity commit as parents. Its tree contains **no recognized root `.disot.*`**.
+Afterward the individual archived-lineage ref may be deleted because the terminal
+commit and its ancestry remain reachable from the common archive ref.
 
-This gives a strict separation:
+This is retention topology only:
 
 ```text
-authorized/timestamped relinquishment in entity history
-    = semantic archival
+authorized/timestamped relinquishment in semantic history
+    = DISOT archival semantics
 
 synthetic merge into archive branch
-    = Git reachability/retention only
+    = Git reachability only
 ```
 
-Archive-retention commits MUST NOT be interpreted as entities, renames,
-reactivations, or new archive operations. They may have parents from unrelated
-DISOT histories. Their lack of `.disot.*` is not itself a semantic tombstone,
-because they are outside the semantic continuation of any one entity and exist
-only to retain their ancestors.
-
-Consequently, a generic rule such as "any merge without `.disot.*` archives its
-parents" would be wrong. A relinquishment/tombstone is established in the
-trusted semantic history of a particular entity first; arbitrary later
-no-metadata merges are retention topology only.
-
-The archive retention commits themselves do not need semantic signatures or
-trusted timestamps because they assert nothing about DISOT. The authoritative
-terminal commits in their ancestry carry the archival semantics.
-
-If another storage layer such as CAS/DISOT guarantees retention independently of
-Git reachability, these Git retention refs may become unnecessary.
-
-### Interaction with signatures and trusted timestamps
-
-The root `.disot.*` file is part of the Git tree, and the tree hash is part of
-the commit payload. A DID signature over the commit (`gpgsig2` in the companion
-prototype) therefore authenticates the exact DISOT metadata without an
-additional Git naming header.
-
-Trusted timestamps are not merely optional metadata for shared DISOT trust.
-Following the architecture rule, externally shared semantic history requires
-accepted timestamp evidence in addition to accepted signatures. A direct
-`tstsig` is one form; an accepted timestamped descendant/merge may also anchor
-an ancestor when the trusted-timestamp specification permits it.
-
-The same applies to relinquishment/archive: the authority signature authenticates
-the transition, while trusted timestamp evidence establishes its time for shared
-trust.
-
-A resolver must distinguish:
-
-- **described as** — the `name` from root `.disot.*`, expanded to an effective
-  absolute name when necessary;
-- **signed by** — identities that authenticated the exact commit;
-- **trusted as** — whether those signatures are authorized by policy to
-  establish, advance, rename, or archive the entity;
-- **anchored at** — accepted trusted timestamp evidence, direct or ancestral;
-- **locked to** — exact immutable hashes selected for dependencies;
-- **kept reachable by** — Git refs, which have no DISOT semantics.
+Archive-retention commits MUST NOT be interpreted as entities, semantic merges,
+renames, reactivations, or new archive operations. They may combine unrelated
+DISOT histories. They need no semantic authority/timestamp evidence because
+they assert nothing about DISOT.
 
 ### Future encodings — P5
 
@@ -606,94 +545,80 @@ metadata value, for example:
 
 Adding an encoding MUST NOT add semantics. Every supported representation must
 round-trip the same data model, validation rules, name meaning, and lock
-behavior. An encoding whose native data model cannot represent the canonical
-DISOT value without ambiguity or loss should not be added merely because its
-syntax is popular.
-
-Multiple recognized `.disot.*` files at the commit root remain an error even
-after more encodings are introduced. Nested files with those basenames remain
-ordinary content.
+behavior. Multiple recognized `.disot.*` files at the commit root remain an
+error. Nested files with those basenames remain ordinary content.
 
 ### Prototype tasks
 
 - [ ] Define the canonical logical `.disot` schema with one required path-valued
       `name` and an optional recursive `lock`.
-- [ ] Define canonical `.disot.json` serialization and parsing.
-- [ ] Define canonical `.disot.data.js` serialization and parsing with exactly
-      the same logical value and validation semantics.
-- [ ] Inspect recognized `.disot.*` only at the commit-tree root; prove nested
-      files with those basenames are ordinary content.
-- [ ] Reject a commit root containing more than one recognized `.disot.*` file.
-- [ ] Specify the canonical absolute-name grammar `/<identity>/<path...>` and
-      relative self-name grammar such as `./name`.
-- [ ] Define how a newly introduced `./name` expands using the trusted
-      cryptographic author's DID and ensure later signers do not reinterpret an
-      unchanged relative self-name.
-- [ ] Make absolute names the recommended form and discourage `./name`,
-      especially for shared/transferable/multi-controller entities.
-- [ ] Keep multiple `name` values out of P3; separately specify authority and
-      relative-resolution semantics before considering a `name` array.
-- [ ] Treat root `.disot.*` as untrusted data until the containing commit's
-      signature is accepted by the resolver's trust policy.
-- [ ] Require trusted adoption to establish an authoritative `.disot.*` value;
-      prove that an unsigned/untrusted introduction establishes no identity.
-- [ ] Require accepted trusted-timestamp evidence in addition to an accepted
-      signature before an externally shared semantic revision is authoritative.
-- [ ] Specify/test direct timestamp evidence and ancestry-based timestamp
-      anchoring through exact Git parent hashes according to the companion
-      timestamp design.
-- [ ] Prove a later trusted descendant can adopt unchanged metadata without
-      retroactively trusting the earlier commit.
-- [ ] Apply the same trust/timestamp rules to advancement, name changes, trusted
-      merges, and relinquishment/archive.
-- [ ] Define a name change as independent old-name relinquishment and new-name
-      establishment assertions, each checked under its own authority policy.
-- [ ] Prove a signer authorized only for the new name cannot archive the old
-      name, and a signer authorized only for the old name cannot establish the
-      new one.
-- [ ] Define no implicit redirect on rename; redirects/aliases require their own
-      explicit authorized representation.
-- [ ] Implement relative-reference resolution from the namespace portion of the
-      entity's effective absolute name, with exact lock bindings as overrides.
+- [ ] Define canonical `.disot.json` and `.disot.data.js` encodings with the
+      same logical semantics.
+- [ ] Recognize `.disot.*` only at the commit-tree root and reject multiple
+      recognized root encodings.
+- [ ] Specify canonical absolute names `/<identity>/<path...>` and relative
+      self-names such as `./name`.
+- [ ] Require one unique distinct accepted establishing DID for `./name`; reject
+      ambiguous multi-authority establishment and require an absolute name.
+- [ ] Ensure later attestations do not reinterpret an already-established
+      relative self-name.
+- [ ] Discourage `./name` for shared/transferable/multi-controller entities.
+- [ ] Keep multiple `name` values out of P3 until authority/resolution semantics
+      are defined.
+- [ ] Define a representation-independent authority-attestation interface used
+      by naming resolution.
+- [ ] Support detached DISOT provenance/signature blocks without rewriting Git
+      commits; treat `gpgsig2` as an optional Git-native attestation encoding.
+- [ ] Define representation-independent trusted timestamp evidence; keep `tstsig`
+      as one optional Git-native encoding.
+- [ ] Require accepted authority evidence + accepted trusted timestamp evidence
+      for externally shared authoritative semantic revisions.
+- [ ] Specify/test direct and ancestry-based timestamp anchoring according to
+      the companion timestamp design.
+- [ ] Define Git-backed final-name authority as root `.disot.*` + accepted
+      authority/timestamp evidence + ancestry; signed directories are discovery,
+      alias/trust-path, or non-Git naming mechanisms and cannot override it.
+- [ ] Update `todo/plan/architecture.md` when this model is adopted so the old
+      directory-to-hash final-binding rule excludes Git-backed named entities.
+- [ ] Implement relative-reference resolution from the effective absolute name,
+      with exact lock bindings as terminal overrides.
+- [ ] Define name changes as independent old-name relinquishment and new-name
+      establishment assertions.
+- [ ] Prove authority for only the new name cannot archive the old name, and
+      authority for only the old name cannot establish the new one.
+- [ ] Define no implicit redirect on rename.
+- [ ] Define root `.disot.*` removal as no-new-name relinquishment.
+- [ ] Make relinquishment ancestry-scoped: it affects only active heads in its
+      ancestry and never incomparable authoritative heads.
+- [ ] Test a tombstone on one fork, tombstones/merge covering all forks, and a
+      later-discovered incomparable fork.
 - [ ] Implement ancestry-based active-head detection and explicit ambiguity on
       incomparable authoritative forks.
-- [ ] Define root `.disot.*` removal as the no-new-name form of authorized
-      relinquishment/archive.
-- [ ] Ensure Git ref names are never inputs to DISOT identity, rename, archival,
-      authority, discovery, or semantic head-selection logic.
-- [ ] Use persistent Git refs only as reachability roots for commits that must
-      survive ordinary Git garbage collection.
-- [ ] Implement/test a single synthetic archive retention branch that merges
-      terminal commits from many unrelated archived entities, then permits
-      removal of their individual retention refs.
-- [ ] Prove archive-retention commits containing no root `.disot.*` have no
-      DISOT entity semantics and cannot accidentally archive/merge unrelated
-      names.
-- [ ] Test branch rename/deletion and prove neither changes entity semantics when
-      required commits remain reachable elsewhere.
-- [ ] Test ambiguous authoritative forks, a later trusted semantic merge,
-      authorized renames/transfers, tombstones, archive-retention merges, and
-      locks pinning historical/forked revisions.
-- [ ] Test ordinary Git rebase, cherry-pick, merge, squash, clone/fetch/push,
-      pack/unpack, and garbage collection to establish exactly when tree-carried
-      DISOT metadata and retained history survive ordinary Git workflows.
+- [ ] Ensure Git ref names are never semantic inputs; use persistent refs only
+      for reachability/GC protection.
+- [ ] Implement/test one synthetic archive-retention branch for terminal commits
+      from many unrelated archived lineages.
+- [ ] Prove archive-retention commits have no DISOT semantics.
+- [ ] Test branch rename/deletion, ordinary Git rebase/cherry-pick/merge/squash,
+      clone/fetch/push, pack/unpack, and garbage collection.
 - [ ] P5: evaluate `.disot.yml` and `.disot.toml` only after JSON/DataJS are
       stable and a consumer actually needs another encoding.
 
 ### Related
 
 - [DISOT architecture](./plan/architecture.md) — global hashes, trust-relative
-  human-readable paths, and the signed + timestamped trust requirement.
-- [DISOT vision](./plan/vision.md) — the `~/Alice/...` web-of-trust namespace.
+  human-readable paths, signed/timestamped trust, and the older signed-directory
+  final-binding model that this Git-specific design partially supersedes.
+- [DISOT vision](./plan/vision.md) — detached CAS provenance/signature blocks and
+  the `~/Alice/...` web-of-trust namespace.
 - [Evo product materialization — PR #1902](https://github.com/functionalscript/functionalscript/pull/1902)
   — companion TODO for consuming resolved dependency graphs without rewriting
-  source objects; link to the PR until its file is present on `main`.
+  source objects.
 - [`vnd.fjs.revision`](../fjs/media/revision/README.md) — current revision and
-  recursive lock-map model; resolution policy is deliberately outside the
-  format.
+  recursive lock-map model.
 - [`vnd.fjs.lock`](../fjs/media/lock/README.md) — current shared lock-map value;
   the future source/content convention carries naming/resolution metadata in
-  root `.disot.*` files in the Git tree.
+  root `.disot.*` files.
 - [Git trusted timestamp signatures — PR #1903](https://github.com/functionalscript/functionalscript/pull/1903)
-  — companion proposal for DID signatures and trusted timestamps inside standard
-  Git commits; link to the PR until its file is present on `main`.
+  — optional Git-native DID-signature / trusted-timestamp encodings; naming
+  semantics remain representation-independent.

--- a/todo/git-name-resolution.md
+++ b/todo/git-name-resolution.md
@@ -7,13 +7,13 @@
 
 Content hashes are universal immutable addresses, but they are not the names
 people use to collaborate. A module, document, website, dataset, or other
-evolving object needs a human-readable name whose meaning is relative to a
-trust namespace rather than to a globally allocated DNS-like namespace.
+evolving object needs a human-readable name without depending on a globally
+allocated DNS-like namespace.
 
 The convention must work for **any programming language, hypertext format, or
-other content**. Git is only the immutable history/transport container; the
-naming model must not depend on JavaScript, Python, HTML, a package manager, a
-Git branch name, or a particular Git hosting service.
+other content**. Git is only an immutable history/transport container. DISOT
+semantics must not depend on JavaScript, Python, HTML, a package manager, a Git
+branch name, or a particular Git hosting service.
 
 The DISOT architecture already describes paths such as:
 
@@ -22,32 +22,30 @@ The DISOT architecture already describes paths such as:
 /<identity>/Alice/Bob/plan.md
 ```
 
-where every hop is authenticated and `~` is relative to a trust anchor.
+where every hop is authenticated and `~` is relative to a trust context.
 
-The design keeps four things separate:
+Keep these concepts separate:
 
-1. **name** — human-readable and contextual;
-2. **namespace** — the identity whose namespace gives the name meaning;
-3. **hash** — the final immutable revision/content selected by resolution;
-4. **Git refs** — mutable, disposable indexes that may help discover commits.
-
-A commit signer is deliberately **not** the namespace. A contributor may sign
-a new commit without changing the logical identity of the content or silently
-reinterpreting its relative references.
+1. **DISOT name** — a human-readable path identifying an evolving entity;
+2. **hash** — an immutable revision/content address;
+3. **signature/trust** — who is allowed to establish or advance a name;
+4. **Git ancestry** — evolution, forks, merges, and archival markers;
+5. **Git refs** — reachability roots used only to keep Git objects from becoming
+   unreachable and eligible for garbage collection.
 
 ### Put DISOT metadata in the tree, not custom Git headers
 
-Do **not** add `name` or `namespace` as custom Git commit headers.
+Do **not** put the DISOT name in a custom Git commit header.
 
 A custom header is preserved while the exact commit object is transported, but
 ordinary Git operations that create a new commit — for example rebase,
-cherry-pick, squash, or a normal `git commit` — do not know that the custom
+cherry-pick, squash, or a normal `git commit` — do not know that an unknown
 header must be copied. The metadata can therefore disappear when a user works
 with standard Git tooling.
 
 Instead, keep it as an ordinary file in the commit tree. Standard Git tooling
-then treats the metadata exactly like the source/content it describes: a new
-commit normally inherits it unless the tree is intentionally changed.
+then treats it like the source/content it describes and normally carries it
+forward when creating a descendant commit.
 
 The initial canonical filenames are:
 
@@ -63,37 +61,117 @@ They are two serializations of **one logical DISOT metadata value**:
 
 A tree SHOULD contain at most one recognized `.disot.*` metadata file. If more
 than one recognized encoding is present, a resolver MUST reject the ambiguity
-rather than choose one by filename priority or trust that their values happen
-to agree.
+rather than choose one by filename priority or assume that equivalent-looking
+files have the same semantics.
 
-The leading dot makes the file infrastructure metadata rather than ordinary
-user content, while the `disot` namespace makes accidental collision much less
-likely than generic names such as `manifest.json`, `.meta.json`, or
-`package.json`.
+The leading dot marks infrastructure metadata, while the `disot` namespace
+makes accidental collision much less likely than generic names such as
+`manifest.json`, `.meta.json`, or `package.json`.
+
+### One path-valued `name`
+
+Use one path-valued `name` instead of a separate `namespace` + local-name pair.
+
+Preferred form:
+
+```json
+{
+  "name": "/secp256k1:23a/coolJsModule"
+}
+```
+
+The namespace is already part of the absolute path, so a separate field would
+only split a value that the resolver immediately recombines.
+
+The same DISOT name type can then be used consistently in metadata, redirects,
+resolver APIs, logs, indexes, and user interfaces.
+
+The initial P3 schema keeps `name` singular. Supporting several names for the
+same entity is a useful possible extension, for example:
+
+```json
+{
+  "name": [
+    "/secp256k1:23a/coolJsModule",
+    "/secp256k2:456/alsoCool"
+  ]
+}
+```
+
+but this is deliberately **not** part of the initial format. Names in different
+namespaces may require independent authority, and multiple names need an
+unambiguous rule for which namespace supplies the base for relative references.
+Aliases/redirects can provide additional names without making the entity itself
+multi-named. Revisit a `name` array only after those authority and resolution
+rules are specified.
+
+### Relative self-names
+
+A DISOT metadata file MAY use a relative self-name:
+
+```json
+{
+  "name": "./coolJsModule"
+}
+```
+
+When a trusted commit first establishes or changes such a relative self-name,
+the relative name is expanded using the cryptographically authenticated DID of
+the trusted author/controller accepted for that operation. It is **not** the
+textual name or email in Git's `author` header.
+
+Conceptually:
+
+```text
+trusted establishing author = secp256k1:23a
+name                        = ./coolJsModule
+
+=> /secp256k1:23a/coolJsModule
+```
+
+The resulting effective absolute name belongs to the trusted history. A later
+commit by another signer that merely carries the unchanged `.disot.*` file MUST
+NOT reinterpret `./coolJsModule` relative to the later signer. Otherwise an
+ordinary contribution would silently rename the entity.
+
+Relative self-names SHOULD be discouraged. They couple initial naming to the
+identity that happened to establish the entity and become especially awkward
+for shared, organizational, transferable, or multi-controller entities.
+Shared entities SHOULD use an explicit absolute name whose namespace represents
+the shared entity/project rather than one contributor:
+
+```json
+{
+  "name": "/<project-or-shared-DID>/coolJsModule"
+}
+```
+
+Tools MAY make `./name` convenient for personal entities while warning before
+using it for an entity intended to have shared or transferable control.
 
 ### Trust establishes metadata; presence does not
 
 A `.disot.*` file is only bytes in a Git tree until a trusted signature adopts
-it. Its presence MUST NOT by itself establish `(namespace, name)`, a lock, or
-any other DISOT semantics.
+it. Its presence MUST NOT by itself establish a name, lock, or any other DISOT
+semantics.
 
 A commit that **introduces** `.disot.*` is authoritative only if that exact
-commit is validly signed by a party the resolver's trust policy accepts as
-allowed to establish/control the claimed namespace/object. An unsigned commit,
-or a commit signed only by an untrusted party, cannot claim a trusted namespace
-merely by writing:
+commit is validly signed by a party accepted by the resolver's trust policy as
+allowed to establish/control the claimed name.
+
+For example, an unsigned or untrusted commit cannot claim Alice's namespace by
+writing:
 
 ```json
 {
-  "namespace": "DID:Alice",
-  "name": "parser"
+  "name": "/DID:Alice/parser"
 }
 ```
 
-The same principle applies to later metadata changes: changing `namespace`,
-`name`, or lock data does not become authoritative merely because Git accepted
-the commit. The resolver evaluates the signature(s) and its trust policy before
-accepting the changed metadata into the trusted named history.
+The same principle applies to later metadata changes. Changing `name` or lock
+data does not become authoritative merely because Git accepted the commit. The
+resolver evaluates signatures and trust policy before accepting the change into
+the trusted named history.
 
 An untrusted commit may introduce `.disot.*`, and a later trusted descendant may
 leave the file unchanged and sign the new commit. Because the later signature
@@ -108,9 +186,9 @@ C1  adds .disot.json     unsigned / untrusted   -> not authoritative
 C2  same .disot.json     trusted signature      -> metadata adopted here
 ```
 
-Trust is subjective and policy-driven. "Trusted party" does not necessarily
-mean one hard-coded signer equal to `namespace`: delegation, key rotation,
-multiple controllers, or community trust rules may all authorize a signature.
+Trust is subjective and policy-driven. A trusted party does not necessarily
+mean one hard-coded signer equal to the namespace DID: delegation, key rotation,
+multiple controllers, or community trust rules may authorize signatures.
 
 ### Shape
 
@@ -118,141 +196,86 @@ Conceptually:
 
 ```json
 {
-  "namespace": "<identity>",
-  "name": "parser",
+  "name": "/DID:Alice/parser",
   "lock": {
     "json": "<immutable-hash>"
   }
 }
 ```
 
-The exact lock-map schema may reuse/evolve the existing recursive lock-map
-work. The important semantics are:
+The exact lock-map schema may reuse/evolve the existing recursive lock-map work.
+The important semantics are:
 
-- `namespace` — the namespace in which this named object and its otherwise
-  unresolved relative references are interpreted;
-- `name` — this object's name inside that namespace;
+- `name` — the entity's DISOT path, absolute in the preferred form and relative
+  only under the rules above;
 - `lock` — optional exact immutable resolutions for relative dependencies,
   including nested/scoped choices where one flat map is insufficient.
 
-The logical object identity is therefore:
+The Git repository containing the commit and every Git ref pointing at it are
+not part of the entity identity. Copying the exact history to another repository
+or changing the ref layout changes no DISOT semantics.
 
-```text
-(namespace, name)
-```
+### Relative references
 
+The namespace portion of the entity's **effective absolute name** supplies the
+default namespace for otherwise-unlocked relative references in its content.
 For example:
 
 ```text
-namespace = DID:Alice
-name      = parser
+entity = /DID:Alice/parser
+relative dependency = ./json
 
-=> DID:Alice/parser
+=> /DID:Alice/json
 ```
 
-The Git repository containing the commit and the Git ref used to find it are not
-part of that identity. The same commit/tree copied to another repository or
-reachable under another branch still describes the same object.
+If the metadata used `./parser`, the trusted establishment step first expands it
+to `/DID:Alice/parser`; subsequent dependency resolution uses that effective
+absolute name rather than the signer of each later commit.
 
-### Why `namespace`, not `root`
+The resolver does not need to understand whether a relative reference was
+spelled as an ECMAScript `import`, Python import, HTML URL, CSS URL, Markdown
+link, or a reference in some future language. Language/hypertext-specific
+tooling discovers the relative reference; DISOT resolves the DISOT name.
 
-`namespace` states what the value actually is and avoids overloading `root` with
-filesystem, repository, trust-root, and dependency-root meanings.
-
-It also gives relative resolution a language-independent base. For example,
-content containing a relative reference conceptually equivalent to:
-
-```text
-./json
-```
-
-resolves, when not already locked, as:
-
-```text
-DID:Alice/json
-```
-
-for an object whose `.disot.*` says:
-
-```text
-namespace = DID:Alice
-```
-
-The resolver does not need to understand whether the source spelling was an
-ECMAScript `import`, Python import, HTML URL, CSS URL, Markdown link, or a
-reference in some future language. Language-specific tooling discovers the
-relative name; DISOT resolves that name.
-
-### Relative paths
-
-The human-facing path syntax has two root forms:
+The human-facing namespace syntax may also include trust-context paths such as:
 
 ```text
 ~/Alice/parser
 /<identity>/Alice/parser
 ```
 
-`~` is the current user's/trust context at the point an **unresolved** path is
-entered. Once a concrete object is selected, its `.disot.*` supplies the
-`namespace` used to interpret that object's own relative names, and exact lock
-bindings override mutable resolution.
-
-Resolution is hop-by-hop. Conceptually:
-
-```text
-(current trust context, "Alice")
-    -> authenticated Alice namespace
-(Alice, "parser")
-    -> authenticated named history
-    -> selected commit
-    -> tree containing .disot.*
-    -> immutable content
-```
-
-Discovery may use Git refs, local indexes, signed directories, CAS/DISOT
-indexes, or network services. Those are lookup mechanisms, not identity.
+Discovery may use local indexes, signed directories, CAS/DISOT indexes, or
+network services. Git branch names are not a naming or discovery primitive in
+the DISOT model defined here.
 
 ### Forks and contributions
 
-**Signing a fork does not change `namespace` or `name`.**
+Signing a descendant does not rename the entity.
 
-Suppose Alice has:
+Suppose Alice has an authoritative history whose metadata says:
 
-```text
-.disot.json:
-    namespace = DID:Alice
-    name      = parser
+```json
+{
+  "name": "/DID:Alice/parser"
+}
 ```
 
-Bob checks out Alice's commit, changes the source, and creates a new commit on
-top signed by Bob. Unless Bob intentionally edits `.disot.json`, the new tree
-still says:
+Bob checks it out, changes source, and creates a commit signed by Bob. Unless an
+authorized operation changes `.disot.*`, the new tree still describes
+`/DID:Alice/parser`. Bob's signature authenticates Bob's revision; whether Bob
+is trusted to advance Alice's authoritative named history is a separate trust
+policy decision.
 
-```text
-namespace = DID:Alice
-name      = parser
-```
-
-Therefore existing relative references still resolve in Alice's namespace.
-This is exactly what is wanted for a contribution intended to go back to
-Alice: Bob's signature authenticates Bob's revision; it does not rename or
-re-root Alice's object. Whether Bob is trusted to advance Alice's authoritative
-named history is a separate trust-policy decision.
-
-If Bob intentionally creates his own independent object, changing identity is
-an ordinary, reviewable tree change:
+A genuine rename or transfer is an explicit, reviewable tree edit:
 
 ```diff
-- "namespace": "DID:Alice",
-- "name": "parser",
-+ "namespace": "DID:Bob",
-+ "name": "my-parser",
+- "name": "/DID:Alice/parser"
++ "name": "/DID:Bob/my-parser"
 ```
 
-Changing `namespace` may change the fallback meaning of relative references
-that are not pinned by `lock`. A tool performing this operation should resolve
-and update the lock explicitly so the semantic effect is visible rather than
-silently caused by the signer changing.
+Changing the namespace component may change the fallback meaning of relative
+references that are not pinned by `lock`. A tool performing such an operation
+should resolve/update the lock explicitly so the semantic effect is visible.
 
 ### Lock semantics
 
@@ -262,148 +285,188 @@ For each applicable relative dependency:
 
 ```text
 relative name
-    -> namespace/name
+    -> effective DISOT name
     -> exact immutable hash
 ```
 
 an exact lock binding wins over mutable name resolution. A locked hash is
 terminal for resolution: it is not reinterpreted as another mutable name.
 
-This also solves the fork case without parsing unknown source languages. If a
-tree already has `.disot.*`, standard Git carries the namespace and lock
-forward. If a tree has no DISOT metadata and a DISOT-aware tool wants to turn it
-into a named/signed object, the tool creates the metadata file before signing
-the resulting commit; the new identity is accepted only when that signature is
-trusted to establish it.
-
-The tool does not need to discover every import/reference merely to preserve the
-namespace context: `namespace` covers unknown relative references, while lock
-entries pin the ones whose immutable resolution has been recorded.
+If a tree already has `.disot.*`, standard Git normally carries the naming and
+lock context forward. If a tree has no DISOT metadata and a DISOT-aware tool
+wants to turn it into a named entity, the tool creates `.disot.*` before signing
+the resulting commit; the identity is accepted only when the signature/trust
+policy authorizes it.
 
 ### Removing `.disot.*` archives the entity
 
-Once a trusted named history has established `(namespace, name)`, a later
-**trusted signed descendant that removes the recognized `.disot.*` file** is an
-explicit archive operation for that entity.
+Once a trusted history has established a DISOT name, a later **trusted signed
+semantic descendant that removes the recognized `.disot.*` file** archives that
+entity.
 
 ```text
-C1  .disot.json = { namespace: DID:Alice, name: parser }   trusted
+C1  .disot.json = { name: /DID:Alice/parser }   trusted
  |
-C2  .disot.json unchanged                                 trusted
+C2  .disot.json unchanged                      trusted
  |
-C3  .disot.json removed                                   trusted controller
-     -> DID:Alice/parser is archived
+C3  .disot.json removed                        trusted controller
+     -> /DID:Alice/parser is archived
 ```
 
-The archive meaning comes from the trusted ancestry: `C3` no longer contains
-the identity file, so the entity being archived is the authoritative
-`(namespace, name)` inherited from its trusted parent history. The removal MUST
-NOT archive anything when the removing commit is unsigned or not trusted to
-control that entity.
+The archived identity comes from trusted ancestry. The removing commit no longer
+contains `.disot.*`, so it acts as a tombstone for the authoritative entity it
+descends from. An unsigned commit or a commit not trusted to control that entity
+has no archival effect.
 
-Here "author" means an identity trusted by policy to control/advance the entity,
-not merely the string in Git's `author` header. The cryptographic signature and
-trust policy are what authorize archival.
+Here "author" means a cryptographically authenticated identity accepted by the
+trust policy to control/advance the entity, not the textual Git `author` field.
 
-Archiving does not delete history. Every previous revision remains addressable
-by its Git/content hash, and copies of the history remain valid. Archiving only
-changes mutable name resolution: the entity has no active trusted head after the
-archive commit unless a later authorized operation explicitly reactivates it.
+Archiving does not delete history. Earlier revisions remain immutable and
+addressable by hash. Archival only means that mutable name resolution has no
+active trusted head after the tombstone unless a later authorized operation
+explicitly reactivates/re-establishes the entity.
 
-A branch deletion is **not** archival, and a branch rename is **not** a rename
-of the entity. Refs are secondary indexes; only trusted signed history and the
-presence/removal of `.disot.*` carry this semantic meaning.
+### Heads, forks, and archival
 
-For an initial implementation, a removal commit with multiple authoritative
-parents may archive a name only when those parents resolve to the same
-`(namespace, name)`. If different named entities meet in one merge and the
-result has no `.disot.*`, the resolver MUST report ambiguity rather than infer
-which entity was archived.
-
-### Heads, forks, archival, and ambiguity
-
-A name may have many commits. Given known **trusted** commits whose trees
-describe the same `(namespace, name)`, plus trusted archive descendants, a
-resolver considers ancestry rather than timestamps, refs, or arrival order:
+For one effective DISOT name, consider known trusted semantic revisions and
+tombstones by ancestry rather than timestamps, ref names, or arrival order:
 
 - an ancestor is an older revision, not a competing head;
-- one maximal active descendant is the current unambiguous head;
+- one maximal active descendant is an unambiguous active head;
 - several incomparable maximal active commits are forks/concurrent heads;
-- a trusted merge commit descending from those heads can make the history
-  unambiguous again;
-- a trusted authorized descendant that removes `.disot.*` is an archive marker,
-  not an active head.
-
-An untrusted commit does not become an authoritative head or archive marker
-merely because it descends from a trusted commit. It may be retained as a
-candidate/contribution for inspection, but trusted resolution evaluates trust
-before giving it semantic effect.
+- a trusted merge descending from those heads may restore one unambiguous head;
+- an authorized descendant that removes `.disot.*` is an archive tombstone, not
+  an active head.
 
 A resolver MUST NOT choose among incomparable heads merely by commit time,
-lexicographic hash order, branch name, network arrival order, or which server
-answered first. It either applies an explicit caller trust/policy rule or
-reports the ambiguity. An exact lock binding removes the ambiguity for that
-dependency.
+lexicographic hash order, Git branch name, network arrival order, or which
+server answered first. It either applies an explicit trust/policy rule or
+reports ambiguity. An exact lock binding removes ambiguity for that dependency.
 
-### Git refs are secondary projections
+An untrusted descendant is not automatically an authoritative head or archive
+marker. It may be retained as a contribution/candidate but has no trusted DISOT
+semantic effect until adopted according to policy.
 
-Git branches/refs are useful mutable indexes for discovery and compatibility
-with existing Git tooling, but DISOT resolution MUST NOT depend on their names.
+### Git refs exist only for reachability / GC protection
 
-A ref may point to an authoritative head, an older commit, an untrusted
-contribution, or nothing at all. Renaming or deleting a ref changes none of the
-DISOT identity/history semantics above.
+DISOT does **not** use Git branch/ref names as names, identities, authority,
+rename signals, archive signals, or semantic head selection.
 
-A tool may reconstruct convenient refs such as:
+Their sole role in this Git-backed design is pragmatic: ordinary Git may prune
+unreachable objects. A DISOT implementation therefore keeps commits that must
+remain available reachable from persistent Git refs so they are not merely
+detached/unreachable objects eligible for garbage collection.
 
-```text
-refs/heads/parser
-```
-
-from trusted history whose `.disot.*` says:
+Conceptually:
 
 ```text
-namespace = <expected namespace>
-name      = parser
+.disot.* + trusted signed ancestry  = DISOT semantics
+Git refs                            = Git object retention roots only
 ```
 
-and whose ancestry/trust policy yields one unambiguous active head. If several
-maximal trusted heads remain, reconstruction reports a fork rather than
-silently choosing one. If the trusted history ends in an archive marker, the
-branch should not be reconstructed as an active entity.
+A ref name may be arbitrary. Renaming a ref changes nothing. Deleting a ref does
+not archive an entity; it is safe only when the commits that must be retained
+remain reachable through another ref or another storage layer provides the
+retention guarantee.
 
-This keeps a repository a storage/replication container. Moving commits between
-repositories, changing ref layout, renaming a branch, or deleting a branch does
-not rename or archive the objects inside them.
+Reflogs are not the DISOT retention mechanism because they are temporary and may
+expire. Persistent refs provide the ordinary Git-native reachability roots.
+
+Live incomparable heads that must all remain available may temporarily require
+multiple reachability refs. These refs still have no naming semantics.
+
+### One archive ref for many archived entities
+
+Keeping one branch/ref forever for every archived entity would accumulate
+unnecessary refs. Once an entity has a valid trusted tombstone, DISOT may merge
+that tombstone into a single synthetic **archive retention branch**.
+
+For example:
+
+```text
+Alice/foo --- A4        # A4: trusted tombstone, .disot.* removed
+                \
+archive-0 ------ R1
+                  \
+Bob/bar ------- B7 \
+                   R2  -> refs/heads/archive
+```
+
+A simpler implementation can extend the archive branch one tombstone at a time:
+
+```text
+R0
+ |
+R1 ---- archived-A-tombstone
+ |
+R2 ---- archived-B-tombstone
+ |
+R3 ---- archived-C-tombstone
+ ^
+ refs/heads/archive
+```
+
+Each synthetic archive commit uses the previous archive commit and one archived
+entity tombstone as parents. Its tree contains **no recognized `.disot.*`**.
+After the merge, the individual archived-entity ref may be deleted because the
+tombstone and its full ancestry remain reachable from the common archive ref.
+
+This gives a strict separation:
+
+```text
+trusted removal of .disot.* in entity history
+    = semantic archival
+
+synthetic merge into archive branch
+    = Git reachability/retention only
+```
+
+Archive-retention commits MUST NOT be interpreted as entities, renames,
+reactivations, or new archive operations. They may have parents from unrelated
+DISOT histories. Their lack of `.disot.*` is not itself a semantic tombstone,
+because they are outside the semantic continuation of any one entity and exist
+only to retain their ancestors.
+
+Consequently, a generic rule such as "any merge without `.disot.*` archives its
+parents" would be wrong. A tombstone is established in the trusted semantic
+history of a particular entity first; arbitrary later no-metadata merges are
+retention topology only.
+
+The archive retention commits themselves do not need semantic signatures or
+trust because they assert nothing about DISOT. The signed trusted tombstones in
+their ancestry carry the archival semantics.
+
+If another storage layer such as CAS/DISOT guarantees retention independently of
+Git reachability, these Git retention refs may become unnecessary.
 
 ### Interaction with signatures and trusted timestamps
 
 The `.disot.*` file is part of the Git tree, and the tree hash is part of the
-commit payload. Therefore a DID signature over the commit (`gpgsig2` in the
-companion prototype), a trusted timestamp (`tstsig`), and a final conventional
-Git signature transitively authenticate the exact DISOT metadata without any
-additional Git header.
+commit payload. A DID signature over the commit (`gpgsig2` in the companion
+prototype), a trusted timestamp (`tstsig`), and a final conventional Git
+signature therefore transitively authenticate the exact DISOT metadata without
+an additional Git naming header.
 
-The same is true of archival: a trusted signature over a commit whose tree no
-longer contains `.disot.*` authenticates that removal relative to its parent
-history.
+The same applies to a semantic tombstone: a trusted signature over a descendant
+whose tree no longer contains `.disot.*` authenticates the removal relative to
+its trusted entity history.
 
 A resolver must distinguish:
 
-- **described as** — `(namespace, name)` from `.disot.*`;
-- **signed by** — identities that authenticated this exact commit;
-- **trusted as** — whether those signatures are authorized by the resolver's
-  policy to establish, advance, change, or archive that named object;
+- **described as** — the `name` from `.disot.*`, expanded to an effective
+  absolute name when necessary;
+- **signed by** — identities that authenticated the exact commit;
+- **trusted as** — whether those signatures are authorized by policy to
+  establish, advance, rename, or archive the entity;
 - **anchored at** — trusted timestamp evidence, if present;
-- **locked to** — immutable hashes selected for dependencies.
-
-These values may intentionally involve different identities.
+- **locked to** — exact immutable hashes selected for dependencies;
+- **kept reachable by** — Git refs, which have no DISOT semantics.
 
 ### Future encodings — P5
 
 **Priority:** P5
 
-The filename is a small encoding registry:
+Treat the filename as a small encoding registry:
 
 ```text
 .disot.<encoding>
@@ -416,8 +479,8 @@ The initial specification supports only:
 .disot.data.js
 ```
 
-Later, if there is real demand, add other lossless encodings of the same
-logical metadata value, for example:
+Later, if there is real demand, add other lossless encodings of the same logical
+metadata value, for example:
 
 ```text
 .disot.yml
@@ -425,76 +488,77 @@ logical metadata value, for example:
 ```
 
 Adding an encoding MUST NOT add semantics. Every supported representation must
-round-trip the same data model, validation rules, name/namespace meaning, and
-lock behavior. In particular, an encoding whose native data model cannot
-represent the canonical DISOT value without ambiguity or loss should not be
-added merely because the syntax is popular.
+round-trip the same data model, validation rules, name meaning, and lock
+behavior. An encoding whose native data model cannot represent the canonical
+DISOT value without ambiguity or loss should not be added merely because its
+syntax is popular.
 
 Multiple recognized `.disot.*` files in one tree remain an error even after
 more encodings are introduced.
 
 ### Prototype tasks
 
-- [ ] Define the canonical logical `.disot` schema with required `namespace`
-      and `name`, plus the recursive optional `lock`.
+- [ ] Define the canonical logical `.disot` schema with one required path-valued
+      `name` and an optional recursive `lock`.
 - [ ] Define canonical `.disot.json` serialization and parsing.
 - [ ] Define canonical `.disot.data.js` serialization and parsing with exactly
       the same logical value and validation semantics.
 - [ ] Reject a tree containing more than one recognized `.disot.*` file.
-- [ ] Treat `.disot.*` as untrusted data until the containing commit's
-      signature is accepted by the resolver's trust policy.
-- [ ] Require trusted adoption to introduce an authoritative `.disot.*` value;
+- [ ] Specify the canonical absolute-name grammar `/<identity>/<path...>` and
+      relative self-name grammar such as `./name`.
+- [ ] Define how a newly introduced/changed `./name` expands using the trusted
+      cryptographic author's DID and ensure later signers do not reinterpret an
+      unchanged relative self-name.
+- [ ] Make absolute names the recommended form and discourage `./name`,
+      especially for shared/transferable/multi-controller entities.
+- [ ] Keep multiple `name` values out of P3; separately specify authority and
+      relative-resolution semantics before considering a `name` array.
+- [ ] Treat `.disot.*` as untrusted data until the containing commit's signature
+      is accepted by the resolver's trust policy.
+- [ ] Require trusted adoption to establish an authoritative `.disot.*` value;
       prove that an unsigned/untrusted introduction establishes no identity.
 - [ ] Prove a later trusted descendant can adopt unchanged metadata without
       retroactively trusting the earlier commit.
-- [ ] Apply the same trust rule to later `namespace`, `name`, and lock changes.
-- [ ] Define trusted removal of `.disot.*` from an established history as
-      archival; prove unsigned/untrusted removal has no archival effect.
-- [ ] Define merge/archive behavior: no `.disot.*` on a merge archives only when
-      its authoritative parents identify the same entity; otherwise reject the
-      semantic ambiguity.
-- [ ] Ensure branch/ref names are never inputs to DISOT identity, rename,
-      archival, or head-selection semantics; refs are reconstructible indexes.
-- [ ] Define the identity representation shared with DID signatures.
-- [ ] Define the exact textual domain of `name` and namespace path segments.
-- [ ] Implement relative-name resolution using the object's `namespace` as the
-      default base and exact lock bindings as overrides.
-- [ ] Implement ancestry-based head detection and explicit ambiguity on
+- [ ] Apply the same trust rule to later name and lock changes.
+- [ ] Implement relative-reference resolution from the namespace portion of the
+      entity's effective absolute name, with exact lock bindings as overrides.
+- [ ] Implement ancestry-based active-head detection and explicit ambiguity on
       incomparable trusted forks.
-- [ ] Enforce the fork rule: a new signer never implicitly changes
-      `.disot.*`; namespace/name changes are explicit tree edits.
-- [ ] When namespace/name are intentionally changed, resolve/update the lock so
-      changed dependency meaning is explicit and reviewable.
-- [ ] Specify discovery/fetch mechanics separately from semantic resolution so
-      Git refs, CAS indexes, or network services can be swapped.
-- [ ] Test source-identical commits signed by different DIDs and prove their
-      identity and relative-resolution context stay unchanged while `.disot.*`
-      is unchanged.
-- [ ] Test branch rename/deletion and prove neither changes entity identity or
-      archival state.
-- [ ] Test ambiguous same-name trusted forks, a later trusted merge that removes
-      the ambiguity, a trusted archive commit, and locks that deliberately pin
-      historical/forked revisions.
+- [ ] Define trusted signed removal of `.disot.*` from one entity's semantic
+      history as archival; prove unsigned/untrusted removal has no effect.
+- [ ] Ensure Git ref names are never inputs to DISOT identity, rename, archival,
+      authority, or semantic head-selection logic.
+- [ ] Use persistent Git refs only as reachability roots for commits that must
+      survive ordinary Git garbage collection.
+- [ ] Implement/test a single synthetic archive retention branch that merges
+      trusted tombstones from many unrelated entities, then permits removal of
+      their individual retention refs.
+- [ ] Prove archive-retention commits containing no `.disot.*` have no DISOT
+      entity semantics and cannot accidentally archive/merge unrelated names.
+- [ ] Test branch rename/deletion and prove neither changes entity semantics when
+      required commits remain reachable elsewhere.
+- [ ] Test ambiguous trusted forks, a later trusted semantic merge, a trusted
+      tombstone, archive-retention merges, and locks pinning historical/forked
+      revisions.
 - [ ] Test ordinary Git rebase, cherry-pick, merge, squash, clone/fetch/push,
       pack/unpack, and garbage collection to establish exactly when tree-carried
-      DISOT metadata is retained or intentionally changed; newly created
-      unsigned commits remain untrusted until signed/adopted according to policy.
-- [ ] P5: evaluate `.disot.yml` and `.disot.toml` only after the JSON/DataJS
-      model is stable and a consumer actually needs another encoding.
+      DISOT metadata and retained history survive ordinary Git workflows.
+- [ ] P5: evaluate `.disot.yml` and `.disot.toml` only after JSON/DataJS are
+      stable and a consumer actually needs another encoding.
 
 ### Related
 
 - [DISOT architecture](./plan/architecture.md) — global hashes and
-  trust-root-relative human-readable paths.
+  trust-relative human-readable paths.
 - [DISOT vision](./plan/vision.md) — the `~/Alice/...` web-of-trust namespace.
 - [Evo product materialization](../fjs/cas/evo/todo/product-materialization.md)
-  — consumes a resolved dependency graph and must not rewrite source objects.
+  — consumes resolved dependency graphs and must not rewrite source objects.
 - [`vnd.fjs.revision`](../fjs/media/revision/README.md) — current revision and
   recursive lock-map model; resolution policy is deliberately outside the
   format.
 - [`vnd.fjs.lock`](../fjs/media/lock/README.md) — current shared lock-map value;
-  the future source/content convention moves the identity/resolution metadata
-  into `.disot.*` files in the Git tree.
+  the future source/content convention carries naming/resolution metadata in
+  `.disot.*` files in the Git tree.
 - [Git trusted timestamp signatures](./git-trusted-timestamp-signatures.md) —
   companion proposal for DID signatures and trusted timestamps inside standard
   Git commits.

--- a/todo/git-name-resolution.md
+++ b/todo/git-name-resolution.md
@@ -6,112 +6,242 @@
 ### Problem
 
 Content hashes are universal immutable addresses, but they are not the names
-people use to collaborate. A module, document, repository, or other evolving
-object needs a human-readable name whose meaning is relative to a trust root,
-not a globally allocated DNS-like namespace.
+people use to collaborate. A module, document, website, dataset, or other
+evolving object needs a human-readable name whose meaning is relative to a
+trust namespace rather than to a globally allocated DNS-like namespace.
+
+The convention must work for **any programming language, hypertext format, or
+other content**. Git is only the immutable history/transport container; the
+naming model must not depend on JavaScript, Python, HTML, a package manager, or
+a particular Git hosting service.
 
 The DISOT architecture already describes paths such as:
 
 ```text
 ~/Alice/Bob/plan.md
-/secp256k1:<key>/Alice/Bob/plan.md
+/<identity>/Alice/Bob/plan.md
 ```
 
-where every hop is authenticated and `~` is relative to a root identity. Git
-already gives us immutable commit objects, ancestry, merges, ordinary transport,
-and signatures. The missing piece for using Git commits directly in this model
-is a small naming convention plus a resolver that can turn a relative name into
-an exact immutable commit/content address.
+where every hop is authenticated and `~` is relative to a trust anchor.
 
 The design must keep three things separate:
 
-1. **name** — human-readable, contextual, mutable through history;
-2. **identity / trust root** — whose namespace gives the name meaning;
-3. **hash** — the final immutable object selected by resolution.
+1. **name** — human-readable and contextual;
+2. **namespace** — the identity whose namespace gives the name meaning;
+3. **hash** — the final immutable revision/content selected by resolution.
 
-A signer is not automatically the namespace root. This distinction matters for
-forks: another person may sign new commits in a fork without silently changing
-what the fork's existing relative dependencies mean.
+A commit signer is deliberately **not** the namespace. A contributor may sign
+a new commit without changing the logical identity of the content or silently
+reinterpreting its relative references.
 
-### Commit `name`
+### Put DISOT metadata in the tree, not custom Git headers
 
-Prototype one optional, non-repeatable Git commit header:
+Do **not** add `name` or `namespace` as custom Git commit headers.
+
+A custom header is preserved while the exact commit object is transported, but
+ordinary Git operations that create a new commit — for example rebase,
+cherry-pick, squash, or a normal `git commit` — do not know that the custom
+header must be copied. The metadata can therefore disappear when a user works
+with standard Git tooling.
+
+Instead, keep it as an ordinary file in the commit tree. Standard Git tooling
+then treats the metadata exactly like the source/content it describes: a new
+commit normally inherits it unless the tree is intentionally changed.
+
+The initial canonical filenames are:
 
 ```text
-tree <tree>
-parent <parent>
-name coolPythonModule
-author ...
-committer ...
-
-<message>
+.disot.json
+.disot.data.js
 ```
 
-`name` is a human-readable name for the logical object represented by the
-commit. It is not a Git ref, branch name, DNS name, or globally unique package
-name. Its meaning is always relative to a namespace root.
+They are two serializations of **one logical DISOT metadata value**:
 
-A sequence of commits with the same effective root/name and connected ancestry
-is the evolution of one named object. A new commit does not acquire a new
-logical identity merely because another signer created it; signatures say who
-attested to a commit, not what namespace its relative references belong to.
+- `.disot.json` — JSON;
+- `.disot.data.js` — DataJS.
 
-Conversely, two unrelated histories that happen to use the same string are not
-silently the same object. They are distinct candidates/forks until ancestry,
-trust policy, an explicit root, or a lock selects one.
+A tree SHOULD contain at most one recognized `.disot.*` metadata file. If more
+than one recognized encoding is present, a resolver MUST reject the ambiguity
+rather than choose one by filename priority or trust that their values happen
+to agree.
 
-The prototype must decide and pin the exact textual domain of `name` (UTF-8,
-normalization, reserved separators, empty name, and maximum size). The initial
-format should prefer one path segment per `name`; path structure belongs to the
-resolver rather than to one commit header.
+The leading dot makes the file infrastructure metadata rather than ordinary
+user content, while the `disot` namespace makes accidental collision much less
+likely than generic names such as `manifest.json`, `.meta.json`, or
+`package.json`.
 
-Unknown commit headers are part of the commit bytes. Compatibility tests must
-prove that stock Git preserves `name` through object storage, clone/fetch/push,
-packing, fsck, and garbage collection wherever the commit itself remains
-reachable.
+### Shape
+
+Conceptually:
+
+```json
+{
+  "namespace": "<identity>",
+  "name": "parser",
+  "lock": {
+    "json": "<immutable-hash>"
+  }
+}
+```
+
+The exact lock-map schema may reuse/evolve the existing recursive lock-map
+work. The important semantics are:
+
+- `namespace` — the namespace in which this named object and its otherwise
+  unresolved relative references are interpreted;
+- `name` — this object's name inside that namespace;
+- `lock` — optional exact immutable resolutions for relative dependencies,
+  including nested/scoped choices where one flat map is insufficient.
+
+The logical object identity is therefore:
+
+```text
+(namespace, name)
+```
+
+For example:
+
+```text
+namespace = DID:Alice
+name      = parser
+
+=> DID:Alice/parser
+```
+
+The Git repository containing the commit is not part of that identity. The same
+commit/tree copied to another repository still describes the same object.
+
+### Why `namespace`, not `root`
+
+`namespace` states what the value actually is and avoids overloading `root` with
+filesystem, repository, trust-root, and dependency-root meanings.
+
+It also gives relative resolution a language-independent base. For example,
+content containing a relative reference conceptually equivalent to:
+
+```text
+./json
+```
+
+resolves, when not already locked, as:
+
+```text
+DID:Alice/json
+```
+
+for an object whose `.disot.*` says:
+
+```text
+namespace = DID:Alice
+```
+
+The resolver does not need to understand whether the source spelling was an
+ECMAScript `import`, Python import, HTML URL, CSS URL, Markdown link, or a
+reference in some future language. Language-specific tooling discovers the
+relative name; DISOT resolves that name.
 
 ### Relative paths
 
 The human-facing path syntax has two root forms:
 
 ```text
-~/Alice/coolPythonModule
-/<identity>/Alice/coolPythonModule
+~/Alice/parser
+/<identity>/Alice/parser
 ```
 
-For the Git prototype, `<identity>` should use the same DID/public-key identity
-form used by the commit-signature work; the exact textual form is specified by
-that identity layer rather than duplicated here.
-
-`~` means "the resolver's current trust root" **only while a path is still
-unlocked**. The explicit form names that root directly. After resolution is
-locked, the lock's `root` records what `~` meant, so the same source is not
-reinterpreted merely because another user, machine, or fork is doing the build.
+`~` is the current user's/trust context at the point an **unresolved** path is
+entered. Once a concrete object is selected, its `.disot.*` supplies the
+`namespace` used to interpret that object's own relative names, and exact lock
+bindings override mutable resolution.
 
 Resolution is hop-by-hop. Conceptually:
 
 ```text
-(root, "Alice")
-    -> authenticated identity/object for Alice
-(Alice, "coolPythonModule")
-    -> authenticated named Git history
+(current trust context, "Alice")
+    -> authenticated Alice namespace
+(Alice, "parser")
+    -> authenticated named history
     -> selected commit
-    -> immutable tree/content
+    -> tree containing .disot.*
+    -> immutable content
 ```
 
-Every hop is subject to the caller's trust policy. A resolver may use local
-indexes, Git refs, signed directories, cached discovery data, or a network
-service to discover candidates; those are lookup mechanisms, not part of the
-name's identity. The semantic result is an authenticated chain ending in an
-immutable hash.
+Discovery may use Git refs, local indexes, signed directories, CAS/DISOT
+indexes, or network services. Those are lookup mechanisms, not identity.
+
+### Forks and contributions
+
+**Signing a fork does not change `namespace` or `name`.**
+
+Suppose Alice has:
+
+```text
+.disot.json:
+    namespace = DID:Alice
+    name      = parser
+```
+
+Bob checks out Alice's commit, changes the source, and creates a new commit on
+top signed by Bob. Unless Bob intentionally edits `.disot.json`, the new tree
+still says:
+
+```text
+namespace = DID:Alice
+name      = parser
+```
+
+Therefore existing relative references still resolve in Alice's namespace.
+This is exactly what is wanted for a contribution intended to go back to
+Alice: Bob's signature authenticates Bob's revision; it does not rename or
+re-root Alice's object.
+
+If Bob intentionally creates his own independent object, changing identity is
+an ordinary, reviewable tree change:
+
+```diff
+- "namespace": "DID:Alice",
+- "name": "parser",
++ "namespace": "DID:Bob",
++ "name": "my-parser",
+```
+
+Changing `namespace` may change the fallback meaning of relative references
+that are not pinned by `lock`. A tool performing this operation should resolve
+and update the lock explicitly so the semantic effect is visible rather than
+silently caused by the signer changing.
+
+### Lock semantics
+
+The lock is a reproducibility record, not merely a cache.
+
+For each applicable relative dependency:
+
+```text
+relative name
+    -> namespace/name
+    -> exact immutable hash
+```
+
+an exact lock binding wins over mutable name resolution. A locked hash is
+terminal for resolution: it is not reinterpreted as another mutable name.
+
+This also solves the fork case without parsing unknown source languages. If a
+tree already has `.disot.*`, standard Git carries the namespace and lock
+forward. If a tree has no DISOT metadata and a DISOT-aware tool wants to turn it
+into a named/signed object, the tool creates the metadata file before signing
+the resulting commit.
+
+The tool does not need to discover every import/reference merely to preserve the
+namespace context: `namespace` covers unknown relative references, while lock
+entries pin the ones whose immutable resolution has been recorded.
 
 ### Heads, forks, and ambiguity
 
-A name may have many commits. Given the commits currently known for one
-root/name, a resolver considers ancestry rather than timestamps or arrival
-order:
+A name may have many commits. Given known commits whose trees describe the same
+`(namespace, name)`, a resolver considers ancestry rather than timestamps or
+arrival order:
 
-- an ancestor is an older version, not a competing head;
+- an ancestor is an older revision, not a competing head;
 - one maximal descendant is the current unambiguous head;
 - several incomparable maximal commits are forks/concurrent heads;
 - a merge commit descending from those heads can make the history unambiguous
@@ -120,160 +250,113 @@ order:
 A resolver MUST NOT choose among incomparable heads merely by commit time,
 lexicographic hash order, network arrival order, or which server answered
 first. It either applies an explicit caller trust/policy rule or reports the
-ambiguity. A lock removes that ambiguity by naming exact immutable results.
+ambiguity. An exact lock binding removes the ambiguity for that dependency.
 
-This makes mutable resolution intentionally context-dependent while locked
-resolution remains reproducible.
+### Git refs are projections
 
-### Lock files
+Git branches/refs are useful mutable indexes, but they are not authoritative
+object identity.
 
-The source/product convention should use one of these filenames:
-
-```text
-lock.json
-lock.data.js
-```
-
-`lock.json` is the JSON encoding; `lock.data.js` is the DataJS encoding. They
-represent the same logical lock data and a resolver must not give one different
-semantics from the other. The filenames are the future product/source
-convention; do not expose `vnd.fjs.lock` as a required filename.
-
-The lock records the immutable answers produced by name resolution. In
-particular it has a `root` field in addition to dependency bindings:
-
-```json
-{
-  "root": "<identity>",
-  "lock": {
-    "Alice": {
-      "coolPythonModule": "<immutable-hash>"
-    }
-  }
-}
-```
-
-The exact schema may reuse/evolve the existing recursive lock-map work. The
-important semantic distinction is:
-
-- `root` identifies the trust-root context in which relative names were
-  resolved;
-- leaf bindings identify immutable commit/snapshot/content hashes;
-- nested maps preserve scoped choices where the same relative name resolves
-  differently in different dependency paths.
-
-A lock is therefore more than a cache. It is the reproducible receipt of a
-context-dependent name resolution.
-
-### `lock.root` and forks
-
-**Forking does not change `lock.root`.**
-
-If Bob forks a project whose lock was resolved from Alice's namespace root,
-Bob's new commits may be signed by Bob while the copied lock continues to say:
+A tool may reconstruct a convenient branch such as:
 
 ```text
-root = Alice
+refs/heads/parser
 ```
 
-and every existing relative dependency keeps resolving exactly as it did in the
-source history. The signer authenticates Bob's changes; it does not implicitly
-re-root the project's namespace.
+from commits whose trees say:
 
-This is the critical fork rule. Without it, cloning/forking a project under a
-new identity could silently reinterpret every `~/...` dependency and produce a
-different program while the source text stayed byte-for-byte identical.
+```text
+namespace = <expected namespace>
+name      = parser
+```
 
-Re-rooting is an explicit operation. A fork that intentionally wants its own
-namespace changes/regenerates `lock.root` and re-resolves the symbolic names.
-That operation may change many bindings and should be reviewable as such.
+and whose ancestry/trust policy yields one unambiguous head. If several maximal
+heads remain, reconstruction reports a fork rather than silently choosing one.
 
-The same rule applies when the fork keeps all dependency hashes unchanged:
-changing the signer alone is not a reason to rewrite the lock.
+This keeps a repository a storage/replication container. Moving commits between
+repositories or changing ref layout does not rename the objects inside them.
 
-### Resolution order
+### Interaction with signatures and trusted timestamps
 
-For a path used by a source object, the initial resolver should behave
-conceptually as follows:
-
-1. Determine the effective root:
-   - an explicit absolute root from the path; otherwise
-   - `lock.root` when a lock is present; otherwise
-   - the caller's current `~` trust root.
-2. Walk the human-readable path under that root, using the caller's trust
-   policy to discover authenticated name bindings/candidates.
-3. At each dependency scope, prefer an exact applicable lock binding when one
-   exists; a locked hash is the answer and is not reinterpreted as another
-   mutable name.
-4. If no lock binding exists, resolve the mutable named history, requiring an
-   unambiguous head or an explicit policy for choosing among forks.
-5. Materialize/use the resulting immutable commit/tree/content hash.
-6. When producing/updating a lock, write the effective root and every selected
-   immutable binding needed to reproduce the result.
-
-The implementation may optimize this heavily; the observable semantics must be
-the same.
-
-### Interaction with Git signatures and trusted timestamps
-
-`name` is ordinary commit data. DID signatures (`gpgsig2` in the companion Git
-signature prototype), trusted timestamps (`tstsig`), and a final conventional
-Git signature therefore cover it exactly as they cover `tree`, `parent`, and
-the commit message.
+The `.disot.*` file is part of the Git tree, and the tree hash is part of the
+commit payload. Therefore a DID signature over the commit (`gpgsig2` in the
+companion prototype), a trusted timestamp (`tstsig`), and a final conventional
+Git signature transitively authenticate the exact DISOT metadata without any
+additional Git header.
 
 A resolver must distinguish:
 
-- **named by** — the namespace/path under which the commit was discovered;
-- **signed by** — identities that authenticated the exact commit;
+- **described as** — `(namespace, name)` from `.disot.*`;
+- **signed by** — identities that authenticated this exact commit;
 - **anchored at** — trusted timestamp evidence, if present;
-- **locked to** — the immutable hash selected for a dependency.
+- **locked to** — immutable hashes selected for dependencies.
 
-These can intentionally name different identities. A fork is the common case:
-the namespace root can remain Alice, the new commit can be signed by Bob, and
-the dependency lock can remain byte-for-byte unchanged.
+These values may intentionally involve different identities.
 
-### Discovery is separate from identity
+### Future encodings — P5
 
-Git refs are useful indexes for finding named heads, but they are mutable local
-transport metadata and MUST NOT define the object identity themselves. An
-implementation may publish conventional or custom refs for efficient discovery,
-but two stores using different ref layouts must still be able to agree that the
-same signed commit is the same named candidate once found.
+**Priority:** P5
 
-Likewise, a standard Git fetch only guarantees transfer of objects reachable
-from the refs/history it fetches. A custom name or lock reference to an otherwise
-unreachable object is not enough to make ordinary Git transfer that object.
-The prototype must therefore specify how all locked dependencies remain
-reachable/fetchable — for example through explicit refs or a CAS/DISOT fetch
-path — without changing the naming semantics above.
+The filename is a small encoding registry:
+
+```text
+.disot.<encoding>
+```
+
+The initial specification supports only:
+
+```text
+.disot.json
+.disot.data.js
+```
+
+Later, if there is real demand, add other lossless encodings of the same
+logical metadata value, for example:
+
+```text
+.disot.yml
+.disot.toml
+```
+
+Adding an encoding MUST NOT add semantics. Every supported representation must
+round-trip the same data model, validation rules, name/namespace meaning, and
+lock behavior. In particular, an encoding whose native data model cannot
+represent the canonical DISOT value without ambiguity or loss should not be
+added merely because the syntax is popular.
+
+Multiple recognized `.disot.*` files in one tree remain an error even after
+more encodings are introduced.
 
 ### Prototype tasks
 
-- [ ] Specify the exact `name` header grammar and canonical placement in a Git
-      commit; reject repeated/malformed names.
-- [ ] Build parsing/verification support for `name` without changing normal Git
-      commit identity semantics.
-- [ ] Define the root identity representation shared with DID signatures.
-- [ ] Implement relative-path parsing for `~/...` and explicit-root paths.
+- [ ] Define the canonical logical `.disot` schema with required `namespace`
+      and `name`, plus the recursive optional `lock`.
+- [ ] Define canonical `.disot.json` serialization and parsing.
+- [ ] Define canonical `.disot.data.js` serialization and parsing with exactly
+      the same logical value and validation semantics.
+- [ ] Reject a tree containing more than one recognized `.disot.*` file.
+- [ ] Define the identity representation shared with DID signatures.
+- [ ] Define the exact textual domain of `name` and namespace path segments.
+- [ ] Implement relative-name resolution using the object's `namespace` as the
+      default base and exact lock bindings as overrides.
 - [ ] Implement ancestry-based head detection and explicit ambiguity on
       incomparable forks.
-- [ ] Define `lock.json` and `lock.data.js` as two encodings of one logical
-      lock schema, including `root` plus recursive immutable bindings.
-- [ ] Enforce the fork rule: copying/forking a project preserves `lock.root`;
-      changing signer identity alone never re-roots resolution.
-- [ ] Add an explicit re-root operation that updates `root` and re-resolves the
-      affected names instead of doing so implicitly.
-- [ ] Keep locked leaf hashes terminal: do not interpret a locked immutable hash
-      as a mutable named history.
+- [ ] Enforce the fork rule: a new signer never implicitly changes
+      `.disot.*`; namespace/name changes are explicit tree edits.
+- [ ] When namespace/name are intentionally changed, resolve/update the lock so
+      changed dependency meaning is explicit and reviewable.
 - [ ] Specify discovery/fetch mechanics separately from semantic resolution so
-      custom Git refs, CAS indexes, or network services can be swapped.
-- [ ] Test source-identical forks signed by different DIDs and prove their
-      locked dependencies stay identical until an explicit re-root.
+      Git refs, CAS indexes, or network services can be swapped.
+- [ ] Test source-identical commits signed by different DIDs and prove their
+      identity and relative-resolution context stay unchanged while `.disot.*`
+      is unchanged.
 - [ ] Test ambiguous same-name forks, a later merge that removes the ambiguity,
-      and lock files that deliberately pin either fork.
-- [ ] Test stock Git compatibility for commits carrying `name`, including
-      clone/fetch/push, pack/unpack, `git fsck`, `git log`, and garbage
-      collection of reachable named commits.
+      and locks that deliberately pin either fork.
+- [ ] Test ordinary Git rebase, cherry-pick, merge, squash, clone/fetch/push,
+      pack/unpack, and garbage collection to establish exactly when tree-carried
+      DISOT metadata is retained or intentionally changed.
+- [ ] P5: evaluate `.disot.yml` and `.disot.toml` only after the JSON/DataJS
+      model is stable and a consumer actually needs another encoding.
 
 ### Related
 
@@ -285,9 +368,9 @@ path — without changing the naming semantics above.
 - [`vnd.fjs.revision`](../fjs/media/revision/README.md) — current revision and
   recursive lock-map model; resolution policy is deliberately outside the
   format.
-- [`vnd.fjs.lock`](../fjs/media/lock/README.md) — current shared lock-map blob;
-  the future source/product filenames in this design are `lock.json` and
-  `lock.data.js`.
+- [`vnd.fjs.lock`](../fjs/media/lock/README.md) — current shared lock-map value;
+  the future source/content convention moves the identity/resolution metadata
+  into `.disot.*` files in the Git tree.
 - [Git trusted timestamp signatures](./git-trusted-timestamp-signatures.md) —
   companion proposal for DID signatures and trusted timestamps inside standard
   Git commits.

--- a/todo/git-name-resolution.md
+++ b/todo/git-name-resolution.md
@@ -32,11 +32,12 @@ Keep these concepts separate:
 
 Do **not** put the DISOT name in a custom Git commit header.
 
-A custom header is preserved while the exact commit object is transported, but
-ordinary Git operations that create a new commit — for example rebase,
-cherry-pick, squash, or a normal `git commit` — do not know that an unknown
-header must be copied. The metadata can therefore disappear when a user works
-with standard Git tooling.
+A custom header is preserved while the exact commit object is transported.
+However, many common Git operations that synthesize new commits — including a
+normal `git commit`, rebase, cherry-pick, and squash — do not preserve arbitrary
+custom headers. Some operations, such as `git commit --amend`, may preserve them.
+Therefore DISOT semantic metadata cannot rely on custom headers surviving
+ordinary Git workflows.
 
 Instead, keep naming/resolution metadata as an ordinary file in the commit tree.
 Standard Git tooling then treats it like the source/content it describes and
@@ -106,33 +107,41 @@ A DISOT metadata file MAY use a relative self-name:
 ```
 
 A relative self-name is a convenience for a personal namespace. When the entity
-is first established, `./name` expands using the **unique distinct DID that is
-accepted as the authority establishing that revision**. It is never derived from
-the textual Git `author` name/email.
+is first established, `./name` expands using the **unique cryptographically
+authenticated author DID for that revision**. The author DID comes from
+authorship evidence for the revision; it is not inferred from the set of
+identities that later authorize, endorse, or otherwise attest to the same
+revision, and it is never derived from the textual Git `author` name/email.
 
 Conceptually:
 
 ```text
-unique establishing authority = secp256k1:23a
-name                          = ./coolJsModule
+authenticated author DID = secp256k1:23a
+name                     = ./coolJsModule
 
 => /secp256k1:23a/coolJsModule
 ```
 
-If more than one distinct DID is accepted as an establishing authority on the
-same first authoritative revision, `./name` is ambiguous and MUST NOT establish
-a name. The author must use an explicit absolute name instead:
+If more than one distinct DID is accepted specifically as an author of the same
+first revision, `./name` is ambiguous and MUST NOT establish a name. The author
+must use an explicit absolute name instead:
 
 ```text
-accepted establishing DIDs = Alice, Bob
-name                        = ./parser
+authenticated author DIDs = Alice, Bob
+name                      = ./parser
 
 => ERROR: ambiguous relative self-name
 ```
 
-Multiple later attestations may accumulate trust for an already-established
-revision without reinterpreting the effective name. An unchanged `./name` is
-resolved from its original effective absolute name, not from later signers.
+Authority is evaluated separately after the relative name is expanded. For
+example, a Bob attestation may authorize or endorse a revision authored by Alice
+only if the applicable policy permits Bob to act for `/Alice/...`; it does not
+change the name base from Alice to Bob.
+
+Later authority/trust/timestamp attestations may accumulate evidence for the
+same immutable revision without reinterpreting its effective name. An unchanged
+`./name` remains relative to its authenticated author DID even when later
+evidence arrives from other identities.
 
 Relative self-names SHOULD be discouraged, especially for shared,
 organizational, transferable, or multi-controller entities. Shared entities
@@ -184,7 +193,7 @@ At least two encodings can provide such evidence:
 
 1. **detached DISOT provenance/signature blocks**, for example a CAS object that
    references the exact stored object hash and carries a signature + signer DID;
-2. **Git-native embedded signatures**, such as the companion `gpgsig2`
+2. **Git-native embedded signatures**, such as the companion `didsig`
    prototype, whose own specification defines the signed projection/payload.
 
 These forms are interoperable at the naming layer but are not required to have
@@ -193,7 +202,7 @@ encoding decides whether the attestation authenticates the semantic revision;
 this naming design only consumes the verified result.
 
 Detached attestations remain important because independent parties can add
-trust later without rewriting the Git commit. Embedded `gpgsig2` is therefore a
+trust later without rewriting the Git commit. Embedded `didsig` is therefore a
 Git-native attestation encoding, not a replacement for detached DISOT
 provenance.
 
@@ -226,6 +235,10 @@ later:
 
 This does not mutate `C1`, change its hash, or rewrite history. Only the
 resolver's evidence set has changed.
+
+For a relative self-name, late evidence does not recompute the author DID. The
+authenticated author is a property of the revision's authorship evidence, while
+later authority, endorsement, and timestamp evidence is evaluated separately.
 
 A later descendant can instead adopt unchanged metadata at its own revision:
 
@@ -579,17 +592,19 @@ error. Nested files with those basenames remain ordinary content.
       recognized root encodings.
 - [ ] Specify canonical absolute names `/<identity>/<path...>` and relative
       self-names such as `./name`.
-- [ ] Require one unique distinct accepted establishing DID for `./name`; reject
-      ambiguous multi-authority establishment and require an absolute name.
-- [ ] Ensure later attestations do not reinterpret an already-established
-      relative self-name.
+- [ ] Require one unique cryptographically authenticated author DID for
+      `./name`; reject ambiguous multi-author authorship and require an absolute
+      name.
+- [ ] Keep authorship separate from later authority/trust attestations; prove
+      late co-attestations do not reinterpret an already-established relative
+      self-name.
 - [ ] Discourage `./name` for shared/transferable/multi-controller entities.
 - [ ] Keep multiple `name` values out of P3 until authority/resolution semantics
       are defined.
 - [ ] Define a representation-independent authority-attestation interface used
       by naming resolution.
 - [ ] Support detached DISOT provenance/signature blocks without rewriting Git
-      commits; treat `gpgsig2` as an optional Git-native attestation encoding.
+      commits; treat `didsig` as an optional Git-native attestation encoding.
 - [ ] Define representation-independent trusted timestamp evidence; keep `tstsig`
       as one optional Git-native encoding.
 - [ ] Define late-evidence adoption: detached authority/timestamp evidence may
@@ -625,8 +640,12 @@ error. Nested files with those basenames remain ordinary content.
 - [ ] Keep archive-retention compaction out of P3. If it proves necessary,
       define a durable classification rule before implementing synthetic archive
       merges; otherwise drop the optimization.
-- [ ] Test branch rename/deletion, ordinary Git rebase/cherry-pick/merge/squash,
-      clone/fetch/push, pack/unpack, and garbage collection.
+- [ ] Test custom-header behavior across ordinary commit-producing operations,
+      including normal descendant commits, rebase, cherry-pick, squash, and
+      `git commit --amend`; do not rely on either universal preservation or
+      universal dropping of unknown headers.
+- [ ] Test branch rename/deletion, clone/fetch/push, pack/unpack, and garbage
+      collection.
 - [ ] P5: evaluate `.disot.yml` and `.disot.toml` only after JSON/DataJS are
       stable and a consumer actually needs another encoding.
 
@@ -645,6 +664,6 @@ error. Nested files with those basenames remain ordinary content.
 - [`vnd.fjs.lock`](../fjs/media/lock/README.md) — current shared lock-map value;
   the future source/content convention carries naming/resolution metadata in
   root `.disot.*` files.
-- [Git trusted timestamp signatures — PR #1903](https://github.com/functionalscript/functionalscript/pull/1903)
-  — optional Git-native DID-signature / trusted-timestamp encodings; naming
-  semantics remain representation-independent.
+- [Git trusted timestamp signatures](./git-trusted-timestamp-signatures.md) —
+  optional Git-native `didsig` / `tstsig` encodings; naming semantics remain
+  representation-independent.

--- a/todo/git-name-resolution.md
+++ b/todo/git-name-resolution.md
@@ -12,8 +12,8 @@ trust namespace rather than to a globally allocated DNS-like namespace.
 
 The convention must work for **any programming language, hypertext format, or
 other content**. Git is only the immutable history/transport container; the
-naming model must not depend on JavaScript, Python, HTML, a package manager, or
-a particular Git hosting service.
+naming model must not depend on JavaScript, Python, HTML, a package manager, a
+Git branch name, or a particular Git hosting service.
 
 The DISOT architecture already describes paths such as:
 
@@ -24,11 +24,12 @@ The DISOT architecture already describes paths such as:
 
 where every hop is authenticated and `~` is relative to a trust anchor.
 
-The design must keep three things separate:
+The design keeps four things separate:
 
 1. **name** — human-readable and contextual;
 2. **namespace** — the identity whose namespace gives the name meaning;
-3. **hash** — the final immutable revision/content selected by resolution.
+3. **hash** — the final immutable revision/content selected by resolution;
+4. **Git refs** — mutable, disposable indexes that may help discover commits.
 
 A commit signer is deliberately **not** the namespace. A contributor may sign
 a new commit without changing the logical identity of the content or silently
@@ -76,11 +77,11 @@ A `.disot.*` file is only bytes in a Git tree until a trusted signature adopts
 it. Its presence MUST NOT by itself establish `(namespace, name)`, a lock, or
 any other DISOT semantics.
 
-In particular, a commit that **introduces** `.disot.*` is authoritative only if
-that exact commit is validly signed by a party the resolver's trust policy
-accepts as allowed to establish/control the claimed namespace/object. An
-unsigned commit, or a commit signed only by an untrusted party, cannot claim a
-trusted namespace merely by writing:
+A commit that **introduces** `.disot.*` is authoritative only if that exact
+commit is validly signed by a party the resolver's trust policy accepts as
+allowed to establish/control the claimed namespace/object. An unsigned commit,
+or a commit signed only by an untrusted party, cannot claim a trusted namespace
+merely by writing:
 
 ```json
 {
@@ -94,14 +95,10 @@ The same principle applies to later metadata changes: changing `namespace`,
 the commit. The resolver evaluates the signature(s) and its trust policy before
 accepting the changed metadata into the trusted named history.
 
-A useful consequence is that an untrusted commit may introduce `.disot.*`, and
-a later trusted descendant may leave the file unchanged and sign the new commit.
-Because the later signature covers the complete tree, that trusted descendant
-**adopts** the metadata at that point. The earlier untrusted commit does not
-become trusted retroactively; the later signed commit is the first authoritative
-DISOT revision carrying that value.
-
-Conceptually:
+An untrusted commit may introduce `.disot.*`, and a later trusted descendant may
+leave the file unchanged and sign the new commit. Because the later signature
+covers the complete tree, that trusted descendant **adopts** the metadata at
+that point. The earlier untrusted commit does not become trusted retroactively.
 
 ```text
 C0  no .disot.*
@@ -114,8 +111,6 @@ C2  same .disot.json     trusted signature      -> metadata adopted here
 Trust is subjective and policy-driven. "Trusted party" does not necessarily
 mean one hard-coded signer equal to `namespace`: delegation, key rotation,
 multiple controllers, or community trust rules may all authorize a signature.
-The format records identity and signatures; the resolver decides whether the
-signer is trusted to make the assertion.
 
 ### Shape
 
@@ -155,8 +150,9 @@ name      = parser
 => DID:Alice/parser
 ```
 
-The Git repository containing the commit is not part of that identity. The same
-commit/tree copied to another repository still describes the same object.
+The Git repository containing the commit and the Git ref used to find it are not
+part of that identity. The same commit/tree copied to another repository or
+reachable under another branch still describes the same object.
 
 ### Why `namespace`, not `root`
 
@@ -284,52 +280,101 @@ The tool does not need to discover every import/reference merely to preserve the
 namespace context: `namespace` covers unknown relative references, while lock
 entries pin the ones whose immutable resolution has been recorded.
 
-### Heads, forks, and ambiguity
+### Removing `.disot.*` archives the entity
+
+Once a trusted named history has established `(namespace, name)`, a later
+**trusted signed descendant that removes the recognized `.disot.*` file** is an
+explicit archive operation for that entity.
+
+```text
+C1  .disot.json = { namespace: DID:Alice, name: parser }   trusted
+ |
+C2  .disot.json unchanged                                 trusted
+ |
+C3  .disot.json removed                                   trusted controller
+     -> DID:Alice/parser is archived
+```
+
+The archive meaning comes from the trusted ancestry: `C3` no longer contains
+the identity file, so the entity being archived is the authoritative
+`(namespace, name)` inherited from its trusted parent history. The removal MUST
+NOT archive anything when the removing commit is unsigned or not trusted to
+control that entity.
+
+Here "author" means an identity trusted by policy to control/advance the entity,
+not merely the string in Git's `author` header. The cryptographic signature and
+trust policy are what authorize archival.
+
+Archiving does not delete history. Every previous revision remains addressable
+by its Git/content hash, and copies of the history remain valid. Archiving only
+changes mutable name resolution: the entity has no active trusted head after the
+archive commit unless a later authorized operation explicitly reactivates it.
+
+A branch deletion is **not** archival, and a branch rename is **not** a rename
+of the entity. Refs are secondary indexes; only trusted signed history and the
+presence/removal of `.disot.*` carry this semantic meaning.
+
+For an initial implementation, a removal commit with multiple authoritative
+parents may archive a name only when those parents resolve to the same
+`(namespace, name)`. If different named entities meet in one merge and the
+result has no `.disot.*`, the resolver MUST report ambiguity rather than infer
+which entity was archived.
+
+### Heads, forks, archival, and ambiguity
 
 A name may have many commits. Given known **trusted** commits whose trees
-describe the same `(namespace, name)`, a resolver considers ancestry rather
-than timestamps or arrival order:
+describe the same `(namespace, name)`, plus trusted archive descendants, a
+resolver considers ancestry rather than timestamps, refs, or arrival order:
 
 - an ancestor is an older revision, not a competing head;
-- one maximal descendant is the current unambiguous head;
-- several incomparable maximal commits are forks/concurrent heads;
-- a merge commit descending from those heads can make the history unambiguous
-  again.
+- one maximal active descendant is the current unambiguous head;
+- several incomparable maximal active commits are forks/concurrent heads;
+- a trusted merge commit descending from those heads can make the history
+  unambiguous again;
+- a trusted authorized descendant that removes `.disot.*` is an archive marker,
+  not an active head.
 
-An untrusted commit does not become an authoritative head merely because it is
-a descendant of a trusted commit. It may be retained as a candidate/contribution
-for inspection, but head selection for trusted resolution filters/evaluates
-trust before treating it as an authoritative revision.
+An untrusted commit does not become an authoritative head or archive marker
+merely because it descends from a trusted commit. It may be retained as a
+candidate/contribution for inspection, but trusted resolution evaluates trust
+before giving it semantic effect.
 
 A resolver MUST NOT choose among incomparable heads merely by commit time,
-lexicographic hash order, network arrival order, or which server answered
-first. It either applies an explicit caller trust/policy rule or reports the
-ambiguity. An exact lock binding removes the ambiguity for that dependency.
+lexicographic hash order, branch name, network arrival order, or which server
+answered first. It either applies an explicit caller trust/policy rule or
+reports the ambiguity. An exact lock binding removes the ambiguity for that
+dependency.
 
-### Git refs are projections
+### Git refs are secondary projections
 
-Git branches/refs are useful mutable indexes, but they are not authoritative
-object identity.
+Git branches/refs are useful mutable indexes for discovery and compatibility
+with existing Git tooling, but DISOT resolution MUST NOT depend on their names.
 
-A tool may reconstruct a convenient branch such as:
+A ref may point to an authoritative head, an older commit, an untrusted
+contribution, or nothing at all. Renaming or deleting a ref changes none of the
+DISOT identity/history semantics above.
+
+A tool may reconstruct convenient refs such as:
 
 ```text
 refs/heads/parser
 ```
 
-from commits whose trees say:
+from trusted history whose `.disot.*` says:
 
 ```text
 namespace = <expected namespace>
 name      = parser
 ```
 
-and whose ancestry/trust policy yields one unambiguous trusted head. If several
+and whose ancestry/trust policy yields one unambiguous active head. If several
 maximal trusted heads remain, reconstruction reports a fork rather than
-silently choosing one.
+silently choosing one. If the trusted history ends in an archive marker, the
+branch should not be reconstructed as an active entity.
 
 This keeps a repository a storage/replication container. Moving commits between
-repositories or changing ref layout does not rename the objects inside them.
+repositories, changing ref layout, renaming a branch, or deleting a branch does
+not rename or archive the objects inside them.
 
 ### Interaction with signatures and trusted timestamps
 
@@ -339,12 +384,16 @@ companion prototype), a trusted timestamp (`tstsig`), and a final conventional
 Git signature transitively authenticate the exact DISOT metadata without any
 additional Git header.
 
+The same is true of archival: a trusted signature over a commit whose tree no
+longer contains `.disot.*` authenticates that removal relative to its parent
+history.
+
 A resolver must distinguish:
 
 - **described as** — `(namespace, name)` from `.disot.*`;
 - **signed by** — identities that authenticated this exact commit;
 - **trusted as** — whether those signatures are authorized by the resolver's
-  policy to establish or advance that named object;
+  policy to establish, advance, change, or archive that named object;
 - **anchored at** — trusted timestamp evidence, if present;
 - **locked to** — immutable hashes selected for dependencies.
 
@@ -399,6 +448,13 @@ more encodings are introduced.
 - [ ] Prove a later trusted descendant can adopt unchanged metadata without
       retroactively trusting the earlier commit.
 - [ ] Apply the same trust rule to later `namespace`, `name`, and lock changes.
+- [ ] Define trusted removal of `.disot.*` from an established history as
+      archival; prove unsigned/untrusted removal has no archival effect.
+- [ ] Define merge/archive behavior: no `.disot.*` on a merge archives only when
+      its authoritative parents identify the same entity; otherwise reject the
+      semantic ambiguity.
+- [ ] Ensure branch/ref names are never inputs to DISOT identity, rename,
+      archival, or head-selection semantics; refs are reconstructible indexes.
 - [ ] Define the identity representation shared with DID signatures.
 - [ ] Define the exact textual domain of `name` and namespace path segments.
 - [ ] Implement relative-name resolution using the object's `namespace` as the
@@ -414,8 +470,11 @@ more encodings are introduced.
 - [ ] Test source-identical commits signed by different DIDs and prove their
       identity and relative-resolution context stay unchanged while `.disot.*`
       is unchanged.
+- [ ] Test branch rename/deletion and prove neither changes entity identity or
+      archival state.
 - [ ] Test ambiguous same-name trusted forks, a later trusted merge that removes
-      the ambiguity, and locks that deliberately pin either fork.
+      the ambiguity, a trusted archive commit, and locks that deliberately pin
+      historical/forked revisions.
 - [ ] Test ordinary Git rebase, cherry-pick, merge, squash, clone/fetch/push,
       pack/unpack, and garbage collection to establish exactly when tree-carried
       DISOT metadata is retained or intentionally changed; newly created

--- a/todo/git-name-resolution.md
+++ b/todo/git-name-resolution.md
@@ -28,9 +28,12 @@ Keep these concepts separate:
 
 1. **DISOT name** — a human-readable path identifying an evolving entity;
 2. **hash** — an immutable revision/content address;
-3. **signature/trust** — who is allowed to establish or advance a name;
-4. **Git ancestry** — evolution, forks, merges, and archival markers;
-5. **Git refs** — reachability roots used only to keep Git objects from becoming
+3. **signature/trust** — who is allowed to establish, advance, rename, or
+   archive a name;
+4. **trusted timestamp evidence** — when an authenticated revision/history is
+   proven to have existed;
+5. **Git ancestry** — evolution, forks, merges, renames, and archival markers;
+6. **Git refs** — reachability roots used only to keep Git objects from becoming
    unreachable and eligible for garbage collection.
 
 ### Put DISOT metadata in the tree, not custom Git headers
@@ -59,10 +62,29 @@ They are two serializations of **one logical DISOT metadata value**:
 - `.disot.json` — JSON;
 - `.disot.data.js` — DataJS.
 
-A tree SHOULD contain at most one recognized `.disot.*` metadata file. If more
-than one recognized encoding is present, a resolver MUST reject the ambiguity
-rather than choose one by filename priority or assume that equivalent-looking
-files have the same semantics.
+### Metadata lookup boundary
+
+DISOT metadata is recognized **only at the root of the Git commit tree**.
+Resolvers inspect only direct root entries for recognized `.disot.*` filenames.
+They MUST NOT recursively scan nested trees for metadata.
+
+For example:
+
+```text
+.disot.json                 # recognized for this commit/entity
+src/.disot.json             # ordinary content
+vendor/x/.disot.data.js     # ordinary content
+```
+
+This keeps one Git commit history from accidentally acquiring several DISOT
+entities merely because vendored, generated, archived, or arbitrary content
+contains a file with a recognized basename. A nested subtree can be treated as a
+separate DISOT entity only when it is independently committed/resolved as such.
+
+The commit root SHOULD contain at most one recognized `.disot.*` metadata file.
+If more than one recognized encoding is present at the root, a resolver MUST
+reject the ambiguity rather than choose one by filename priority or assume that
+equivalent-looking files have the same semantics.
 
 The leading dot marks infrastructure metadata, while the `disot` namespace
 makes accidental collision much less likely than generic names such as
@@ -115,10 +137,10 @@ A DISOT metadata file MAY use a relative self-name:
 }
 ```
 
-When a trusted commit first establishes or changes such a relative self-name,
-the relative name is expanded using the cryptographically authenticated DID of
-the trusted author/controller accepted for that operation. It is **not** the
-textual name or email in Git's `author` header.
+When an authorized commit first establishes such a relative self-name, the
+relative name is expanded using the cryptographically authenticated DID of the
+trusted author/controller accepted for that operation. It is **not** the textual
+name or email in Git's `author` header.
 
 Conceptually:
 
@@ -151,13 +173,13 @@ using it for an entity intended to have shared or transferable control.
 
 ### Trust establishes metadata; presence does not
 
-A `.disot.*` file is only bytes in a Git tree until a trusted signature adopts
-it. Its presence MUST NOT by itself establish a name, lock, or any other DISOT
-semantics.
+A root `.disot.*` file is only bytes in a Git tree until authenticated trust
+adopts it. Its presence MUST NOT by itself establish a name, lock, or any other
+DISOT semantics.
 
-A commit that **introduces** `.disot.*` is authoritative only if that exact
-commit is validly signed by a party accepted by the resolver's trust policy as
-allowed to establish/control the claimed name.
+A commit that introduces `.disot.*` is eligible to establish the claimed name
+only when its cryptographic signature is accepted by the resolver's trust policy
+as authorized for that operation.
 
 For example, an unsigned or untrusted commit cannot claim Alice's namespace by
 writing:
@@ -183,12 +205,51 @@ C0  no .disot.*
  |
 C1  adds .disot.json     unsigned / untrusted   -> not authoritative
  |
-C2  same .disot.json     trusted signature      -> metadata adopted here
+C2  same .disot.json     authorized signature   -> metadata adopted here
 ```
 
 Trust is subjective and policy-driven. A trusted party does not necessarily
 mean one hard-coded signer equal to the namespace DID: delegation, key rotation,
 multiple controllers, or community trust rules may authorize signatures.
+
+### Trusted timestamps are required for shared authoritative history
+
+This proposal follows the DISOT architecture rule that content shared outside
+its author's process must be **both signed and timestamped** before it is
+trusted.
+
+A locally created signed commit MAY be treated as provisional/local state by its
+author before timestamp evidence exists. It MUST NOT become an authoritative
+shared DISOT revision for another process merely because its signature verifies.
+
+For externally shared resolution, accepting a commit as an authoritative
+semantic revision therefore requires both:
+
+1. an accepted signature authorizing the relevant operation; and
+2. accepted trusted-timestamp evidence proving the authenticated commit/history
+   existed no later than the trusted time.
+
+Timestamp evidence may be **direct** (for example, a valid `tstsig` on the
+commit) or **ancestral** when the trusted-timestamp specification allows a later
+trusted timestamped descendant/merge to anchor the exact ancestor through Git
+parent hashes. A descendant can anchor an ancestor only when its cryptographic
+ancestry commits to that exact ancestor object; timestamp policy remains defined
+by the companion trusted-timestamp specification.
+
+Thus:
+
+```text
+valid authorized signature only
+    -> authenticated/provisional revision
+
+valid authorized signature + accepted timestamp evidence
+    -> eligible authoritative shared revision
+```
+
+The timestamp rule applies equally to establishment, advancement, rename,
+relinquishment/archive, and trusted merges. Synthetic retention-only commits are
+not semantic DISOT revisions and therefore do not need semantic signatures or
+timestamps.
 
 ### Shape
 
@@ -264,18 +325,59 @@ Bob checks it out, changes source, and creates a commit signed by Bob. Unless an
 authorized operation changes `.disot.*`, the new tree still describes
 `/DID:Alice/parser`. Bob's signature authenticates Bob's revision; whether Bob
 is trusted to advance Alice's authoritative named history is a separate trust
-policy decision.
+policy decision. For shared authoritative use, the timestamp requirement above
+also applies.
 
-A genuine rename or transfer is an explicit, reviewable tree edit:
+### A name change is two independent operations
 
-```diff
-- "name": "/DID:Alice/parser"
-+ "name": "/DID:Bob/my-parser"
+Changing `.disot.*` from one effective name to another is not automatically a
+single privileged "rename" operation. Semantically it contains two independent
+assertions:
+
+1. **relinquish/archive the old name**; and
+2. **establish the new name**.
+
+Each assertion is evaluated under the authority/trust policy of the name it
+affects.
+
+For example:
+
+```text
+C1  name = /DID:Alice/parser
+ |
+C2  name = /DID:Bob/my-parser
 ```
 
+The effects are:
+
+- if C2 is authorized for both Alice's old name and Bob's new name, C2 is a
+  rename/transfer: `/DID:Alice/parser` becomes archived and
+  `/DID:Bob/my-parser` becomes active;
+- if C2 is authorized only for Bob's new name, it establishes a new/forked
+  entity at `/DID:Bob/my-parser`, while `/DID:Alice/parser` remains active at
+  its last authoritative head;
+- if C2 is authorized only to relinquish Alice's old name, the old name becomes
+  archived but the new Bob name is not authoritatively established;
+- if C2 is authorized for neither assertion, it has no authoritative naming
+  effect.
+
+For shared authoritative resolution, each accepted assertion also requires the
+trusted timestamp evidence described above.
+
+There is **no implicit redirect** from the old name to the new name. If a
+redirect/alias is desired, it must be established explicitly under the authority
+of the namespace that owns the alias.
+
+A same-namespace rename follows the same rule; it is simply common for one
+controller to be authorized for both names.
+
 Changing the namespace component may change the fallback meaning of relative
-references that are not pinned by `lock`. A tool performing such an operation
-should resolve/update the lock explicitly so the semantic effect is visible.
+references that are not pinned by `lock`. A tool performing an authorized rename
+or transfer should resolve/update the lock explicitly so the semantic effect is
+visible.
+
+This model also prevents a fork signer from retiring somebody else's name by
+merely editing `.disot.*` in a descendant commit.
 
 ### Lock semantics
 
@@ -295,62 +397,69 @@ terminal for resolution: it is not reinterpreted as another mutable name.
 If a tree already has `.disot.*`, standard Git normally carries the naming and
 lock context forward. If a tree has no DISOT metadata and a DISOT-aware tool
 wants to turn it into a named entity, the tool creates `.disot.*` before signing
-the resulting commit; the identity is accepted only when the signature/trust
-policy authorizes it.
+and timestamping/adopting the resulting commit according to trust policy.
 
 ### Removing `.disot.*` archives the entity
 
-Once a trusted history has established a DISOT name, a later **trusted signed
-semantic descendant that removes the recognized `.disot.*` file** archives that
-entity.
+Removing the recognized root `.disot.*` file from an established semantic
+history is the special case of a name transition with **no new name**.
+
+Once a trusted history has established a DISOT name, a later authorized semantic
+descendant whose root no longer contains recognized `.disot.*` relinquishes and
+archives that old name when the required trust and timestamp evidence are
+accepted.
 
 ```text
-C1  .disot.json = { name: /DID:Alice/parser }   trusted
+C1  .disot.json = { name: /DID:Alice/parser }   authoritative
  |
-C2  .disot.json unchanged                      trusted
+C2  .disot.json unchanged                      authoritative
  |
-C3  .disot.json removed                        trusted controller
+C3  root .disot.* removed                      authorized + timestamped
      -> /DID:Alice/parser is archived
 ```
 
-The archived identity comes from trusted ancestry. The removing commit no longer
-contains `.disot.*`, so it acts as a tombstone for the authoritative entity it
-descends from. An unsigned commit or a commit not trusted to control that entity
-has no archival effect.
+The archived identity comes from trusted ancestry. An unsigned/untrusted removal
+or a removal lacking the required shared timestamp evidence has no authoritative
+archival effect.
 
 Here "author" means a cryptographically authenticated identity accepted by the
-trust policy to control/advance the entity, not the textual Git `author` field.
+trust policy to control/advance/relinquish the entity, not the textual Git
+`author` field.
 
 Archiving does not delete history. Earlier revisions remain immutable and
 addressable by hash. Archival only means that mutable name resolution has no
-active trusted head after the tombstone unless a later authorized operation
-explicitly reactivates/re-establishes the entity.
+active authoritative head after the tombstone unless a later authorized
+operation explicitly re-establishes the entity.
 
-### Heads, forks, and archival
+### Heads, forks, renames, and archival
 
-For one effective DISOT name, consider known trusted semantic revisions and
-tombstones by ancestry rather than timestamps, ref names, or arrival order:
+For one effective DISOT name, consider known authoritative semantic revisions,
+name-transition assertions, and tombstones by ancestry rather than commit
+timestamps, ref names, or arrival order:
 
 - an ancestor is an older revision, not a competing head;
 - one maximal active descendant is an unambiguous active head;
 - several incomparable maximal active commits are forks/concurrent heads;
-- a trusted merge descending from those heads may restore one unambiguous head;
-- an authorized descendant that removes `.disot.*` is an archive tombstone, not
-  an active head.
+- an authorized trusted merge descending from those heads may restore one
+  unambiguous head;
+- an accepted relinquishment caused by either a name change or `.disot.*`
+  removal terminates the old name and acts as an archive marker for it.
 
 A resolver MUST NOT choose among incomparable heads merely by commit time,
 lexicographic hash order, Git branch name, network arrival order, or which
 server answered first. It either applies an explicit trust/policy rule or
 reports ambiguity. An exact lock binding removes ambiguity for that dependency.
 
-An untrusted descendant is not automatically an authoritative head or archive
-marker. It may be retained as a contribution/candidate but has no trusted DISOT
-semantic effect until adopted according to policy.
+An unauthenticated, unauthorized, or insufficiently timestamped shared
+descendant is not automatically an authoritative head, rename, or archive
+marker. It may be retained as a contribution/candidate but has no authoritative
+shared DISOT semantic effect until adopted according to policy.
 
 ### Git refs exist only for reachability / GC protection
 
 DISOT does **not** use Git branch/ref names as names, identities, authority,
-rename signals, archive signals, or semantic head selection.
+rename signals, archive signals, discovery semantics, or semantic head
+selection.
 
 Their sole role in this Git-backed design is pragmatic: ordinary Git may prune
 unreachable objects. A DISOT implementation therefore keeps commits that must
@@ -360,8 +469,8 @@ detached/unreachable objects eligible for garbage collection.
 Conceptually:
 
 ```text
-.disot.* + trusted signed ancestry  = DISOT semantics
-Git refs                            = Git object retention roots only
+.disot.* + trusted signed/timestamped ancestry  = DISOT semantics
+Git refs                                        = Git object retention roots only
 ```
 
 A ref name may be arbitrary. Renaming a ref changes nothing. Deleting a ref does
@@ -378,13 +487,14 @@ multiple reachability refs. These refs still have no naming semantics.
 ### One archive ref for many archived entities
 
 Keeping one branch/ref forever for every archived entity would accumulate
-unnecessary refs. Once an entity has a valid trusted tombstone, DISOT may merge
-that tombstone into a single synthetic **archive retention branch**.
+unnecessary refs. Once an entity has a valid authoritative tombstone or other
+accepted relinquishment marker, DISOT may merge that terminal commit into a
+single synthetic **archive retention branch**.
 
 For example:
 
 ```text
-Alice/foo --- A4        # A4: trusted tombstone, .disot.* removed
+Alice/foo --- A4        # A4: trusted tombstone / relinquishment
                 \
 archive-0 ------ R1
                   \
@@ -392,29 +502,31 @@ Bob/bar ------- B7 \
                    R2  -> refs/heads/archive
 ```
 
-A simpler implementation can extend the archive branch one tombstone at a time:
+A simpler implementation can extend the archive branch one terminal history at
+a time:
 
 ```text
 R0
  |
-R1 ---- archived-A-tombstone
+R1 ---- archived-A-terminal
  |
-R2 ---- archived-B-tombstone
+R2 ---- archived-B-terminal
  |
-R3 ---- archived-C-tombstone
+R3 ---- archived-C-terminal
  ^
  refs/heads/archive
 ```
 
 Each synthetic archive commit uses the previous archive commit and one archived
-entity tombstone as parents. Its tree contains **no recognized `.disot.*`**.
-After the merge, the individual archived-entity ref may be deleted because the
-tombstone and its full ancestry remain reachable from the common archive ref.
+entity's terminal commit as parents. Its tree contains **no recognized root
+`.disot.*`**. After the merge, the individual archived-entity ref may be deleted
+because the terminal commit and its full ancestry remain reachable from the
+common archive ref.
 
 This gives a strict separation:
 
 ```text
-trusted removal of .disot.* in entity history
+authorized/timestamped relinquishment in entity history
     = semantic archival
 
 synthetic merge into archive branch
@@ -428,37 +540,42 @@ because they are outside the semantic continuation of any one entity and exist
 only to retain their ancestors.
 
 Consequently, a generic rule such as "any merge without `.disot.*` archives its
-parents" would be wrong. A tombstone is established in the trusted semantic
-history of a particular entity first; arbitrary later no-metadata merges are
-retention topology only.
+parents" would be wrong. A relinquishment/tombstone is established in the
+trusted semantic history of a particular entity first; arbitrary later
+no-metadata merges are retention topology only.
 
 The archive retention commits themselves do not need semantic signatures or
-trust because they assert nothing about DISOT. The signed trusted tombstones in
-their ancestry carry the archival semantics.
+trusted timestamps because they assert nothing about DISOT. The authoritative
+terminal commits in their ancestry carry the archival semantics.
 
 If another storage layer such as CAS/DISOT guarantees retention independently of
 Git reachability, these Git retention refs may become unnecessary.
 
 ### Interaction with signatures and trusted timestamps
 
-The `.disot.*` file is part of the Git tree, and the tree hash is part of the
-commit payload. A DID signature over the commit (`gpgsig2` in the companion
-prototype), a trusted timestamp (`tstsig`), and a final conventional Git
-signature therefore transitively authenticate the exact DISOT metadata without
-an additional Git naming header.
+The root `.disot.*` file is part of the Git tree, and the tree hash is part of
+the commit payload. A DID signature over the commit (`gpgsig2` in the companion
+prototype) therefore authenticates the exact DISOT metadata without an
+additional Git naming header.
 
-The same applies to a semantic tombstone: a trusted signature over a descendant
-whose tree no longer contains `.disot.*` authenticates the removal relative to
-its trusted entity history.
+Trusted timestamps are not merely optional metadata for shared DISOT trust.
+Following the architecture rule, externally shared semantic history requires
+accepted timestamp evidence in addition to accepted signatures. A direct
+`tstsig` is one form; an accepted timestamped descendant/merge may also anchor
+an ancestor when the trusted-timestamp specification permits it.
+
+The same applies to relinquishment/archive: the authority signature authenticates
+the transition, while trusted timestamp evidence establishes its time for shared
+trust.
 
 A resolver must distinguish:
 
-- **described as** — the `name` from `.disot.*`, expanded to an effective
+- **described as** — the `name` from root `.disot.*`, expanded to an effective
   absolute name when necessary;
 - **signed by** — identities that authenticated the exact commit;
 - **trusted as** — whether those signatures are authorized by policy to
   establish, advance, rename, or archive the entity;
-- **anchored at** — trusted timestamp evidence, if present;
+- **anchored at** — accepted trusted timestamp evidence, direct or ancestral;
 - **locked to** — exact immutable hashes selected for dependencies;
 - **kept reachable by** — Git refs, which have no DISOT semantics.
 
@@ -493,8 +610,9 @@ behavior. An encoding whose native data model cannot represent the canonical
 DISOT value without ambiguity or loss should not be added merely because its
 syntax is popular.
 
-Multiple recognized `.disot.*` files in one tree remain an error even after
-more encodings are introduced.
+Multiple recognized `.disot.*` files at the commit root remain an error even
+after more encodings are introduced. Nested files with those basenames remain
+ordinary content.
 
 ### Prototype tasks
 
@@ -503,43 +621,59 @@ more encodings are introduced.
 - [ ] Define canonical `.disot.json` serialization and parsing.
 - [ ] Define canonical `.disot.data.js` serialization and parsing with exactly
       the same logical value and validation semantics.
-- [ ] Reject a tree containing more than one recognized `.disot.*` file.
+- [ ] Inspect recognized `.disot.*` only at the commit-tree root; prove nested
+      files with those basenames are ordinary content.
+- [ ] Reject a commit root containing more than one recognized `.disot.*` file.
 - [ ] Specify the canonical absolute-name grammar `/<identity>/<path...>` and
       relative self-name grammar such as `./name`.
-- [ ] Define how a newly introduced/changed `./name` expands using the trusted
+- [ ] Define how a newly introduced `./name` expands using the trusted
       cryptographic author's DID and ensure later signers do not reinterpret an
       unchanged relative self-name.
 - [ ] Make absolute names the recommended form and discourage `./name`,
       especially for shared/transferable/multi-controller entities.
 - [ ] Keep multiple `name` values out of P3; separately specify authority and
       relative-resolution semantics before considering a `name` array.
-- [ ] Treat `.disot.*` as untrusted data until the containing commit's signature
-      is accepted by the resolver's trust policy.
+- [ ] Treat root `.disot.*` as untrusted data until the containing commit's
+      signature is accepted by the resolver's trust policy.
 - [ ] Require trusted adoption to establish an authoritative `.disot.*` value;
       prove that an unsigned/untrusted introduction establishes no identity.
+- [ ] Require accepted trusted-timestamp evidence in addition to an accepted
+      signature before an externally shared semantic revision is authoritative.
+- [ ] Specify/test direct timestamp evidence and ancestry-based timestamp
+      anchoring through exact Git parent hashes according to the companion
+      timestamp design.
 - [ ] Prove a later trusted descendant can adopt unchanged metadata without
       retroactively trusting the earlier commit.
-- [ ] Apply the same trust rule to later name and lock changes.
+- [ ] Apply the same trust/timestamp rules to advancement, name changes, trusted
+      merges, and relinquishment/archive.
+- [ ] Define a name change as independent old-name relinquishment and new-name
+      establishment assertions, each checked under its own authority policy.
+- [ ] Prove a signer authorized only for the new name cannot archive the old
+      name, and a signer authorized only for the old name cannot establish the
+      new one.
+- [ ] Define no implicit redirect on rename; redirects/aliases require their own
+      explicit authorized representation.
 - [ ] Implement relative-reference resolution from the namespace portion of the
       entity's effective absolute name, with exact lock bindings as overrides.
 - [ ] Implement ancestry-based active-head detection and explicit ambiguity on
-      incomparable trusted forks.
-- [ ] Define trusted signed removal of `.disot.*` from one entity's semantic
-      history as archival; prove unsigned/untrusted removal has no effect.
+      incomparable authoritative forks.
+- [ ] Define root `.disot.*` removal as the no-new-name form of authorized
+      relinquishment/archive.
 - [ ] Ensure Git ref names are never inputs to DISOT identity, rename, archival,
-      authority, or semantic head-selection logic.
+      authority, discovery, or semantic head-selection logic.
 - [ ] Use persistent Git refs only as reachability roots for commits that must
       survive ordinary Git garbage collection.
 - [ ] Implement/test a single synthetic archive retention branch that merges
-      trusted tombstones from many unrelated entities, then permits removal of
-      their individual retention refs.
-- [ ] Prove archive-retention commits containing no `.disot.*` have no DISOT
-      entity semantics and cannot accidentally archive/merge unrelated names.
+      terminal commits from many unrelated archived entities, then permits
+      removal of their individual retention refs.
+- [ ] Prove archive-retention commits containing no root `.disot.*` have no
+      DISOT entity semantics and cannot accidentally archive/merge unrelated
+      names.
 - [ ] Test branch rename/deletion and prove neither changes entity semantics when
       required commits remain reachable elsewhere.
-- [ ] Test ambiguous trusted forks, a later trusted semantic merge, a trusted
-      tombstone, archive-retention merges, and locks pinning historical/forked
-      revisions.
+- [ ] Test ambiguous authoritative forks, a later trusted semantic merge,
+      authorized renames/transfers, tombstones, archive-retention merges, and
+      locks pinning historical/forked revisions.
 - [ ] Test ordinary Git rebase, cherry-pick, merge, squash, clone/fetch/push,
       pack/unpack, and garbage collection to establish exactly when tree-carried
       DISOT metadata and retained history survive ordinary Git workflows.
@@ -548,17 +682,18 @@ more encodings are introduced.
 
 ### Related
 
-- [DISOT architecture](./plan/architecture.md) — global hashes and
-  trust-relative human-readable paths.
+- [DISOT architecture](./plan/architecture.md) — global hashes, trust-relative
+  human-readable paths, and the signed + timestamped trust requirement.
 - [DISOT vision](./plan/vision.md) — the `~/Alice/...` web-of-trust namespace.
-- [Evo product materialization](../fjs/cas/evo/todo/product-materialization.md)
-  — consumes resolved dependency graphs and must not rewrite source objects.
+- [Evo product materialization — PR #1902](https://github.com/functionalscript/functionalscript/pull/1902)
+  — companion TODO for consuming resolved dependency graphs without rewriting
+  source objects; link to the PR until its file is present on `main`.
 - [`vnd.fjs.revision`](../fjs/media/revision/README.md) — current revision and
   recursive lock-map model; resolution policy is deliberately outside the
   format.
 - [`vnd.fjs.lock`](../fjs/media/lock/README.md) — current shared lock-map value;
   the future source/content convention carries naming/resolution metadata in
-  `.disot.*` files in the Git tree.
-- [Git trusted timestamp signatures](./git-trusted-timestamp-signatures.md) —
-  companion proposal for DID signatures and trusted timestamps inside standard
-  Git commits.
+  root `.disot.*` files in the Git tree.
+- [Git trusted timestamp signatures — PR #1903](https://github.com/functionalscript/functionalscript/pull/1903)
+  — companion proposal for DID signatures and trusted timestamps inside standard
+  Git commits; link to the PR until its file is present on `main`.

--- a/todo/git-name-resolution.md
+++ b/todo/git-name-resolution.md
@@ -1,0 +1,293 @@
+## Git names and relative name resolution
+
+**Priority:** P3
+**Status:** open
+
+### Problem
+
+Content hashes are universal immutable addresses, but they are not the names
+people use to collaborate. A module, document, repository, or other evolving
+object needs a human-readable name whose meaning is relative to a trust root,
+not a globally allocated DNS-like namespace.
+
+The DISOT architecture already describes paths such as:
+
+```text
+~/Alice/Bob/plan.md
+/secp256k1:<key>/Alice/Bob/plan.md
+```
+
+where every hop is authenticated and `~` is relative to a root identity. Git
+already gives us immutable commit objects, ancestry, merges, ordinary transport,
+and signatures. The missing piece for using Git commits directly in this model
+is a small naming convention plus a resolver that can turn a relative name into
+an exact immutable commit/content address.
+
+The design must keep three things separate:
+
+1. **name** — human-readable, contextual, mutable through history;
+2. **identity / trust root** — whose namespace gives the name meaning;
+3. **hash** — the final immutable object selected by resolution.
+
+A signer is not automatically the namespace root. This distinction matters for
+forks: another person may sign new commits in a fork without silently changing
+what the fork's existing relative dependencies mean.
+
+### Commit `name`
+
+Prototype one optional, non-repeatable Git commit header:
+
+```text
+tree <tree>
+parent <parent>
+name coolPythonModule
+author ...
+committer ...
+
+<message>
+```
+
+`name` is a human-readable name for the logical object represented by the
+commit. It is not a Git ref, branch name, DNS name, or globally unique package
+name. Its meaning is always relative to a namespace root.
+
+A sequence of commits with the same effective root/name and connected ancestry
+is the evolution of one named object. A new commit does not acquire a new
+logical identity merely because another signer created it; signatures say who
+attested to a commit, not what namespace its relative references belong to.
+
+Conversely, two unrelated histories that happen to use the same string are not
+silently the same object. They are distinct candidates/forks until ancestry,
+trust policy, an explicit root, or a lock selects one.
+
+The prototype must decide and pin the exact textual domain of `name` (UTF-8,
+normalization, reserved separators, empty name, and maximum size). The initial
+format should prefer one path segment per `name`; path structure belongs to the
+resolver rather than to one commit header.
+
+Unknown commit headers are part of the commit bytes. Compatibility tests must
+prove that stock Git preserves `name` through object storage, clone/fetch/push,
+packing, fsck, and garbage collection wherever the commit itself remains
+reachable.
+
+### Relative paths
+
+The human-facing path syntax has two root forms:
+
+```text
+~/Alice/coolPythonModule
+/<identity>/Alice/coolPythonModule
+```
+
+For the Git prototype, `<identity>` should use the same DID/public-key identity
+form used by the commit-signature work; the exact textual form is specified by
+that identity layer rather than duplicated here.
+
+`~` means "the resolver's current trust root" **only while a path is still
+unlocked**. The explicit form names that root directly. After resolution is
+locked, the lock's `root` records what `~` meant, so the same source is not
+reinterpreted merely because another user, machine, or fork is doing the build.
+
+Resolution is hop-by-hop. Conceptually:
+
+```text
+(root, "Alice")
+    -> authenticated identity/object for Alice
+(Alice, "coolPythonModule")
+    -> authenticated named Git history
+    -> selected commit
+    -> immutable tree/content
+```
+
+Every hop is subject to the caller's trust policy. A resolver may use local
+indexes, Git refs, signed directories, cached discovery data, or a network
+service to discover candidates; those are lookup mechanisms, not part of the
+name's identity. The semantic result is an authenticated chain ending in an
+immutable hash.
+
+### Heads, forks, and ambiguity
+
+A name may have many commits. Given the commits currently known for one
+root/name, a resolver considers ancestry rather than timestamps or arrival
+order:
+
+- an ancestor is an older version, not a competing head;
+- one maximal descendant is the current unambiguous head;
+- several incomparable maximal commits are forks/concurrent heads;
+- a merge commit descending from those heads can make the history unambiguous
+  again.
+
+A resolver MUST NOT choose among incomparable heads merely by commit time,
+lexicographic hash order, network arrival order, or which server answered
+first. It either applies an explicit caller trust/policy rule or reports the
+ambiguity. A lock removes that ambiguity by naming exact immutable results.
+
+This makes mutable resolution intentionally context-dependent while locked
+resolution remains reproducible.
+
+### Lock files
+
+The source/product convention should use one of these filenames:
+
+```text
+lock.json
+lock.data.js
+```
+
+`lock.json` is the JSON encoding; `lock.data.js` is the DataJS encoding. They
+represent the same logical lock data and a resolver must not give one different
+semantics from the other. The filenames are the future product/source
+convention; do not expose `vnd.fjs.lock` as a required filename.
+
+The lock records the immutable answers produced by name resolution. In
+particular it has a `root` field in addition to dependency bindings:
+
+```json
+{
+  "root": "<identity>",
+  "lock": {
+    "Alice": {
+      "coolPythonModule": "<immutable-hash>"
+    }
+  }
+}
+```
+
+The exact schema may reuse/evolve the existing recursive lock-map work. The
+important semantic distinction is:
+
+- `root` identifies the trust-root context in which relative names were
+  resolved;
+- leaf bindings identify immutable commit/snapshot/content hashes;
+- nested maps preserve scoped choices where the same relative name resolves
+  differently in different dependency paths.
+
+A lock is therefore more than a cache. It is the reproducible receipt of a
+context-dependent name resolution.
+
+### `lock.root` and forks
+
+**Forking does not change `lock.root`.**
+
+If Bob forks a project whose lock was resolved from Alice's namespace root,
+Bob's new commits may be signed by Bob while the copied lock continues to say:
+
+```text
+root = Alice
+```
+
+and every existing relative dependency keeps resolving exactly as it did in the
+source history. The signer authenticates Bob's changes; it does not implicitly
+re-root the project's namespace.
+
+This is the critical fork rule. Without it, cloning/forking a project under a
+new identity could silently reinterpret every `~/...` dependency and produce a
+different program while the source text stayed byte-for-byte identical.
+
+Re-rooting is an explicit operation. A fork that intentionally wants its own
+namespace changes/regenerates `lock.root` and re-resolves the symbolic names.
+That operation may change many bindings and should be reviewable as such.
+
+The same rule applies when the fork keeps all dependency hashes unchanged:
+changing the signer alone is not a reason to rewrite the lock.
+
+### Resolution order
+
+For a path used by a source object, the initial resolver should behave
+conceptually as follows:
+
+1. Determine the effective root:
+   - an explicit absolute root from the path; otherwise
+   - `lock.root` when a lock is present; otherwise
+   - the caller's current `~` trust root.
+2. Walk the human-readable path under that root, using the caller's trust
+   policy to discover authenticated name bindings/candidates.
+3. At each dependency scope, prefer an exact applicable lock binding when one
+   exists; a locked hash is the answer and is not reinterpreted as another
+   mutable name.
+4. If no lock binding exists, resolve the mutable named history, requiring an
+   unambiguous head or an explicit policy for choosing among forks.
+5. Materialize/use the resulting immutable commit/tree/content hash.
+6. When producing/updating a lock, write the effective root and every selected
+   immutable binding needed to reproduce the result.
+
+The implementation may optimize this heavily; the observable semantics must be
+the same.
+
+### Interaction with Git signatures and trusted timestamps
+
+`name` is ordinary commit data. DID signatures (`gpgsig2` in the companion Git
+signature prototype), trusted timestamps (`tstsig`), and a final conventional
+Git signature therefore cover it exactly as they cover `tree`, `parent`, and
+the commit message.
+
+A resolver must distinguish:
+
+- **named by** — the namespace/path under which the commit was discovered;
+- **signed by** — identities that authenticated the exact commit;
+- **anchored at** — trusted timestamp evidence, if present;
+- **locked to** — the immutable hash selected for a dependency.
+
+These can intentionally name different identities. A fork is the common case:
+the namespace root can remain Alice, the new commit can be signed by Bob, and
+the dependency lock can remain byte-for-byte unchanged.
+
+### Discovery is separate from identity
+
+Git refs are useful indexes for finding named heads, but they are mutable local
+transport metadata and MUST NOT define the object identity themselves. An
+implementation may publish conventional or custom refs for efficient discovery,
+but two stores using different ref layouts must still be able to agree that the
+same signed commit is the same named candidate once found.
+
+Likewise, a standard Git fetch only guarantees transfer of objects reachable
+from the refs/history it fetches. A custom name or lock reference to an otherwise
+unreachable object is not enough to make ordinary Git transfer that object.
+The prototype must therefore specify how all locked dependencies remain
+reachable/fetchable — for example through explicit refs or a CAS/DISOT fetch
+path — without changing the naming semantics above.
+
+### Prototype tasks
+
+- [ ] Specify the exact `name` header grammar and canonical placement in a Git
+      commit; reject repeated/malformed names.
+- [ ] Build parsing/verification support for `name` without changing normal Git
+      commit identity semantics.
+- [ ] Define the root identity representation shared with DID signatures.
+- [ ] Implement relative-path parsing for `~/...` and explicit-root paths.
+- [ ] Implement ancestry-based head detection and explicit ambiguity on
+      incomparable forks.
+- [ ] Define `lock.json` and `lock.data.js` as two encodings of one logical
+      lock schema, including `root` plus recursive immutable bindings.
+- [ ] Enforce the fork rule: copying/forking a project preserves `lock.root`;
+      changing signer identity alone never re-roots resolution.
+- [ ] Add an explicit re-root operation that updates `root` and re-resolves the
+      affected names instead of doing so implicitly.
+- [ ] Keep locked leaf hashes terminal: do not interpret a locked immutable hash
+      as a mutable named history.
+- [ ] Specify discovery/fetch mechanics separately from semantic resolution so
+      custom Git refs, CAS indexes, or network services can be swapped.
+- [ ] Test source-identical forks signed by different DIDs and prove their
+      locked dependencies stay identical until an explicit re-root.
+- [ ] Test ambiguous same-name forks, a later merge that removes the ambiguity,
+      and lock files that deliberately pin either fork.
+- [ ] Test stock Git compatibility for commits carrying `name`, including
+      clone/fetch/push, pack/unpack, `git fsck`, `git log`, and garbage
+      collection of reachable named commits.
+
+### Related
+
+- [DISOT architecture](./plan/architecture.md) — global hashes and
+  trust-root-relative human-readable paths.
+- [DISOT vision](./plan/vision.md) — the `~/Alice/...` web-of-trust namespace.
+- [Evo product materialization](../fjs/cas/evo/todo/product-materialization.md)
+  — consumes a resolved dependency graph and must not rewrite source objects.
+- [`vnd.fjs.revision`](../fjs/media/revision/README.md) — current revision and
+  recursive lock-map model; resolution policy is deliberately outside the
+  format.
+- [`vnd.fjs.lock`](../fjs/media/lock/README.md) — current shared lock-map blob;
+  the future source/product filenames in this design are `lock.json` and
+  `lock.data.js`.
+- [Git trusted timestamp signatures](./git-trusted-timestamp-signatures.md) —
+  companion proposal for DID signatures and trusted timestamps inside standard
+  Git commits.

--- a/todo/git-name-resolution.md
+++ b/todo/git-name-resolution.md
@@ -70,6 +70,53 @@ user content, while the `disot` namespace makes accidental collision much less
 likely than generic names such as `manifest.json`, `.meta.json`, or
 `package.json`.
 
+### Trust establishes metadata; presence does not
+
+A `.disot.*` file is only bytes in a Git tree until a trusted signature adopts
+it. Its presence MUST NOT by itself establish `(namespace, name)`, a lock, or
+any other DISOT semantics.
+
+In particular, a commit that **introduces** `.disot.*` is authoritative only if
+that exact commit is validly signed by a party the resolver's trust policy
+accepts as allowed to establish/control the claimed namespace/object. An
+unsigned commit, or a commit signed only by an untrusted party, cannot claim a
+trusted namespace merely by writing:
+
+```json
+{
+  "namespace": "DID:Alice",
+  "name": "parser"
+}
+```
+
+The same principle applies to later metadata changes: changing `namespace`,
+`name`, or lock data does not become authoritative merely because Git accepted
+the commit. The resolver evaluates the signature(s) and its trust policy before
+accepting the changed metadata into the trusted named history.
+
+A useful consequence is that an untrusted commit may introduce `.disot.*`, and
+a later trusted descendant may leave the file unchanged and sign the new commit.
+Because the later signature covers the complete tree, that trusted descendant
+**adopts** the metadata at that point. The earlier untrusted commit does not
+become trusted retroactively; the later signed commit is the first authoritative
+DISOT revision carrying that value.
+
+Conceptually:
+
+```text
+C0  no .disot.*
+ |
+C1  adds .disot.json     unsigned / untrusted   -> not authoritative
+ |
+C2  same .disot.json     trusted signature      -> metadata adopted here
+```
+
+Trust is subjective and policy-driven. "Trusted party" does not necessarily
+mean one hard-coded signer equal to `namespace`: delegation, key rotation,
+multiple controllers, or community trust rules may all authorize a signature.
+The format records identity and signatures; the resolver decides whether the
+signer is trusted to make the assertion.
+
 ### Shape
 
 Conceptually:
@@ -193,7 +240,8 @@ name      = parser
 Therefore existing relative references still resolve in Alice's namespace.
 This is exactly what is wanted for a contribution intended to go back to
 Alice: Bob's signature authenticates Bob's revision; it does not rename or
-re-root Alice's object.
+re-root Alice's object. Whether Bob is trusted to advance Alice's authoritative
+named history is a separate trust-policy decision.
 
 If Bob intentionally creates his own independent object, changing identity is
 an ordinary, reviewable tree change:
@@ -229,7 +277,8 @@ This also solves the fork case without parsing unknown source languages. If a
 tree already has `.disot.*`, standard Git carries the namespace and lock
 forward. If a tree has no DISOT metadata and a DISOT-aware tool wants to turn it
 into a named/signed object, the tool creates the metadata file before signing
-the resulting commit.
+the resulting commit; the new identity is accepted only when that signature is
+trusted to establish it.
 
 The tool does not need to discover every import/reference merely to preserve the
 namespace context: `namespace` covers unknown relative references, while lock
@@ -237,15 +286,20 @@ entries pin the ones whose immutable resolution has been recorded.
 
 ### Heads, forks, and ambiguity
 
-A name may have many commits. Given known commits whose trees describe the same
-`(namespace, name)`, a resolver considers ancestry rather than timestamps or
-arrival order:
+A name may have many commits. Given known **trusted** commits whose trees
+describe the same `(namespace, name)`, a resolver considers ancestry rather
+than timestamps or arrival order:
 
 - an ancestor is an older revision, not a competing head;
 - one maximal descendant is the current unambiguous head;
 - several incomparable maximal commits are forks/concurrent heads;
 - a merge commit descending from those heads can make the history unambiguous
   again.
+
+An untrusted commit does not become an authoritative head merely because it is
+a descendant of a trusted commit. It may be retained as a candidate/contribution
+for inspection, but head selection for trusted resolution filters/evaluates
+trust before treating it as an authoritative revision.
 
 A resolver MUST NOT choose among incomparable heads merely by commit time,
 lexicographic hash order, network arrival order, or which server answered
@@ -270,8 +324,9 @@ namespace = <expected namespace>
 name      = parser
 ```
 
-and whose ancestry/trust policy yields one unambiguous head. If several maximal
-heads remain, reconstruction reports a fork rather than silently choosing one.
+and whose ancestry/trust policy yields one unambiguous trusted head. If several
+maximal trusted heads remain, reconstruction reports a fork rather than
+silently choosing one.
 
 This keeps a repository a storage/replication container. Moving commits between
 repositories or changing ref layout does not rename the objects inside them.
@@ -288,6 +343,8 @@ A resolver must distinguish:
 
 - **described as** — `(namespace, name)` from `.disot.*`;
 - **signed by** — identities that authenticated this exact commit;
+- **trusted as** — whether those signatures are authorized by the resolver's
+  policy to establish or advance that named object;
 - **anchored at** — trusted timestamp evidence, if present;
 - **locked to** — immutable hashes selected for dependencies.
 
@@ -335,12 +392,19 @@ more encodings are introduced.
 - [ ] Define canonical `.disot.data.js` serialization and parsing with exactly
       the same logical value and validation semantics.
 - [ ] Reject a tree containing more than one recognized `.disot.*` file.
+- [ ] Treat `.disot.*` as untrusted data until the containing commit's
+      signature is accepted by the resolver's trust policy.
+- [ ] Require trusted adoption to introduce an authoritative `.disot.*` value;
+      prove that an unsigned/untrusted introduction establishes no identity.
+- [ ] Prove a later trusted descendant can adopt unchanged metadata without
+      retroactively trusting the earlier commit.
+- [ ] Apply the same trust rule to later `namespace`, `name`, and lock changes.
 - [ ] Define the identity representation shared with DID signatures.
 - [ ] Define the exact textual domain of `name` and namespace path segments.
 - [ ] Implement relative-name resolution using the object's `namespace` as the
       default base and exact lock bindings as overrides.
 - [ ] Implement ancestry-based head detection and explicit ambiguity on
-      incomparable forks.
+      incomparable trusted forks.
 - [ ] Enforce the fork rule: a new signer never implicitly changes
       `.disot.*`; namespace/name changes are explicit tree edits.
 - [ ] When namespace/name are intentionally changed, resolve/update the lock so
@@ -350,11 +414,12 @@ more encodings are introduced.
 - [ ] Test source-identical commits signed by different DIDs and prove their
       identity and relative-resolution context stay unchanged while `.disot.*`
       is unchanged.
-- [ ] Test ambiguous same-name forks, a later merge that removes the ambiguity,
-      and locks that deliberately pin either fork.
+- [ ] Test ambiguous same-name trusted forks, a later trusted merge that removes
+      the ambiguity, and locks that deliberately pin either fork.
 - [ ] Test ordinary Git rebase, cherry-pick, merge, squash, clone/fetch/push,
       pack/unpack, and garbage collection to establish exactly when tree-carried
-      DISOT metadata is retained or intentionally changed.
+      DISOT metadata is retained or intentionally changed; newly created
+      unsigned commits remain untrusted until signed/adopted according to policy.
 - [ ] P5: evaluate `.disot.yml` and `.disot.toml` only after the JSON/DataJS
       model is stable and a consumer actually needs another encoding.
 

--- a/todo/git-name-resolution.md
+++ b/todo/git-name-resolution.md
@@ -202,18 +202,44 @@ The same representation-independence applies to timestamp evidence: an embedded
 may provide another. Naming semantics depend on accepted evidence, not the
 container used to carry it.
 
-An untrusted commit may introduce `.disot.*`, and a later authoritative
-revision may leave the metadata unchanged and adopt it. The earlier untrusted
-commit does not become trusted retroactively.
+### Late evidence may adopt the exact immutable revision
+
+Authority/trust is evaluated from the evidence currently known to the resolver.
+Detached authority or timestamp evidence may arrive **after** the Git commit it
+targets. If later evidence directly authenticates that exact immutable revision
+and satisfies the applicable authority/timestamp policy, the same existing
+revision may become authoritative without creating a new Git commit.
+
+For example:
 
 ```text
-C0  no .disot.*
- |
-C1  adds .disot.json     no accepted authority attestation
- |                       -> not authoritative
-C2  same .disot.json     accepted authority attestation
-                         -> metadata adopted here
+C1  adds .disot.json
+    no accepted authority/timestamp evidence
+    -> provisional / not authoritative
+
+later:
+    detached authority attestation -> exact C1
+    trusted timestamp evidence      -> exact C1
+
+    -> C1 becomes eligible as an authoritative shared revision
 ```
+
+This does not mutate `C1`, change its hash, or rewrite history. Only the
+resolver's evidence set has changed.
+
+A later descendant can instead adopt unchanged metadata at its own revision:
+
+```text
+C1  adds .disot.json     no accepted authority attestation
+ |
+C2  same .disot.json     accepted authority/timestamp evidence for C2
+                         -> metadata adopted at C2
+```
+
+Evidence for `C2` does **not** automatically authenticate `C1`. Evidence affects
+exactly the revision/projection it authenticates. A timestamped descendant may
+anchor the existence time of an ancestor only under the separate ancestry-based
+timestamp rules.
 
 Trust is subjective and policy-driven. Delegation, key rotation, multiple
 controllers, or community trust rules may authorize attestations.
@@ -249,8 +275,7 @@ accepted authority attestation + accepted timestamp evidence
 ```
 
 The rule applies to establishment, advancement, rename, relinquishment/archive,
-and semantic merges. Synthetic retention-only commits are not DISOT semantic
-revisions and do not need semantic authority/timestamp evidence.
+and semantic merges.
 
 ### Git-backed names vs signed DISOT directories
 
@@ -480,43 +505,39 @@ Reflogs are not sufficient because they expire.
 Live incomparable heads may temporarily require multiple reachability refs.
 Those refs still have no naming semantics.
 
-### One archive ref for many archived lineages
+### Archive-retention compaction — open optimization question
 
-Keeping one branch forever for every archived lineage would accumulate needless
-refs. Once a lineage has a valid terminal relinquishment/tombstone, DISOT may
-merge that terminal commit into a single synthetic archive-retention branch.
+One possible Git-only retention optimization is to merge terminal archived
+lineages into a common archive branch so individual retention refs can be
+deleted. This could reduce the number of long-lived refs.
 
-```text
-R0
- |
-R1 ---- archived-A-terminal
- |
-R2 ---- archived-B-terminal
- |
-R3 ---- archived-C-terminal
- ^
- refs/heads/archive
-```
+However, the current semantic format does **not** define a durable way to
+distinguish such a synthetic retention merge from a metadata-free semantic
+relinquishment/merge after the commit is transported independently of its ref.
+Adding a `type`, `retention`, dedicated marker file, or other protocol surface
+would be premature before we know this optimization is needed.
 
-Each synthetic archive commit uses the previous archive commit and one terminal
-entity commit as parents. Its tree contains **no recognized root `.disot.*`**.
-Afterward the individual archived-lineage ref may be deleted because the terminal
-commit and its ancestry remain reachable from the common archive ref.
+Therefore this optimization is **not part of the P3 semantic contract**. No
+`.disot.*` field, filename, or commit-header marker is reserved for it now.
+Implementations should keep whatever refs are required for GC safety, or use a
+storage layer with its own retention guarantees.
 
-This is retention topology only:
+If archive-ref compaction becomes necessary later, first answer:
 
-```text
-authorized/timestamped relinquishment in semantic history
-    = DISOT archival semantics
+- Do we need to distinguish retention-only commits from semantic no-metadata
+  commits after arbitrary transport?
+- Can another invariant or storage layer eliminate the need for synthetic
+  retention commits entirely?
+- If a durable distinction is necessary, what is the smallest representation
+  that does not unnecessarily expand the permanent DISOT format?
 
-synthetic merge into archive branch
-    = Git reachability only
-```
+The optimization may be dropped entirely if experience shows it is unnecessary.
 
-Archive-retention commits MUST NOT be interpreted as entities, semantic merges,
-renames, reactivations, or new archive operations. They may combine unrelated
-DISOT histories. They need no semantic authority/timestamp evidence because
-they assert nothing about DISOT.
+### Open questions
+
+- **Archive-retention classification:** Is a synthetic archive branch needed at
+  all? If yes, define a durable, transport-independent classification rule
+  before implementing it. Do not reserve a schema field or marker yet.
 
 ### Future encodings — P5
 
@@ -571,6 +592,11 @@ error. Nested files with those basenames remain ordinary content.
       commits; treat `gpgsig2` as an optional Git-native attestation encoding.
 - [ ] Define representation-independent trusted timestamp evidence; keep `tstsig`
       as one optional Git-native encoding.
+- [ ] Define late-evidence adoption: detached authority/timestamp evidence may
+      make the exact immutable revision it targets authoritative without a new
+      Git commit.
+- [ ] Prove evidence for a descendant does not automatically authenticate its
+      ancestors; ancestry-based timestamp anchoring remains a separate rule.
 - [ ] Require accepted authority evidence + accepted trusted timestamp evidence
       for externally shared authoritative semantic revisions.
 - [ ] Specify/test direct and ancestry-based timestamp anchoring according to
@@ -596,9 +622,9 @@ error. Nested files with those basenames remain ordinary content.
       incomparable authoritative forks.
 - [ ] Ensure Git ref names are never semantic inputs; use persistent refs only
       for reachability/GC protection.
-- [ ] Implement/test one synthetic archive-retention branch for terminal commits
-      from many unrelated archived lineages.
-- [ ] Prove archive-retention commits have no DISOT semantics.
+- [ ] Keep archive-retention compaction out of P3. If it proves necessary,
+      define a durable classification rule before implementing synthetic archive
+      merges; otherwise drop the optimization.
 - [ ] Test branch rename/deletion, ordinary Git rebase/cherry-pick/merge/squash,
       clone/fetch/push, pack/unpack, and garbage collection.
 - [ ] P5: evaluate `.disot.yml` and `.disot.toml` only after JSON/DataJS are


### PR DESCRIPTION
Add a design TODO for language- and hypertext-independent DISOT naming and relative resolution on top of ordinary Git trees.

The design keeps naming/resolution metadata at the Git commit-tree root in `.disot.json` or `.disot.data.js`; nested `.disot.*` files are ordinary content. P3 uses one path-valued `name`, preferably absolute (`/<DID>/name`). `./name` is allowed as a personal convenience but derives from one unique cryptographically authenticated author DID; later authority, endorsement, or timestamp attestations for the same immutable revision do not reinterpret that name. Multi-author authorship is ambiguous for `./name` and must use an absolute name instead. Multi-name arrays remain a future extension.

Naming trust is representation-independent. The resolver consumes verified authority attestations and trusted timestamp evidence rather than requiring a particular signature container. Detached DISOT provenance/signature blocks can arrive later and may make the exact immutable revision they target authoritative without creating a new Git commit; evidence for a descendant does not automatically authenticate its ancestors. `didsig` / `tstsig` are optional Git-native encodings defined by the companion signature/timestamp design.

For Git-backed named entities, root `.disot.*` + accepted authority/timestamp evidence + Git ancestry define the authoritative final-name history. Signed DISOT directories remain useful for trust-path traversal, aliases, discovery, and non-Git objects, but cannot override a validated Git-backed history; this Git-specific rule partially supersedes the older directory-to-hash final-binding model and includes a follow-up architecture-doc update.

Name changes are independent old-name relinquishment and new-name establishment assertions. Relinquishment is causal/ancestry-scoped: a tombstone or rename retires only authoritative active heads in its ancestry and never incomparable forks. There is no implicit redirect.

Git refs have no DISOT semantics; they are only retention roots protecting required objects from ordinary Git garbage collection. A possible common archive-retention branch remains an open optimization question rather than P3 behavior. No `type`, `retention`, marker file, or other protocol surface is reserved for it.

The TODO also clarifies that arbitrary custom Git headers are not reliably preserved across commit-producing workflows: normal descendant commits, rebase, cherry-pick, and squash may drop them, while `git commit --amend` may preserve them. DISOT therefore keeps semantic metadata in the tree and does not rely on universal header preservation or dropping.

The TODO keeps exact lock bindings terminal and records `.disot.yml` / `.disot.toml` as P5 future encodings after JSON/DataJS are stable.

Docs-only TODO; no runtime behavior changes.