### PR TITLE
ebnf: `literals`, a word list as a prefix tree

### DIFF
--- a/fjs/djs/todo/ebnf-ll1-port.md
+++ b/fjs/djs/todo/ebnf-ll1-port.md
@@ -82,7 +82,7 @@ Two ports, tokenizer first, each a grammar rewrite plus a backend swap:
 
 1. **Tokenizer.** Left-factor `*` in the block comment and `/` out of
    `comment` and `operator`; build the operator prefix tree from the
-   literal list with a helper; drop the `numError`
+   literal list with `literals` in `fjs/ebnf`; drop the `numError`
    poison and decide the number boundary in the layer above the tokens —
    a number or bigint token directly followed by a token that begins with
    an identifier character or a digit, no trivia between, is the error
@@ -129,6 +129,8 @@ reads values, not text.
       it is the consumer's, as that module's README says.
 - [ ] `ebnf/token_symbol/` moved, with proof; ebnf-migration's stage 4 half
       ticked.
+- [x] `literals`, the prefix tree over a word list, in `fjs/ebnf` with
+      proof; the punctuators of JavaScript build as one LL(1) rule.
 - [ ] Tokenizer grammar in EBNF beside the classical one, LL(1), with the
       comparison proof over the tokenizer's corpus.
 - [ ] Tokenizer on `ebnf/ll1`: mappings, the token-boundary check, error

--- a/fjs/ebnf/ll1/proof.f.mjs
+++ b/fjs/ebnf/ll1/proof.f.mjs
@@ -11,7 +11,7 @@ import { assert, assertEq, assertStructurallySame } from '../../asserts/module.f
 import { stringToCodePointList } from '../../text/utf16/module.f.mjs'
 import { toArray } from '../../types/list/module.f.mjs'
 import { unwrap } from '../../types/result/module.f.mjs'
-import { eof, join, option, range, repeat, repeatFrom0, repeatFrom1, times } from '../module.f.mjs'
+import { eof, join, literals, option, range, repeat, repeatFrom0, repeatFrom1, times } from '../module.f.mjs'
 import { toData } from '../data/module.f.mjs'
 import { dataJs } from '../lib/datajs/module.f.mjs'
 import { json } from '../lib/json/module.f.mjs'
@@ -266,6 +266,25 @@ const integers = text => {
     return listValue(ast)
 }
 
+/**
+ * The word under a node: its input symbols in order, a variant's tag
+ * passed over.
+ *
+ * @type {(node: Ast<Rule, unknown> | string) => string}
+ */
+const word = node =>
+    typeof node === 'string' ? '' :
+    node instanceof Array ? node.map(word).join('') :
+    String.fromCodePoint(node.symbol)
+
+/** The punctuators of JavaScript. */
+const punctuators = [
+    '{', '}', '(', ')', '[', ']', '.', '...', ';', ',', '<', '>', '<=', '>=', '==', '!=', '===', '!==',
+    '+', '-', '*', '%', '**', '++', '--', '<<', '>>', '>>>', '&', '|', '^', '!', '~', '&&', '||', '??',
+    '?', '?.', ':', '=', '+=', '-=', '*=', '%=', '**=', '<<=', '>>=', '>>>=', '&=', '|=', '^=', '&&=',
+    '||=', '??=', '=>', '/', '/=',
+]
+
 /** A JSON document is the grammar's `json` rule, then the end of input. */
 const document = /**@type {const}*/([json, eof])
 
