### PR TITLE
todo: namespace Git attestations and DISOT metadata

### DIFF
--- a/todo/git-name-resolution.md
+++ b/todo/git-name-resolution.md
@@ -55,6 +55,19 @@ They are two serializations of **one logical DISOT metadata value**:
 - `.disot.json` — JSON;
 - `.disot.data.js` — DataJS.
 
+That logical value MUST identify its format explicitly:
+
+```json
+{
+  "dialect": "vnd.fjs.disot"
+}
+```
+
+`vnd.fjs.disot` follows the same vendor-style `vnd.fjs.*` dialect convention as
+other FunctionalScript formats. The dialect is part of the metadata value, not
+inferred from the filename, so every supported `.disot.*` encoding carries the
+same required `dialect` field.
+
 ### Metadata lookup boundary
 
 DISOT metadata is recognized **only at the root of the Git commit tree**.
@@ -84,6 +97,7 @@ Preferred form:
 
 ```json
 {
+  "dialect": "vnd.fjs.disot",
   "name": "/secp256k1:23a/coolJsModule"
 }
 ```
@@ -102,6 +116,7 @@ A DISOT metadata file MAY use a relative self-name:
 
 ```json
 {
+  "dialect": "vnd.fjs.disot",
   "name": "./coolJsModule"
 }
 ```
@@ -150,6 +165,7 @@ entity/project rather than one contributor:
 
 ```json
 {
+  "dialect": "vnd.fjs.disot",
   "name": "/<project-or-shared-DID>/coolJsModule"
 }
 ```
@@ -160,6 +176,7 @@ Conceptually:
 
 ```json
 {
+  "dialect": "vnd.fjs.disot",
   "name": "/DID:Alice/parser",
   "lock": {
     "json": "<immutable-hash>"
@@ -170,6 +187,8 @@ Conceptually:
 The exact lock-map schema may reuse/evolve the existing recursive lock-map work.
 The important semantics are:
 
+- `dialect` — required constant `vnd.fjs.disot`, identifying the logical DISOT
+  metadata format independently of its file encoding;
 - `name` — the entity's DISOT path, absolute in the preferred form and relative
   only under the rules above;
 - `lock` — optional exact immutable resolutions for relative dependencies,
@@ -193,8 +212,9 @@ At least two encodings can provide such evidence:
 
 1. **detached DISOT provenance/signature blocks**, for example a CAS object that
    references the exact stored object hash and carries a signature + signer DID;
-2. **Git-native embedded signatures**, such as the companion `didsig`
-   prototype, whose own specification defines the signed projection/payload.
+2. **Git-native embedded signatures**, such as the companion
+   `vnd.fjs.gpgsig` prototype, whose own specification defines the signed
+   projection/payload.
 
 These forms are interoperable at the naming layer but are not required to have
 the same wire representation or target hash. The signature verifier for each
@@ -202,14 +222,14 @@ encoding decides whether the attestation authenticates the semantic revision;
 this naming design only consumes the verified result.
 
 Detached attestations remain important because independent parties can add
-trust later without rewriting the Git commit. Embedded `didsig` is therefore a
-Git-native attestation encoding, not a replacement for detached DISOT
-provenance.
+trust later without rewriting the Git commit. Embedded `vnd.fjs.gpgsig` is
+therefore a Git-native attestation encoding, not a replacement for detached
+DISOT provenance.
 
 The same representation-independence applies to timestamp evidence: an embedded
-`tstsig` may be one encoding, while detached DISOT timestamp/provenance blocks
-may provide another. Naming semantics depend on accepted evidence, not the
-container used to carry it.
+`vnd.fjs.ttssig` may be one encoding, while detached DISOT timestamp/provenance
+blocks may provide another. Naming semantics depend on accepted evidence, not
+the container used to carry it.
 
 ### Late evidence may adopt the exact immutable revision
 
@@ -372,6 +392,7 @@ Suppose Alice has an authoritative history whose metadata says:
 
 ```json
 {
+  "dialect": "vnd.fjs.disot",
   "name": "/DID:Alice/parser"
 }
 ```
@@ -415,11 +436,11 @@ Removing the recognized root `.disot.*` from an established semantic lineage is
 the no-new-name form of relinquishment.
 
 ```text
