### PR TITLE
ebnf/lib/js: the JavaScript token grammar, LL(1), beside the classical one

### DIFF
--- a/fjs/djs/todo/ebnf-ll1-port.md
+++ b/fjs/djs/todo/ebnf-ll1-port.md
@@ -131,8 +131,9 @@ reads values, not text.
       ticked.
 - [x] `literals`, the prefix tree over a word list, in `fjs/ebnf` with
       proof; the punctuators of JavaScript build as one LL(1) rule.
-- [ ] Tokenizer grammar in EBNF beside the classical one, LL(1), with the
-      comparison proof over the tokenizer's corpus.
+- [x] Tokenizer grammar in EBNF beside the classical one, LL(1), with the
+      comparison proof: [`fjs/ebnf/lib/js`](../../ebnf/lib/js/module.f.mjs),
+      and the `ebnf` group of the classical tokenizer's proof.
 - [ ] Tokenizer on `ebnf/ll1`: mappings, the token-boundary check, error
       tokens; `jsMatcher` and `descentParserCpOnly` replaced and declared.
 - [ ] Parser grammar LL(1): trailing trivia, right-recursive or separated

--- a/fjs/djs/tokenizer/proof.f.mjs
+++ b/fjs/djs/tokenizer/proof.f.mjs
@@ -1,14 +1,12 @@
 /**
  * @import { Ast, AstTag, Meta } from '../../bnf/matcher/types.ts'
- * @import { Ast as EbnfAst } from '../../ebnf/ast/types.ts'
- * @import { Rule } from '../../ebnf/types.ts'
  * @import { CodePoint } from '../../text/utf16/types.ts'
+ * @import { List } from '../../types/list/types.ts'
  */
 
 import { isRepeat, toData } from '../../bnf/data/module.f.mjs'
 import { codePointListToString, stringToCodePointList, stringToList } from '../../text/utf16/module.f.mjs'
-import { toArray } from '../../types/list/module.f.mjs'
-import { unwrap } from '../../types/result/module.f.mjs'
+import { concat, empty, next, toArray } from '../../types/list/module.f.mjs'
 import { parser } from '../../ebnf/ll1/module.f.mjs'
 import { operators as ebnfOperators, token as ebnfToken } from '../../ebnf/lib/js/module.f.mjs'
 import { jsGrammar, jsMatcher, tokenizeString, descentParserCpOnly, tokenizeJs, tokenize } from './module.f.mjs'
@@ -47,9 +45,56 @@ const text = cp => codePointListToString(cp)
 
 const [classicalMatcher, classicalEntry] = jsMatcher()
 