@@ -491,6 +510,29 @@ export const proof = {
         // front would be paid once per token by a layer that resumes.
         unread: () => {
             assertStructurallySame(parser(digit)([s('1'), sym(0.5)]), ['ok', [s('1'), 1]])
+        },
+        // A prefix tree is read greedily: an optional round starts whenever
+        // the lookahead continues a word, so the longest word matches, and
+        // a word nothing continues stops where it ends. The word read is
+        // the symbols under the node.
+        literals: () => {
+            const p = parser(literals(['=', '==', '===', '=>', '!', '!=']))
+            /** @type {(text: string) => readonly [string, number]} */
+            const read = text => {
+                const [node, end] = unwrap(p(cps(text)))
+                return [word(node), end]
+            }
+            assertStructurallySame(read('==='), ['===', 3])
+            assertStructurallySame(read('==x'), ['==', 2])
+            assertStructurallySame(read('=>='), ['=>', 2])
+            assertStructurallySame(read('!'), ['!', 1])
+            assertStructurallySame(read('!x'), ['!', 1])
+            assertStructurallySame(p(cps('?')), ['error', 0])
+            assertStructurallySame(p(cps('')), ['error', 0])
+            // The punctuators of JavaScript, sharing prefixes throughout,
+            // are one LL(1) rule this way — the list a tokenizer's operator
+            // variant cannot be.
+            assertStructurallySame(unwrap(parser(literals(punctuators))(cps('>>>=')))[1], 4)
         },
     },
     // The rewrite set, folded into the parse: a mapped rule's node is handed
@@ -740,5 +782,8 @@ export const proof = {
         // the next integer's, and the backend refuses it, so a token layer
         // resumes a one-token parser instead (`mapping.resumed`).
         tokenRepeat: () => parser(repeatFrom0({ integer, punctuation })),
+        // What follows a prefix tree may not continue one of its words: `ab`
+        // would read two ways, and the backend says so before any input.
+        literalsFollow: () => parser([literals(['a', 'ab']), 'b']),
     },
 }

--- a/fjs/ebnf/ll1/proof.f.mjs
+++ b/fjs/ebnf/ll1/proof.f.mjs
@@ -529,6 +529,13 @@ export const proof = {
             assertStructurallySame(read('!x'), ['!', 1])
             assertStructurallySame(p(cps('?')), ['error', 0])
             assertStructurallySame(p(cps('')), ['error', 0])
+            // Going on is decided on one symbol and never undone: where the
+            // words have a gap, the symbol past the gap commits to the
+            // longer word, and the shorter one is not a fallback.
+            const dots = parser(literals(['.', '...']))
+            assertStructurallySame(unwrap(dots(cps('...')))[1], 3)
+            assertStructurallySame(unwrap(dots(cps('.x')))[1], 1)
+            assertStructurallySame(dots(cps('..x')), ['error', 2])
             // The punctuators of JavaScript, sharing prefixes throughout,
             // are one LL(1) rule this way — the list a tokenizer's operator
             // variant cannot be.

--- a/fjs/ebnf/module.f.mjs
+++ b/fjs/ebnf/module.f.mjs
@@ -185,7 +185,8 @@ const node = words => {
 }
 
 /**
- * One of the words, the longest that matches: the words as a prefix tree.
+ * One of the words, the longest the lookahead leads to: the words as a
+ * prefix tree.
  *
  * A variant of the words is not LL(1) where two share a first character —
  * `=`, `==` and `===` begin alike, and one symbol of lookahead cannot pick
@@ -194,6 +195,13 @@ const node = words => {
  * word ends there and longer words continue. An optional round starts
  * whenever the lookahead is in its first set, so a parse reads the longest
  * word, which is what a tokenizer means by maximal munch.
+ *
+ * Going on is decided on one symbol and never undone, as every LL(1)
+ * choice is. Where the words have a gap — `.` and `...` with no `..` —
+ * the second `.` commits to `...`, so `..x` is refused at the `x` rather
+ * than read as `.` twice: the shorter word is not a fallback, since a
+ * fallback is a second reading and this backend takes one. A grammar that
+ * wants `..` as two words says so in the list.
  *
  * What follows the rule in a grammar may not begin with a character that
  * continues a word: `literals(['a', 'ab'])` then `'b'` reads `ab` two

--- a/fjs/ebnf/module.f.mjs
+++ b/fjs/ebnf/module.f.mjs
@@ -9,6 +9,7 @@
  * @module
  *
  * @import { RangeSet } from '../types/range_set/types.ts'
+ * @import { StringMap } from '../types/object/types.ts'
  * @import { Info, Set, Rule, Repeat, Option, RepeatFrom, Times } from './types.ts'
  */
 
@@ -16,9 +17,11 @@ import { assert } from "../asserts/module.f.mjs"
 import { codePointListToString, stringToCodePointList } from "../text/utf16/module.f.mjs"
 import { isFixedArray } from "../types/array/module.f.mjs"
 import { toArray } from "../types/list/module.f.mjs"
+import { definedEntries } from "../types/object/module.f.mjs"
 import { complement, empty, fromRange, intersection, union as setUnion } from "../types/range_set/module.f.mjs"
 
 const { isSafeInteger } = Number
+const { fromEntries } = Object
 
 const isFixedArray2 =
     isFixedArray(2)
@@ -155,6 +158,65 @@ export const option = rule => () => ['repeat', 0, 1, rule]
  *  Option<readonly[R, RepeatFrom<0, readonly[S, R]>]>}
  */
 export const join = s => r => option([r, repeatFrom0([s, r])])