-C1  .disot.json = { name: /DID:Alice/parser }   authoritative
+C1  .disot.json = { dialect: vnd.fjs.disot, name: /DID:Alice/parser }   authoritative
  |
-C2  .disot.json unchanged                      authoritative
+C2  .disot.json unchanged                                              authoritative
  |
-C3  root .disot.* removed                      authorized + timestamped
+C3  root .disot.* removed                                              authorized + timestamped
 ```
 
 `C3` relinquishes the inherited name **only for the lineage(s) it causally
@@ -578,16 +599,18 @@ metadata value, for example:
 ```
 
 Adding an encoding MUST NOT add semantics. Every supported representation must
-round-trip the same data model, validation rules, name meaning, and lock
-behavior. Multiple recognized `.disot.*` files at the commit root remain an
-error. Nested files with those basenames remain ordinary content.
+round-trip the same data model, including the required
+`dialect: "vnd.fjs.disot"`, validation rules, name meaning, and lock behavior.
+Multiple recognized `.disot.*` files at the commit root remain an error. Nested
+files with those basenames remain ordinary content.
 
 ### Prototype tasks
 
-- [ ] Define the canonical logical `.disot` schema with one required path-valued
-      `name` and an optional recursive `lock`.
+- [ ] Define the canonical logical `.disot` schema with required
+      `dialect: "vnd.fjs.disot"`, one required path-valued `name`, and an optional
+      recursive `lock`.
 - [ ] Define canonical `.disot.json` and `.disot.data.js` encodings with the
-      same logical semantics.
+      same logical semantics and required dialect.
 - [ ] Recognize `.disot.*` only at the commit-tree root and reject multiple
       recognized root encodings.
 - [ ] Specify canonical absolute names `/<identity>/<path...>` and relative
@@ -604,9 +627,10 @@ error. Nested files with those basenames remain ordinary content.
 - [ ] Define a representation-independent authority-attestation interface used
       by naming resolution.
 - [ ] Support detached DISOT provenance/signature blocks without rewriting Git
-      commits; treat `didsig` as an optional Git-native attestation encoding.
-- [ ] Define representation-independent trusted timestamp evidence; keep `tstsig`
-      as one optional Git-native encoding.
+      commits; treat `vnd.fjs.gpgsig` as an optional Git-native attestation
+      encoding.
+- [ ] Define representation-independent trusted timestamp evidence; keep
+      `vnd.fjs.ttssig` as one optional Git-native encoding.
 - [ ] Define late-evidence adoption: detached authority/timestamp evidence may
       make the exact immutable revision it targets authoritative without a new
       Git commit.
@@ -665,5 +689,5 @@ error. Nested files with those basenames remain ordinary content.
   the future source/content convention carries naming/resolution metadata in
   root `.disot.*` files.
 - [Git trusted timestamp signatures](./git-trusted-timestamp-signatures.md) —
-  optional Git-native `didsig` / `tstsig` encodings; naming semantics remain
-  representation-independent.
+  optional Git-native `vnd.fjs.gpgsig` / `vnd.fjs.ttssig` encodings; naming
+  semantics remain representation-independent.

--- a/todo/git-name-resolution.md
+++ b/todo/git-name-resolution.md
@@ -213,7 +213,7 @@ At least two encodings can provide such evidence:
 1. **detached DISOT provenance/signature blocks**, for example a CAS object that
    references the exact stored object hash and carries a signature + signer DID;
 2. **Git-native embedded signatures**, such as the companion
-   `vnd.fjs.gpgsig` prototype, whose own specification defines the signed
+   `vnd.fjs.didsig` prototype, whose own specification defines the signed
    projection/payload.
 
 These forms are interoperable at the naming layer but are not required to have
@@ -222,7 +222,7 @@ encoding decides whether the attestation authenticates the semantic revision;
 this naming design only consumes the verified result.
 
 Detached attestations remain important because independent parties can add
-trust later without rewriting the Git commit. Embedded `vnd.fjs.gpgsig` is
+trust later without rewriting the Git commit. Embedded `vnd.fjs.didsig` is
 therefore a Git-native attestation encoding, not a replacement for detached
 DISOT provenance.
 
