### PR TITLE
todo: two names that outlived the design around them

### DIFF
--- a/fjs/cas/todo/66o-read-streamfile-dedup.md
+++ b/fjs/cas/todo/66o-read-streamfile-dedup.md
@@ -115,8 +115,12 @@ conversion. So the caveat stands as a thing to check, not as a cast to plan for.
       required for the `List<ReadBytes,…>` → `List<FileCasOperation,…>`
       conversion, or whether the source parameter has already retired it.
 - [ ] Delete `streamFile` and point `casAddFile` at the moved loop as well, with
-      a chunk source of its own; keep the `read` JSDoc about "missing shard /
-      read error is an explicit error item, never EOF".
+      a chunk source of its own; keep what `read`'s comment now says about a
+      missing shard or a read error — that it fails the stream, a cell's own
+      failure being one the `undefined` that ends a stream can never be
+      mistaken for. The error *item* that wording used to name went with
+      `List`'s move of the failure into the cell
+      ([`../../effects/list/types.ts`](../../effects/list/types.ts)).
 - [ ] Run `tsc` and `fjs t`; confirm `fjs/cas/proof.f.mjs` still passes,
       including the short-final-chunk and read-error paths.
 

--- a/fjs/effects/node/todo/streaming-http-bodies.md
+++ b/fjs/effects/node/todo/streaming-http-bodies.md
@@ -74,8 +74,10 @@ export type RequestListener<O extends Operation> =
 ```
 
 `ServerResponse` gains `O` because a lazy body *is* an effect, and the
-operations it performs are the listener's own — `fjs/web`'s would be
-`ReadBytes`. It gains `release` because a lazy body may also *hold* something,
+operations it performs are the listener's own — `fjs/web`'s would be the
+handle effect's bounded read, and not `ReadBytes`, which takes a path and so
+resolves the name again on every chunk, for the reason "What the bound holds"
+below gives. It gains `release` because a lazy body may also *hold* something,
 and the runner is the only party present at every way one ends.
 `CreateServer`'s `RequestListener<Operation>` spelling does not change, and it
 is not erasure that keeps it there: the declaration pins


### PR DESCRIPTION
Two Codex findings on #1900 arrived after it merged, so they land here instead. Both
are residue: text that stopped being true when a later round of that PR settled the
design around it.

**`streaming-http-bodies.md`** — the type explanation still answered "which operations
does `fjs/web`'s body perform" with `ReadBytes`. That operation is
`(path, offset, size)` (`fjs/effects/node/types.ts:127`) and so resolves the name again
on every chunk — the race the same document's "What the bound holds" section, and its
own stage-1 tasks, introduce the held handle to prevent. The sentence predates that
section. It now names the handle effect's bounded read, using the name the tree already
uses rather than inventing a type name for an effect still to be designed, and keeps
`ReadBytes` as the operation explicitly ruled out, since `fjs/cas` does read by name and
a reader could otherwise carry that assumption across.

**`66o-read-streamfile-dedup.md`** — a task asked the implementation to keep a `read`
JSDoc about "missing shard / read error is an explicit error item, never EOF". There is
no such JSDoc: `e9c1ef4d` deleted that line, and `fileCas.read` is now an `ioStep` whose
comment says a failed read fails the stream and cannot be mistaken for the `undefined`
that ends one — the contract `fjs/effects/list/types.ts:35-45` states. The task now asks
to keep that distinction in the wording the code carries.

The Problem section's older sketches in that file are left alone: its Status note
already declares them stale in exactly this respect, which is a separate edit.

Markdown only. `node --test` 5462/5462, `node ./fjs/module.mjs t` 5501/0, on the pinned
Node 26.8.1. `tsc` was not run — the pinned typescript-go is unavailable here — but
neither file is TypeScript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