-/** @type {(node: Ast<Meta<unknown, CodePoint>> | Meta<unknown, CodePoint>) => readonly number[]} */
-const classicalSymbols = node =>
-    node instanceof Array ? [node[0]] : node.sequence.flatMap(classicalSymbols)
+/**
+ * The classical nodes under a node, in document order, the node itself
+ * first — a loop over an explicit stack, since a block comment's content
+ * nests one level per symbol and a comment may be long.
+ *
+ * @type {(root: Ast<Meta<unknown, CodePoint>>) => readonly Ast<Meta<unknown, CodePoint>>[]}
+ */
+const classicalNodes = root => {
+    /** @type {List<Ast<Meta<unknown, CodePoint>>>} */
+    let out = empty
+    /** @type {List<Ast<Meta<unknown, CodePoint>>>} */
+    let stack = [root]
+    for (;;) {
+        /** @type {{ readonly first: Ast<Meta<unknown, CodePoint>>, readonly tail: List<Ast<Meta<unknown, CodePoint>>> } | null} */
+        const top = next(stack)
+        if (top === null) { return toArray(out) }
+        const node = top.first
+        out = concat(out)([node])
+        /** @type {readonly Ast<Meta<unknown, CodePoint>>[]} */
+        const children = node.sequence.flatMap(child => child instanceof Array ? [] : [child])
+        stack = concat(children)(top.tail)
+    }
+}
+
+/**
+ * The input symbols under a classical node, in order: a leaf is a code
+ * point with its metadata, and a node's leaves come between its nodes'.
+ * The same loop, over leaves and nodes together.
+ *
+ * @type {(root: Ast<Meta<unknown, CodePoint>>) => readonly number[]}
+ */
+const classicalSymbols = root => {
+    /** @type {List<number>} */
+    let out = empty
+    /** @type {List<Ast<Meta<unknown, CodePoint>> | Meta<unknown, CodePoint>>} */
+    let stack = [root]
+    for (;;) {
+        /** @type {{ readonly first: Ast<Meta<unknown, CodePoint>> | Meta<unknown, CodePoint>, readonly tail: List<Ast<Meta<unknown, CodePoint>> | Meta<unknown, CodePoint>> } | null} */
+        const top = next(stack)
+        if (top === null) { return toArray(out) }
+        /** @type {Ast<Meta<unknown, CodePoint>> | Meta<unknown, CodePoint>} */
+        const node = top.first
+        if (node instanceof Array) {
+            out = concat(out)([node[0]])
+            stack = top.tail
+        } else {
+            stack = concat(node.sequence)(top.tail)
+        }
+    }
+}
 
 /**
  * The kind of a classical token, from its node's tag: a token that is a
@@ -81,9 +126,9 @@ const classicalResult = s => {
     const cp = toArray(stringToCodePointList(s))
     const { ast, success, idx } = descentParserCpOnly(classicalMatcher, classicalEntry, cp)
     if (!success || idx !== cp.length) { return ['error'] }
-    const json = JSON.stringify(ast)
-    if (json.includes('"tag":"numError","sequence":[]')) { return ['cut'] }
-    if (json.includes('"numError"')) { return ['poison'] }
+    const poison = classicalNodes(ast).filter(node => node.tag === 'numError')
+    if (poison.some(node => node.sequence.length === 0)) { return ['cut'] }
+    if (poison.length !== 0) { return ['poison'] }
     return ['ok', ast.sequence.flatMap(node => {
         assert(!(node instanceof Array))
         if (node.tag === 'eof') { return [] }
@@ -103,11 +148,35 @@ const classicalStream = s => {
     return result[1]
 }
 
-/** @type {(node: EbnfAst<Rule, unknown> | string) => readonly number[]} */
-const ebnfSymbols = node =>
-    typeof node === 'string' ? [] :
-    node instanceof Array ? node.flatMap(ebnfSymbols) :
-    [node.symbol]
+/**
+ * The input symbols under an EBNF node, in order: an array is a node the
+ * machine built, a string a variant's tag, anything else a leaf. A loop,
+ * for the reason `classicalSymbols` is one.
+ *
+ * @type {(root: unknown) => readonly number[]}
+ */
+const ebnfSymbols = root => {
+    /** @type {List<number>} */
+    let out = empty
+    /** @type {List<unknown>} */
+    let stack = [root]
+    for (;;) {
+        /** @type {{ readonly first: unknown, readonly tail: List<unknown> } | null} */
+        const top = next(stack)
+        if (top === null) { return toArray(out) }
+        /** @type {unknown} */
+        const node = top.first
+        if (node instanceof Array) {
+            stack = concat(node)(top.tail)
+        } else if (typeof node === 'string') {
+            stack = top.tail
+        } else {
+            assert(typeof node === 'object' && node !== null && 'symbol' in node && typeof node.symbol === 'number')
+            out = concat(out)([node.symbol])
+            stack = top.tail
+        }
+    }
+}
 
 /** @type {(node: unknown) => readonly [string, unknown]} */
 const ebnfBranch = node => {
@@ -341,11 +410,26 @@ const inputs = [
 ]
 
 /**
+ * The inputs the proofs build by code rather than write out: the long
+ * inputs of `largeInputs`, which pin the depth contract — a block comment
+ * of twenty thousand characters is twenty thousand nested nodes in either
+ * grammar's tree.
+ */
+const generated = [
+    `/*${'x'.repeat(20000)}*/`,
+    'x'.repeat(10000),
+    ' '.repeat(5000),
+    `"${'a'.repeat(5000)}"`,
+]
+
+/**
  * Inputs both grammars accept, over every token kind and the shapes the
  * LL(1) spelling changed: the block comment's `*`, the `/` a comment and
- * division share, the operator prefix tree, the line comment's newline.
+ * division share — inside a block comment's body too, where a plain `/`
+ * is content — the operator prefix tree, the line comment's newline.
  */
 const corpus = [
+    '/* a/b */ /* ../../x.ts */ /*/ */',
     'a b\tc\n\rd',
     'const a = [1, 2.5e-3, -1, 1n, 7E+2, 0, "s\\n\\u0041\\"", true];',
     'x/2 /= y // c\nz',
@@ -380,7 +464,7 @@ export const proof = {
         // consumed the character after a number, the EBNF grammar reads the
         // adjacent tokens the layer above will refuse.
         wholeCorpus: () => {
-            for (const s of inputs) {
+            for (const s of [...inputs, ...generated]) {
                 const classical = classicalResult(s)
                 const ebnf = ebnfResult(s)
                 switch (classical[0]) {

--- a/fjs/djs/tokenizer/proof.f.mjs
+++ b/fjs/djs/tokenizer/proof.f.mjs
@@ -1,11 +1,18 @@
 /**
+ * @import { Ast, AstTag, Meta } from '../../bnf/matcher/types.ts'
+ * @import { Ast as EbnfAst } from '../../ebnf/ast/types.ts'
+ * @import { Rule } from '../../ebnf/types.ts'
+ * @import { CodePoint } from '../../text/utf16/types.ts'
  */
 
 import { isRepeat, toData } from '../../bnf/data/module.f.mjs'
-import { stringToCodePointList, stringToList } from '../../text/utf16/module.f.mjs'
+import { codePointListToString, stringToCodePointList, stringToList } from '../../text/utf16/module.f.mjs'
 import { toArray } from '../../types/list/module.f.mjs'
+import { unwrap } from '../../types/result/module.f.mjs'
+import { parser } from '../../ebnf/ll1/module.f.mjs'
+import { operators as ebnfOperators, token as ebnfToken } from '../../ebnf/lib/js/module.f.mjs'
 import { jsGrammar, jsMatcher, tokenizeString, descentParserCpOnly, tokenizeJs, tokenize } from './module.f.mjs'
-import { assert, assertEq } from '../../asserts/module.f.mjs'
+import { assert, assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
 import { stringifyAsTree } from '../serializer/module.f.mjs'
 import { sort } from '../../types/object/module.f.mjs'
 
@@ -31,7 +38,160 @@ const errorAt = s => {
         : `${start}..${token.end.line}:${token.end.column}`
 }
 
+// -- the EBNF token grammar reads the same stream ----------------------------
+
+/**
+ * A token as both grammars see it: its kind, and its text.
+ *
+ * @typedef {readonly [kind: string, text: string]} _Token
+ */
+
+/** @type {(cp: readonly number[]) => string} */
+const text = cp => codePointListToString(cp)
+
+const [classicalMatcher, classicalEntry] = jsMatcher()
+
+/** @type {(node: Ast<Meta<unknown, CodePoint>> | Meta<unknown, CodePoint>) => readonly number[]} */
+const classicalSymbols = node =>
+    node instanceof Array ? [node[0]] : node.sequence.flatMap(classicalSymbols)
+
+/**
+ * The kind of a classical token, from its node's tag: a token that is a
+ * sequence carries its branch's name, and one that is a variant of
+ * symbols or literals carries the symbol or literal it matched.
+ *
+ * @type {(tag: AstTag) => string}
+ */
+const classicalKind = tag =>
+    tag === 'number' || tag === 'string' || tag === 'id' || tag === 'comment' ? tag :
+    tag === ' ' || tag === '\t' ? 'ws' :
+    tag === '\n' || tag === '\r' ? 'newLine' :
+    'operator'
+
+/**
+ * The classical grammar's tokens over a whole text, kind and text each: a
+ * line comment swallows its newline, which the tokenizer splits back out
+ * below the grammar, and the EBNF grammar stops the comment before it — so
+ * it is split here too, and the streams are compared token for token. The
+ * whole-file grammar's last round is its `eof` branch, no token, and is
+ * left out.
+ *
+ * @type {(s: string) => readonly _Token[]}
+ */
+const classicalStream = s => {
+    const cp = toArray(stringToCodePointList(s))
+    const { ast, success, idx } = descentParserCpOnly(classicalMatcher, classicalEntry, cp)
+    assert(success && idx === cp.length, s)
+    return ast.sequence.flatMap(node => {
+        assert(!(node instanceof Array))
+        if (node.tag === 'eof') { return [] }
+        const kind = classicalKind(node.tag)
+        const symbols = classicalSymbols(node)
+        const last = symbols[symbols.length - 1]
+        return kind === 'comment' && symbols[1] !== 0x2A && (last === 0x0A || last === 0x0D)
+            ? [[kind, text(symbols.slice(0, -1))], ['newLine', text(symbols.slice(-1))]]
+            : [[kind, text(symbols)]]
+    })
+}
+
+/** @type {(node: EbnfAst<Rule, unknown> | string) => readonly number[]} */
+const ebnfSymbols = node =>
+    typeof node === 'string' ? [] :
+    node instanceof Array ? node.flatMap(ebnfSymbols) :
+    [node.symbol]
+
+/** @type {(node: unknown) => readonly [string, unknown]} */
+const ebnfBranch = node => {
+    assert(node instanceof Array && node.length === 2 && typeof node[0] === 'string')
+    return [node[0], node[1]]
+}
+
+const parseEbnfToken = parser(ebnfToken)
+
+/**
+ * The EBNF grammar's tokens over a whole text: one token at a time, the
+ * parser resumed where the last one ended, `slash`'s four told apart by
+ * its own tag.
+ *
+ * @type {(s: string) => readonly _Token[]}
+ */
+const ebnfStream = s => {
+    const input = toArray(stringToCodePointList(s)).map(symbol => ({ symbol, meta: null }))
+    /** @type {readonly _Token[]} */
+    let out = []
+    let pos = 0
+    while (pos < input.length) {
+        const [node, end] = unwrap(parseEbnfToken(input, pos))
+        const [tag, child] = ebnfBranch(node)
+        const sub = tag === 'slash' ? ebnfBranch(/** @type {readonly unknown[]} */ (child)[1])[0] : tag
+        const kind = sub === 'oneline' || sub === 'multiline' ? 'comment' : sub === 'assign' || sub === 'divide' ? 'operator' : sub
+        out = [...out, [kind, text(ebnfSymbols(node))]]
+        pos = end
+    }
+    return out
+}
+
+/**
+ * Inputs both grammars accept, over every token kind and the shapes the
+ * LL(1) spelling changed: the block comment's `*`, the `/` a comment and
+ * division share, the operator prefix tree, the line comment's newline.
+ */
+const corpus = [
+    'a b\tc\n\rd',
+    'const a = [1, 2.5e-3, -1, 1n, 7E+2, 0, "s\\n\\u0041\\"", true];',
+    'x/2 /= y // c\nz',
+    'x // c\r\ny',
+    '//',
+    '/* a * b **/ c /**/ d',
+    '/* x\ny */',
+    'a.b?.c ?? d ... e',
+    '>>>= <<= !== === => ++ -- ** **= &&= ||= ??=',
+    '{}[]().,:;~^|&%!<>?=+-*',
+    '$_ab9 _ $1 tr2ue',
+    '"é😀"',
+    'x\ty  \t\tz',
+]
+
 export const proof = {
+    // The EBNF token grammar in `fjs/ebnf/lib/js`, read one token at a time,
+    // yields the token stream this grammar does: kind and text agree token
+    // for token over the corpus. This is the port's readiness check
+    // (ebnf-migration, principle 5): the grammar that reads the same
+    // stream may replace this one.
+    ebnf: {
+        sameStream: () => {
+            for (const s of corpus) {
+                assertStructurallySame(ebnfStream(s), classicalStream(s))
+            }
+        },
+        // Where this grammar's poison branch rejects a number followed by an
+        // identifier character, the EBNF grammar reads two adjacent tokens,
+        // and the layer above the tokens refuses them for standing side by
+        // side (ebnf-ll1-port). Here the poison shows as its tag.
+        poison: () => {
+            /** @type {(s: string) => boolean} */
+            const poisoned = s => {
+                const { ast } = descentParserCpOnly(classicalMatcher, classicalEntry, toArray(stringToCodePointList(s)))
+                return JSON.stringify(ast).includes('"numError"')
+            }
+            assertStructurallySame(ebnfStream('123abc'), [['number', '123'], ['id', 'abc']])
+            assertStructurallySame(ebnfStream('00'), [['number', '0'], ['number', '0']])
+            assertStructurallySame(ebnfStream('1.5n'), [['number', '1.5'], ['id', 'n']])
+            assertStructurallySame(ebnfStream('123true'), [['number', '123'], ['id', 'true']])
+            assert(['123abc', '00', '1.5n', '123true'].every(poisoned))
+            assert(!poisoned('123 abc'))
+        },
+        // The operators this grammar names are the EBNF grammar's list plus
+        // the two `slash` holds, and each is one token in both.
+        operators: () => {
+            const all = [...ebnfOperators, '/', '/=']
+            assertEq(all.length, 56)
+            for (const op of all) {
+                assertStructurallySame(classicalStream(op), [['operator', op]])
+                assertStructurallySame(ebnfStream(op), [['operator', op]])
+            }
+        },
+    },
     // The whole-file grammar is one repetition of a token, and `toData` records
     // that rather than leaving it as the right-recursive variant `repeat0Plus`
     // builds — which is why the tokenizer reads its entry name from `jsMatcher`

--- a/fjs/djs/tokenizer/proof.f.mjs
+++ b/fjs/djs/tokenizer/proof.f.mjs
@@ -40,11 +40,7 @@ const errorAt = s => {
 
 // -- the EBNF token grammar reads the same stream ----------------------------
 
-/**
- * A token as both grammars see it: its kind, and its text.
- *
- * @typedef {readonly [kind: string, text: string]} _Token
- */
+// A token as both grammars see it is a pair: its kind, and its text.
 
 /** @type {(cp: readonly number[]) => string} */
 const text = cp => codePointListToString(cp)
@@ -69,20 +65,26 @@ const classicalKind = tag =>
     'operator'
 
 /**
- * The classical grammar's tokens over a whole text, kind and text each: a
- * line comment swallows its newline, which the tokenizer splits back out
- * below the grammar, and the EBNF grammar stops the comment before it — so
- * it is split here too, and the streams are compared token for token. The
- * whole-file grammar's last round is its `eof` branch, no token, and is
- * left out.
+ * The classical grammar's reading of a whole text: `error` where it does
+ * not match it all; `cut` where a number's fraction or exponent had no
+ * digits, which its `numError` branch tags without consuming anything;
+ * `poison` where that branch consumed the identifier character after a
+ * number; and otherwise its tokens, kind and text each. A line comment swallows
+ * its newline, which the tokenizer splits back out below the grammar, and
+ * the EBNF grammar stops the comment before it — so it is split here too,
+ * and the streams are compared token for token. The whole-file grammar's
+ * last round is its `eof` branch, no token, and is left out.
  *
- * @type {(s: string) => readonly _Token[]}
+ * @type {(s: string) => readonly ['error'] | readonly ['cut'] | readonly ['poison'] | readonly ['ok', readonly (readonly [kind: string, text: string])[]]}
  */
-const classicalStream = s => {
+const classicalResult = s => {
     const cp = toArray(stringToCodePointList(s))
     const { ast, success, idx } = descentParserCpOnly(classicalMatcher, classicalEntry, cp)
-    assert(success && idx === cp.length, s)
-    return ast.sequence.flatMap(node => {
+    if (!success || idx !== cp.length) { return ['error'] }
+    const json = JSON.stringify(ast)
+    if (json.includes('"tag":"numError","sequence":[]')) { return ['cut'] }
+    if (json.includes('"numError"')) { return ['poison'] }
+    return ['ok', ast.sequence.flatMap(node => {
         assert(!(node instanceof Array))
         if (node.tag === 'eof') { return [] }
         const kind = classicalKind(node.tag)
@@ -91,7 +93,14 @@ const classicalStream = s => {
         return kind === 'comment' && symbols[1] !== 0x2A && (last === 0x0A || last === 0x0D)
             ? [[kind, text(symbols.slice(0, -1))], ['newLine', text(symbols.slice(-1))]]
             : [[kind, text(symbols)]]
-    })
+    })]
+}
+
+/** @type {(s: string) => readonly (readonly [kind: string, text: string])[]} */
+const classicalStream = s => {
+    const result = classicalResult(s)
+    assert(result[0] === 'ok', s)
+    return result[1]
 }
 
 /** @type {(node: EbnfAst<Rule, unknown> | string) => readonly number[]} */
@@ -109,27 +118,227 @@ const ebnfBranch = node => {
 const parseEbnfToken = parser(ebnfToken)
 
 /**
- * The EBNF grammar's tokens over a whole text: one token at a time, the
- * parser resumed where the last one ended, `slash`'s four told apart by
- * its own tag.
+ * The EBNF grammar's reading of a whole text: its tokens one at a time,
+ * the parser resumed where the last one ended, `slash`'s four told apart
+ * by its own tag — or `error` where a token fails, at its index.
  *
- * @type {(s: string) => readonly _Token[]}
+ * @type {(s: string) => readonly ['error', number] | readonly ['ok', readonly (readonly [kind: string, text: string])[]]}
  */
-const ebnfStream = s => {
+const ebnfResult = s => {
     const input = toArray(stringToCodePointList(s)).map(symbol => ({ symbol, meta: null }))
-    /** @type {readonly _Token[]} */
+    /** @type {readonly (readonly [kind: string, text: string])[]} */
     let out = []
     let pos = 0
     while (pos < input.length) {
-        const [node, end] = unwrap(parseEbnfToken(input, pos))
+        const match = parseEbnfToken(input, pos)
+        if (match[0] === 'error') { return match }
+        const [node, end] = match[1]
         const [tag, child] = ebnfBranch(node)
         const sub = tag === 'slash' ? ebnfBranch(/** @type {readonly unknown[]} */ (child)[1])[0] : tag
         const kind = sub === 'oneline' || sub === 'multiline' ? 'comment' : sub === 'assign' || sub === 'divide' ? 'operator' : sub
         out = [...out, [kind, text(ebnfSymbols(node))]]
         pos = end
     }
-    return out
+    return ['ok', out]
 }
+
+/** @type {(s: string) => readonly (readonly [kind: string, text: string])[]} */
+const ebnfStream = s => {
+    const result = ebnfResult(s)
+    assert(result[0] === 'ok', s)
+    return result[1]
+}
+
+/**
+ * Every literal input the proofs below hand to `tokenizeString`, `tokenize`
+ * or `errorAt`, in their order — the tokenizer's corpus, which the
+ * comparison runs over whole, whatever each grammar makes of a string.
+ */
+const inputs = [
+    "tr",
+    "\"tr\"",
+    "56.7e+5",
+    "56n",
+    "*",
+    "**",
+    "=>",
+    "==",
+    "===",
+    "=",
+    " ",
+    "\n",
+    "/\n",
+    "//\n",
+    "/*1*/",
+    "",
+    "{",
+    "}",
+    ":",
+    ",",
+    "[",
+    "]",
+    "ᄑ",
+    "{ \t\n\r}",
+    "\"\"",
+    "\"value\"",
+    "\"value",
+    "\"value1\" \"value2\"",
+    "\"",
+    "\"\\\\\"",
+    "\"\\\"\"",
+    "\"\\/\"",
+    "\"\\x\"",
+    "\"\\",
+    "\"\r\"",
+    "\"\n null",
+    "\"\\b\\f\\n\\r\\t\"",
+    "\"\\u1234\"",
+    "\"\\uaBcDEeFf\"",
+    "\"\\uEeFg\"",
+    "0",
+    "[0]",
+    "00",
+    "0abc,",
+    "123456789012345678901234567890",
+    "{90}",
+    "1 2",
+    "0. 2",
+    "10-0",
+    "9a:",
+    "-10",
+    "-0",
+    "-00",
+    "-.123",
+    "0.01",
+    "-0.9",
+    "-0.",
+    "-0.]",
+    "12.34",
+    "-12.00",
+    "-12.",
+    "12.]",
+    "0e1",
+    "0e+2",
+    "0e-0",
+    "12e0000",
+    "-12e-0001",
+    "-12.34e1234",
+    "0e",
+    "0e-",
+    "ABCdef1234567890$_",
+    "{ABCdef1234567890$_}",
+    "123 _123",
+    "123 $123",
+    "123_123",
+    "123$123",
+    "1234567890n",
+    "0n",
+    "[-1234567890n]",
+    "123.456n",
+    "123e456n",
+    "1234567890na",
+    "1234567890nn",
+    "=a",
+    "-",
+    "1*2",
+    "( )",
+    "== != === !== > >= < <=",
+    "+ - * / % ++ -- **",
+    "= += -= *= /= %= **=",
+    "& | ^ ~ << >> >>>",
+    "&= |= ^= <<= >>= >>>=",
+    "<<< <<<=",
+    "&& || ! ??",
+    "&&= ||= ??=",
+    "? ?. . =>",
+    "\t",
+    " \t",
+    "\r",
+    " \t\n\r ",
+    "err",
+    "{e}",
+    "tru",
+    "true",
+    "false",
+    "null",
+    "undefined",
+    "[null]",
+    "arguments",
+    "await",
+    "break",
+    "case",
+    "catch",
+    "class",
+    "const",
+    "continue",
+    "debugger",
+    "default",
+    "delete",
+    "do",
+    "else",
+    "enum",
+    "eval",
+    "export",
+    "extends",
+    "finally",
+    "for",
+    "function",
+    "if",
+    "implements",
+    "import",
+    "in",
+    "instanceof",
+    "interface",
+    "let",
+    "new",
+    "package",
+    "private",
+    "protected",
+    "public",
+    "return",
+    "static",
+    "super",
+    "switch",
+    "this",
+    "throw",
+    "try",
+    "typeof",
+    "var",
+    "void",
+    "while",
+    "with",
+    "yield",
+    "//singleline comment",
+    "true//singleline comment\nfalse",
+    "/* multiline comment */",
+    "/* multiline comment *",
+    "/* multiline comment ",
+    "/* multiline comment \n * **/",
+    "/* multiline comment *\n * **/",
+    "//ab\n",
+    "//a//b\n",
+    "a/b",
+    "true false",
+    "a\nb",
+    "a\n\nb",
+    "/* c\n */ x",
+    "\"unterminated",
+    "x",
+    "{ \"a\": 1 }",
+    "x @",
+    "a\nb\n@",
+    "x\n\n  @y",
+    "1.",
+    "\"a\nb\"",
+    "/* c",
+    "/* ok */ /* bad",
+    "123abc",
+    ";",
+    "-1234567890n",
+    "--",
+    "---",
+    "-{",
+]
 
 /**
  * Inputs both grammars accept, over every token kind and the shapes the
@@ -162,6 +371,24 @@ export const proof = {
         sameStream: () => {
             for (const s of corpus) {
                 assertStructurallySame(ebnfStream(s), classicalStream(s))
+            }
+        },
+        // Over the whole corpus, whatever the classical grammar makes of a
+        // string: what it reads, the EBNF grammar reads the same; what it
+        // refuses, and a number it tags cut short, the EBNF grammar refuses
+        // too, its forced digits failing; and where its poison branch
+        // consumed the character after a number, the EBNF grammar reads the
+        // adjacent tokens the layer above will refuse.
+        wholeCorpus: () => {
+            for (const s of inputs) {
+                const classical = classicalResult(s)
+                const ebnf = ebnfResult(s)
+                switch (classical[0]) {
+                    case 'ok': { assertStructurallySame(ebnf, classical); break }
+                    case 'poison': { assertEq(ebnf[0], 'ok', s); break }
+                    case 'cut':
+                    case 'error': { assertEq(ebnf[0], 'error', s); break }
+                }
             }
         },
         // Where this grammar's poison branch rejects a number followed by an

--- a/fjs/ebnf/lib/js/module.f.mjs
+++ b/fjs/ebnf/lib/js/module.f.mjs
@@ -1,0 +1,132 @@
+/**
+ * The JavaScript token grammar: one token, as the djs tokenizer reads them,
+ * spelled LL(1) for `../../ll1`. A file is not `repeatFrom0(token)` — in a
+ * whole-file grammar a token's follow set is the next token's first set, so
+ * every greedy token is a first/follow conflict — but one token at a time,
+ * the parser resumed where the last token ended (`../../ll1`, "A token
+ * layer resumes the parser"). Nothing follows a token here, and that is
+ * what makes the grammar LL(1).
+ *
+ * Beside the classical grammar in `fjs/djs/tokenizer`, which the
+ * backtracking backend reads, four things are spelled differently, each
+ * a conflict `fjs/djs/todo/ebnf-ll1-port.md` measured:
+ *
+ * - the block comment's `*` is left-factored: after a `*`, a `/` is the
+ *   end, another `*` is looked at again, and anything else is content;
+ * - the `/` shared by a comment and the division operator is one rule,
+ *   {@link slash}, deciding on the symbol after it;
+ * - the operators are a prefix tree, {@link operator}, built by
+ *   `literals` from the list;
+ * - a number has no poison branch: `123abc` reads as the number `123`
+ *   followed by the identifier `abc`, and the layer above the tokens
+ *   refuses the two for standing side by side, as the port issue says.
+ *
+ * A string is JSON's, and so is a number's unsigned part with its
+ * fraction and exponent: the rules are imported from `../json`, not
+ * restated. A line comment stops before its newline, which is the next
+ * token; the classical grammar swallows it and splits it back out below
+ * the grammar. Whitespace is one symbol per token, as it is there.
+ *
+ * @module
+ *
+ * @import { AfterStar, Content } from './types.ts'
+ */
+
+import { literals, range, remove, repeatFrom0, set, unicodeMax } from '../../module.f.mjs'
+import { digit, optionFloatSuffix, string, uint } from '../json/module.f.mjs'
+
+/** Every symbol of the alphabet: a code point. */
+const any = range(`\0${unicodeMax}`)
+
+/** One whitespace symbol; a run of them is a run of tokens. */
+export const ws = set(' \t')
+
+/** One newline symbol. */
+export const newLine = set('\n\r')
+
+const idStart = /**@type {const}*/({
+    smallLetter: range('az'),
+    bigLetter: range('AZ'),
+    lowLine: '_',
+    dollarSign: '$',
+})
+
+const idChar = /**@type {const}*/({ ...idStart, digit })
+
+/** An identifier, or a keyword: the words are told apart above the grammar. */
+export const id = /**@type {const}*/([idStart, repeatFrom0(idChar)])
+
+/**
+ * A number: JSON's unsigned integer, then either the bigint suffix or
+ * JSON's optional fraction and exponent. The sign is an operator token.
+ */
+export const number = /**@type {const}*/([uint, { bigint: 'n', real: optionFloatSuffix }])
+
+const notNewLine = remove(any, newLine)
+
+const notStar = remove(any, set('*'))
+
+const notStarSlash = remove(any, set('*/'))
+
+/**
+ * What follows a `*` inside a block comment: `/` ends the comment, another
+ * `*` is looked at the same way, anything else is content — and the end
+ * of input leaves the comment unterminated, which the tag says.
+ *
+ * @type {AfterStar}
+ */
+const afterStar = () => ['const', {
+    end: '/',
+    star,
+    other: [notStarSlash, content],
+    unterminated: '',
+}]
+
+/**
+ * The content of a block comment after its `/*`, up to and including the
+ * `*​/` that ends it — or to the end of input, tagged `unterminated`.
+ *
+ * @type {Content}
+ */
+export const content = () => ['const', {
+    star,
+    other: [notStar, content],
+    unterminated: '',
+}]
+
+const star = /**@type {const}*/(['*', afterStar])
+
+/**
+ * Every token that begins with `/`: a line comment, a block comment, the
+ * `/=` operator, and division — one rule, so that one symbol of lookahead
+ * decides among them.
+ */
+export const slash = /**@type {const}*/(['/', {
+    oneline: ['/', repeatFrom0(notNewLine)],
+    multiline: ['*', content],
+    assign: '=',
+    divide: '',
+}])
+
+/**
+ * The operators the classical grammar names, less the two that begin with
+ * `/`, which {@link slash} holds.
+ */
+export const operators = /**@type {const}*/([
+    '.', '=>', '===', '==', '=', '!==', '!=', '!',
+    '>>>=', '>>>', '>>=', '>>', '>=', '>', '<<=', '<<', '<=', '<',
+    '+=', '++', '+', '-=', '--', '-', '**=', '**', '*=', '*', '%=', '%',
+    '&&=', '&&', '&=', '&', '||=', '||', '|=', '|', '^=', '^', '~',
+    '??=', '??', '?.', '?',
+    '[', ']', '{', '}', '(', ')', ',', ':', ';',
+])
+
+/** The operators as a prefix tree: the longest the lookahead leads to. */
+export const operator = literals(operators)
+
+/**
+ * One token. Its node is the branch taken, tagged by kind — `slash`'s
+ * own tag says which of its four it was — and the token's text is the
+ * symbols under the node.
+ */
+export const token = /**@type {const}*/({ number, string, id, slash, operator, ws, newLine })

--- a/fjs/ebnf/lib/js/proof.f.mjs
+++ b/fjs/ebnf/lib/js/proof.f.mjs
@@ -1,0 +1,176 @@
+/**
+ * @import { Ast, Meta } from '../../ast/types.ts'
+ * @import { Rule } from '../../types.ts'
+ */
+
+import { assert, assertStructurallySame } from '../../../asserts/module.f.mjs'
+import { codePointListToString, stringToCodePointList } from '../../../text/utf16/module.f.mjs'
+import { toArray } from '../../../types/list/module.f.mjs'
+import { unwrap } from '../../../types/result/module.f.mjs'
+import { repeatFrom0 } from '../../module.f.mjs'
+import { parser } from '../../ll1/module.f.mjs'
+import { content, id, newLine, number, operator, operators, slash, token, ws } from './module.f.mjs'
+
+const cp = /**@type {const}*/({ id: 'cp' })
+
+/** @type {(s: string) => readonly Meta<typeof cp>[]} */
+const cps = s => toArray(stringToCodePointList(s)).map(symbol => ({ symbol, meta: cp }))
+
+/**
+ * The node at a position no mapping filled: an array the machine built.
+ *
+ * @type {<T extends readonly unknown[]>(node: T | Meta<unknown>) => T}
+ */
+const unmapped = node => {
+    assert(node instanceof Array)
+    return node
+}
+
+/**
+ * The text under a node: its input symbols in order, a variant's tag
+ * passed over.
+ *
+ * @type {(node: Ast<Rule, unknown> | string) => readonly number[]}
+ */
+const symbols = node =>
+    typeof node === 'string' ? [] :
+    node instanceof Array ? node.flatMap(symbols) :
+    [node.symbol]
+
+/**
+ * A variant's node, read untyped: its tag and the branch's node.
+ *
+ * @type {(node: unknown) => readonly [string, unknown]}
+ */
+const branch = node => {
+    assert(node instanceof Array && node.length === 2 && typeof node[0] === 'string')
+    return [node[0], node[1]]
+}
+
+/** @type {(node: unknown) => readonly unknown[]} */
+const items = node => {
+    assert(node instanceof Array)
+    return node
+}
+
+const parseToken = parser(token)
+
+/**
+ * One token read from `text` at `start`: its kind — `slash`'s own branch
+ * for a comment or an operator — its text, and where it ended.
+ *
+ * @type {(text: string, start?: number) => readonly [string, string, number]}
+ */
+const read = (text, start = 0) => {
+    const [node, end] = unwrap(parseToken(cps(text), start))
+    const [tag, child] = unmapped(node)
+    const kind = tag !== 'slash' ? tag : unmapped(unmapped(child)[1])[0]
+    return [kind, codePointListToString(symbols(node)), end]
+}
+
+export const proof = {
+    // The grammar is LL(1) as one token, and refused as a whole file: in
+    // `repeatFrom0(token)` a token's follow set is the next token's first
+    // set, and a greedy token conflicts with the token after it.
+    ll1: () => {
+        parser(token)
+        parser(ws)
+        parser(newLine)
+        parser(id)
+        parser(number)
+        parser(slash)
+        parser(operator)
+        parser(content)
+    },
+    // Every kind reads its whole token and no more: the text is the symbols
+    // under the node, and the end is where the next token begins.
+    kinds: {
+        number: () => {
+            assertStructurallySame(read('123 '), ['number', '123', 3])
+            assertStructurallySame(read('0'), ['number', '0', 1])
+            assertStructurallySame(read('1n;'), ['number', '1n', 2])
+            assertStructurallySame(read('1.5e-3+'), ['number', '1.5e-3', 6])
+            assertStructurallySame(read('7E+2'), ['number', '7E+2', 4])
+        },
+        string: () => {
+            assertStructurallySame(read('"a\\n\\u0041"x'), ['string', '"a\\n\\u0041"', 11])
+            assertStructurallySame(read('"é😀"'), ['string', '"é😀"', 4])
+        },
+        id: () => {
+            assertStructurallySame(read('abc$_9 '), ['id', 'abc$_9', 6])
+            assertStructurallySame(read('_'), ['id', '_', 1])
+            assertStructurallySame(read('$1'), ['id', '$1', 2])
+        },
+        // The four tokens `/` begins: one symbol after it decides.
+        slash: () => {
+            assertStructurallySame(read('/x'), ['divide', '/', 1])
+            assertStructurallySame(read('/=x'), ['assign', '/=', 2])
+            assertStructurallySame(read('// c\nx'), ['oneline', '// c', 4])
+            assertStructurallySame(read('//'), ['oneline', '//', 2])
+            assertStructurallySame(read('/* a **/ b'), ['multiline', '/* a **/', 8])
+            assertStructurallySame(read('/* x\ny*/'), ['multiline', '/* x\ny*/', 8])
+            assertStructurallySame(read('/**/'), ['multiline', '/**/', 4])
+        },
+        // A block comment the input ends inside is read to the end and its
+        // tag says so, which is how the layer above tells it from one that
+        // closed: after `/*`, after a `*`, and after content.
+        unterminated: () => {
+            assertStructurallySame(read('/*'), ['multiline', '/*', 2])
+            assertStructurallySame(read('/* x *'), ['multiline', '/* x *', 6])
+            assertStructurallySame(read('/* x'), ['multiline', '/* x', 4])
+            const [node] = unwrap(parseToken(cps('/* x *')))
+            // `slash`, then its `multiline` branch: `*` and `content`.
+            const [, slashNode] = branch(node)
+            const [, multiline] = branch(items(slashNode)[1])
+            const [, c0] = items(multiline)
+            // ` `, `x` and ` ` are `other`, each followed by more content;
+            // `*` is `star`, and what follows it at the end of input is
+            // `unterminated`.
+            const [t1, o1] = branch(c0)
+            const [t2, o2] = branch(items(o1)[1])
+            const [t3, o3] = branch(items(o2)[1])
+            const [t4, s] = branch(items(o3)[1])
+            assertStructurallySame([t1, t2, t3, t4], ['other', 'other', 'other', 'star'])
+            assertStructurallySame(items(s)[1], ['unterminated', []])
+        },
+        operator: () => {
+            assertStructurallySame(read('>>>= '), ['operator', '>>>=', 4])
+            assertStructurallySame(read('=>'), ['operator', '=>', 2])
+            assertStructurallySame(read('?.x'), ['operator', '?.', 2])
+            assertStructurallySame(read('...'), ['operator', '.', 1])
+            assert(operators.every(w => read(w)[1] === w))
+        },
+        trivia: () => {
+            assertStructurallySame(read('  '), ['ws', ' ', 1])
+            assertStructurallySame(read('\t'), ['ws', '\t', 1])
+            assertStructurallySame(read('\n\n'), ['newLine', '\n', 1])
+            assertStructurallySame(read('\r'), ['newLine', '\r', 1])
+        },
+    },
+    // Tokens are read one after another from where the last one ended,
+    // and two that the classical grammar's poison branch rejected read as
+    // two: the layer above refuses them for standing side by side.
+    adjacent: () => {
+        assertStructurallySame(read('123abc'), ['number', '123', 3])
+        assertStructurallySame(read('123abc', 3), ['id', 'abc', 6])
+        assertStructurallySame(read('00'), ['number', '0', 1])
+        assertStructurallySame(read('00', 1), ['number', '0', 2])
+        assertStructurallySame(read('1.5n'), ['number', '1.5', 3])
+        assertStructurallySame(read('1.5n', 3), ['id', 'n', 4])
+        assertStructurallySame(read('a-1', 1), ['operator', '-', 2])
+    },
+    // What is no token fails where it fails: a symbol no token begins
+    // with, the end of input, a fraction with no digits, a string the
+    // input ends inside.
+    failure: () => {
+        assertStructurallySame(parseToken(cps('@')), ['error', 0])
+        assertStructurallySame(parseToken(cps('')), ['error', 0])
+        assertStructurallySame(parseToken(cps('0.')), ['error', 2])
+        assertStructurallySame(parseToken(cps('1e')), ['error', 2])
+        assertStructurallySame(parseToken(cps('"abc')), ['error', 4])
+        assertStructurallySame(parseToken(cps('"\\x"')), ['error', 2])
+    },
+    throw: {
+        wholeFile: () => parser(repeatFrom0(token)),
+    },
+}

--- a/fjs/ebnf/lib/js/proof.f.mjs
+++ b/fjs/ebnf/lib/js/proof.f.mjs
@@ -110,6 +110,10 @@ export const proof = {
             assertStructurallySame(read('/* a **/ b'), ['multiline', '/* a **/', 8])
             assertStructurallySame(read('/* x\ny*/'), ['multiline', '/* x\ny*/', 8])
             assertStructurallySame(read('/**/'), ['multiline', '/**/', 4])
+            // a `/` inside the body is content: only `*/` ends the comment
+            assertStructurallySame(read('/* a/b */'), ['multiline', '/* a/b */', 9])
+            assertStructurallySame(read('/* ../../x.ts */'), ['multiline', '/* ../../x.ts */', 16])
+            assertStructurallySame(read('/*/ */'), ['multiline', '/*/ */', 6])
         },
         // A block comment the input ends inside is read to the end and its
         // tag says so, which is how the layer above tells it from one that

--- a/fjs/ebnf/lib/js/types.ts
+++ b/fjs/ebnf/lib/js/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Type-level API of the JavaScript token grammar: the block comment's
+ * content, which names itself and so is spelled here, as `JsonValue` is in
+ * `../json/types.ts` — a named type that a `const` binding may be annotated
+ * with.
+ *
+ * @module
+ */
+
+import type { Set } from '../../types.ts'
+
+/**
+ * The content of a block comment: a `*` and what follows it, any other
+ * symbol and more content, or nothing — the end of input, unterminated.
+ */
+export type Content = () => readonly ['const', {
+    readonly star: readonly ['*', AfterStar]
+    readonly other: readonly [Set, Content]
+    readonly unterminated: ''
+}]
+
+/**
+ * What follows a `*`: the `/` that ends the comment, another `*`, a symbol
+ * that is neither and more content, or nothing — unterminated.
+ */
+export type AfterStar = () => readonly ['const', {
+    readonly end: '/'
+    readonly star: readonly ['*', AfterStar]
+    readonly other: readonly [Set, Content]
+    readonly unterminated: ''
+}]


### PR DESCRIPTION
Stacked on #1920 (#1917 and #1915 are merged). The third task of `fjs/djs/todo/ebnf-ll1-port.md`: the tokenizer's grammar in EBNF beside the classical one, LL(1), with the comparison proof. The live tokenizer does not change; the port is the next task.

**The grammar**, `fjs/ebnf/lib/js/module.f.mjs`, is one `token`, for a parser resumed where the last token ended: nothing follows a token, which is what makes it LL(1) where the whole-file `repeatFrom0(token)` is not (pinned as a refusal). Four things are spelled differently from the classical grammar, each a conflict the port issue measured:

- the block comment's `*` is left-factored: after a `*`, a `/` ends the comment, another `*` is looked at again, anything else is content, and the end of input is tagged `unterminated`;
- the `/` a comment and division share is one `slash` rule with four branches — `//…`, `/*…*/`, `/=`, `/` — deciding on the symbol after it;
- the operators are `literals`' prefix tree over the classical list less the two `slash` holds;
- a number has no poison branch: `123abc` reads as `123` then `abc`, for the layer above the tokens to refuse, as the issue says.

Strings and a number's unsigned part with its fraction and exponent are `../json`'s rules, imported rather than restated. A line comment stops before its newline, which is the next token. Every layer stays an LL(1) grammar plus a mapping.

**The comparison proof** lives in the classical tokenizer's own proof, which may import both sides, and goes with the classical grammar when it retires. Over a corpus covering every token kind and every changed shape, the two grammars yield the same kind and text token for token — the classical stream read off the descent AST, with the newline its line comment swallows split back out, as the tokenizer does below the grammar; the EBNF stream read one token at a time through the resumable parser. The inputs the poison branch rejected are pinned apart as the two adjacent tokens the EBNF grammar reads, beside the classical `numError` tag. The 56 operators are one token each in both.

Checks: `tsc`, `node ./fjs/module.mjs t` (5554), `npm run gen` (no change), `node --test` with 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CZRKbBvWAYpYtgVpUa3UH