@@ -627,7 +627,7 @@ files with those basenames remain ordinary content.
 - [ ] Define a representation-independent authority-attestation interface used
       by naming resolution.
 - [ ] Support detached DISOT provenance/signature blocks without rewriting Git
-      commits; treat `vnd.fjs.gpgsig` as an optional Git-native attestation
+      commits; treat `vnd.fjs.didsig` as an optional Git-native attestation
       encoding.
 - [ ] Define representation-independent trusted timestamp evidence; keep
       `vnd.fjs.ttssig` as one optional Git-native encoding.
@@ -689,5 +689,5 @@ files with those basenames remain ordinary content.
   the future source/content convention carries naming/resolution metadata in
   root `.disot.*` files.
 - [Git trusted timestamp signatures](./git-trusted-timestamp-signatures.md) —
-  optional Git-native `vnd.fjs.gpgsig` / `vnd.fjs.ttssig` encodings; naming
+  optional Git-native `vnd.fjs.didsig` / `vnd.fjs.ttssig` encodings; naming
   semantics remain representation-independent.

--- a/todo/git-trusted-timestamp-signatures.md
+++ b/todo/git-trusted-timestamp-signatures.md
@@ -35,15 +35,22 @@ RFC 3161 defines a `TimeStampToken` whose signed `TSTInfo` contains the
 
 Prototype two new repeatable commit headers:
 
-- `vnd.fjs.gpgsig` — a DID-addressed author/attestor signature;
+- `vnd.fjs.didsig` — a DID-addressed author/attestor signature;
 - `vnd.fjs.ttssig` — an RFC 3161 `TimeStampToken`.
 
 The `vnd.fjs.*` prefix follows FunctionalScript's existing vendor-style dialect
 namespace and makes these explicitly FJS-defined extensions rather than Git
-standard headers. `vnd.fjs.gpgsig` deliberately does **not** begin with
+standard headers. `vnd.fjs.didsig` deliberately does **not** begin with
 `gpgsig`: current Git's signed-payload reconstruction treats `gpgsig*` headers as
 signature material, so a name such as `gpgsig2` would be excluded from the
 payload covered by a later ordinary `gpgsig`.
+
+`didsig` is intentionally DID-native rather than GPG/OpenPGP-specific. The
+signature algorithm and key representation come from the DID verification
+method, so the format can support DID methods using `secp256k1`, P-256,
+Ed25519, or future algorithms without requiring them to map to an OpenPGP key
+or signature format. The existing Git `gpgsig` header remains the conventional
+Git-signature layer and may use whatever signature formats Git supports.
 
 `tts` means **Trusted Time-Stamp**. The doubled `t` in `ttssig` is intentional;
 `tstsig` is avoided because it visually reads as "test signature".
@@ -64,7 +71,7 @@ committer ...
 <message>
 ```
 
-`A` MUST contain no `gpgsig`, `gpgsig-sha256`, `vnd.fjs.gpgsig`, or
+`A` MUST contain no `gpgsig`, `gpgsig-sha256`, `vnd.fjs.didsig`, or
 `vnd.fjs.ttssig` headers. A tool asked to create this form from an already
 signed/attested commit MUST reject it rather than silently remove signatures:
 removing an existing `gpgsig` changes the object being attested to, while adding
@@ -74,7 +81,7 @@ verification.
 All ordinary commit fields, parents, and the message are frozen once signing
 starts.
 
-#### 2. DID signatures (`vnd.fjs.gpgsig`)
+#### 2. DID signatures (`vnd.fjs.didsig`)
 
 Create zero or more independent DID signatures over the same canonical `A`:
 
@@ -84,13 +91,13 @@ S2 = DIDSign(did2, key2, Hash(A))
 ...
 ```
 
-Form `B` by adding every `vnd.fjs.gpgsig` header to `A`:
+Form `B` by adding every `vnd.fjs.didsig` header to `A`:
 
 ```text
-B = A + vnd.fjs.gpgsig(S1) + vnd.fjs.gpgsig(S2) + ...
+B = A + vnd.fjs.didsig(S1) + vnd.fjs.didsig(S2) + ...
 ```
 
-All `vnd.fjs.gpgsig` signatures therefore refer to the same base payload; they
+All `vnd.fjs.didsig` signatures therefore refer to the same base payload; they
 do not form a signature chain. Each value must bind at least:
 
 - the DID;
