### PR TITLE
ebnf/byte: the byte alphabet

### DIFF
--- a/fjs/bnf/todo/unicode-rules.md
+++ b/fjs/bnf/todo/unicode-rules.md
@@ -262,8 +262,11 @@ the parser port.
 - [ ] Leave `fjs/bnf/todo/proof-recognizer-and-fixtures.md`'s shared fixture
       as the directly authored `RuleSet` it specifies: it imports no text
       helper, neither this adapter's nor the classical one's.
-- [ ] Add byte helper proofs for byte boundaries and representative binary
-      sequences/ranges; Unicode proofs cover string/code-point conversion and
+- [x] Add byte helper proofs for byte boundaries and representative binary
+      sequences/ranges — shipped with
+      [`fjs/ebnf/byte/`](../../ebnf/byte/proof.f.mjs), which pins the
+      alphabet's boundaries and every rule form over bytes.
+- [ ] Add Unicode proofs covering string/code-point conversion and
       boundaries; the generic `fjs/ebnf/` proofs exercise abstract symbols.
 - [ ] Document the boundary: the core is generic; `fjs/ebnf/unicode` and
       `fjs/ebnf/byte` adapt concrete alphabets to generic grammar symbols.

--- a/fjs/bnf/todo/unicode-rules.md
+++ b/fjs/bnf/todo/unicode-rules.md
@@ -228,8 +228,10 @@ the parser port.
 
 - [ ] Add `fjs/ebnf/unicode/module.f.mjs` for Unicode code-point rule
       helpers, at that final path — not under `fjs/bnf/`.
-- [ ] Add `fjs/ebnf/byte/module.f.mjs` for binary byte-stream rule helpers,
-      likewise at its final path.
+- [x] Add `fjs/ebnf/byte/module.f.mjs` for binary byte-stream rule helpers,
+      likewise at its final path — shipped as
+      [`fjs/ebnf/byte/`](../../ebnf/byte/README.md), for
+      [git-objects](../../../todo/git-objects.md).
 - [ ] Have `fjs/ebnf/token_symbol` take `unicodeRange` from `fjs/ebnf/unicode`
       when it lands, so no `ebnf/` module reads text constants from a front
       end — a repoint of one constant after the adapter exists, which

--- a/fjs/ebnf/byte/README.md
+++ b/fjs/ebnf/byte/README.md
@@ -6,7 +6,8 @@ grammar reads. It is the byte half of
 [unicode-rules](../../bnf/todo/unicode-rules.md), landed for its first
 consumer, [git-objects](../../../todo/git-objects.md).
 
-- `module.f.mjs` — `byte`, `not`, `bytes`, `symbols`, `meta`, `byteParser`;
+- `module.f.mjs` — `byte`, `not`, `bytes`, `symbols`, `meta`, `byteParser`,
+  and `isByte`, the alphabet's membership for a consumer holding a `number`;
 - `types.ts` — `Byte`, the metadata of a byte.
 
 ## What it is

--- a/fjs/ebnf/byte/README.md
+++ b/fjs/ebnf/byte/README.md
@@ -7,7 +7,9 @@ grammar reads. It is the byte half of
 consumer, [git-objects](../../../todo/git-objects.md).
 
 - `module.f.mjs` — `byte`, `not`, `bytes`, `symbols`, `meta`, `byteParser`,
-  and `isByte`, the alphabet's membership for a consumer holding a `number`;
+  and, for a consumer holding numbers it means as bytes, `isByte`, the
+  alphabet's membership, and `byteArray`, a list as a dense array of bytes
+  with anything else refused, a hole included;
 - `types.ts` — `Byte`, the metadata of a byte.
 
 ## What it is

--- a/fjs/ebnf/byte/README.md
+++ b/fjs/ebnf/byte/README.md
@@ -34,7 +34,9 @@ one `Meta<Byte>` per byte with one shared metadata record, in the shape of
 `byteParser(rule, set)` is `parser` from [`../ll1`](../ll1/README.md) behind
 a check of the grammar against the alphabet, run before any input over the
 identity map `toData` returns — the map is keyed by every rule the lowering
-met, a string literal included, so the literal is checked as the text it is:
+met, a string literal included, so the literal is checked as the text it is;
+the one rule it does not key, a `const` thunk's payload, the check reaches
+through the thunk:
 
 - a **string** that is not ASCII;
 - a **symbol** that is not a byte — negative, fractional, `-0`, or `256`

--- a/fjs/ebnf/byte/README.md
+++ b/fjs/ebnf/byte/README.md
@@ -42,10 +42,12 @@ through the thunk:
 - a **string** that is not ASCII;
 - a **symbol** that is not a byte — negative, fractional, `-0`, or `256`
   and above;
-- a **set** with a boundary past `256`, or with an open tail — an odd
+- a **set** with a boundary outside `0..256`, or with an open tail — an odd
   number of boundaries runs to infinity from the last, so `['set', 256]`
-  holds every symbol above the bytes and no byte. EOF's `[-1, 0]` is within
-  both rules.
+  holds every symbol above the bytes and no byte. A boundary below `0` is
+  refused because the lowering would clip it, so `['set', -1, 2]` would
+  read as `[0, 2)`, a rule its author did not write; EOF is `null` in the
+  front end and never reaches this check as a set.
 
 What it cannot refuse is a text argument to `set` or `range` above `0x7F`.
 Both constructors lower it eagerly, so `set('é')` reaches the map as the set

