### PR TITLE
Update Node.js, Rust, Bun, and FunctionalScript versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@
           "uses": "actions/checkout@v7.0.1"
         },
         {
-          "run": "test \"$(./nix/run node --version)\" = \"v26.7.0\""
+          "run": "test \"$(./nix/run node --version)\" = \"v26.8.1\""
         },
         {
           "run": "./nix/run npm ci"
@@ -62,7 +62,7 @@
           "uses": "actions/checkout@v7.0.1"
         },
         {
-          "run": "test \"$(./nix/run node --version)\" = \"v26.7.0\""
+          "run": "test \"$(./nix/run node --version)\" = \"v26.8.1\""
         },
         {
           "run": "./nix/run npm ci"
@@ -94,7 +94,7 @@
           "uses": "actions/checkout@v7.0.1"
         },
         {
-          "run": "test \"$(./nix/run node --version)\" = \"v26.7.0\""
+          "run": "test \"$(./nix/run node --version)\" = \"v26.8.1\""
         },
         {
           "run": "./nix/run npm ci"
@@ -126,7 +126,7 @@
           "uses": "actions/checkout@v7.0.1"
         },
         {
-          "run": "test \"$(./nix/run node --version)\" = \"v26.7.0\""
+          "run": "test \"$(./nix/run node --version)\" = \"v26.8.1\""
         },
         {
           "run": "./nix/run npm ci"
@@ -152,7 +152,7 @@
       "runs-on": "windows-2025",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.98.0",
+          "uses": "dtolnay/rust-toolchain@1.98.1",
           "with": {
             "components": "rustfmt,clippy",
             "targets": "i686-pc-windows-msvc"
@@ -161,11 +161,11 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "26.7.0"
+            "node-version": "26.8.1"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.48.0"
+          "run": "npm install -g functionalscript@0.49.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -203,7 +203,7 @@
       "runs-on": "windows-11-arm",
       "steps": [
         {
-          "uses": "dtolnay/rust-toolchain@1.98.0",
+          "uses": "dtolnay/rust-toolchain@1.98.1",
           "with": {
             "components": "rustfmt,clippy"
           }
@@ -211,11 +211,11 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "26.7.0"
+            "node-version": "26.8.1"
           }
         },
         {
-          "run": "npm install -g functionalscript@0.48.0"
+          "run": "npm install -g functionalscript@0.49.0"
         },
         {
           "uses": "actions/checkout@v7.0.1"
@@ -353,7 +353,7 @@
           "uses": "actions/checkout@v7.0.1"
         },
         {
-          "run": "test \"$(./nix/run bun --version)\" = \"1.4.0\""
+          "run": "test \"$(./nix/run bun --version)\" = \"1.4.2\""
         },
         {
           "run": "./nix/run bun install --frozen-lockfile"
@@ -413,7 +413,7 @@
           "uses": "actions/checkout@v7.0.1"
         },
         {
-          "run": "test \"$(./nix/run node --version)\" = \"v26.7.0\""
+          "run": "test \"$(./nix/run node --version)\" = \"v26.8.1\""
         },
         {
           "run": "test \"$(./nix/run tsc --version)\" = \"Version 7.0.2\""
@@ -461,7 +461,7 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "26.7.0"
+            "node-version": "26.8.1"
           }
         },
         {

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,7 @@
         {
           "uses": "actions/setup-node@v7.0.0",
           "with": {
-            "node-version": "26.7.0",
+            "node-version": "26.8.1",
             "registry-url": "https://registry.npmjs.org/"
           }
         },

--- a/fjs/ci/README.md
+++ b/fjs/ci/README.md
@@ -184,7 +184,7 @@ version, so unlike `pkgs.nodejs_26` they cannot be checked against the configura
 without evaluating them.
 
 The one runtime with no check is the `wasm` job's Rust, and for the reason that makes
-the others worth checking: its flake says `rust-bin.stable."1.98.0"`, naming the
+the others worth checking: its flake says `rust-bin.stable."1.98.1"`, naming the
 release in full rather than a major or nothing at all, so a check could only restate
 the flake it was meant to test.
 

--- a/fjs/ci/README.md
+++ b/fjs/ci/README.md
@@ -165,7 +165,7 @@ canonical job asserts, as its first command, that its own shell reports the vers
 `config/module.f.mjs` records for it:
 
 ```sh
-test "$(./nix/run node --version)" = "v26.7.0"
+test "$(./nix/run node --version)" = "v26.8.1"
 test "$(./nix/run deno eval 'console.log(Deno.version.deno)')" = "2.8.3"
 test "$(./nix/node22/run node --version)" = "v22.23.2"
 ```

--- a/fjs/ci/config/module.f.mjs
+++ b/fjs/ci/config/module.f.mjs
@@ -25,7 +25,7 @@ export const images = /** @type {const} */({
 // published FunctionalScript release; do not tie it to package.json's current
 // in-repo version.
 // https://www.npmjs.com/package/functionalscript
-export const functionalscript = /** @type {const} */ '0.48.0'
+export const functionalscript = /** @type {const} */ '0.49.0'
 
 // The one runtime a generated flake takes from outside the pinned snapshot.
 // Nixpkgs ships 1.3.13 — on the pin and on `master` — and two of this
@@ -39,7 +39,7 @@ export const functionalscript = /** @type {const} */ '0.48.0'
 // package definition. Delete this and the table below the day the snapshot
 // carries a Bun this suite passes on.
 // https://bun.sh/
-export const bun = '1.4.0'
+export const bun = '1.4.2'
 
 // The archive that release publishes for each system a generated flake targets,
 // with the SHA-256 its content must have, as an SRI string.
@@ -60,19 +60,19 @@ export const bun = '1.4.0'
 export const bunSources = {
     'aarch64-linux': {
         archive: 'bun-linux-aarch64',
-        hash: 'sha256-SxozLuhhmD65O8/m93D/+U4+MbLDiL2uo8jtNeWO7Q4=',
+        hash: 'sha256-VDKLvC2cjgyfiSxUTWbFeoO4QTnjSQnl7oF1jxrI/ac=',
     },
     'x86_64-linux': {
         archive: 'bun-linux-x64',
-        hash: 'sha256-LQP7X7g6yLVnrKCigbLOGhoZ1Ij1bClo2Iw/Jekv5FI=',
+        hash: 'sha256-NjaPrvdSeHXV/6UuU81IAhdB8qg+tiCKjdZAaNQiqRM=',
     },
     'aarch64-darwin': {
         archive: 'bun-darwin-aarch64',
-        hash: 'sha256-xmnpf2Fk4cluBwF0jbmN+ndJKQjL2DlMdVcTSnNd44E=',
+        hash: 'sha256-kJh6OhbX21VtiGrD1VHnttPt8KHPQ6yu1iLoZ2vh0S8=',
     },
     'x86_64-darwin': {
         archive: 'bun-darwin-x64-baseline',
-        hash: 'sha256-2pufG0unZsbymXEfON+qmGI+HtnECJaqU9uAPFLsH6A=',
+        hash: 'sha256-utW71s8U0JgNEV9ZVMn/kE32GdXplNLaH/zNPzFjALA=',
     },
 }
 
@@ -92,7 +92,7 @@ export const deno = '2.8.3'
 // versions it offers rather than the latest release.
 // https://nodejs.org/en/download
 export const node = /** @type {const} */({
-    default: '26.7.0',
+    default: '26.8.1',
     node22: '22.23.2',
     node24: '24.19.0',
 })
@@ -129,7 +129,7 @@ export const typescript = /** @type {const} */({
 // `dtolnay/rust-toolchain` installs; the two are the same constant so they
 // cannot drift.
 // https://rust-lang.org/
-export const rust = '1.98.0'
+export const rust = '1.98.1'
 
 // Official Nixpkgs snapshot used by the generated CI flakes. `ref` is the
 // stable channel the commit is accepted from; `commit` is the exact revision
@@ -146,7 +146,7 @@ export const nixpkgs = /** @type {const} */({
     owner: 'NixOS',
     repo: 'nixpkgs',
     ref: 'nixos-26.05',
-    commit: '062346a6d85bc4b49dfaa61c986e9c5be21217d1',
+    commit: '93108a538f079596c9a16c72cf03e9322782b6dd',
 })
 
 // Wasmtime and Wasmer are installed by their own setup actions, so these are
@@ -165,7 +165,7 @@ export const rustOverlay = /** @type {const} */({
     owner: 'oxalica',
     repo: 'rust-overlay',
     ref: 'master',
-    commit: '996e9b0b019a4a9eb9e9a5641aefa06d801b5895',
+    commit: '6ae57a71bcb0bebc7a66cc2bd76942c4cf649167',
 })
 
 // Moving either `commit` above needs `npm run lock-update` (real Nix) to

--- a/fjs/ci/rust/module.f.mjs
+++ b/fjs/ci/rust/module.f.mjs
@@ -136,7 +136,7 @@ export const i686System = /** @type {const} */ ('x86_64-linux')
  *
  * The target is an addition to what every system's toolchain carries rather
  * than a toolchain of its own: the shell already has `rust-overlay`'s
- * `1.98.0` with the WASM targets, and this is one more `rust-std` on the
+ * `1.98.1` with the WASM targets, and this is one more `rust-std` on the
  * platform that can link it.
  *
  * @type {{ readonly [system: string]: NixPerSystem }}
@@ -250,7 +250,7 @@ const wasmTargetCommands = target =>
  * so the targets below and `wasmTargets` above cannot come apart —
  * `../dev/module.f.mjs` takes this whole record.
  *
- * The flake names `1.98.0` in full, so no job checks the toolchain's version:
+ * The flake names `1.98.1` in full, so no job checks the toolchain's version:
  * a check could only restate the flake. The two runtimes are the opposite
  * case, and the checks below are the whole of that tie.
  *

--- a/fjs/ci/todo/65z-ci-nix.md
+++ b/fjs/ci/todo/65z-ci-nix.md
@@ -52,9 +52,9 @@ So the job's flake takes its toolchain from a **second input**,
 `github:oxalica/rust-overlay`, and this issue's "one official Nixpkgs snapshot" scope
 is widened by exactly that much. What the overlay does is not a different build; it is
 a different acquisition. Rust publishes a manifest per release —
-`channel-rust-1.98.0.toml`, every component and target with a URL and a hash — and the
+`channel-rust-1.98.1.toml`, every component and target with a URL and a hash — and the
 overlay checks a generated Nix file per version into its own repository, so
-`rust-bin.stable."1.98.0".minimal.override { extensions targets }` selects among the
+`rust-bin.stable."1.98.1".minimal.override { extensions targets }` selects among the
 same tarballs `rustup` would install, pinned by hashes that live in a flake input this
 repository pins. Nixpkgs ignores that manifest and builds the compiler from source,
 which is the whole of the difference.
@@ -67,7 +67,7 @@ deliberate: `default` would add `rust-docs`, a download nothing here opens.
 
 The two runtimes stay official: `pkgs.wasmtime` and `pkgs.wasmer`, whose attributes
 carry no version, so the job checks both from inside the shell exactly as `deno` does.
-Its Rust it does not check — `stable."1.98.0"` names the release in full, so a check
+Its Rust it does not check — `stable."1.98.1"` names the release in full, so a check
 would restate the flake rather than test it. The snapshot's Wasmtime is 45.0.2, which
 predates the wasi-threads removal in 47 that
 [wasmtime-threads](../../../todo/blocked/wasmtime-threads.md) records, so the
@@ -78,9 +78,10 @@ cannot; revisit when the snapshot moves past 47.
 
 Bun was attempted, reverted, and then migrated a third way. Nixpkgs ships 1.3.13 — on
 the pin and on `master` — and two of this repository's proofs fail on it while passing
-on 1.4.0. One is a real difference in when `Symbol.species` is read rather than a slow
-machine, so no timeout or configuration change reaches it, and weakening a proof to
-move a job to Nix was never a trade worth making.
+on 1.4.0 and 1.4.2, the version now pinned. One is a real difference in when
+`Symbol.species` is read rather than a slow machine, so no timeout or configuration
+change reaches it, and weakening a proof to move a job to Nix was never a trade worth
+making.
 
 What changed is the reading of the problem. Nixpkgs fetches Bun as a **prebuilt
 archive** — `stdenvNoCC.mkDerivation`, `dontBuild = true`, unzip, `install -Dm 755`,
@@ -89,8 +90,8 @@ builds. The job's flake therefore keeps that recipe and replaces only `src`:
 
 ```nix
 pinned = pkgs.bun.overrideAttrs {
-    version = "1.4.0";
-    src = pkgs.fetchurl { url = "…/bun-v1.4.0/bun-linux-aarch64.zip"; hash = "sha256-…"; };
+    version = "1.4.2";
+    src = pkgs.fetchurl { url = "…/bun-v1.4.2/bun-linux-aarch64.zip"; hash = "sha256-…"; };
 };
 ```
 

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787753485,
-        "narHash": "sha256-BZWCi9ZRJiARTuKTbbtvFTj7t1TK4G3UEckT3HyNfRg=",
+        "lastModified": 1788807765,
+        "narHash": "sha256-J9oC0bKnkXUrMegqRTXVkyDFJ0gn2U/Qpoo9HgGMQmA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "062346a6d85bc4b49dfaa61c986e9c5be21217d1",
+        "rev": "93108a538f079596c9a16c72cf03e9322782b6dd",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "062346a6d85bc4b49dfaa61c986e9c5be21217d1",
+        "rev": "93108a538f079596c9a16c72cf03e9322782b6dd",
         "type": "github"
       }
     },
@@ -29,17 +29,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1787993548,
-        "narHash": "sha256-+IAEnmmx5YIhUWo0lp15jLLHchnXo5yKgWsi6C6Cf+0=",
+        "lastModified": 1788851328,
+        "narHash": "sha256-YOwlUD0Lt/3SulKhZ7z0Jmgbq/DWh8SjnGwUlFSw+YM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "996e9b0b019a4a9eb9e9a5641aefa06d801b5895",
+        "rev": "6ae57a71bcb0bebc7a66cc2bd76942c4cf649167",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "996e9b0b019a4a9eb9e9a5641aefa06d801b5895",
+        "rev": "6ae57a71bcb0bebc7a66cc2bd76942c4cf649167",
         "type": "github"
       }
     }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -1,15 +1,15 @@
 {
-    inputs.nixpkgs.url = "github:NixOS/nixpkgs/062346a6d85bc4b49dfaa61c986e9c5be21217d1";
-    inputs.rust-overlay.url = "github:oxalica/rust-overlay/996e9b0b019a4a9eb9e9a5641aefa06d801b5895";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/93108a538f079596c9a16c72cf03e9322782b6dd";
+    inputs.rust-overlay.url = "github:oxalica/rust-overlay/6ae57a71bcb0bebc7a66cc2bd76942c4cf649167";
     inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
     outputs = { nixpkgs, rust-overlay, ... }: let
         shell = { pkgs, targets, shellHook, url, hash, ... }: let
-            rust = pkgs.rust-bin.stable."1.98.0".minimal.override {
+            rust = pkgs.rust-bin.stable."1.98.1".minimal.override {
                 extensions = [ "clippy" "rustfmt" ];
                 targets = targets;
             };
             pinned = pkgs.bun.overrideAttrs {
-                version = "1.4.0";
+                version = "1.4.2";
                 src = pkgs.fetchurl {
                     url = url;
                     hash = hash;
@@ -32,8 +32,8 @@
             pkgs = pkgs;
             targets = [ "wasm32-wasip1" "wasm32-wasip2" "wasm32-unknown-unknown" "wasm32-wasip1-threads" ];
             shellHook = "";
-            url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-linux-aarch64.zip";
-            hash = "sha256-SxozLuhhmD65O8/m93D/+U4+MbLDiL2uo8jtNeWO7Q4=";
+            url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.2/bun-linux-aarch64.zip";
+            hash = "sha256-VDKLvC2cjgyfiSxUTWbFeoO4QTnjSQnl7oF1jxrI/ac=";
         };
         devShells.x86_64-linux.default = let
             pkgs = import nixpkgs {
@@ -47,8 +47,8 @@
             shellHook = ''
                 export CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER=${pkgs.pkgsi686Linux.stdenv.cc}/bin/cc
             '';
-            url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-linux-x64.zip";
-            hash = "sha256-LQP7X7g6yLVnrKCigbLOGhoZ1Ij1bClo2Iw/Jekv5FI=";
+            url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.2/bun-linux-x64.zip";
+            hash = "sha256-NjaPrvdSeHXV/6UuU81IAhdB8qg+tiCKjdZAaNQiqRM=";
         };
         devShells.aarch64-darwin.default = let
             pkgs = import nixpkgs {
@@ -60,8 +60,8 @@
             pkgs = pkgs;
             targets = [ "wasm32-wasip1" "wasm32-wasip2" "wasm32-unknown-unknown" "wasm32-wasip1-threads" ];
             shellHook = "";
-            url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-darwin-aarch64.zip";
-            hash = "sha256-xmnpf2Fk4cluBwF0jbmN+ndJKQjL2DlMdVcTSnNd44E=";
+            url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.2/bun-darwin-aarch64.zip";
+            hash = "sha256-kJh6OhbX21VtiGrD1VHnttPt8KHPQ6yu1iLoZ2vh0S8=";
         };
         devShells.x86_64-darwin.default = let
             pkgs = import nixpkgs {
@@ -73,8 +73,8 @@
             pkgs = pkgs;
             targets = [ "wasm32-wasip1" "wasm32-wasip2" "wasm32-unknown-unknown" "wasm32-wasip1-threads" ];
             shellHook = "";
-            url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-darwin-x64-baseline.zip";
-            hash = "sha256-2pufG0unZsbymXEfON+qmGI+HtnECJaqU9uAPFLsH6A=";
+            url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.2/bun-darwin-x64-baseline.zip";
+            hash = "sha256-utW71s8U0JgNEV9ZVMn/kE32GdXplNLaH/zNPzFjALA=";
         };
     };
 }

--- a/nix/node22/flake.lock
+++ b/nix/node22/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787753485,
-        "narHash": "sha256-BZWCi9ZRJiARTuKTbbtvFTj7t1TK4G3UEckT3HyNfRg=",
+        "lastModified": 1788807765,
+        "narHash": "sha256-J9oC0bKnkXUrMegqRTXVkyDFJ0gn2U/Qpoo9HgGMQmA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "062346a6d85bc4b49dfaa61c986e9c5be21217d1",
+        "rev": "93108a538f079596c9a16c72cf03e9322782b6dd",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "062346a6d85bc4b49dfaa61c986e9c5be21217d1",
+        "rev": "93108a538f079596c9a16c72cf03e9322782b6dd",
         "type": "github"
       }
     },

--- a/nix/node22/flake.nix
+++ b/nix/node22/flake.nix
@@ -1,5 +1,5 @@
 {
-    inputs.nixpkgs.url = "github:NixOS/nixpkgs/062346a6d85bc4b49dfaa61c986e9c5be21217d1";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/93108a538f079596c9a16c72cf03e9322782b6dd";
     outputs = { nixpkgs, ... }: {
         devShells.aarch64-linux.default = let
             pkgs = import nixpkgs {

--- a/nix/node24/flake.lock
+++ b/nix/node24/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787753485,
-        "narHash": "sha256-BZWCi9ZRJiARTuKTbbtvFTj7t1TK4G3UEckT3HyNfRg=",
+        "lastModified": 1788807765,
+        "narHash": "sha256-J9oC0bKnkXUrMegqRTXVkyDFJ0gn2U/Qpoo9HgGMQmA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "062346a6d85bc4b49dfaa61c986e9c5be21217d1",
+        "rev": "93108a538f079596c9a16c72cf03e9322782b6dd",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "062346a6d85bc4b49dfaa61c986e9c5be21217d1",
+        "rev": "93108a538f079596c9a16c72cf03e9322782b6dd",
         "type": "github"
       }
     },

--- a/nix/node24/flake.nix
+++ b/nix/node24/flake.nix
@@ -1,5 +1,5 @@
 {
-    inputs.nixpkgs.url = "github:NixOS/nixpkgs/062346a6d85bc4b49dfaa61c986e9c5be21217d1";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/93108a538f079596c9a16c72cf03e9322782b6dd";
     outputs = { nixpkgs, ... }: {
         devShells.aarch64-linux.default = let
             pkgs = import nixpkgs {

--- a/todo/blocked/bun-optional-chain-parentheses.md
+++ b/todo/blocked/bun-optional-chain-parentheses.md
@@ -10,9 +10,11 @@ When `a` is nullish, `(a?.b)(c)` calls `undefined` and throws. JavaScriptCore,
 and therefore `bun`, carries the short-circuit through the parentheses instead
 and evaluates the whole expression to `undefined`.
 
-Measured against Node v22.22.2 (V8) on `bun` 1.3.11 and 1.4.0 — the latter is
-the version pinned in [`fjs/ci/config/module.f.mjs`](../../fjs/ci/config/module.f.mjs),
-so this is what CI runs — with `u` nullish:
+Measured against Node v22.22.2 (V8) on `bun` 1.3.11, 1.4.0, and 1.4.2 — the
+last is the version pinned in [`fjs/ci/config/module.f.mjs`](../../fjs/ci/config/module.f.mjs),
+so this is what CI runs — with `u` nullish. All three `bun` versions agree,
+including through `eval` and `new Function`, which is why the table has one
+`bun` column rather than one per version:
 
 |expression|Node (V8)|bun (JavaScriptCore)|
 |---|---|---|


### PR DESCRIPTION
## Summary
This PR updates several key development dependencies and toolchain versions across the project's CI configuration and Nix flake definitions.

## Key Changes
- **Node.js**: Updated from v26.7.0 to v26.8.1 across all CI workflows and configuration files
- **Rust**: Updated from 1.98.0 to 1.98.1 in Rust toolchain setup
- **Bun**: Updated from 1.4.0 to 1.4.2, including updated download URLs and SHA-256 hashes for all supported platforms (aarch64-linux, x86_64-linux, aarch64-darwin, x86_64-darwin)
- **FunctionalScript**: Updated from 0.48.0 to 0.49.0 in npm global installation
- **Nixpkgs**: Updated to a newer commit (93108a538f079596c9a16c72cf03e9322782b6dd) across all Nix flake configurations
- **Rust Overlay**: Updated to a newer commit (6ae57a71bcb0bebc7a66cc2bd76942c4cf649167)

## Implementation Details
- All version updates are reflected consistently across CI workflow files (.github/workflows/ci.yml, npm-publish.yml)
- Bun binary hashes were updated for all four supported platform combinations in both nix/flake.nix and fjs/ci/config/module.f.mjs
- Nix flake.lock files were updated to reflect the new Nixpkgs and Rust overlay commits
- Documentation in fjs/ci/README.md was updated to reflect the new Node.js version assertion

https://claude.ai/code/session_015hvopDMwsh8pBVZyzWyK25