@@ -118,12 +125,12 @@ If the DID method cannot establish contemporaneous authorization, the verifier
 may report the key signature itself but MUST NOT present it as a historically
 verified DID identity.
 
-Once trusted timestamping starts, `vnd.fjs.gpgsig` headers MUST NOT be added,
+Once trusted timestamping starts, `vnd.fjs.didsig` headers MUST NOT be added,
 removed, or changed.
 
 #### 3. Trusted timestamps (`vnd.fjs.ttssig`)
 
-Timestamp `B`, including all `vnd.fjs.gpgsig` headers:
+Timestamp `B`, including all `vnd.fjs.didsig` headers:
 
 ```text
 H = Hash(B)
@@ -165,7 +172,7 @@ supports.
 
 #### 4. Existing Git signature (`gpgsig`)
 
-After all `vnd.fjs.gpgsig` and `vnd.fjs.ttssig` headers are final, optionally
+After all `vnd.fjs.didsig` and `vnd.fjs.ttssig` headers are final, optionally
 add a normal Git signature using existing Git semantics:
 
 ```text
@@ -175,7 +182,7 @@ D = C + gpgsig(G)
 
 This step is deliberately last. Current Git removes the recognized `gpgsig`
 header when reconstructing its signed payload, while the non-colliding
-`vnd.fjs.gpgsig` and `vnd.fjs.ttssig` headers remain. It therefore verifies `G`
+`vnd.fjs.didsig` and `vnd.fjs.ttssig` headers remain. It therefore verifies `G`
 against `C`, covering the DID signatures and timestamp tokens exactly as they
 were when `G` was produced.
 
@@ -189,16 +196,16 @@ general multi-signature facility.
 A specialized verifier reconstructs three different payloads from the final
 commit.
 
-For every `vnd.fjs.gpgsig`:
+For every `vnd.fjs.didsig`:
 
 ```text
 remove all standard Git signature headers
 remove all vnd.fjs.ttssig headers
-remove all vnd.fjs.gpgsig headers
+remove all vnd.fjs.didsig headers
 => A
 ```
 
-Verify every `vnd.fjs.gpgsig` cryptographically against `Hash(A)` and its bound
+Verify every `vnd.fjs.didsig` cryptographically against `Hash(A)` and its bound
 key. Separately verify the DID-to-key authorization at the relevant trusted-time
 bound before reporting a historical DID identity.
 
@@ -207,7 +214,7 @@ For every `vnd.fjs.ttssig`:
 ```text
 remove all standard Git signature headers
 remove all vnd.fjs.ttssig headers
-KEEP all vnd.fjs.gpgsig headers
+KEEP all vnd.fjs.didsig headers
 => B
 ```
 
@@ -234,7 +241,7 @@ A: commit payload
     |
     +-- zero or more DID signatures
     v
-B: A + vnd.fjs.gpgsig*
+B: A + vnd.fjs.didsig*
     |
     +-- zero or more independent RFC 3161 timestamps
     v
@@ -247,7 +254,7 @@ D: final Git commit
 
 The assertions are intentionally different:
 
-- `vnd.fjs.gpgsig`: key K signed `A`; DID attribution additionally requires
+- `vnd.fjs.didsig`: key K signed `A`; DID attribution additionally requires
   historical authorization of K for that DID;
 - `vnd.fjs.ttssig`: `B`, including all listed DID signatures, existed by the
   token/policy's trusted upper time bound;