--- a/fjs/ebnf/byte/README.md
+++ b/fjs/ebnf/byte/README.md
@@ -1,0 +1,52 @@
+# The byte alphabet
+
+The `ebnf/byte/` piece of [ebnf-migration](../../todo/ebnf-migration.md): the
+adapter a grammar over bytes is written against, and the input such a
+grammar reads. It is the byte half of
+[unicode-rules](../../bnf/todo/unicode-rules.md), landed for its first
+consumer, [git-objects](../../../todo/git-objects.md).
+
+- `module.f.mjs` — `byte`, `not`, `bytes`, `symbols`, `meta`, `byteParser`;
+- `types.ts` — `Byte`, the metadata of a byte.
+
+## What it is
+
+The LL(1) backend already fits bytes: its symbols are non-negative safe
+integers with EOF at `-1`, so a byte is an ordinary symbol and no byte has
+to stand in for the end of input. What a byte grammar lacks is a spelling
+for its terminals, because the front end spells a terminal as a code point
+— a string lowers to one symbol per code point, and `set` and `range` read
+their argument as text. Below `0x80` a code point and its byte coincide, so
+`'tree '` and `set(' \n')` spell the bytes they look like and a byte grammar
+uses them as they are. Above it the two part ways: `'é'` is one code point
+and two UTF-8 bytes, and a rule spelled that way matches the byte `0xE9`
+where its author may have meant `0xC3 0xA9` — a rule that matches and
+means nothing.
+
+So this module gives a byte grammar terminals of its own — `byte`, the
+universe; `not`, its complement; `bytes(...)`, one of the bytes given, the
+spelling for a byte above `0x7F` — and one reading of the input, `symbols`,
+one `Meta<Byte>` per byte with one shared metadata record, in the shape of
+[`../utf16`](../utf16/module.f.mjs).
+
+## What `byteParser` refuses, and what it cannot
+
+`byteParser(rule, set)` is `parser` from [`../ll1`](../ll1/README.md) behind
+a check of the grammar against the alphabet, run before any input over the
+identity map `toData` returns — the map is keyed by every rule the lowering
+met, a string literal included, so the literal is checked as the text it is:
+
+- a **string** that is not ASCII;
+- a **symbol** that is not a byte — negative, fractional, `-0`, or `256`
+  and above;
+- a **set** with a boundary past `256`. EOF's `[-1, 0]` is within it.
+
+What it cannot refuse is a text argument to `set` or `range` above `0x7F`.
+Both constructors lower it eagerly, so `set('é')` reaches the map as the set
+`[233, 234]`, which is `bytes(0xE9)` spelled another way and is accepted as
+that. The rule for a byte grammar is therefore a convention this module
+states and review holds: **a byte above `0x7F` is spelled through `bytes`
+or as a number, never through the front end's text helpers.** The `Set`
+type's phantom spelling still carries the constructor argument at the type
+level, so a type-level refusal of a non-ASCII spelling is the next step if
+the convention proves too weak.

--- a/fjs/ebnf/byte/README.md
+++ b/fjs/ebnf/byte/README.md
@@ -41,7 +41,10 @@ through the thunk:
 - a **string** that is not ASCII;
 - a **symbol** that is not a byte — negative, fractional, `-0`, or `256`
   and above;
-- a **set** with a boundary past `256`. EOF's `[-1, 0]` is within it.
+- a **set** with a boundary past `256`, or with an open tail — an odd
+  number of boundaries runs to infinity from the last, so `['set', 256]`
+  holds every symbol above the bytes and no byte. EOF's `[-1, 0]` is within
+  both rules.
 
 What it cannot refuse is a text argument to `set` or `range` above `0x7F`.
 Both constructors lower it eagerly, so `set('é')` reaches the map as the set