+
+/**
+ * The subtree of the words that begin here: each word is the tail left
+ * after the characters above, and an empty tail marks a word that ends
+ * here. At least one word, and no word twice.
+ *
+ * @type {(words: readonly (readonly number[])[]) => Rule}
+ */
+const node = words => {
+    /** @type {StringMap<readonly (readonly number[])[]>} */
+    const groups = words
+        .filter(w => w.length !== 0)
+        .reduce(
+            /** @type {(m: StringMap<readonly (readonly number[])[]>, w: readonly number[]) => StringMap<readonly (readonly number[])[]>} */
+            ((m, [c, ...tail]) => {
+                const k = codePointListToString([c])
+                return { ...m, [k]: [...(m[k] ?? []), tail] }
+            }),
+            {})
+    // A branch is its character alone where the one word through it ends
+    // right there, and the character then the subtree of what goes on.
+    const branches = fromEntries(definedEntries(groups).map(([k, tails]) =>
+        [k, tails.every(tail => tail.length === 0) ? k : [k, node(tails)]]))
+    return words.some(w => w.length === 0) ? option(branches) : branches
+}
+
+/**
+ * One of the words, the longest that matches: the words as a prefix tree.
+ *
+ * A variant of the words is not LL(1) where two share a first character —
+ * `=`, `==` and `===` begin alike, and one symbol of lookahead cannot pick
+ * one — but it can decide whether to go on, so the tree asks that instead:
+ * each node is a variant keyed by the next character, optional where a
+ * word ends there and longer words continue. An optional round starts
+ * whenever the lookahead is in its first set, so a parse reads the longest
+ * word, which is what a tokenizer means by maximal munch.
+ *
+ * What follows the rule in a grammar may not begin with a character that
+ * continues a word: `literals(['a', 'ab'])` then `'b'` reads `ab` two
+ * ways, and the backend refuses it as the first/follow conflict it is. A
+ * one-token grammar has nothing after it, and that is where this belongs.
+ *
+ * The tree is the words' own structure, so the node a match builds is
+ * nested — the word's characters down its branches — and a mapping reads
+ * the word back as the symbols under the node, as `lexeme` in
+ * `fjs/media/json/parser` does.
+ *
+ * @throws On no words, on an empty word — a rule that may match nothing
+ * decides nothing, and a token is never empty — and on a word spelled
+ * twice.
+ *
+ * @type {(words: readonly string[]) => Rule}
+ */
+export const literals = words => {
+    assert(words.length !== 0)
+    assert(words.every(w => w !== ''))
+    assert(new Set(words).size === words.length)
+    return node(words.map(w => toArray(stringToCodePointList(w))))
+}
 
 /**
  * The end of input, as a rule. A grammar that must consume the whole input

--- a/fjs/ebnf/proof.f.mjs
+++ b/fjs/ebnf/proof.f.mjs
@@ -6,6 +6,7 @@ import { assertStructurallySame } from '../asserts/module.f.mjs'
 import {
     eof,
     join,
+    literals,
     option,
     range,
     rangeEncode,
@@ -164,7 +165,32 @@ export const proof = {
             force(join(',')('a')),
             ['repeat', 0, 1, ['a', ['repeat', 0, Infinity, [',', 'a']]]])
     },
+    // A word list is a prefix tree: a variant keyed by the next character,
+    // optional where a word ends and longer words go on, and a character
+    // alone where the one word through it ends right there.
+    literals: {
+        tree: () => {
+            assertStructurallySame(
+                force(literals(['=', '==', '=>', '!'])),
+                { '=': ['=', ['repeat', 0, 1, { '=': '=', '>': '>' }]], '!': '!' })
+        },
+        // Order does not matter: the tree is the words', not the list's.
+        order: () => {
+            assertStructurallySame(force(literals(['===', '=', '=='])), force(literals(['=', '==', '==='])))
+        },
+        // A branch is one word's whole tail, however long, and an astral
+        // character is one branch, not two.
+        deep: () => {
+            assertStructurallySame(force(literals(['abc'])), { a: ['a', { b: ['b', { c: 'c' }] }] })
+            assertStructurallySame(force(literals([unicodeMax])), { [unicodeMax]: unicodeMax })
+        },
+    },
     throw: {
+        // A word list holds at least one word, no empty word — a rule that
+        // may match nothing decides nothing — and no word twice.
+        literalsRejectsNone: () => literals([]),
+        literalsRejectsEmptyWord: () => literals(['a', '']),
+        literalsRejectsRepeated: () => literals(['a', 'b', 'a']),
         // `range` takes exactly two symbols: one is not a range, and three is
         // not one either.
         rangeRejectsOne: () => range('a'),


### PR DESCRIPTION
Stacked on #1917, which is stacked on #1915. The prefix-tree helper `fjs/djs/todo/ebnf-ll1-port.md` names for the tokenizer's operator list, ahead of the grammar rewrite that uses it.

A variant of the words is not LL(1) where two share a first character — `=`, `==` and `===` begin alike, and one symbol of lookahead cannot pick one — but it can decide whether to go on, so the tree asks that instead: each node is a variant keyed by the next character, optional where a word ends there and longer words continue. An optional round starts whenever the lookahead is in its first set, so a parse reads the longest word, which is what a tokenizer means by maximal munch. Every layer stays an LL(1) grammar plus a mapping.

- `literals(words)` in `fjs/ebnf/module.f.mjs`, returning a `Rule`. No words, an empty word and a repeated word are refused.
- What follows the rule may not continue one of its words: `[literals(['a', 'ab']), 'b']` is refused by the backend as the first/follow conflict it is, pinned in `ll1`'s throw group. A one-token grammar has nothing after it, which is where the rule belongs.
- Proofs: the tree's shape in `ebnf/proof.f.mjs` (order-independent, a word's whole tail as one branch, an astral character as one branch), and its reading in `ll1/proof.f.mjs` — the longest word matches, a word nothing continues stops where it ends, the word is read back as the symbols under the node, and the 57 punctuators of JavaScript build as one LL(1) rule and read `>>>=` whole.
- The port issue names the helper and ticks it.

Checks: `tsc`, `node ./fjs/module.mjs t` (5540), `npm run gen` (no change), `node --test` with 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CZRKbBvWAYpYtgVpUa3UH

---
_Generated by [Claude Code](https://claude.ai/code/session_014CZRKbBvWAYpYtgVpUa3UH)_