@@ -267,7 +274,7 @@ parent <B>
 parent <C>
 ```
 
-Those parent object IDs are part of the payload covered by `vnd.fjs.gpgsig` and
+Those parent object IDs are part of the payload covered by `vnd.fjs.didsig` and
 `vnd.fjs.ttssig`. A single trusted timestamp on such a merge therefore anchors
 all of its parents, and recursively the histories named by those parents, under
 the usual hash-security assumptions.
@@ -285,10 +292,11 @@ patching Git itself.
 Creation should:
 
 - [ ] parse a prospective commit payload and reject pre-existing `gpgsig`,
-  `gpgsig-sha256`, `vnd.fjs.gpgsig`, or `vnd.fjs.ttssig` when starting a new
+  `gpgsig-sha256`, `vnd.fjs.didsig`, or `vnd.fjs.ttssig` when starting a new
   attested commit;
-- [ ] produce zero or more `vnd.fjs.gpgsig` values over exactly `A`, binding the
-  DID and immutable verification key/fingerprint;
+- [ ] produce zero or more `vnd.fjs.didsig` values over exactly `A`, binding the
+  DID and immutable verification key/fingerprint, using the signature algorithm
+  defined by the DID verification method rather than requiring OpenPGP;
 - [ ] produce one or more RFC 3161 requests over exactly `B`, accept only a
   successful response, extract its `TimeStampToken`, and embed that token as a
   repeatable `vnd.fjs.ttssig` header;
@@ -313,13 +321,15 @@ Git signature:
 Compatibility tests should cover:
 
 - [ ] `git cat-file -p`, `git show`, `git log`, `git fsck`, clone/fetch/push, and
-  garbage collection with `vnd.fjs.gpgsig`/`vnd.fjs.ttssig` present;
+  garbage collection with `vnd.fjs.didsig`/`vnd.fjs.ttssig` present;
 - [ ] capture the exact payload stock Git passes to its verifier and confirm
-  `vnd.fjs.gpgsig` and `vnd.fjs.ttssig` remain covered by a later ordinary
+  `vnd.fjs.didsig` and `vnd.fjs.ttssig` remain covered by a later ordinary
   `gpgsig`;
 - [ ] `git verify-commit` on a final commit whose ordinary `gpgsig` was added
   after `vnd.fjs.ttssig`;
-- [ ] zero, one, and multiple `vnd.fjs.gpgsig` values;
+- [ ] zero, one, and multiple `vnd.fjs.didsig` values;
+- [ ] DID key/signature algorithms not representable as the same OpenPGP key,
+  including a `secp256k1` case;
 - [ ] DID key rotation/recovery cases, including rejection or downgraded identity
   status when historical authorization cannot be established;
 - [ ] one and multiple `vnd.fjs.ttssig` values from different TSAs, all
@@ -331,7 +341,7 @@ Compatibility tests should cover:
 - [ ] SHA-1 and SHA-256 repositories, including the existing
   `gpgsig-sha256` transition rules;
 - [ ] malformed/duplicate/unsupported signature encodings and rejection rules;
-- [ ] attempting to add `vnd.fjs.gpgsig` or `vnd.fjs.ttssig` after an ordinary
+- [ ] attempting to add `vnd.fjs.didsig` or `vnd.fjs.ttssig` after an ordinary
   `gpgsig` has already sealed the commit.
 
 If the prototype demonstrates stable interoperability, prepare an upstream Git

--- a/todo/git-trusted-timestamp-signatures.md
+++ b/todo/git-trusted-timestamp-signatures.md
@@ -35,13 +35,18 @@ RFC 3161 defines a `TimeStampToken` whose signed `TSTInfo` contains the
 
 Prototype two new repeatable commit headers:
 
-- `didsig` — a DID-addressed author/attestor signature;
-- `tstsig` — an RFC 3161 `TimeStampToken`.
+- `vnd.fjs.gpgsig` — a DID-addressed author/attestor signature;
+- `vnd.fjs.ttssig` — an RFC 3161 `TimeStampToken`.
 
-The names are provisional, but `didsig` deliberately does **not** begin with
+The `vnd.fjs.*` prefix follows FunctionalScript's existing vendor-style dialect
+namespace and makes these explicitly FJS-defined extensions rather than Git
+standard headers. `vnd.fjs.gpgsig` deliberately does **not** begin with
 `gpgsig`: current Git's signed-payload reconstruction treats `gpgsig*` headers as
 signature material, so a name such as `gpgsig2` would be excluded from the
 payload covered by a later ordinary `gpgsig`.
+
+`tts` means **Trusted Time-Stamp**. The doubled `t` in `ttssig` is intentional;
+`tstsig` is avoided because it visually reads as "test signature".
 
 The important part is the payload projection defined for each signature class.
 
@@ -59,16 +64,17 @@ committer ...
 <message>
 ```
 