--- a/fjs/ebnf/byte/module.f.mjs
+++ b/fjs/ebnf/byte/module.f.mjs
@@ -57,15 +57,26 @@ export const isByte = b => isInteger(b) && b >= 0 && b < byteEnd && !sameValue(b
  */
 export const meta = { id: 'byte' }
 
+const { from } = Array
+
 /**
- * @throws If `b` is not a byte.
+ * A list of numbers a caller means as bytes, as a dense array of them:
+ * every position visited, so a hole in a sparse array is met as
+ * `undefined` and refused like any other value that is no byte, where
+ * `map` and `every` would skip it and hand a hole on.
  *
- * @type {(b: number) => Meta<Byte>}
+ * @throws If an item is not a byte.
+ *
+ * @type {(input: List<number>) => readonly number[]}
  */
-const symbol = b => {
-    assert(isByte(b), ['not a byte', b])
-    return { symbol: b, meta }
+export const byteArray = input => {
+    const a = from(toArray(input))
+    assert(a.every(isByte), ['not bytes', a])
+    return a
 }
+
+/** @type {(b: number) => Meta<Byte>} */
+const symbol = b => ({ symbol: b, meta })
 
 /**
  * The input a parser over this alphabet is given: the bytes of a list, in
@@ -79,7 +90,7 @@ const symbol = b => {
  *
  * @type {(input: List<number>) => readonly Meta<Byte>[]}
  */
-export const symbols = input => toArray(input).map(symbol)
+export const symbols = input => byteArray(input).map(symbol)
 
 /** Any one byte: the byte universe as a terminal. */
 export const byte = rangeEncode(0, 0xFF)

--- a/fjs/ebnf/byte/module.f.mjs
+++ b/fjs/ebnf/byte/module.f.mjs
@@ -117,14 +117,16 @@ const isAscii = s => toArray(stringToCodePointList(s)).every(c => c < 0x80)
 /**
  * Refuses a rule the lowering met that reaches past the alphabet: a string
  * that is not ASCII, a symbol that is not a byte, a set with a boundary
- * past the byte universe or with an open tail — an odd number of
+ * outside `0..256` or with an open tail. A boundary below `0` is refused
+ * because the lowering clips it — `['set', -1, 2]` would lower to `[0, 2)`,
+ * a rule with a meaning its author did not write — and EOF never arrives
+ * here as a set, being `null` in the front end; an odd number of
  * boundaries runs to infinity from the last one, so `['set', 256]` holds no
  * byte and every symbol above. A tuple, a variant and a repeat carry no symbol
  * of their own, and the rules under them are met on their own. A `const`
  * thunk's payload is not: the lowering names the payload under the thunk
  * and never registers it, so the thunk *is* the payload here, and a bare
- * string or number behind one is checked as if it were the key. EOF's set,
- * `[-1, 0]`, is within every boundary a byte set has.
+ * string or number behind one is checked as if it were the key.
  *
  * @type {(rule: Rule) => void}
  */
@@ -137,7 +139,7 @@ const check = rule => {
         const info = rule()
         if (info[0] === 'set') {
             const [, ...s] = info
-            assert(s.length % 2 === 0 && s.every(b => b <= byteEnd), ['a set in a byte grammar holds bytes only', s])
+            assert(s.length % 2 === 0 && s.every(b => b >= 0 && b <= byteEnd), ['a set in a byte grammar holds bytes only', s])
         } else if (info[0] === 'const') {
             check(info[1])
         }

--- a/fjs/ebnf/byte/module.f.mjs
+++ b/fjs/ebnf/byte/module.f.mjs
@@ -114,7 +114,9 @@ const isAscii = s => toArray(stringToCodePointList(s)).every(c => c < 0x80)
 /**
  * Refuses a rule the lowering met that reaches past the alphabet: a string
  * that is not ASCII, a symbol that is not a byte, a set with a boundary
- * past the byte universe. A tuple, a variant and a repeat carry no symbol
+ * past the byte universe or with an open tail — an odd number of
+ * boundaries runs to infinity from the last one, so `['set', 256]` holds no
+ * byte and every symbol above. A tuple, a variant and a repeat carry no symbol
  * of their own, and the rules under them are met on their own. A `const`
  * thunk's payload is not: the lowering names the payload under the thunk
  * and never registers it, so the thunk *is* the payload here, and a bare
@@ -132,7 +134,7 @@ const check = rule => {
         const info = rule()
         if (info[0] === 'set') {
             const [, ...s] = info
-            assert(s.every(b => b <= byteEnd), ['a set in a byte grammar holds bytes only', s])
+            assert(s.length % 2 === 0 && s.every(b => b <= byteEnd), ['a set in a byte grammar holds bytes only', s])
         } else if (info[0] === 'const') {
             check(info[1])
         }
@@ -153,8 +155,13 @@ const check = rule => {
  * cannot be seen here: `set('é')` reaches the map as the set `[233, 234]`,
  * which is `bytes(0xE9)` spelled another way, and is accepted as that.
  *
+ * The input's metadata `I` is this alphabet's, `Byte`, or a record carrying
+ * its `id` beside more — an offset, say — and never another alphabet's: a
+ * rewrite set written against another layer's input is refused at the
+ * type, so a mapping keeps to the layer it was written for.
+ *
  * @template {Rule} const R
- * @template [I=Byte]
+ * @template {Byte} [I=Byte]
  * @template [O=never]
  * @param {R} rule
  * @param {RewriteSet<I, O>} [set]

--- a/fjs/ebnf/byte/module.f.mjs
+++ b/fjs/ebnf/byte/module.f.mjs
@@ -1,0 +1,162 @@
+/**
+ * The byte alphabet: the terminals a grammar over bytes is written with,
+ * and the input such a grammar reads — one symbol per byte, `0..255`, each
+ * carrying the alphabet's metadata.
+ *
+ * The front end spells a terminal as a code point: a string lowers to one
+ * symbol per code point, and `set` and `range` read their argument as text.
+ * Below `0x80` a code point and its byte coincide, so `'tree '` and
+ * `set(' \n')` spell bytes as they are. Above it the two part ways — `'é'`
+ * is one code point and two UTF-8 bytes — and a rule spelled that way
+ * matches the byte `0xE9` where its author may have meant `0xC3 0xA9`. So a
+ * byte grammar takes its terminals above ASCII from {@link bytes}, and
+ * {@link byteParser} refuses, before any input, a string rule that is not
+ * ASCII, a symbol that is not a byte, and a set that reaches past the byte
+ * universe. What it cannot refuse is a text argument to `set` or `range`
+ * above `0x7F`: both lower it eagerly, so `set('é')` is `bytes(0xE9)` by
+ * the time any check sees it. See `./README.md`.
+ *
+ * @module
+ *
+ * @import { List } from '../../types/list/types.ts'
+ * @import { Ast, Meta } from '../ast/types.ts'
+ * @import { Parser, RewriteSet } from '../ll1/types.ts'
+ * @import { Rule, Set } from '../types.ts'
+ * @import { Byte } from './types.ts'
+ */
+
+import { assert } from '../../asserts/module.f.mjs'
+import { stringToCodePointList } from '../../text/utf16/module.f.mjs'
+import { toArray } from '../../types/list/module.f.mjs'
+import { rangeEncode, remove, union } from '../module.f.mjs'
+import { toData } from '../data/module.f.mjs'
+import { parser } from '../ll1/module.f.mjs'
+
+const { isInteger } = Number
+const { is: sameValue } = Object
+
+/** One past the last byte: the boundary a byte set never reaches past. */
+const byteEnd = 0x100
+
+/**
+ * Whether `b` is a byte: an integer in `0..255`, and not `-0`, which the
+ * data layer refuses as a second spelling of `0`.
+ *
+ * @type {(b: number) => boolean}
+ */
+const isByte = b => isInteger(b) && b >= 0 && b < byteEnd && !sameValue(b, -0)
+
+/**
+ * The metadata of every byte: one frozen record, shared by every leaf, so
+ * that a parse allocates nothing per symbol beyond the leaf itself.
+ *
+ * @type {Byte}
+ */
+export const meta = { id: 'byte' }
+
+/**
+ * @throws If `b` is not a byte.
+ *
+ * @type {(b: number) => Meta<Byte>}
+ */
+const symbol = b => {
+    assert(isByte(b), ['not a byte', b])
+    return { symbol: b, meta }
+}
+
+/**
+ * The input a parser over this alphabet is given: the bytes of a list, in
+ * order, each with the shared metadata. A `Vec` is read through
+ * `u8List(msb)` from `fjs/types/bit_vec`, and a `Uint8Array` through
+ * `fromArrayLike` from `fjs/types/list`.
+ *
+ * @throws If an item is not a byte: the input is refused at the boundary,
+ * where a value that is no byte would otherwise fail to match a set and
+ * read as a parse error somewhere inside the object.
+ *
+ * @type {(input: List<number>) => readonly Meta<Byte>[]}
+ */
+export const symbols = input => toArray(input).map(symbol)
+
+/** Any one byte: the byte universe as a terminal. */
+export const byte = rangeEncode(0, 0xFF)
+
+/**
+ * The bytes not in `s`: the front end's `remove` with the byte universe
+ * named, where its `unicodeMax` would be the wrong one.
+ *
+ * @type {<const S extends Set>(s: S) => Set<readonly ['remove', typeof byte, S]>}
+ */
+export const not = s => remove(byte, s)
+
+/**
+ * One of the given bytes: the terminal for a byte above `0x7F`, which no
+ * string spells and `set` and `range` mis-spell.
+ *
+ * @throws If no byte is given — a terminal that can never match is a
+ * mistake at the call site — or if an argument is not a byte.
+ *
+ * @type {<const B extends readonly number[]>(...b: B) => Set<readonly ['bytes', ...B]>}
+ */
+export const bytes = (...b) => {
+    assert(b.length !== 0 && b.every(isByte), ['not bytes', b])
+    const info = union(...b.map(v => rangeEncode(v, v)))()
+    return () => info
+}
+
+/**
+ * Whether every code point of `s` is ASCII, and so spells the byte it is.
+ *
+ * @type {(s: string) => boolean}
+ */
+const isAscii = s => toArray(stringToCodePointList(s)).every(c => c < 0x80)
+
+/**
+ * Refuses a rule the lowering met that reaches past the alphabet: a string
+ * that is not ASCII, a symbol that is not a byte, a set with a boundary
+ * past the byte universe. A tuple, a variant, a repeat and a `const` thunk
+ * carry no symbol of their own, and the rules under them are met on their
+ * own. EOF's set, `[-1, 0]`, is within every boundary a byte set has.
+ *
+ * @type {(rule: Rule) => void}
+ */
+const check = rule => {
+    if (typeof rule === 'string') {
+        assert(isAscii(rule), ['a string in a byte grammar is ASCII', rule])
+    } else if (typeof rule === 'number') {
+        assert(isByte(rule), ['a symbol in a byte grammar is a byte', rule])
+    } else if (typeof rule === 'function') {
+        const info = rule()
+        if (info[0] === 'set') {
+            const [, ...s] = info
+            assert(s.every(b => b <= byteEnd), ['a set in a byte grammar holds bytes only', s])
+        }
+    }
+}
+
+/**
+ * `parser` from `../ll1` for a grammar over bytes: the rule is refused
+ * before any input where it spells a symbol no byte is, and parsed as
+ * `parser` parses it otherwise.
+ *
+ * The check runs over the identity map `toData` returns, which is keyed by
+ * every rule the lowering met — a string literal included, so the literal
+ * is checked as the text it is, before its code points become sets. A text
+ * argument to `set` or `range` is lowered eagerly by its constructor and
+ * cannot be seen here: `set('é')` reaches the map as the set `[233, 234]`,
+ * which is `bytes(0xE9)` spelled another way, and is accepted as that.
+ *
+ * @template {Rule} const R
+ * @template [I=Byte]
+ * @template [O=never]
+ * @param {R} rule
+ * @param {RewriteSet<I, O>} [set]
+ * @returns {Parser<Ast<R, I, O>, I>}
+ */
+export const byteParser = (rule, set = []) => {
+    const [, , names] = toData(rule)
+    for (const key of names.keys()) {
+        check(key)
+    }
+    return parser(rule, set)
+}

--- a/fjs/ebnf/byte/module.f.mjs
+++ b/fjs/ebnf/byte/module.f.mjs
@@ -36,15 +36,18 @@ const { isInteger } = Number
 const { is: sameValue } = Object
 
 /** One past the last byte: the boundary a byte set never reaches past. */
-const byteEnd = 0x100
+const byteEnd = /** @type {const} */ (0x100)
 
 /**
  * Whether `b` is a byte: an integer in `0..255`, and not `-0`, which the
- * data layer refuses as a second spelling of `0`.
+ * data layer refuses as a second spelling of `0`. The alphabet's
+ * membership, for a consumer that holds a `number` it means as a byte —
+ * a `List<number>` it is about to write, say — and has to refuse one that
+ * is not.
  *
  * @type {(b: number) => boolean}
  */
-const isByte = b => isInteger(b) && b >= 0 && b < byteEnd && !sameValue(b, -0)
+export const isByte = b => isInteger(b) && b >= 0 && b < byteEnd && !sameValue(b, -0)
 
 /**
  * The metadata of every byte: one frozen record, shared by every leaf, so

--- a/fjs/ebnf/byte/module.f.mjs
+++ b/fjs/ebnf/byte/module.f.mjs
@@ -114,9 +114,12 @@ const isAscii = s => toArray(stringToCodePointList(s)).every(c => c < 0x80)
 /**
  * Refuses a rule the lowering met that reaches past the alphabet: a string
  * that is not ASCII, a symbol that is not a byte, a set with a boundary
- * past the byte universe. A tuple, a variant, a repeat and a `const` thunk
- * carry no symbol of their own, and the rules under them are met on their
- * own. EOF's set, `[-1, 0]`, is within every boundary a byte set has.
+ * past the byte universe. A tuple, a variant and a repeat carry no symbol
+ * of their own, and the rules under them are met on their own. A `const`
+ * thunk's payload is not: the lowering names the payload under the thunk
+ * and never registers it, so the thunk *is* the payload here, and a bare
+ * string or number behind one is checked as if it were the key. EOF's set,
+ * `[-1, 0]`, is within every boundary a byte set has.
  *
  * @type {(rule: Rule) => void}
  */
@@ -130,6 +133,8 @@ const check = rule => {
         if (info[0] === 'set') {
             const [, ...s] = info
             assert(s.every(b => b <= byteEnd), ['a set in a byte grammar holds bytes only', s])
+        } else if (info[0] === 'const') {
+            check(info[1])
         }
     }
 }
@@ -141,7 +146,9 @@ const check = rule => {
  *
  * The check runs over the identity map `toData` returns, which is keyed by
  * every rule the lowering met — a string literal included, so the literal
- * is checked as the text it is, before its code points become sets. A text
+ * is checked as the text it is, before its code points become sets. The one
+ * rule the map does not key is a `const` thunk's payload, which the
+ * lowering names under the thunk; the check follows the thunk to it. A text
  * argument to `set` or `range` is lowered eagerly by its constructor and
  * cannot be seen here: `set('é')` reaches the map as the set `[233, 234]`,
  * which is `bytes(0xE9)` spelled another way, and is accepted as that.

--- a/fjs/ebnf/byte/proof.f.mjs
+++ b/fjs/ebnf/byte/proof.f.mjs
@@ -128,6 +128,22 @@ export const proof = {
                 { id: 'word', bytes: ascii('42') },
             ])
         },
+        // The input's metadata may carry more than the alphabet's `id` — an
+        // offset here — and a rewrite set written against that record is
+        // one over this alphabet still.
+        extended: () => {
+            /** @type {Mappings<{ readonly id: 'byte', readonly offset: number }, { readonly id: 'at', readonly offset: number }>} */
+            const at = mapping
+            const w = repeatFrom1(range('az'))
+            const parse = byteParser(/** @type {const} */ ([w, eof]), [
+                at(w, bs => ({ symbol: 0, meta: { id: 'at', offset: bs[0].meta.offset } })),
+            ])
+            const [ast] = unwrap(parse(ascii('git').map((symbol, offset) => ({ symbol, meta: { id: 'byte', offset } }))))
+            assert(ast instanceof Array)
+            const [word] = ast
+            assert(!(word instanceof Array))
+            assertStructurallySame(word.meta, { id: 'at', offset: 0 })
+        },
         // A grammar that stops where its rule does reports the index it
         // left, so a reader can slice the rest.
         prefix: () => {
@@ -146,6 +162,9 @@ export const proof = {
             constSymbol: () => byteParser(() => ['const', 0x100]),
             set: () => byteParser(range(` ${unicodeMax}`)),
             rangeEncode: () => byteParser({ a: 'a', b: rangeEncode(0xFF, 0x100) }),
+            // An odd number of boundaries is open above the last one.
+            openAboveBytes: () => byteParser(() => ['set', 0x100]),
+            openFromZero: () => byteParser(() => ['set', 0]),
         },
     },
 }