-`A` MUST contain no `gpgsig`, `gpgsig-sha256`, `didsig`, or `tstsig` headers.
-A tool asked to create this form from an already signed/attested commit MUST
-reject it rather than silently remove signatures: removing an existing
-`gpgsig` changes the object being attested to, while adding ordinary fields to
-an already-`gpgsig`-signed commit breaks normal Git signature verification.
+`A` MUST contain no `gpgsig`, `gpgsig-sha256`, `vnd.fjs.gpgsig`, or
+`vnd.fjs.ttssig` headers. A tool asked to create this form from an already
+signed/attested commit MUST reject it rather than silently remove signatures:
+removing an existing `gpgsig` changes the object being attested to, while adding
+ordinary fields to an already-`gpgsig`-signed commit breaks normal Git signature
+verification.
 
 All ordinary commit fields, parents, and the message are frozen once signing
 starts.
 
-#### 2. DID signatures (`didsig`)
+#### 2. DID signatures (`vnd.fjs.gpgsig`)
 
 Create zero or more independent DID signatures over the same canonical `A`:
 
@@ -78,14 +84,14 @@ S2 = DIDSign(did2, key2, Hash(A))
 ...
 ```
 
-Form `B` by adding every `didsig` header to `A`:
+Form `B` by adding every `vnd.fjs.gpgsig` header to `A`:
 
 ```text
-B = A + didsig(S1) + didsig(S2) + ...
+B = A + vnd.fjs.gpgsig(S1) + vnd.fjs.gpgsig(S2) + ...
 ```
 
-All `didsig` signatures therefore refer to the same base payload; they do not
-form a signature chain. Each value must bind at least:
+All `vnd.fjs.gpgsig` signatures therefore refer to the same base payload; they
+do not form a signature chain. Each value must bind at least:
 
 - the DID;
 - the verification-method/key identifier;
@@ -112,12 +118,12 @@ If the DID method cannot establish contemporaneous authorization, the verifier
 may report the key signature itself but MUST NOT present it as a historically
 verified DID identity.
 
-Once trusted timestamping starts, `didsig` headers MUST NOT be added, removed,
-or changed.
+Once trusted timestamping starts, `vnd.fjs.gpgsig` headers MUST NOT be added,
+removed, or changed.
 
-#### 3. Trusted timestamps (`tstsig`)
+#### 3. Trusted timestamps (`vnd.fjs.ttssig`)
 
-Timestamp `B`, including all `didsig` headers:
+Timestamp `B`, including all `vnd.fjs.gpgsig` headers:
 
 ```text
 H = Hash(B)
@@ -131,19 +137,19 @@ from its own clock and signs the resulting `TSTInfo` inside a `TimeStampToken`.
 
 An RFC 3161 `TimeStampResp` is only the protocol response wrapper. On successful
 status, the prototype MUST extract its `timeStampToken` and store exactly that
-`TimeStampToken` in `tstsig`, not the surrounding `TimeStampResp`.
+`TimeStampToken` in `vnd.fjs.ttssig`, not the surrounding `TimeStampResp`.
 
-Form `C` by adding zero or more independent `tstsig` headers:
+Form `C` by adding zero or more independent `vnd.fjs.ttssig` headers:
 
 ```text
-C = B + tstsig(T1) + tstsig(T2) + ...
+C = B + vnd.fjs.ttssig(T1) + vnd.fjs.ttssig(T2) + ...
 ```
 
-Every `tstsig` MUST timestamp exactly the same `B`. Multiple TSA tokens are
-parallel witnesses, not a chain: TSA2 does not timestamp TSA1's token. This also
-means an additional TSA token may be added later while no standard `gpgsig` has
-yet been added, because all `tstsig` fields are excluded when reconstructing
-`B`.
+Every `vnd.fjs.ttssig` MUST timestamp exactly the same `B`. Multiple TSA tokens
+are parallel witnesses, not a chain: TSA2 does not timestamp TSA1's token. This
+also means an additional TSA token may be added later while no standard
+`gpgsig` has yet been added, because all `vnd.fjs.ttssig` fields are excluded
+when reconstructing `B`.
 
 The prototype must define a deterministic text encoding for the binary
 `TimeStampToken`, for example base64 of its DER encoding using Git-style
@@ -159,8 +165,8 @@ supports.
 
 #### 4. Existing Git signature (`gpgsig`)
 
-After all `didsig` and `tstsig` headers are final, optionally add a normal Git
-signature using existing Git semantics:
+After all `vnd.fjs.gpgsig` and `vnd.fjs.ttssig` headers are final, optionally
+add a normal Git signature using existing Git semantics:
 
 ```text
 G = GitSign(C)
@@ -168,9 +174,10 @@ D = C + gpgsig(G)
 ```
 
 This step is deliberately last. Current Git removes the recognized `gpgsig`
-header when reconstructing its signed payload, while the non-colliding `didsig`
-and `tstsig` headers remain. It therefore verifies `G` against `C`, covering the
-DID signatures and timestamp tokens exactly as they were when `G` was produced.
+header when reconstructing its signed payload, while the non-colliding
+`vnd.fjs.gpgsig` and `vnd.fjs.ttssig` headers remain. It therefore verifies `G`
+against `C`, covering the DID signatures and timestamp tokens exactly as they
+were when `G` was produced.
 
 For the initial compatibility experiment, use the standard signature shapes Git
 already supports (`gpgsig`, and `gpgsig-sha256` where applicable). Do not depend
@@ -182,25 +189,25 @@ general multi-signature facility.
 A specialized verifier reconstructs three different payloads from the final
 commit.
 
-For every `didsig`:
+For every `vnd.fjs.gpgsig`:
 
 ```text
 remove all standard Git signature headers
-remove all tstsig headers
-remove all didsig headers
+remove all vnd.fjs.ttssig headers
+remove all vnd.fjs.gpgsig headers
 => A
 ```
 
-Verify every `didsig` cryptographically against `Hash(A)` and its bound key.
-Separately verify the DID-to-key authorization at the relevant trusted-time
+Verify every `vnd.fjs.gpgsig` cryptographically against `Hash(A)` and its bound
+key. Separately verify the DID-to-key authorization at the relevant trusted-time
 bound before reporting a historical DID identity.
 
-For every `tstsig`:
+For every `vnd.fjs.ttssig`:
 
 ```text
 remove all standard Git signature headers
-remove all tstsig headers
-KEEP all didsig headers
+remove all vnd.fjs.ttssig headers
+KEEP all vnd.fjs.gpgsig headers
 => B
 ```
 
@@ -227,11 +234,11 @@ A: commit payload
     |
     +-- zero or more DID signatures
     v
-B: A + didsig*
+B: A + vnd.fjs.gpgsig*
     |
     +-- zero or more independent RFC 3161 timestamps
     v
-C: B + tstsig*
+C: B + vnd.fjs.ttssig*
     |
     +-- optional current-Git signature
     v
@@ -240,12 +247,12 @@ D: final Git commit
 
 The assertions are intentionally different:
 
-- `didsig`: key K signed `A`; DID attribution additionally requires historical
-  authorization of K for that DID;
-- `tstsig`: `B`, including all listed DID signatures, existed by the
+- `vnd.fjs.gpgsig`: key K signed `A`; DID attribution additionally requires
+  historical authorization of K for that DID;
+- `vnd.fjs.ttssig`: `B`, including all listed DID signatures, existed by the
   token/policy's trusted upper time bound;
-- `gpgsig`: the conventional Git signer signed `C`, including all DID
-  signatures and trusted timestamp tokens.
+- `gpgsig`: the conventional Git signer signed `C`, including all DID signatures
+  and trusted timestamp tokens.
 
 The final `gpgsig` is not claimed to have existed at the trusted time; it may be
 added afterward.