--- a/fjs/ebnf/byte/proof.f.mjs
+++ b/fjs/ebnf/byte/proof.f.mjs
@@ -2,8 +2,8 @@
  * @import { Assert } from '../../asserts/types.ts'
  * @import { Equal } from '../../types/ts/types.ts'
  * @import { List } from '../../types/list/types.ts'
- * @import { Meta } from '../ast/types.ts'
- * @import { Mappings } from '../ll1/types.ts'
+ * @import { Ast, Meta } from '../ast/types.ts'
+ * @import { Mappings, Parser } from '../ll1/types.ts'
  * @import { Set } from '../types.ts'
  * @import { Byte } from './types.ts'
  */
@@ -120,10 +120,10 @@ export const proof = {
         parse: () => {
             const key = repeatFrom1(not(set(' \n')))
             const accent = /** @type {const} */ ([bytes(0xC3), bytes(0xA9)])
-            const value = { accent, plain: ['caf', 0x65] }
+            const value = /** @type {const} */ ({ accent, plain: ['caf', 0x65] })
             const line = () => /** @type {const} */ (['const', [key, ' ', value, '\n']])
             const rest = repeatFrom0(byte)
-            const parse = byteParser(/** @type {const} */ ([line, rest, eof]))
+            const parse = byteParser([line, rest, eof])
             const r = unwrap(parse(symbols([...ascii('k '), 0xC3, 0xA9, ...ascii('\n'), 0xFF, 0])))
             assertEq(r[1], 7)
             const [[k, , [tag, v], nl], tail] = r[0]
@@ -144,7 +144,7 @@ export const proof = {
         // become one symbol of the next alphabet.
         mapped: () => {
             const w = repeatFrom1(not(set(' ')))
-            const parse = byteParser(/** @type {const} */ ([w, ' ', w, eof]), [
+            const parse = byteParser([w, ' ', w, eof], [
                 word(w, bs => ({ symbol: 0, meta: { id: 'word', bytes: bs.map(({ symbol }) => symbol) } })),
             ])
             const [ast] = unwrap(parse(symbols(ascii('tree 42'))))
@@ -165,7 +165,7 @@ export const proof = {
             /** @type {Mappings<{ readonly id: 'byte', readonly offset: number }, { readonly id: 'at', readonly offset: number }>} */
             const at = mapping
             const w = repeatFrom1(range('az'))
-            const parse = byteParser(/** @type {const} */ ([w, eof]), [
+            const parse = byteParser([w, eof], [
                 at(w, bs => ({ symbol: 0, meta: { id: 'at', offset: bs[0].meta.offset } })),
             ])
             const [ast] = unwrap(parse(ascii('git').map((symbol, offset) => ({ symbol, meta: { id: 'byte', offset } }))))
@@ -177,8 +177,13 @@ export const proof = {
         // A grammar that stops where its rule does reports the index it
         // left, so a reader can slice the rest.
         prefix: () => {
-            const parse = byteParser(/** @type {const} */ ([repeatFrom1(range('09')), '\0']))
+            const d = repeatFrom1(range('09'))
+            const parse = byteParser([d, '\0'])
             assertEq(unwrap(parse(symbols([0x31, 0x32, 0, 0xFF, 0xFF])))[1], 3)
+            // `byteParser`'s `const R` keeps the argument a tuple of literals,
+            // where a dropped modifier would widen it to an array and `tsc`
+            // would still pass; this is what makes the modifier load-bearing.
+            /** @typedef {Assert<Equal<typeof parse, Parser<Ast<readonly [typeof d, '\0'], Byte>, Byte>>>} _ConstParameter */
         },
         // Every rule the lowering met is checked, wherever it sits.
         throw: {

--- a/fjs/ebnf/byte/proof.f.mjs
+++ b/fjs/ebnf/byte/proof.f.mjs
@@ -1,6 +1,7 @@
 /**
  * @import { Assert } from '../../asserts/types.ts'
  * @import { Equal } from '../../types/ts/types.ts'
+ * @import { List } from '../../types/list/types.ts'
  * @import { Meta } from '../ast/types.ts'
  * @import { Mappings } from '../ll1/types.ts'
  * @import { Set } from '../types.ts'
@@ -13,10 +14,18 @@ import { fromArrayLike } from '../../types/list/module.f.mjs'
 import { unwrap } from '../../types/result/module.f.mjs'
 import { eof, range, rangeEncode, repeatFrom0, repeatFrom1, set, times, unicodeMax } from '../module.f.mjs'
 import { mapping } from '../ll1/module.f.mjs'
-import { byte, byteParser, bytes, isByte, meta, not, symbols } from './module.f.mjs'
+import { byte, byteArray, byteParser, bytes, isByte, meta, not, symbols } from './module.f.mjs'
 
 /** @type {(s: string) => readonly number[]} */
 const ascii = s => [...s].map(c => c.charCodeAt(0))
+
+/**
+ * A sparse array, as it arrives from outside the type system, narrowed
+ * only at the call that must refuse it.
+ *
+ * @type {unknown}
+ */
+const hole = [, 0x61]
 
 /**
  * A word of bytes folded to one symbol carrying the bytes: the mapping a
@@ -85,6 +94,21 @@ export const proof = {
             above: () => symbols([0x100]),
             below: () => symbols([-1]),
             fraction: () => symbols([0.5]),
+            // A hole is met as `undefined`, not skipped.
+            hole: () => symbols(/** @type {List<number>} */ (hole)),
+        },
+    },
+    // The dense array `symbols` is built on: every position visited, a
+    // lazy list read through, and a hole or a non-byte refused.
+    byteArray: {
+        dense: () => {
+            assertStructurallySame(byteArray([0, 0xFF]), [0, 0xFF])
+            assertStructurallySame(byteArray(fromArrayLike(new Uint8Array([1, 2]))), [1, 2])
+            assertStructurallySame(byteArray([]), [])
+        },
+        throw: {
+            hole: () => byteArray(/** @type {List<number>} */ (hole)),
+            nonByte: () => byteArray([0x100]),
         },
     },
     byteParser: {

--- a/fjs/ebnf/byte/proof.f.mjs
+++ b/fjs/ebnf/byte/proof.f.mjs
@@ -140,6 +140,10 @@ export const proof = {
             stringUnderRepeat: () => byteParser(times(2)('a€')),
             symbol: () => byteParser(0x100),
             negativeSymbol: () => byteParser(['a', -1]),
+            // A `const` thunk's bare payload is never a key of the map,
+            // so the check follows the thunk to it.
+            constString: () => byteParser(() => ['const', 'é']),
+            constSymbol: () => byteParser(() => ['const', 0x100]),
             set: () => byteParser(range(` ${unicodeMax}`)),
             rangeEncode: () => byteParser({ a: 'a', b: rangeEncode(0xFF, 0x100) }),
         },

--- a/fjs/ebnf/byte/proof.f.mjs
+++ b/fjs/ebnf/byte/proof.f.mjs
@@ -1,0 +1,147 @@
+/**
+ * @import { Assert } from '../../asserts/types.ts'
+ * @import { Equal } from '../../types/ts/types.ts'
+ * @import { Meta } from '../ast/types.ts'
+ * @import { Mappings } from '../ll1/types.ts'
+ * @import { Set } from '../types.ts'
+ * @import { Byte } from './types.ts'
+ */
+
+import { assert, assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
+import { msb, u8List, u8ListToVec } from '../../types/bit_vec/module.f.mjs'
+import { fromArrayLike } from '../../types/list/module.f.mjs'
+import { unwrap } from '../../types/result/module.f.mjs'
+import { eof, range, rangeEncode, repeatFrom0, repeatFrom1, set, times, unicodeMax } from '../module.f.mjs'
+import { mapping } from '../ll1/module.f.mjs'
+import { byte, byteParser, bytes, meta, not, symbols } from './module.f.mjs'
+
+/** @type {(s: string) => readonly number[]} */
+const ascii = s => [...s].map(c => c.codePointAt(0) ?? 0)
+
+/**
+ * A word of bytes folded to one symbol carrying the bytes: the mapping a
+ * byte grammar's consumer writes, over the layer's metadata types.
+ *
+ * @type {Mappings<Byte, { readonly id: 'word', readonly bytes: readonly number[] }>}
+ */
+const word = mapping
+
+export const proof = {
+    // The universe is every byte, spelled as the range it is.
+    byte: () => {
+        assertStructurallySame(byte(), ['set', 0, 0x100])
+        /** @typedef {Assert<Equal<typeof byte, Set<readonly ['rangeEncode', 0, 255]>>>} _Spelling */
+    },
+    // `not` complements within the byte universe, not the Unicode one.
+    not: () => {
+        assertStructurallySame(not(set('\0'))(), ['set', 1, 0x100])
+        assertStructurallySame(not(set(' \n'))(), ['set', 0, 0x0A, 0x0B, 0x20, 0x21, 0x100])
+        assertStructurallySame(not(byte)(), ['set'])
+    },
+    bytes: {
+        // One run per byte, merged where they touch, and the spelling kept
+        // in the type.
+        set: () => {
+            const e = bytes(0xE9)
+            assertStructurallySame(e(), ['set', 0xE9, 0xEA])
+            assertStructurallySame(bytes(0xFF, 0, 1)(), ['set', 0, 2, 0xFF, 0x100])
+            /** @typedef {Assert<Equal<typeof e, Set<readonly ['bytes', 0xE9]>>>} _Spelling */
+        },
+        throw: {
+            none: () => bytes(),
+            above: () => bytes(0x100),
+            below: () => bytes(-1),
+            negativeZero: () => bytes(-0),
+            fraction: () => bytes(0.5),
+        },
+    },
+    symbols: {
+        // One symbol per byte, in order, and every leaf carries the one
+        // shared record, which names the alphabet.
+        list: () => {
+            const s = symbols([0x61, 0xFF, 0])
+            assertStructurallySame(s.map(({ symbol }) => symbol), [0x61, 0xFF, 0])
+            assert(s.every(x => x.meta === meta))
+            assertEq(meta.id, 'byte')
+        },
+        // The two inputs a caller holds at a boundary: a `Vec`, and a
+        // `Uint8Array`.
+        vec: () => {
+            const v = u8ListToVec(msb)([0x67, 0x69, 0x74])
+            assertStructurallySame(symbols(u8List(msb)(v)).map(({ symbol }) => symbol), [0x67, 0x69, 0x74])
+        },
+        uint8Array: () => {
+            const s = symbols(fromArrayLike(new Uint8Array([0xC3, 0xA9])))
+            assertStructurallySame(s.map(({ symbol }) => symbol), [0xC3, 0xA9])
+        },
+        empty: () => assertStructurallySame(symbols([]), []),
+        throw: {
+            above: () => symbols([0x100]),
+            below: () => symbols([-1]),
+            fraction: () => symbols([0.5]),
+        },
+    },
+    byteParser: {
+        // A grammar over every rule form — a string, a number, `not`,
+        // `bytes`, a repeat, a `const` thunk, a tuple, a variant, EOF — that
+        // reads a header line and takes the rest as bytes, with the two
+        // bytes of `é` spelled through `bytes`, where a string would have
+        // spelled one.
+        parse: () => {
+            const key = repeatFrom1(not(set(' \n')))
+            const accent = /** @type {const} */ ([bytes(0xC3), bytes(0xA9)])
+            const value = { accent, plain: ['caf', 0x65] }
+            const line = () => /** @type {const} */ (['const', [key, ' ', value, '\n']])
+            const rest = repeatFrom0(byte)
+            const parse = byteParser(/** @type {const} */ ([line, rest, eof]))
+            const r = unwrap(parse(symbols([...ascii('k '), 0xC3, 0xA9, ...ascii('\n'), 0xFF, 0])))
+            assertEq(r[1], 7)
+            const [[k, , [tag, v], nl], tail] = r[0]
+            assertStructurallySame(k.map(({ symbol }) => symbol), [0x6B])
+            assertEq(tag, 'accent')
+            assert(v instanceof Array)
+            assertStructurallySame(v.map(x => !(x instanceof Array) && x.symbol), [0xC3, 0xA9])
+            // A string's node is its symbols, one leaf for `'\n'`.
+            assertEq(nl[0].symbol, 0x0A)
+            assertStructurallySame(tail.map(({ symbol }) => symbol), [0xFF, 0])
+            // The other branch: a string's node is its symbols, and a
+            // number's the one symbol, so the tuple holds a list and a leaf.
+            assertStructurallySame(
+                unwrap(parse(symbols(ascii('k cafe\n'))))[0][0][2],
+                ['plain', [symbols(ascii('caf')), symbols([0x65])[0]]])
+        },
+        // A rewrite set is folded as `parser` folds it: the word's bytes
+        // become one symbol of the next alphabet.
+        mapped: () => {
+            const w = repeatFrom1(not(set(' ')))
+            const parse = byteParser(/** @type {const} */ ([w, ' ', w, eof]), [
+                word(w, bs => ({ symbol: 0, meta: { id: 'word', bytes: bs.map(({ symbol }) => symbol) } })),
+            ])
+            const [ast] = unwrap(parse(symbols(ascii('tree 42'))))
+            // The entry is unmapped, so its node is the tuple the machine
+            // built; the two words under it are mapped, so each is a symbol.
+            assert(ast instanceof Array)
+            const [a, , b] = ast
+            assert(!(a instanceof Array) && !(b instanceof Array))
+            assertStructurallySame([a.meta, b.meta], [
+                { id: 'word', bytes: ascii('tree') },
+                { id: 'word', bytes: ascii('42') },
+            ])
+        },
+        // A grammar that stops where its rule does reports the index it
+        // left, so a reader can slice the rest.
+        prefix: () => {
+            const parse = byteParser(/** @type {const} */ ([repeatFrom1(range('09')), '\0']))
+            assertEq(unwrap(parse(symbols([0x31, 0x32, 0, 0xFF, 0xFF])))[1], 3)
+        },
+        // Every rule the lowering met is checked, wherever it sits.
+        throw: {
+            string: () => byteParser('é'),
+            stringUnderRepeat: () => byteParser(times(2)('a€')),
+            symbol: () => byteParser(0x100),
+            negativeSymbol: () => byteParser(['a', -1]),
+            set: () => byteParser(range(` ${unicodeMax}`)),
+            rangeEncode: () => byteParser({ a: 'a', b: rangeEncode(0xFF, 0x100) }),
+        },
+    },
+}

--- a/fjs/ebnf/byte/proof.f.mjs
+++ b/fjs/ebnf/byte/proof.f.mjs
@@ -13,10 +13,10 @@ import { fromArrayLike } from '../../types/list/module.f.mjs'
 import { unwrap } from '../../types/result/module.f.mjs'
 import { eof, range, rangeEncode, repeatFrom0, repeatFrom1, set, times, unicodeMax } from '../module.f.mjs'
 import { mapping } from '../ll1/module.f.mjs'
-import { byte, byteParser, bytes, meta, not, symbols } from './module.f.mjs'
+import { byte, byteParser, bytes, isByte, meta, not, symbols } from './module.f.mjs'
 
 /** @type {(s: string) => readonly number[]} */
-const ascii = s => [...s].map(c => c.codePointAt(0) ?? 0)
+const ascii = s => [...s].map(c => c.charCodeAt(0))
 
 /**
  * A word of bytes folded to one symbol carrying the bytes: the mapping a
@@ -37,6 +37,12 @@ export const proof = {
         assertStructurallySame(not(set('\0'))(), ['set', 1, 0x100])
         assertStructurallySame(not(set(' \n'))(), ['set', 0, 0x0A, 0x0B, 0x20, 0x21, 0x100])
         assertStructurallySame(not(byte)(), ['set'])
+    },
+    // The membership every check here rests on: the integers `0..255`, and
+    // no other number.
+    isByte: () => {
+        assert([0, 1, 0x7F, 0x80, 0xFF].every(isByte))
+        assert([-1, 0x100, 0.5, -0, NaN, Infinity].every(b => !isByte(b)))
     },
     bytes: {
         // One run per byte, merged where they touch, and the spelling kept

--- a/fjs/ebnf/byte/proof.f.mjs
+++ b/fjs/ebnf/byte/proof.f.mjs
@@ -171,6 +171,8 @@ export const proof = {
             // An odd number of boundaries is open above the last one.
             openAboveBytes: () => byteParser(() => ['set', 0x100]),
             openFromZero: () => byteParser(() => ['set', 0]),
+            // A negative boundary would be clipped by the lowering.
+            negativeBoundary: () => byteParser(() => ['set', -1, 2]),
         },
     },
 }

--- a/fjs/ebnf/byte/types.ts
+++ b/fjs/ebnf/byte/types.ts
@@ -1,0 +1,13 @@
+/**
+ * Type-level API of the byte alphabet: the metadata of a byte.
+ *
+ * @module
+ */
+
+/**
+ * The metadata of a byte with nothing the grammar ignored about it — the
+ * alphabet's `id` and nothing else. A caller that knows more about a byte,
+ * its offset say, hands over a record carrying this `id` beside it, and a
+ * parser over this alphabet accepts it as it is.
+ */
+export type Byte = { readonly id: 'byte' }

--- a/fjs/todo/ebnf-migration.md
+++ b/fjs/todo/ebnf-migration.md
@@ -199,7 +199,7 @@ fjs/ebnf/
   terminal/                the symbol domain, EOF, integer helpers over range_set (rewrite)
   unicode/                 text adapter: str, not, unicodeRange, …   (rewrite)
   utf16/                   the code-unit alphabet: its metadata, and a text as symbols (shipped)
-  byte/                    binary alphabet adapter, when a consumer needs it (rewrite)
+  byte/                    the byte alphabet: its terminals, its metadata, and bytes as symbols (shipped)
   data/                    RuleSet IR with bounded Repeat, emptyTagMap (rewrite)
   matcher/                 cursor, EOF, AST, transformer tools       (retire, unless a second backend wants it — see the triage)
   ast/                     the typed AST with its metadata channel   (shipped)
@@ -373,9 +373,10 @@ consumer port"), never by number, so a renumbering here cannot strand them.
    `repeatItem` as its own either way.
 3. **`ebnf/unicode/`.** The text adapter in EBNF forms, before anything that
    imports it. `ebnf/byte/`, the other half of unicode-rules, has the same
-   owner and lands whenever its first consumer wants it — the recognizer
-   backend, per that issue; nothing in this plan needs it earlier, and
-   nothing forbids it earlier. `ebnf/matcher/` was this stage's too, and is
+   owner and was to land whenever its first consumer wanted it — shipped as
+   [`ebnf/byte/`](../ebnf/byte/README.md) for
+   [git-objects](../../todo/git-objects.md), ahead of `unicode/`, since it
+   depends on nothing this stage adds. `ebnf/matcher/` was this stage's too, and is
    no longer anyone's: the backend shipped without it (the triage's
    `matcher/` row, **Amended**).
 4. **`ebnf/token_symbol/` and `ebnf/ll1/`.** `token_symbol`
@@ -437,7 +438,7 @@ consumer port"), never by number, so a renumbering here cannot strand them.
       [README](../ebnf/data/README.md); rule-visitor absorbed, 042 moved,
       665 left with `bnf/data`.
 - [ ] Stage 3: `ebnf/unicode/` with proof; unicode-rules' `unicode/` half
-      settled, its `byte/` half owed to the first consumer that wants it.
+      settled, its `byte/` half shipped as `ebnf/byte/`.
       `ebnf/matcher/` and `showAst` retired from the stage (**Amended**).
 - [x] `ebnf/ast/` with the metadata channel, and `ebnf/ll1/` folding the
       rewrite set keyed by rule identity, with proof; `ebnf/map/`, the

--- a/todo/git-objects.md
+++ b/todo/git-objects.md
@@ -263,7 +263,7 @@ reader slices the remainder as the payload without a grammar ever seeing
 it. That is what keeps a blob out of every parser — its payload is bytes
 the reader hands back — and it holds the size to the same standard: the
 reader compares it with the remainder's length and refuses the object on a
-mismatch. `type` is one word up to the space, `repeatFrom1(not(' '))`,
+mismatch. `type` is one word up to the space, `repeatFrom1(not(set(' ')))`,
 with the mapping accepting the four types and refusing any other word — a
 variant of the four keywords is not LL(1), since `tree` and `tag` share
 their first byte, and the generic word is how the header block reads its
@@ -308,7 +308,7 @@ Which of those forms are worth accepting is decided when one is met, as an
 issue naming the object.
 
 **Tree** is `repeatFrom0(entry)` then `eof`, with
-`entry = [repeatFrom1(octal), ' ', repeatFrom1(not('\0')), '\0', times(n)(byte)]`
+`entry = [repeatFrom1(octal), ' ', repeatFrom1(not(set('\0'))), '\0', times(n)(byte)]`
 for the repository's id width `n`. The mode set and its spelling, the entry
 order Git requires (by name, a subtree as if its name ended in `/`), and a
 name holding `/` are `git fsck`'s checks; they belong in a `validate` over

--- a/todo/git-objects.md
+++ b/todo/git-objects.md
@@ -374,8 +374,9 @@ approximated:
 
 ### Tasks
 
-- [ ] `fjs/ebnf/byte/`: `byte`, `not`, `bytes`, `symbols`, alphabet
-      validation, `byteParser`; proof.
+- [x] `fjs/ebnf/byte/`: `byte`, `not`, `bytes`, `symbols`, alphabet
+      validation, `byteParser`; proof — shipped as
+      [`fjs/ebnf/byte/`](../fjs/ebnf/byte/README.md).
 - [ ] `fjs/git/object/`: the envelope grammar, and the reader that slices
       the payload after the NUL and checks the size.
 - [ ] `fjs/git/header/`: the header block, shared by commit and tag.


### PR DESCRIPTION
Stacked on [#1921](https://github.com/functionalscript/functionalscript/pull/1921), whose branch it targets. The first implementation piece of [`todo/git-objects.md`](https://github.com/functionalscript/functionalscript/blob/claude/ebnf-byte/todo/git-objects.md): the alphabet adapter every grammar in that design is written against, with no Git-specific content — the byte half of unicode-rules, which ebnf-migration reserved for its first consumer.

## What it adds

`fjs/ebnf/byte/`, in the shape of `fjs/ebnf/utf16/`:

- `byte` — the byte universe as a terminal, `rangeEncode(0, 0xFF)`.
- `not(s)` — the bytes not in `s`: the front end's `remove` with the byte universe named, where its `unicodeMax` would be the wrong one.
- `bytes(...b)` — one of the bytes given: the spelling for a byte above `0x7F`, which no string spells and `set` and `range` mis-spell. Refuses no bytes, a value that is no byte, and `-0`.
- `symbols(list)` — the input a parser is given: one `Meta<Byte>` per byte over one shared metadata record, `meta`. A `Vec` is read through `u8List(msb)`, a `Uint8Array` through `fromArrayLike`. Refuses a value that is no byte at the boundary.
- `byteParser(rule, set)` — `parser` from `ebnf/ll1` behind a check of the grammar against the alphabet, run before any input over the identity map `toData` returns. That map is keyed by every rule the lowering met, a string literal included, so the literal is checked as the text it is. Refused: a string that is not ASCII, a symbol that is not a byte, a set with a boundary past 256.
- `Byte` in `types.ts`, the metadata of a byte.

## What it cannot refuse, and says so

A text argument to `set` or `range` above `0x7F` is lowered eagerly by its constructor, so `set('é')` reaches the map as `['set', 233, 234]`, which is `bytes(0xE9)` spelled another way. The README states the convention: in a byte grammar, a byte above `0x7F` is spelled through `bytes` or as a number, never through the front end's text helpers — and names the `Set` type's phantom spelling as the type-level refusal to add if the convention proves too weak. This is the answer the design issue settled on in #1921.

## Proof

100% line, branch and function coverage of `module.f.mjs`. The `byteParser` cases run a grammar over every rule form — a string, a number, `not`, `bytes`, a repeat, a `const` thunk, a tuple, a variant, EOF — and pin the tree it builds; a mapped case folds words to symbols of a next alphabet through a `Mappings<Byte, …>` binding; a prefix case shows a rule without `eof` reporting the index it stopped at, which is how the design's envelope reader slices a payload. Type-level asserts pin the spellings `byte` and `bytes` carry.

Also marks the adapter shipped in `fjs/todo/ebnf-migration.md` and checks its task off in `todo/git-objects.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdU8wW4oihFS1gj4dUAcPS

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdU8wW4oihFS1gj4dUAcPS)_