@@ -260,10 +267,10 @@ parent <B>
 parent <C>
 ```
 
-Those parent object IDs are part of the payload covered by `didsig` and
-`tstsig`. A single trusted timestamp on such a merge therefore anchors all of
-its parents, and recursively the histories named by those parents, under the
-usual hash-security assumptions.
+Those parent object IDs are part of the payload covered by `vnd.fjs.gpgsig` and
+`vnd.fjs.ttssig`. A single trusted timestamp on such a merge therefore anchors
+all of its parents, and recursively the histories named by those parents, under
+the usual hash-security assumptions.
 
 This does not retroactively make an unsigned parent "signed by" the merge
 signer. An aware client should distinguish direct signatures from anchoring, for
@@ -278,12 +285,13 @@ patching Git itself.
 Creation should:
 
 - [ ] parse a prospective commit payload and reject pre-existing `gpgsig`,
-  `gpgsig-sha256`, `didsig`, or `tstsig` when starting a new attested commit;
-- [ ] produce zero or more `didsig` values over exactly `A`, binding the DID and
-  immutable verification key/fingerprint;
+  `gpgsig-sha256`, `vnd.fjs.gpgsig`, or `vnd.fjs.ttssig` when starting a new
+  attested commit;
+- [ ] produce zero or more `vnd.fjs.gpgsig` values over exactly `A`, binding the
+  DID and immutable verification key/fingerprint;
 - [ ] produce one or more RFC 3161 requests over exactly `B`, accept only a
   successful response, extract its `TimeStampToken`, and embed that token as a
-  repeatable `tstsig` header;
+  repeatable `vnd.fjs.ttssig` header;
 - [ ] optionally add an ordinary Git `gpgsig` last;
 - [ ] write the final object as a standard Git `commit` object and update a ref.
 
@@ -305,16 +313,17 @@ Git signature:
 Compatibility tests should cover:
 
 - [ ] `git cat-file -p`, `git show`, `git log`, `git fsck`, clone/fetch/push, and
-  garbage collection with `didsig`/`tstsig` present;
+  garbage collection with `vnd.fjs.gpgsig`/`vnd.fjs.ttssig` present;
 - [ ] capture the exact payload stock Git passes to its verifier and confirm
-  `didsig` and `tstsig` remain covered by a later ordinary `gpgsig`;
+  `vnd.fjs.gpgsig` and `vnd.fjs.ttssig` remain covered by a later ordinary
+  `gpgsig`;
 - [ ] `git verify-commit` on a final commit whose ordinary `gpgsig` was added
-  after `tstsig`;
-- [ ] zero, one, and multiple `didsig` values;
+  after `vnd.fjs.ttssig`;
+- [ ] zero, one, and multiple `vnd.fjs.gpgsig` values;
 - [ ] DID key rotation/recovery cases, including rejection or downgraded identity
   status when historical authorization cannot be established;
-- [ ] one and multiple `tstsig` values from different TSAs, all verifying the
-  same reconstructed `B`;
+- [ ] one and multiple `vnd.fjs.ttssig` values from different TSAs, all
+  verifying the same reconstructed `B`;
 - [ ] RFC 3161 responses with success/failure status, absent token, and tokens
   with/without explicit accuracy;
 - [ ] merge commits with multiple parents, including previously unsigned parent
@@ -322,8 +331,8 @@ Compatibility tests should cover:
 - [ ] SHA-1 and SHA-256 repositories, including the existing
   `gpgsig-sha256` transition rules;
 - [ ] malformed/duplicate/unsupported signature encodings and rejection rules;
-- [ ] attempting to add `didsig` or `tstsig` after an ordinary `gpgsig` has
-  already sealed the commit.
+- [ ] attempting to add `vnd.fjs.gpgsig` or `vnd.fjs.ttssig` after an ordinary
+  `gpgsig` has already sealed the commit.
 
 If the prototype demonstrates stable interoperability, prepare an upstream Git
 RFC proposing the header names, canonical payload projections, encodings, and


### PR DESCRIPTION
Rename the experimental Git attestation headers to the FunctionalScript vendor namespace:

- `didsig` -> `vnd.fjs.didsig`
- `tstsig` -> `vnd.fjs.ttssig`

`vnd.fjs.didsig` is intentionally DID-native rather than GPG/OpenPGP-specific. Its signature algorithm and key representation come from the DID verification method, so DID methods using `secp256k1`, P-256, Ed25519, or future algorithms are not required to map to an OpenPGP key/signature format. The existing Git `gpgsig` remains the conventional Git-signature layer.

`tts` means Trusted Time-Stamp; the doubled `t` is intentional. The vendor prefix makes the extension origin explicit while also avoiding Git's special `gpgsig*` payload handling.

Also make `dialect: "vnd.fjs.disot"` a required part of the logical `.disot` metadata value, shared by `.disot.json`, `.disot.data.js`, and any future lossless encoding.

Updates the trusted-timestamp and Git name-resolution TODOs only; no runtime behavior changes.