### PR TITLE
djs/tokenizer: read tokens with the LL(1) backend, one token at a time

### DIFF
--- a/fjs/bnf/todo/proof-recognizer-and-fixtures.md
+++ b/fjs/bnf/todo/proof-recognizer-and-fixtures.md
@@ -13,8 +13,9 @@ text helper.
 `fjs/bnf/testlib.f.mjs`, which owns the two JSON grammars (`classic`,
 `deterministic`) that four proof files import. Three smaller pieces of the same
 kind never made it there and are copy-pasted instead, across
-`fjs/bnf/descent/proof.f.mjs`, `fjs/bnf/ll1/proof.f.mjs`, and
-`fjs/djs/tokenizer/proof.f.mjs`.
+`fjs/bnf/descent/proof.f.mjs` and `fjs/bnf/ll1/proof.f.mjs`, with
+`fjs/djs/tokenizer/proof.f.mjs` carrying its own copy of the corpus and a
+third spelling of the recognizer.
 
 This design predates the alphabet split. Its shared `number` fixture currently
 constructs Unicode terminals with core `range('--')` / `range('09')`, and its
@@ -26,11 +27,11 @@ backends do not consume ([ebnf-range-set](./ebnf-range-set.md)). Only a
 classical fixture that still spells rules functionally keeps the classical
 helper, and it stays in `fjs/bnf/testlib.f.mjs`.
 
-#### 1. The "recognizes the whole input" helper — 8 copies
+#### 1. The "recognizes the whole input" helper — 7 copies plus 1 in a third shape
 
 Every recognizer test needs the same question answered: *did the parser accept
-and consume all of the input?* It is spelled out inline eight times, in two
-backend-specific shapes:
+and consume all of the input?* It is spelled out inline seven times in
+`fjs/bnf`, in two backend-specific shapes:
 
 ```ts
 // descent shape — fjs/bnf/descent/proof.f.mjs:202, :228, :244
@@ -53,15 +54,22 @@ differ: descent returns the record `DescentMatchResult`
 (`fjs/bnf/descent/types.ts:52-57` — `{ ast, success, idx, failure? }`),
 while ll1's `MatchResult` is still a tuple. Any adapter has to speak both.
 
-`fjs/djs/tokenizer/proof.f.mjs:33` is an eighth site in the descent shape, with
-`JSON.stringify([s, mr])` as its message instead of `mr`.
+`fjs/djs/tokenizer/proof.f.mjs`'s `covers` is the same question in a third
+shape, over the surviving backend: it resumes `fjs/ebnf/ll1`'s `parser` of
+the one-token grammar `fjs/ebnf/lib/js` from where the last token ended, and
+answers `false` at the first token the grammar refuses and `true` once the
+loop reaches the end. It is what `ll1Recognizer` below looks like once a
+grammar is read token by token rather than in one match; the tokenizer's
+`isValid` is the site to convert to the shared `assertRecognizes`. Before the
+port it was an eighth copy of the descent shape
+([ebnf-ll1-port](../../djs/todo/ebnf-ll1-port.md)).
 
 The copies have drifted in exactly the ways copies do: the start-rule name is
-`''` in seven sites and `'value'` in one; `isSuccess` is a named local in three
-ll1 sites and inline in the fourth; the failure message differs. None of these
-differences is intentional.
+`''` except where the JSON grammar's root is named `'value'`; `isSuccess` is a
+named local in three ll1 sites and inline in the fourth; the failure message
+differs, and `covers` reports none. None of these differences is intentional.
 
-The two shapes are the same predicate — *accepted, and the remainder is empty* —
+The shapes are the same predicate — *accepted, and the remainder is empty* —
 differing only in how each backend reports the remainder. That difference belongs
 in one adapter, not in eight test bodies.
 

--- a/fjs/bnf/todo/proof-recognizer-and-fixtures.md
+++ b/fjs/bnf/todo/proof-recognizer-and-fixtures.md
@@ -153,11 +153,12 @@ carry its own entry. `ll1Recognizer` builds via `parserRuleSet(ruleSet)`, which 
 already exposes, so no production API is added here; a `bnf`-local descent
 adapter builds via `descentParserRuleSet(ruleSet)` the same way.
 
-That local adapter also absorbs the proof-local copy of `descentParserCpOnly`.
-Leave the DJS tokenizer's own `descentParserCpOnly` export to the djs port:
-its proof has typed-result consumers beyond the recognition corpus, and the
-port replaces it with an LL(1) equivalent as part of that module's own API
-change ([ebnf-migration](../../todo/ebnf-migration.md), the consumer port).
+That local adapter also absorbs the proof-local copy of `descentParserCpOnly`,
+which is now the only one: the DJS tokenizer's own export of that name went
+with its port to the LL(1) backend, retired with no equivalent
+([ebnf-ll1-port](../../djs/todo/ebnf-ll1-port.md)) — the tokenizer reads
+`fjs/ebnf/lib/js` one token at a time, and its proof asks the grammar what
+it covers rather than reading a match result.
 
 `stringToCodePointList` / `toArray` / code-point mapping stay inside the Unicode
 recognizer adapter, which takes them from `fjs/text/utf16` — input decoding,
@@ -217,8 +218,8 @@ explicit named override list for the rows where token-stream acceptance differs.
       the first task removes) and no `''` default.
 - [ ] Fold the proof-local `descentParserCpOnly` / code-point adapter into a
       `bnf/descent`-local `descentRecognizer` that reuses the shared
-      `Recognizer` type and `assertRecognizes`; leave the DJS tokenizer's
-      public export to the djs port.
+      `Recognizer` type and `assertRecognizes`. The DJS tokenizer's export of
+      that name is gone with its port, so nothing else spells it.
 - [ ] Add `number` as a directly authored `RuleSet` and entry name — no
       functional `Rule`, no `toData` in the shared testlib — and add
       `jsonCases`.

--- a/fjs/djs/todo/ebnf-ll1-port.md
+++ b/fjs/djs/todo/ebnf-ll1-port.md
@@ -134,8 +134,11 @@ reads values, not text.
 - [x] Tokenizer grammar in EBNF beside the classical one, LL(1), with the
       comparison proof: [`fjs/ebnf/lib/js`](../../ebnf/lib/js/module.f.mjs),
       and the `ebnf` group of the classical tokenizer's proof.
-- [ ] Tokenizer on `ebnf/ll1`: mappings, the token-boundary check, error
-      tokens; `jsMatcher` and `descentParserCpOnly` replaced and declared.
+- [x] Tokenizer on `ebnf/ll1`: the grammar read one token at a time, the
+      trivia fold, the boundary check and the error tokens one layer up;
+      `jsGrammar`, `jsMatcher` and `descentParserCpOnly` retired and
+      declared. The comparison proof retired with the classical grammar;
+      the tokenizer's corpus stands unchanged as the port's proof.
 - [ ] Parser grammar LL(1): trailing trivia, right-recursive or separated
       list, the terminator per stage 5.
 - [ ] Parser on `ebnf/ll1`, on the `media/datajs` reader pattern.

--- a/fjs/djs/tokenizer/module.f.mjs
+++ b/fjs/djs/tokenizer/module.f.mjs
@@ -26,12 +26,14 @@
  * consumed the offending character; an LL(1) grammar cannot, and the token
  * stream shows the same fact one layer up.
  *
- * An error is the whole output: the first, in document order, of a token
- * the grammar refuses (`invalid token`, from where the token began to the
- * end of input), a number cut short (`invalid number`, at the character
- * where digits were expected), a block comment the input ends inside
- * (`*​/ expected`, from its `/*` to the end of input), and the boundary
- * above.
+ * An error is the whole output: the first, in document order, of the
+ * boundary above, a block comment the input ends inside (`*​/ expected`,
+ * from its `/*` to the end of input), a number cut short (`invalid
+ * number`, at the character where digits were expected), and a token the
+ * grammar refuses (`invalid token`, from where the token began to the end
+ * of input). The grammar stops at the token it refuses, so the fold above
+ * it runs over what came before first, and the refused token is reported
+ * only where nothing before it was wrong.
  *
  * @module
  *
@@ -266,14 +268,6 @@ const failed = (message, metadata, end) => [at(end === undefined ? { kind: 'erro
  */
 export const tokenizeJs = input => path => {
     const { lexemes, failure, final } = lex(path)(toArray(input))
-    if (failure !== null) {
-        // A number cut short — `1.`, `0e` — fails where its digits were
-        // expected, and that character is the one to point at, with no
-        // end, since what is wrong runs backwards from there. Any other
-        // token is refused whole, from where it began to the end of input:
-        // nothing past a lexical failure is tokenized.
-        return failure.number ? failed('invalid number', failure.at) : failed('invalid token', failure.start, final)
-    }
     /** @type {List<JsTokenWithMetadata>} */
     let out = empty
     /** @type {_Trivia} */
@@ -316,6 +310,21 @@ export const tokenizeJs = input => path => {
             out = concat(out)([at({ kind: 'nl' }, start)])
         }
         previous = kind
+    }
+    if (failure !== null) {
+        // The token the grammar refused comes after every token it read,
+        // so an error among those — the fold above has just looked — is
+        // reported first, and this one only where nothing came before it.
+        // A number that stands directly against the number before it is
+        // that boundary error, wherever it then failed: `01.` is refused at
+        // the `1`. A number cut short — `1.`, `0e` — fails where its digits
+        // were expected, and that character is the one to point at, with
+        // no end, since what is wrong runs backwards from there. Any other
+        // token is refused whole, from where it began to the end of input:
+        // nothing past a lexical failure is tokenized.
+        return failure.number
+            ? failed('invalid number', previous === 'number' ? failure.start : failure.at)
+            : failed('invalid token', failure.start, final)
     }
     if (trivia !== null) {
         out = concat(out)([at({ kind: trivia.kind }, trivia.metadata)])

--- a/fjs/djs/tokenizer/module.f.mjs
+++ b/fjs/djs/tokenizer/module.f.mjs
@@ -1,47 +1,50 @@
 /**
- * Experimental DJS parser implementation.
+ * The DJS tokenizer, in layers, each an LL(1) grammar or a fold over the
+ * layer below:
+ *
+ * ```text
+ * code points ==the token grammar, one token at a time==> lexemes
+ *             ==fold: trivia merged, words classified, boundaries checked==> JsToken stream
+ *             ==fold: keywords demoted, `-` folded into a number==> DjsToken stream
+ * ```
+ *
+ * The grammar is [`fjs/ebnf/lib/js`](../../ebnf/lib/js/module.f.mjs), one
+ * token, read by the LL(1) backend resumed where the last token ended
+ * ([`fjs/ebnf/ll1`](../../ebnf/ll1/README.md), "A token layer resumes the
+ * parser"). A token's text is the input between where it began and where
+ * it ended, so nothing walks its tree but the one question a block comment
+ * leaves open — whether it closed — and that walk is a loop, since the
+ * comment's content is right-recursive and a comment may be long.
+ *
+ * What the grammar leaves to the fold above it: a run of whitespace and
+ * newlines is one token, `nl` where the run holds a newline and anchored
+ * at the first, `ws` otherwise; a word is a keyword or an identifier; a
+ * number is a `number` or a `bigint`; and a number directly followed by a
+ * word or a number, no trivia between — `123abc`, `1nabc`, `00` — is the
+ * error `invalid number`, at the token that should not be there. The
+ * classical grammar refused those inside the number, with a branch that
+ * consumed the offending character; an LL(1) grammar cannot, and the token
+ * stream shows the same fact one layer up.
+ *
+ * An error is the whole output: the first, in document order, of a token
+ * the grammar refuses (`invalid token`, from where the token began to the
+ * end of input), a number cut short (`invalid number`, at the character
+ * where digits were expected), a block comment the input ends inside
+ * (`*​/ expected`, from its `/*` to the end of input), and the boundary
+ * above.
  *
  * @module
  *
- * @import { Ast, AstSequence, AstTag, Meta } from '../../bnf/matcher/types.ts'
- * @import { DescentMatch, DescentMatchResult } from '../../bnf/descent/types.ts'
- * @import { DataRule, Rule } from '../../bnf/types.ts'
- * @import {
- *   JsToken,
- *   JsTokenWithMetadata,
- *   TokenMetadata,
- *   TokenPosition,
- * } from '../../js/tokenizer/types.ts'
- * @import { CodePoint } from '../../text/utf16/types.ts'
+ * @import { ErrorToken, JsToken, JsTokenWithMetadata, TokenMetadata, TokenPosition } from '../../js/tokenizer/types.ts'
  * @import { StateScan } from '../../types/function/operator/types.ts'
  * @import { List } from '../../types/list/types.ts'
  * @import { DjsToken, DjsTokenWithMetadata } from './types.ts'
- * @import { TriviaKind } from '../../js/tokenizer/types.ts'
- * @import { Nullable } from '../../types/nullable/types.ts'
- * @import {
- *   _DjsScanState,
- *   _FlatToken,
- *   _StringDecodeState,
- *   _Token,
- *   _TokenScanState,
- * } from './private.ts'
+ * @import { _DjsScanState, _Failure, _Kind, _Lexed, _Lexeme, _StringDecodeState, _Trivia } from './private.ts'
  */
 
-import { assert, assertEq } from '../../asserts/module.f.mjs'
-import { descentParserRuleSet } from '../../bnf/descent/module.f.mjs'
-import { toData } from '../../bnf/data/module.f.mjs'
-import {
-    eof,
-    none,
-    notSet,
-    option,
-    range,
-    remove,
-    repeat0Plus,
-    set,
-    unicodeMax,
-    unicodeRange,
-} from '../../bnf/module.f.mjs'
+import { assert } from '../../asserts/module.f.mjs'
+import { parser } from '../../ebnf/ll1/module.f.mjs'
+import { token } from '../../ebnf/lib/js/module.f.mjs'
 import { keywords } from '../../js/keywords/module.f.mjs'
 import { escapeToCodePoint } from '../../js/string_escape/module.f.mjs'
 import { isKeywordToken, mergeTrivia } from '../../js/tokenizer/module.f.mjs'
@@ -53,248 +56,71 @@ import {
 } from '../../text/ascii/module.f.mjs'
 import { codePointListToString, stringToCodePointList } from '../../text/utf16/module.f.mjs'
 import { mapUnwrap } from '../../types/nullable/module.f.mjs'
-import { concat, empty, filter, flat, flatMap, fold, map, stateScan, toArray } from '../../types/list/module.f.mjs'
+import { concat, empty, flat, fold, map, stateScan, toArray } from '../../types/list/module.f.mjs'
 import { stringifyAsTree } from '../serializer/module.f.mjs'
 import { sort } from '../../types/object/module.f.mjs'
-import { repeat } from '../../types/array/module.f.mjs'
 
-// Builds the single-token grammar that jsGrammar's whole-file `tokens` rule repeats.
-/**
- * The whitespace characters the grammar's `ws` rule matches.
- *
- * The grammar's rule and every downstream check of a trivia tag are built from
- * this one string: the descent parser emits a range-variant branch's tag as the
- * matched character itself, so the characters the rule accepts *are* the tags it
- * produces. Spelling them a second time is what let the two drift apart.
- *
- * @type {string}
- */
-const wsChars = ' \t'
+// -- layer 1: the grammar, one token at a time ------------------------------
+
+/** The parser of one token, built once: the grammar is analysed per module, not per parse. */
+const parseToken = parser(token)
 
 /**
- * The newline characters the grammar's `newLine` rule matches, the single source
- * for that rule and its tags exactly as {@link wsChars} is.
+ * A variant's node, read untyped: its tag and the branch's node. The tree
+ * is the grammar's by construction, so a shape that is not a variant's is
+ * a broken invariant, not bad input.
  *
- * @type {string}
+ * @type {(node: unknown) => readonly [string, unknown]}
  */
-const nlChars = '\n\r'
-
-/** @type {ReadonlySet<string>} */
-const wsTags = new Set(wsChars)
-
-/** @type {ReadonlySet<string>} */
-const nlTags = new Set(nlChars)
-
-/**
- * The operator vocabulary: each key is the tag the descent parser emits for that
- * branch, and each value the characters it matches.
- *
- * At module scope because it captures nothing from `buildToken`, and because
- * `operatorTags` derives the tag set from these keys rather than re-listing them.
- */
-const operator = {
-    '.': '.',
-    '=>': '=>',
-    '===': '===',
-    '==': '==',
-    '=': '=',
-    '!==': '!==',
-    '!=': '!=',
-    '!': '!',
-    '>>>=': '>>>=',
-    '>>>': '>>>',
-    '>>=': '>>=',
-    '>>': '>>',
-    '>=': '>=',
-    '>': '>',
-    '<<=': '<<=',
-    '<<': '<<',
-    '<=': '<=',
-    '<': '<',
-    '+=': '+=',
-    '++': '++',
-    '+': '+',
-    '-=': '-=',
-    '--': '--',
-    '-': '-',
-    '**=': '**=',
-    '**': '**',
-    '*=': '*=',
-    '*': '*',
-    '/=': '/=',
-    '/': '/',
-    '%=': '%=',
-    '%': '%',
-    '&&=': '&&=',
-    '&&': '&&',
-    '&=': '&=',
-    '&': '&',
-    '||=': '||=',
-    '||': '||',
-    '|=': '|=',
-    '|': '|',
-    '^=': '^=',
-    '^': '^',
-    '~': '~',
-    '??=': '??=',
-    '??': '??',
-    '?.': '?.',
-    '?': '?',
-    '[': '[',
-    ']': ']',
-    '{': '{',
-    '}': '}',
-    '(': '(',
-    ')': ')',
-    ',': ',',
-    ':': ':',
-    ';': ';'
+const branch = node => {
+    assert(node instanceof Array && node.length === 2 && typeof node[0] === 'string', node)
+    return [node[0], node[1]]
 }
 
-/** @type {() => Rule} */
-const buildToken = () => {
+/** @type {(node: unknown) => readonly unknown[]} */
+const items = node => {
+    assert(node instanceof Array, node)
+    return node
+}
 
-    const onenine = range('19')
-
-    /** @type {Rule} */
-    const digit = range('09')
-
-    const string = [
-        '"',
-        repeat0Plus({
-            ...remove(range(` ${unicodeMax}`), set('"\\')),
-            escape: [
-                '\\',
-                {
-                    ...set('"\\bfnrt'),
-                    solidus: '/',
-                    u: [
-                        'u',
-                        ...repeat(4)({
-                            digit,
-                            AF: range('AF'),
-                            af: range('af'),
-                        })
-                    ],
-                }
-            ],
-        }),
-        '"'
-    ]
-
-    const digits0 = repeat0Plus(digit)
-
-    const digits = [digit, digits0]
-
-    const ws = set(wsChars)
-
-    const newLine = set(nlChars)
-
-    const idStart = {
-        smallLetter: range('az'),
-        bigLetter: range('AZ'),
-        lowLine: '_',
-        dollarSign: '$'
-    }
-
-    const idChar = {
-        ...idStart,
-        digit
-    }
-
-    // '.' and 'e'/'E' always succeed once seen, tagging missing digits as `numError`,
-    // so a malformed fraction/exponent (e.g. `0.`, `0e`) fails the whole number instead
-    // of silently ending it early. The sign is matched via string-literal branches
-    // (not `set('+-')`) because a range-variant branch's tag is the matched character
-    // itself, which would collide with the '+'/'-' operator tags in filterFunc.
-    const fracPart = { withDot: ['.', { valid: digits, numError: none }], noDot: none }
-    const expPart = { withExp: [set('Ee'), option({ plus: '+', minus: '-' }), { valid: digits, numError: none }], noExp: none }
-
-    // ECMAScript disallows a NumericLiteral immediately followed by an IdentifierStart
-    // or DecimalDigit (e.g. `00`, `123abc`). Consume that character into the number and
-    // tag it `numError` instead of leaving it to silently start a new token. idChar is
-    // wrapped in a sequence so this branch's own `numError` tag survives — a variant
-    // referenced directly as another variant's branch loses the outer tag to whichever
-    // of its own branches matches.
-    const number = [
-        {
-            0: '0',
-            onenine: [onenine, digits0],
-        },
-        option({
-            bigint: 'n',
-            frac: [fracPart, expPart]
-        }),
-        { numError: [idChar], ok: none }
-    ]
-
-    const id = [idStart, repeat0Plus(idChar)]
-
-    // Recursive rule: tries end (*/) first at every position so **/  → content(*) + terminator(*/).
-    // Falls back to the empty `unterminated` alternative at EOF instead of failing, so `comment`
-    // always succeeds and the descent parser never backtracks into matching '/' and '*' as
-    // separate operators. Callers detect an unterminated comment by checking for this tag.
-    /** @type {() => DataRule} */
-    const multilineContent = () => {
-        /** @type {Rule} */
-        const char = { na: notSet('*'), a: '*' }
-        /** @type {Rule} */
-        const end = ['*', '/']
-        /** @type {Rule} */
-        const more = [char, multilineContent]
-        return { end, more, unterminated: none }
-    }
-
-    const comment = ['/', {
-            // TODO: investigate why `not(commentEnd)` instead of `remove(unicodeRange, newLine)` fail tests.
-            oneline: ['/', repeat0Plus(remove(unicodeRange, newLine)), option(newLine)],
-            multiline: ['*', multilineContent]
+/**
+ * Whether a block comment's content, the node after its `/*`, reached the
+ * `*​/` that closes it before the input ended. Each node is a `*` and what
+ * follows it, or another symbol and more content, or the end: `end` after
+ * a `*` is the close, `unterminated` the end of input. A loop, not a
+ * recursion — the content nests one level per symbol.
+ *
+ * @type {(content: unknown) => boolean}
+ */
+const closed = content => {
+    let node = content
+    for (;;) {
+        const [tag, rest] = branch(node)
+        switch (tag) {
+            case 'end': { return true }
+            case 'unterminated': { return false }
+            default: { node = items(rest)[1] }
         }
-    ]
-
-    const token = {
-        number,
-        string,
-        id,
-        comment,
-        operator,
-        ws,
-        newLine,
-        eof
     }
-
-    return token
 }
-
-// The whole file's token stream as one right-recursive grammar rule. Safe at any input
-// length: descentParser matches on an explicit frame stack, not the JS call stack
-// (see fjs/bnf/descent/module.f.mjs).
-/** @type {() => Rule} */
-export const jsGrammar = () => repeat0Plus(buildToken())
 
 /**
- * The whole-file matcher together with the name of the rule to start it at.
+ * The kind of a token from its node, and whether it closed — which is a
+ * question only for a block comment, `true` for every other token. The
+ * `token` variant's tag is the kind but for `slash`, whose own tag says
+ * which of its four it was.
  *
- * `toData` generates rule names, so the entry name belongs to the conversion
- * rather than to the grammar's spelling and is read back from it here. Building
- * both from one conversion also keeps the grammar built once per matcher.
- *
- * @type {<T>() => readonly [DescentMatch<T>, string]}
+ * @type {(node: unknown) => readonly [_Kind, boolean]}
  */
-export const jsMatcher = () => {
-    const [ruleSet, entry] = toData(jsGrammar())
-    return [descentParserRuleSet(ruleSet), entry]
-}
-
-const stringify = stringifyAsTree(sort)
-
-/** @type {(cp: CodePoint) => Meta<unknown, CodePoint>} */
-const mapCodePoint = cp => [cp, undefined]
-
-/** @type {(m: DescentMatch<unknown>, name: string, cp: readonly CodePoint[]) => DescentMatchResult<unknown>} */
-export const descentParserCpOnly = (m, name, cp) => {
-    const cpm = toArray(map(mapCodePoint)(cp))
-    return m(name, cpm)
+const kindOf = node => {
+    const [tag, child] = branch(node)
+    if (tag !== 'slash') { return [/** @type {_Kind} */ (tag), true] }
+    const [sub, rest] = branch(items(child)[1])
+    switch (sub) {
+        case 'oneline': { return ['comment', true] }
+        case 'multiline': { return ['comment', closed(items(rest)[1])] }
+        default: { return ['operator', true] }
+    }
 }
 
 // Advances path/line/column by one code point, mirroring fjs/js/tokenizer's tokenizeWithPositionOp.
@@ -303,79 +129,49 @@ const advanceMetadata = cp => metadata => cp === lf
     ? { path: metadata.path, line: metadata.line + 1, column: 1 }
     : { path: metadata.path, line: metadata.line, column: metadata.column + 1 }
 
-// Pairs each code point with the metadata of its position *before* it's consumed.
-/** @type {StateScan<number, TokenMetadata, readonly [Meta<TokenMetadata, CodePoint>]>} */
-const metadataScan = (cp, metadata) => [[[cp, metadata]], advanceMetadata(cp)(metadata)]
+/** @type {(metadata: TokenMetadata) => (cp: readonly number[]) => TokenMetadata} */
+const advance = metadata => cp => fold(advanceMetadata)(metadata)(cp)
 
-/** @type {(path: string) => (cp: readonly number[]) => readonly Meta<TokenMetadata, CodePoint>[]} */
-const codePointsWithMetadata = path => cp => toArray(flat(stateScan(metadataScan)({ path, line: 1, column: 1 })(cp)))
-
-/**
- * The grammar tag of a trivia code point, as the kind `mergeTrivia` speaks in;
- * `null` for every other tag.
- *
- * @type {(tag: string) => Nullable<TriviaKind>}
- */
-const triviaKind = tag =>
-    nlTags.has(tag) ? 'nl' :
-    wsTags.has(tag) ? 'ws' :
-    null
-
-/** @type {StateScan<_FlatToken, _TokenScanState, List<_Token>>} */
-const scanFunc = (input, state) => {
-    const [stateTag, stateMetadata, stateCodePoints] = state
-    if (typeof input === 'string') {
-        // A trivia run continues: `mergeTrivia` decides the run's kind, and
-        // the pending token only has to be restarted under the incoming tag
-        // when that kind is not the one it already has (ws followed by nl).
-        const inputKind = triviaKind(input)
-        const stateKind = triviaKind(stateTag)
-        if (inputKind !== null && stateKind !== null) {
-            return [null, mergeTrivia(stateKind, inputKind) === stateKind ? state : [input, null, []]]
-        }
-        /** @type {_TokenScanState} */
-        const newState = [input, null, []]
-        if (stateTag === '') {
-            return [null, newState]
-        }
-        /** @type {_Token} */
-        const tk = [stateTag, /** @type {TokenMetadata} */ (stateMetadata), toArray(stateCodePoints)]
-        return [[tk], newState]
-    }
-    const [cp, codePointMetadata] = input
-    const startMetadata = stateMetadata === null ? codePointMetadata : stateMetadata
-    return [null, [stateTag, startMetadata, concat(stateCodePoints)([cp])]]
-}
+/** @type {(cp: number) => boolean} */
+const isDigit = cp => cp >= 0x30 && cp <= 0x39
 
 /**
- * All operator tag strings the grammar's `operator` rule produces, derived from
- * the rule itself: the descent parser emits a variant branch's key as its tag,
- * so the keys of {@link operator} *are* the tag set.
+ * Reads the whole input one token at a time, the parser resumed where the
+ * last token ended, until a token the grammar refuses. A token's text is
+ * the input it spans, and its position is carried along rather than
+ * attached to every code point.
  *
- * `'/'` is a member because division is an operator; it does not also swallow
- * the slashes of a comment, since `oneline` consumes the whole rest of the line
- * with `repeat0Plus` and the comment rule matches before the tag reaches here.
- *
- * @type {ReadonlySet<string>}
+ * @type {(path: string) => (cp: readonly number[]) => _Lexed}
  */
-const operatorTags = new Set(Object.keys(operator))
-
-/** @type {(tk: _FlatToken) => boolean} */
-const filterFunc = tk => {
-    if (tk instanceof Array)
-        return true
-    switch (tk) {
-        case 'number':
-        case 'string':
-        case 'id':
-        case 'comment':
-            return true
-        default:
-            // Trivia tags go through `triviaKind` rather than a third copy of
-            // the characters, so they cannot drift from the grammar's rules.
-            return triviaKind(tk) !== null || operatorTags.has(tk)
+const lex = path => cp => {
+    const symbols = cp.map(symbol => ({ symbol, meta: null }))
+    /** @type {List<_Lexeme>} */
+    let lexemes = empty
+    let pos = 0
+    /** @type {TokenMetadata} */
+    let metadata = { path, line: 1, column: 1 }
+    while (pos < cp.length) {
+        const match = parseToken(symbols, pos)
+        if (match[0] === 'error') {
+            /** @type {_Failure} */
+            const failure = {
+                number: isDigit(cp[pos]),
+                start: metadata,
+                at: advance(metadata)(cp.slice(pos, match[1])),
+            }
+            return { lexemes: toArray(lexemes), failure, final: advance(metadata)(cp.slice(pos)) }
+        }
+        const [node, end] = match[1]
+        const text = cp.slice(pos, end)
+        const [kind, ok] = kindOf(node)
+        lexemes = concat(lexemes)([{ kind, text, start: metadata, closed: ok }])
+        metadata = advance(metadata)(text)
+        pos = end
     }
+    return { lexemes: toArray(lexemes), failure: null, final: metadata }
 }
+
+// -- layer 2: the JsToken stream --------------------------------------------
 
 /**
  * A `\uXXXX` escape reaches the `unicode` state only after the grammar has
@@ -390,12 +186,12 @@ const stringDecodeScan = (cp, state) => {
     switch (state.kind) {
         case 'escape': {
             const codePoint = escapeToCodePoint(cp)
-            // The grammar's own `escape` rule (`buildToken`'s `string`) only ever
-            // accepts one of the eight simple escapes or `u` right after a
-            // backslash — any other character fails to parse before a token
-            // reaches this scan at all, so narrowing to those nine is provable,
-            // not merely assumed. `u` is the one the table does not answer for:
-            // the four hex digits that follow decide its meaning.
+            // The grammar's `string` rule only ever accepts one of the eight
+            // simple escapes or `u` right after a backslash — any other
+            // character fails to parse before a token reaches this scan at
+            // all, so narrowing to those nine is provable, not merely
+            // assumed. `u` is the one the table does not answer for: the
+            // four hex digits that follow decide its meaning.
             assert(codePoint !== null || cp === latinSmallLetterU, cp)
             return codePoint === null
                 ? [null, { kind: 'unicode', acc: 0, count: 0 }]  // \u → start 4 hex digits
@@ -416,152 +212,28 @@ const decodeJsonString = codePoints => codePointListToString(flat(stateScan(stri
 /** @type {ReadonlySet<string>} */
 const keywordSet = new Set(keywords)
 
-/** @type {(tk: _Token) => JsToken} */
-const toJsToken = tk => {
-    const [tag, , codePoints] = tk
-    switch (tag) {
-        case '\n':
-        case '\r':
-            return { kind: 'nl' }
-        case ' ':
-        case '\t':
-            return { kind: 'ws' }
-        case 'string':
-            return { kind: 'string', value: decodeJsonString(codePoints) }
-        case 'id': {
-            const value = codePointListToString(codePoints)
-            if (keywordSet.has(value)) return /** @type {JsToken} */ ({ kind: value })
-            return { kind: 'id', value }
-        }
-        case 'number': {
-            const value = codePointListToString(codePoints)
-            if (value.endsWith('n')) return { kind: 'bigint', value: BigInt(value.slice(0, -1)) }
-            return { kind: 'number', value }
-        }
-        case 'comment':
-            if (codePoints[1] === asterisk) // block comment /*...*/
-                return { kind: '/*', value: codePointListToString(codePoints.slice(2, -2)) }
-            return { kind: '//', value: codePointListToString(codePoints.slice(2)) }
-        default:
-            return /** @type {JsToken} */ ({ kind: tag })
-    }
-}
-
-/** @type {(tk: _Token) => List<JsToken>} */
-const toJsTokens = tk => {
-    const token = toJsToken(tk)
-    if (token.kind === '/*') {
-        const hasNl = token.value.includes('\n') || token.value.includes('\r')
-        if (hasNl) return [token, { kind: 'nl' }]
-    }
-    return [token]
-}
-
-// Same as toJsTokens, but pairs each emitted token with tk's start metadata instead of
-// discarding it — used by tokenize (the metadata-aware entry point), not tokenizeString.
-/** @type {(tk: _Token) => List<JsTokenWithMetadata>} */
-const toJsTokenWithMetadata = tk => {
-    const [, metadata] = tk
-    const token = toJsToken(tk)
-    if (token.kind === '/*') {
-        const hasNl = token.value.includes('\n') || token.value.includes('\r')
-        if (hasNl) return [{ token, metadata }, { token: { kind: 'nl' }, metadata }]
-    }
-    return [{ token, metadata }]
-}
-
-/** @type {(value: Ast<Meta<TokenMetadata, CodePoint>>|Meta<TokenMetadata, CodePoint>) => List<_FlatToken>} */
-const getTokensFromAstRuleOrCodePoint = value => {
-    if (value instanceof Array)
-        return [value]
-
-    return getTokensFromAstRule(value)
-}
-
-/** @type {(seq: AstSequence<Meta<TokenMetadata, CodePoint>>) => List<_FlatToken>} */
-const getTokensFromAstSequence = seq => {
-    return flatMap(getTokensFromAstRuleOrCodePoint)(seq)
-}
-
-/** @type {(tag: AstTag) => _FlatToken} */
-const tagToToken = tag => {
-    switch (typeof tag) {
-        case 'string': return tag
-        case 'undefined': return 'undefined'
-        default: return 'true'
-    }
-}
-
-/** @type {(ast: Ast<Meta<TokenMetadata, CodePoint>>) => List<_FlatToken>} */
-const getTokensFromAstRule = ast => {
-    const token = tagToToken(ast.tag)
-    if (ast.sequence.length === 0)
-        return [token]
-
-    return { first: token, tail: getTokensFromAstSequence(ast.sequence) }
-}
-
-/** @type {(s: string) => string} */
-export const tokenizeString = s => {
-    const cp = toArray(stringToCodePointList(s))
-    if (cp.length === 0) {
-        return stringify([{ kind: 'eof' }])
-    }
-    const [m, entry] = jsMatcher()
-    const cpm = codePointsWithMetadata('')(cp)
-    const { ast, success: ok, idx: len } = m(entry, cpm)
-    if (!ok || len !== cp.length)
-        return 'error'
-
-    const flatTokens = toArray(getTokensFromAstRule(ast))
-    // multilineContent tags an unterminated block comment as 'unterminated', and number
-    // tags a malformed fraction/exponent or a disallowed trailing char as 'numError',
-    // rather than failing outright — detect them here instead.
-    if (flatTokens.includes('unterminated') || flatTokens.includes('numError')) return 'error'
-    const filterTokens = concat(filter(filterFunc)(flatTokens))([''])
-    const tokens = flat(stateScan(scanFunc)(['', null, []])(filterTokens))
-    const jsTokens = concat(flatMap(toJsTokens)(tokens))([{ kind: 'eof' }])
-    const result = toArray(jsTokens)
-    return stringify(result)
-}
-
-// Finds `tag` in flatTokens and returns the metadata of the next code point after it.
-// numError/unterminated tags are followed by the poisoning char / EOF-hitting position
-// in the flattened AST walk order, so this pinpoints roughly where tokenization failed.
-//
-// The single call site only passes a `tag` it already confirmed via
-// `flatTokens.includes(tag)`, so `indexOf` here is never -1.
-/** @type {(tag: string, flatTokens: readonly _FlatToken[], fallback: TokenMetadata) => TokenMetadata} */
-const metadataAfterTag = (tag, flatTokens, fallback) => {
-    const idx = flatTokens.indexOf(tag)
-    const found = flatTokens.slice(idx + 1).find((/** @type {_FlatToken} */ t) => t instanceof Array)
-    return found === undefined ? fallback : found[1]
-}
-
 /**
- * Where the token carrying `errorTag` began.
+ * The token a word is: a string decoded, a word a keyword or an identifier,
+ * a number a `number` or a `bigint` by its suffix, a comment its text
+ * between the marks, an operator its own spelling.
  *
- * An unterminated construct is anchored at its opening, not at the point the
- * input ran out: the reader is being told which `"` or `/*` was never closed,
- * and the end of the file is not that. It is also what TypeScript reports for
- * the same input, and what an unterminated *string* already reports here — the
- * comment reporting the end was the odd one out.
- *
- * The search runs backwards from the error tag rather than forwards from the
- * start, so the second comment in `/* ok *\/ /* bad` is the one blamed.
- *
- * Both lookups succeed by construction — an `unterminated` tag exists only
- * inside a `comment`, and a comment always carries at least its opening `/` — so
- * this asserts rather than falling back on a position no input can produce.
- *
- * @type {(tokenTag: string, errorTag: string, flatTokens: readonly _FlatToken[]) => TokenMetadata}
+ * @type {(lexeme: _Lexeme) => JsToken}
  */
-const tokenStartOfTag = (tokenTag, errorTag, flatTokens) => {
-    const tokenIdx = flatTokens.lastIndexOf(tokenTag, flatTokens.indexOf(errorTag))
-    assert(tokenIdx !== -1, ['no enclosing token carried', errorTag])
-    const found = flatTokens.slice(tokenIdx + 1).find((/** @type {_FlatToken} */ t) => t instanceof Array)
-    assert(found !== undefined && found instanceof Array, ['enclosing token had no code points', tokenTag])
-    return found[1]
+const toJsToken = ({ kind, text }) => {
+    const value = codePointListToString(text)
+    switch (kind) {
+        case 'string': { return { kind: 'string', value: decodeJsonString(text) } }
+        case 'id': { return keywordSet.has(value) ? /** @type {JsToken} */ ({ kind: value }) : { kind: 'id', value } }
+        case 'number': {
+            return value.endsWith('n') ? { kind: 'bigint', value: BigInt(value.slice(0, -1)) } : { kind: 'number', value }
+        }
+        case 'comment': {
+            return text[1] === asterisk
+                ? { kind: '/*', value: value.slice(2, -2) }
+                : { kind: '//', value: value.slice(2) }
+        }
+        default: { return /** @type {JsToken} */ ({ kind: value }) }
+    }
 }
 
 /**
@@ -572,64 +244,101 @@ const tokenStartOfTag = (tokenTag, errorTag, flatTokens) => {
  */
 const position = ({ line, column }) => ({ line, column })
 
-/** @type {(input: List<number>) => (path: string) => List<JsTokenWithMetadata>} */
+/** @type {(token: JsToken, metadata: TokenMetadata) => JsTokenWithMetadata} */
+const at = (token, metadata) => ({ token, metadata })
+
+/**
+ * The error the whole output becomes: a lexical failure is reported alone,
+ * as the tokenizer has always reported it, with its span where it has one.
+ *
+ * @type {(message: ErrorToken['message'], metadata: TokenMetadata, end?: TokenMetadata) => readonly JsTokenWithMetadata[]}
+ */
+const failed = (message, metadata, end) => [at(end === undefined ? { kind: 'error', message } : { kind: 'error', message, end: position(end) }, metadata)]
+
+/**
+ * The token stream of a text: the tokens the grammar read, folded — a run
+ * of trivia into one token, a block comment holding a newline followed by
+ * an `nl`, as `fjs/js/tokenizer` emits it — and checked at the one
+ * boundary the grammar cannot see, a number against the token after it.
+ * The whole output is the first error where there is one.
+ *
+ * @type {(input: List<number>) => (path: string) => List<JsTokenWithMetadata>}
+ */
 export const tokenizeJs = input => path => {
-    const cp = toArray(input)
-    /** @type {TokenMetadata} */
-    const initial = { path, line: 1, column: 1 }
-    if (cp.length === 0) return [{ token: { kind: 'eof' }, metadata: initial }]
-
-    const [m, entry] = jsMatcher()
-    const cpm = codePointsWithMetadata(path)(cp)
-    const { ast, success: ok, idx: len } = m(entry, cpm)
-    const finalMetadata = fold(advanceMetadata)(initial)(cp)
-
-    if (!ok || len !== cp.length) {
-        // `len` is always `< cpm.length` (`=== cp.length`) here: `ok` false only
-        // ever happens with `len === 0` (nothing matched at position 0), and a
-        // `len !== cp.length` failure with `ok` true is by definition a partial
-        // match (`len < cp.length`) — `repeat0Plus` never fails after
-        // successfully consuming the whole input, so there is no way to reach
-        // this branch with `len === cp.length`.
-        // the span runs from where matching stopped to where the input ran out:
-        // nothing after that position could be made into a token either
-        return [{
-            token: { kind: 'error', message: 'invalid token', end: position(finalMetadata) },
-            metadata: cpm[len][1],
-        }]
+    const { lexemes, failure, final } = lex(path)(toArray(input))
+    if (failure !== null) {
+        // A number cut short — `1.`, `0e` — fails where its digits were
+        // expected, and that character is the one to point at, with no
+        // end, since what is wrong runs backwards from there. Any other
+        // token is refused whole, from where it began to the end of input:
+        // nothing past a lexical failure is tokenized.
+        return failure.number ? failed('invalid number', failure.at) : failed('invalid token', failure.start, final)
     }
-
-    const flatTokens = toArray(getTokensFromAstRule(ast))
-    // The two structural errors want different anchors, because they are
-    // different questions. An unterminated comment asks "which `/*` was never
-    // closed", so it is reported at that `/*`. A malformed number asks "what is
-    // this character doing here", so it is reported at the character — `123abc`
-    // points at the `a`, not at the `1`.
-    if (flatTokens.includes('unterminated')) {
-        // from the `/*` that was never closed to where the input ran out
-        return [{
-            token: { kind: 'error', message: '*/ expected', end: position(finalMetadata) },
-            metadata: tokenStartOfTag('comment', 'unterminated', flatTokens),
-        }]
+    /** @type {List<JsTokenWithMetadata>} */
+    let out = empty
+    /** @type {_Trivia} */
+    let trivia = null
+    /** @type {_Kind | null} */
+    let previous = null
+    for (const lexeme of lexemes) {
+        const { kind, start } = lexeme
+        if (kind === 'ws' || kind === 'newLine') {
+            // A run of trivia is one token, and its kind is decided by the
+            // run: a newline anywhere makes it `nl`, anchored at that newline,
+            // which is why the pending token restarts under the incoming kind
+            // when that kind is not the one it already has.
+            const incoming = kind === 'ws' ? 'ws' : 'nl'
+            trivia = trivia !== null && mergeTrivia(trivia.kind, incoming) === trivia.kind
+                ? trivia
+                : { kind: incoming, metadata: start }
+            previous = null
+            continue
+        }
+        if (trivia !== null) {
+            out = concat(out)([at({ kind: trivia.kind }, trivia.metadata)])
+            trivia = null
+        }
+        if (kind === 'comment' && !lexeme.closed) {
+            // from the `/*` that was never closed to where the input ran out
+            return failed('*/ expected', start, final)
+        }
+        if (previous === 'number' && (kind === 'id' || kind === 'number')) {
+            // ECMAScript disallows a numeric literal immediately followed by
+            // an identifier start or a digit — `123abc`, `1nabc`, `00`. The
+            // anchor is the token that should not be there, not the number's
+            // start, and there is no end for the same reason: the span a
+            // reader would want runs backwards from the anchor.
+            return failed('invalid number', start)
+        }
+        const jsToken = toJsToken(lexeme)
+        out = concat(out)([at(jsToken, start)])
+        if (jsToken.kind === '/*' && (jsToken.value.includes('\n') || jsToken.value.includes('\r'))) {
+            out = concat(out)([at({ kind: 'nl' }, start)])
+        }
+        previous = kind
     }
-    if (flatTokens.includes('numError')) {
-        // No `end`. This error's anchor is the character that spoiled the
-        // number, not the number's start, so the span a reader would want —
-        // `123a` for `123abc` — runs *backwards* from the anchor and cannot be
-        // expressed as an end. Giving it one means moving the anchor to the
-        // number's start, which changes a reported position for no consumer,
-        // so the anchor convention wins and this error stays a point.
-        return [{
-            token: { kind: 'error', message: 'invalid number' },
-            metadata: metadataAfterTag('numError', flatTokens, finalMetadata),
-        }]
+    if (trivia !== null) {
+        out = concat(out)([at({ kind: trivia.kind }, trivia.metadata)])
     }
-
-    const filterTokens = concat(filter(filterFunc)(flatTokens))([''])
-    const tokens = flat(stateScan(scanFunc)(['', null, []])(filterTokens))
-    const withMetadata = concat(flatMap(toJsTokenWithMetadata)(tokens))
-    return withMetadata([{ token: { kind: 'eof' }, metadata: finalMetadata }])
+    return concat(out)([at({ kind: 'eof' }, final)])
 }
+
+const stringify = stringifyAsTree(sort)
+
+/**
+ * The tokens of a text as one string, positions left out — `error` where
+ * the text does not tokenize.
+ *
+ * @type {(s: string) => string}
+ */
+export const tokenizeString = s => {
+    const tokens = toArray(tokenizeJs(stringToCodePointList(s))(''))
+    return tokens.some(({ token }) => token.kind === 'error')
+        ? 'error'
+        : stringify(tokens.map(({ token }) => token))
+}
+
+// -- layer 3: the DjsToken stream -------------------------------------------
 
 /** @type {(input: JsToken) => List<DjsToken>} */
 const mapDjsToken = input => {
@@ -673,11 +382,11 @@ const parseDjsDefaultState = input => {
 // Folds a leading '-' into the following number/bigint token, mirroring the old
 // fjs/djs/tokenizer's minus-state exactly.
 //
-// No `case '-'` here: the underlying `js/tokenizer` always merges two adjacent
-// `-` characters into a single `'--'` token (the decrement operator), so this
-// state — entered only after a single, unmerged `-` — can never itself see
-// another `'-'`-kind input. Such an input falls through to `default`, which
-// handles it exactly like any other non-number/bigint/eof token.
+// No `case '-'` here: the grammar reads two adjacent `-` characters as the
+// single `'--'` token (the decrement operator), so this state — entered only
+// after a single `-` — can never itself see another `'-'`-kind input. Such an
+// input falls through to `default`, which handles it exactly like any other
+// non-number/bigint/eof token.
 /** @type {(input: JsToken) => readonly [List<DjsToken>, _DjsScanState]} */
 const parseDjsMinusState = input => {
     switch (input.kind) {
@@ -709,18 +418,3 @@ const scanDjsTokenWithMetadata = (input, state) => {
 
 /** @type {(input: List<number>) => (path: string) => List<DjsTokenWithMetadata>} */
 export const tokenize = input => path => flat(stateScan(scanDjsTokenWithMetadata)({ kind: 'def' })(tokenizeJs(input)(path)))
-
-export const proof = {
-    // `tagToToken`'s `true` arm fires only for an `AstTag` of literal `true`.
-    // `bnf/data`'s `emptyTagOf` is the only source of that value, and
-    // `bnf/descent/module.f.mjs` reads it in exactly one place (its variant
-    // arm), always wrapped in `mrFail` — a failure. A failed variant only
-    // propagates as the overall `result` when nothing in it matches, so it
-    // never survives into a successful sequence/AST; a `true` tag therefore
-    // can never appear on a successful `descentParser` match for any
-    // grammar, `jsGrammar` included, so `tokenizeJs` can't reach this arm.
-    // Call it directly to cover that branch.
-    tagToTokenTrueTag: () => {
-        assertEq(tagToToken(true), 'true')
-    },
-}

--- a/fjs/djs/tokenizer/private.ts
+++ b/fjs/djs/tokenizer/private.ts
@@ -4,19 +4,35 @@
  * @module
  */
 
-import type { Meta } from '../../bnf/matcher/types.ts'
-import type { TokenMetadata } from '../../js/tokenizer/types.ts'
-import type { List } from '../../types/list/types.ts'
-import type { CodePoint } from '../../text/utf16/types.ts'
+import type { TokenMetadata, TriviaKind } from '../../js/tokenizer/types.ts'
 
-/** A tag, the metadata of the token's first code point, and its code points. */
-export type _Token = readonly [string, TokenMetadata, readonly number[]]
+/** The kind of a token, as the grammar's `token` variant tags it, `slash`'s four resolved. */
+export type _Kind = 'number' | 'string' | 'id' | 'comment' | 'operator' | 'ws' | 'newLine'
 
-/** One item of a flattened match: a tag, or a code point with its metadata. */
-export type _FlatToken = string | Meta<TokenMetadata, CodePoint>
+/** A token the grammar read: its kind, its code points, where it began, and whether a block comment closed. */
+export type _Lexeme = {
+    readonly kind: _Kind
+    readonly text: readonly number[]
+    readonly start: TokenMetadata
+    readonly closed: boolean
+}
 
-/** A token being accumulated: its tag, start metadata, and code points so far. */
-export type _TokenScanState = readonly [string, TokenMetadata | null, List<number>]
+/** A token the grammar refused: where it began, where it failed, and whether it was a number. */
+export type _Failure = {
+    readonly number: boolean
+    readonly start: TokenMetadata
+    readonly at: TokenMetadata
+}
+
+/** The whole input read: its tokens up to a failure, if any, and the position past the input. */
+export type _Lexed = {
+    readonly lexemes: readonly _Lexeme[]
+    readonly failure: _Failure | null
+    readonly final: TokenMetadata
+}
+
+/** A run of trivia not yet emitted: its kind so far, and where it is anchored. */
+export type _Trivia = { readonly kind: TriviaKind, readonly metadata: TokenMetadata } | null
 
 /** Where a string-literal decode is: plain text, after `\`, or inside `\uXXXX`. */
 export type _StringDecodeState =

--- a/fjs/djs/tokenizer/proof.f.mjs
+++ b/fjs/djs/tokenizer/proof.f.mjs
@@ -688,6 +688,11 @@ export const proof = {
             if (result !== '[{"kind":"/*","value":" multiline comment "},{"kind":"eof"}]') { throw result }
         },
         () => {
+            // a `/` inside the body is content: only `*/` ends the comment
+            const result = tokenizeString('/* a/b ../../x.ts */')
+            if (result !== '[{"kind":"/*","value":" a/b ../../x.ts "},{"kind":"eof"}]') { throw result }
+        },
+        () => {
             const result = tokenizeString('/* multiline comment *')
             assertEq(result, 'error')
         },
@@ -826,6 +831,22 @@ export const proof = {
             // character, not the token start, because that is what the reader
             // has to change — and therefore no end, for the same reason as `00`
             assertEq(errorAt('123abc'), '1:4')
+        },
+        () => {
+            // errors come in document order, the boundary between a number
+            // and the token against it included, whatever that token then
+            // does: `01.` is refused at the `1`, not where its digits ran out,
+            // and `01"` at the `1`, not at the string the input ends inside;
+            // with a space between there is no boundary, and the number cut short
+            // points just past the input, as `1.` alone does
+            assertEq(errorAt('01.'), '1:2')
+            assertEq(errorAt('01"'), '1:2')
+            assertEq(errorAt('0 1.'), '1:5')
+            assertEq(errorAt('1"'), '1:2..1:3')
+            // a malformed number before an unterminated comment is the first
+            // error, where the descent tokenizer looked for the comment first
+            assertEq(errorAt('123abc /* x'), '1:4')
+            assertEq(errorAt('/* x */ 123abc'), '1:12')
         },
     ],
     // DJS-level: keyword remapping and '-'-folding on top of tokenizeJs. Doesn't re-test

--- a/fjs/djs/tokenizer/proof.f.mjs
+++ b/fjs/djs/tokenizer/proof.f.mjs
@@ -55,13 +55,10 @@ const covers = s => {
 }
 
 export const proof = {
-    // The EBNF token grammar in `fjs/ebnf/lib/js`, read one token at a time,
-    // yields the token stream this grammar does: kind and text agree token
-    // for token over the corpus. This is the port's readiness check
-    // (ebnf-migration, principle 5): the grammar that reads the same
-    // stream may replace this one.
     // What the grammar covers, token by token, whatever the layers above
-    // make of the tokens.
+    // make of the tokens. The token stream itself — kind, text, position —
+    // is pinned by every `tokenizeString` and `tokenize` case below, which
+    // the descent tokenizer met before the port and this one meets unchanged.
     isValid: [() => {
             /** @type {(s: string, expected: boolean) => void} */
             const expect = (s, expected) => {

--- a/fjs/djs/tokenizer/proof.f.mjs
+++ b/fjs/djs/tokenizer/proof.f.mjs
@@ -1,16 +1,13 @@
 /**
- * @import { Ast, AstTag, Meta } from '../../bnf/matcher/types.ts'
- * @import { CodePoint } from '../../text/utf16/types.ts'
- * @import { List } from '../../types/list/types.ts'
+ * @import { Meta } from '../../ebnf/ast/types.ts'
  */
 
-import { isRepeat, toData } from '../../bnf/data/module.f.mjs'
-import { codePointListToString, stringToCodePointList, stringToList } from '../../text/utf16/module.f.mjs'
-import { concat, empty, next, toArray } from '../../types/list/module.f.mjs'
+import { stringToCodePointList, stringToList } from '../../text/utf16/module.f.mjs'
+import { toArray } from '../../types/list/module.f.mjs'
 import { parser } from '../../ebnf/ll1/module.f.mjs'
-import { operators as ebnfOperators, token as ebnfToken } from '../../ebnf/lib/js/module.f.mjs'
-import { jsGrammar, jsMatcher, tokenizeString, descentParserCpOnly, tokenizeJs, tokenize } from './module.f.mjs'
-import { assert, assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
+import { token as ebnfToken } from '../../ebnf/lib/js/module.f.mjs'
+import { tokenizeString, tokenizeJs, tokenize } from './module.f.mjs'
+import { assert, assertEq } from '../../asserts/module.f.mjs'
 import { stringifyAsTree } from '../serializer/module.f.mjs'
 import { sort } from '../../types/object/module.f.mjs'
 
@@ -36,414 +33,26 @@ const errorAt = s => {
         : `${start}..${token.end.line}:${token.end.column}`
 }
 
-// -- the EBNF token grammar reads the same stream ----------------------------
-
-// A token as both grammars see it is a pair: its kind, and its text.
-
-/** @type {(cp: readonly number[]) => string} */
-const text = cp => codePointListToString(cp)
-
-const [classicalMatcher, classicalEntry] = jsMatcher()
+/** The grammar's parser of one token, resumed per token below. */
+const parseToken = parser(ebnfToken)
 
 /**
- * The classical nodes under a node, in document order, the node itself
- * first — a loop over an explicit stack, since a block comment's content
- * nests one level per symbol and a comment may be long.
+ * Whether the grammar reads the whole text as tokens — whatever the layers
+ * above then make of them, so `2true` is covered, two tokens side by side.
  *
- * @type {(root: Ast<Meta<unknown, CodePoint>>) => readonly Ast<Meta<unknown, CodePoint>>[]}
+ * @type {(s: string) => boolean}
  */
-const classicalNodes = root => {
-    /** @type {List<Ast<Meta<unknown, CodePoint>>>} */
-    let out = empty
-    /** @type {List<Ast<Meta<unknown, CodePoint>>>} */
-    let stack = [root]
-    for (;;) {
-        /** @type {{ readonly first: Ast<Meta<unknown, CodePoint>>, readonly tail: List<Ast<Meta<unknown, CodePoint>>> } | null} */
-        const top = next(stack)
-        if (top === null) { return toArray(out) }
-        const node = top.first
-        out = concat(out)([node])
-        /** @type {readonly Ast<Meta<unknown, CodePoint>>[]} */
-        const children = node.sequence.flatMap(child => child instanceof Array ? [] : [child])
-        stack = concat(children)(top.tail)
-    }
-}
-
-/**
- * The input symbols under a classical node, in order: a leaf is a code
- * point with its metadata, and a node's leaves come between its nodes'.
- * The same loop, over leaves and nodes together.
- *
- * @type {(root: Ast<Meta<unknown, CodePoint>>) => readonly number[]}
- */
-const classicalSymbols = root => {
-    /** @type {List<number>} */
-    let out = empty
-    /** @type {List<Ast<Meta<unknown, CodePoint>> | Meta<unknown, CodePoint>>} */
-    let stack = [root]
-    for (;;) {
-        /** @type {{ readonly first: Ast<Meta<unknown, CodePoint>> | Meta<unknown, CodePoint>, readonly tail: List<Ast<Meta<unknown, CodePoint>> | Meta<unknown, CodePoint>> } | null} */
-        const top = next(stack)
-        if (top === null) { return toArray(out) }
-        /** @type {Ast<Meta<unknown, CodePoint>> | Meta<unknown, CodePoint>} */
-        const node = top.first
-        if (node instanceof Array) {
-            out = concat(out)([node[0]])
-            stack = top.tail
-        } else {
-            stack = concat(node.sequence)(top.tail)
-        }
-    }
-}
-
-/**
- * The kind of a classical token, from its node's tag: a token that is a
- * sequence carries its branch's name, and one that is a variant of
- * symbols or literals carries the symbol or literal it matched.
- *
- * @type {(tag: AstTag) => string}
- */
-const classicalKind = tag =>
-    tag === 'number' || tag === 'string' || tag === 'id' || tag === 'comment' ? tag :
-    tag === ' ' || tag === '\t' ? 'ws' :
-    tag === '\n' || tag === '\r' ? 'newLine' :
-    'operator'
-
-/**
- * The classical grammar's reading of a whole text: `error` where it does
- * not match it all; `cut` where a number's fraction or exponent had no
- * digits, which its `numError` branch tags without consuming anything;
- * `poison` where that branch consumed the identifier character after a
- * number; and otherwise its tokens, kind and text each. A line comment swallows
- * its newline, which the tokenizer splits back out below the grammar, and
- * the EBNF grammar stops the comment before it — so it is split here too,
- * and the streams are compared token for token. The whole-file grammar's
- * last round is its `eof` branch, no token, and is left out.
- *
- * @type {(s: string) => readonly ['error'] | readonly ['cut'] | readonly ['poison'] | readonly ['ok', readonly (readonly [kind: string, text: string])[]]}
- */
-const classicalResult = s => {
-    const cp = toArray(stringToCodePointList(s))
-    const { ast, success, idx } = descentParserCpOnly(classicalMatcher, classicalEntry, cp)
-    if (!success || idx !== cp.length) { return ['error'] }
-    const poison = classicalNodes(ast).filter(node => node.tag === 'numError')
-    if (poison.some(node => node.sequence.length === 0)) { return ['cut'] }
-    if (poison.length !== 0) { return ['poison'] }
-    return ['ok', ast.sequence.flatMap(node => {
-        assert(!(node instanceof Array))
-        if (node.tag === 'eof') { return [] }
-        const kind = classicalKind(node.tag)
-        const symbols = classicalSymbols(node)
-        const last = symbols[symbols.length - 1]
-        return kind === 'comment' && symbols[1] !== 0x2A && (last === 0x0A || last === 0x0D)
-            ? [[kind, text(symbols.slice(0, -1))], ['newLine', text(symbols.slice(-1))]]
-            : [[kind, text(symbols)]]
-    })]
-}
-
-/** @type {(s: string) => readonly (readonly [kind: string, text: string])[]} */
-const classicalStream = s => {
-    const result = classicalResult(s)
-    assert(result[0] === 'ok', s)
-    return result[1]
-}
-
-/**
- * The input symbols under an EBNF node, in order: an array is a node the
- * machine built, a string a variant's tag, anything else a leaf. A loop,
- * for the reason `classicalSymbols` is one.
- *
- * @type {(root: unknown) => readonly number[]}
- */
-const ebnfSymbols = root => {
-    /** @type {List<number>} */
-    let out = empty
-    /** @type {List<unknown>} */
-    let stack = [root]
-    for (;;) {
-        /** @type {{ readonly first: unknown, readonly tail: List<unknown> } | null} */
-        const top = next(stack)
-        if (top === null) { return toArray(out) }
-        /** @type {unknown} */
-        const node = top.first
-        if (node instanceof Array) {
-            stack = concat(node)(top.tail)
-        } else if (typeof node === 'string') {
-            stack = top.tail
-        } else {
-            assert(typeof node === 'object' && node !== null && 'symbol' in node && typeof node.symbol === 'number')
-            out = concat(out)([node.symbol])
-            stack = top.tail
-        }
-    }
-}
-
-/** @type {(node: unknown) => readonly [string, unknown]} */
-const ebnfBranch = node => {
-    assert(node instanceof Array && node.length === 2 && typeof node[0] === 'string')
-    return [node[0], node[1]]
-}
-
-const parseEbnfToken = parser(ebnfToken)
-
-/**
- * The EBNF grammar's reading of a whole text: its tokens one at a time,
- * the parser resumed where the last one ended, `slash`'s four told apart
- * by its own tag — or `error` where a token fails, at its index.
- *
- * @type {(s: string) => readonly ['error', number] | readonly ['ok', readonly (readonly [kind: string, text: string])[]]}
- */
-const ebnfResult = s => {
-    const input = toArray(stringToCodePointList(s)).map(symbol => ({ symbol, meta: null }))
-    /** @type {readonly (readonly [kind: string, text: string])[]} */
-    let out = []
+const covers = s => {
+    /** @type {readonly Meta<null>[]} */
+    const symbols = toArray(stringToCodePointList(s)).map(symbol => ({ symbol, meta: null }))
     let pos = 0
-    while (pos < input.length) {
-        const match = parseEbnfToken(input, pos)
-        if (match[0] === 'error') { return match }
-        const [node, end] = match[1]
-        const [tag, child] = ebnfBranch(node)
-        const sub = tag === 'slash' ? ebnfBranch(/** @type {readonly unknown[]} */ (child)[1])[0] : tag
-        const kind = sub === 'oneline' || sub === 'multiline' ? 'comment' : sub === 'assign' || sub === 'divide' ? 'operator' : sub
-        out = [...out, [kind, text(ebnfSymbols(node))]]
-        pos = end
+    while (pos < symbols.length) {
+        const match = parseToken(symbols, pos)
+        if (match[0] === 'error') { return false }
+        pos = match[1][1]
     }
-    return ['ok', out]
+    return true
 }
-
-/** @type {(s: string) => readonly (readonly [kind: string, text: string])[]} */
-const ebnfStream = s => {
-    const result = ebnfResult(s)
-    assert(result[0] === 'ok', s)
-    return result[1]
-}
-
-/**
- * Every literal input the proofs below hand to `tokenizeString`, `tokenize`
- * or `errorAt`, in their order — the tokenizer's corpus, which the
- * comparison runs over whole, whatever each grammar makes of a string.
- */
-const inputs = [
-    "tr",
-    "\"tr\"",
-    "56.7e+5",
-    "56n",
-    "*",
-    "**",
-    "=>",
-    "==",
-    "===",
-    "=",
-    " ",
-    "\n",
-    "/\n",
-    "//\n",
-    "/*1*/",
-    "",
-    "{",
-    "}",
-    ":",
-    ",",
-    "[",
-    "]",
-    "ᄑ",
-    "{ \t\n\r}",
-    "\"\"",
-    "\"value\"",
-    "\"value",
-    "\"value1\" \"value2\"",
-    "\"",
-    "\"\\\\\"",
-    "\"\\\"\"",
-    "\"\\/\"",
-    "\"\\x\"",
-    "\"\\",
-    "\"\r\"",
-    "\"\n null",
-    "\"\\b\\f\\n\\r\\t\"",
-    "\"\\u1234\"",
-    "\"\\uaBcDEeFf\"",
-    "\"\\uEeFg\"",
-    "0",
-    "[0]",
-    "00",
-    "0abc,",
-    "123456789012345678901234567890",
-    "{90}",
-    "1 2",
-    "0. 2",
-    "10-0",
-    "9a:",
-    "-10",
-    "-0",
-    "-00",
-    "-.123",
-    "0.01",
-    "-0.9",
-    "-0.",
-    "-0.]",
-    "12.34",
-    "-12.00",
-    "-12.",
-    "12.]",
-    "0e1",
-    "0e+2",
-    "0e-0",
-    "12e0000",
-    "-12e-0001",
-    "-12.34e1234",
-    "0e",
-    "0e-",
-    "ABCdef1234567890$_",
-    "{ABCdef1234567890$_}",
-    "123 _123",
-    "123 $123",
-    "123_123",
-    "123$123",
-    "1234567890n",
-    "0n",
-    "[-1234567890n]",
-    "123.456n",
-    "123e456n",
-    "1234567890na",
-    "1234567890nn",
-    "=a",
-    "-",
-    "1*2",
-    "( )",
-    "== != === !== > >= < <=",
-    "+ - * / % ++ -- **",
-    "= += -= *= /= %= **=",
-    "& | ^ ~ << >> >>>",
-    "&= |= ^= <<= >>= >>>=",
-    "<<< <<<=",
-    "&& || ! ??",
-    "&&= ||= ??=",
-    "? ?. . =>",
-    "\t",
-    " \t",
-    "\r",
-    " \t\n\r ",
-    "err",
-    "{e}",
-    "tru",
-    "true",
-    "false",
-    "null",
-    "undefined",
-    "[null]",
-    "arguments",
-    "await",
-    "break",
-    "case",
-    "catch",
-    "class",
-    "const",
-    "continue",
-    "debugger",
-    "default",
-    "delete",
-    "do",
-    "else",
-    "enum",
-    "eval",
-    "export",
-    "extends",
-    "finally",
-    "for",
-    "function",
-    "if",
-    "implements",
-    "import",
-    "in",
-    "instanceof",
-    "interface",
-    "let",
-    "new",
-    "package",
-    "private",
-    "protected",
-    "public",
-    "return",
-    "static",
-    "super",
-    "switch",
-    "this",
-    "throw",
-    "try",
-    "typeof",
-    "var",
-    "void",
-    "while",
-    "with",
-    "yield",
-    "//singleline comment",
-    "true//singleline comment\nfalse",
-    "/* multiline comment */",
-    "/* multiline comment *",
-    "/* multiline comment ",
-    "/* multiline comment \n * **/",
-    "/* multiline comment *\n * **/",
-    "//ab\n",
-    "//a//b\n",
-    "a/b",
-    "true false",
-    "a\nb",
-    "a\n\nb",
-    "/* c\n */ x",
-    "\"unterminated",
-    "x",
-    "{ \"a\": 1 }",
-    "x @",
-    "a\nb\n@",
-    "x\n\n  @y",
-    "1.",
-    "\"a\nb\"",
-    "/* c",
-    "/* ok */ /* bad",
-    "123abc",
-    ";",
-    "-1234567890n",
-    "--",
-    "---",
-    "-{",
-]
-
-/**
- * The inputs the proofs build by code rather than write out: the long
- * inputs of `largeInputs`, which pin the depth contract — a block comment
- * of twenty thousand characters is twenty thousand nested nodes in either
- * grammar's tree.
- */
-const generated = [
-    `/*${'x'.repeat(20000)}*/`,
-    'x'.repeat(10000),
-    ' '.repeat(5000),
-    `"${'a'.repeat(5000)}"`,
-]
-
-/**
- * Inputs both grammars accept, over every token kind and the shapes the
- * LL(1) spelling changed: the block comment's `*`, the `/` a comment and
- * division share — inside a block comment's body too, where a plain `/`
- * is content — the operator prefix tree, the line comment's newline.
- */
-const corpus = [
-    '/* a/b */ /* ../../x.ts */ /*/ */',
-    'a b\tc\n\rd',
-    'const a = [1, 2.5e-3, -1, 1n, 7E+2, 0, "s\\n\\u0041\\"", true];',
-    'x/2 /= y // c\nz',
-    'x // c\r\ny',
-    '//',
-    '/* a * b **/ c /**/ d',
-    '/* x\ny */',
-    'a.b?.c ?? d ... e',
-    '>>>= <<= !== === => ++ -- ** **= &&= ||= ??=',
-    '{}[]().,:;~^|&%!<>?=+-*',
-    '$_ab9 _ $1 tr2ue',
-    '"é😀"',
-    'x\ty  \t\tz',
-]
 
 export const proof = {
     // The EBNF token grammar in `fjs/ebnf/lib/js`, read one token at a time,
@@ -451,75 +60,12 @@ export const proof = {
     // for token over the corpus. This is the port's readiness check
     // (ebnf-migration, principle 5): the grammar that reads the same
     // stream may replace this one.
-    ebnf: {
-        sameStream: () => {
-            for (const s of corpus) {
-                assertStructurallySame(ebnfStream(s), classicalStream(s))
-            }
-        },
-        // Over the whole corpus, whatever the classical grammar makes of a
-        // string: what it reads, the EBNF grammar reads the same; what it
-        // refuses, and a number it tags cut short, the EBNF grammar refuses
-        // too, its forced digits failing; and where its poison branch
-        // consumed the character after a number, the EBNF grammar reads the
-        // adjacent tokens the layer above will refuse.
-        wholeCorpus: () => {
-            for (const s of [...inputs, ...generated]) {
-                const classical = classicalResult(s)
-                const ebnf = ebnfResult(s)
-                switch (classical[0]) {
-                    case 'ok': { assertStructurallySame(ebnf, classical); break }
-                    case 'poison': { assertEq(ebnf[0], 'ok', s); break }
-                    case 'cut':
-                    case 'error': { assertEq(ebnf[0], 'error', s); break }
-                }
-            }
-        },
-        // Where this grammar's poison branch rejects a number followed by an
-        // identifier character, the EBNF grammar reads two adjacent tokens,
-        // and the layer above the tokens refuses them for standing side by
-        // side (ebnf-ll1-port). Here the poison shows as its tag.
-        poison: () => {
-            /** @type {(s: string) => boolean} */
-            const poisoned = s => {
-                const { ast } = descentParserCpOnly(classicalMatcher, classicalEntry, toArray(stringToCodePointList(s)))
-                return JSON.stringify(ast).includes('"numError"')
-            }
-            assertStructurallySame(ebnfStream('123abc'), [['number', '123'], ['id', 'abc']])
-            assertStructurallySame(ebnfStream('00'), [['number', '0'], ['number', '0']])
-            assertStructurallySame(ebnfStream('1.5n'), [['number', '1.5'], ['id', 'n']])
-            assertStructurallySame(ebnfStream('123true'), [['number', '123'], ['id', 'true']])
-            assert(['123abc', '00', '1.5n', '123true'].every(poisoned))
-            assert(!poisoned('123 abc'))
-        },
-        // The operators this grammar names are the EBNF grammar's list plus
-        // the two `slash` holds, and each is one token in both.
-        operators: () => {
-            const all = [...ebnfOperators, '/', '/=']
-            assertEq(all.length, 56)
-            for (const op of all) {
-                assertStructurallySame(classicalStream(op), [['operator', op]])
-                assertStructurallySame(ebnfStream(op), [['operator', op]])
-            }
-        },
-    },
-    // The whole-file grammar is one repetition of a token, and `toData` records
-    // that rather than leaving it as the right-recursive variant `repeat0Plus`
-    // builds — which is why the tokenizer reads its entry name from `jsMatcher`
-    // instead of naming a rule: the rules that encoded the repetition are gone.
-    jsGrammar: () => {
-        const [ruleSet, entry] = toData(jsGrammar())
-        assert(isRepeat(ruleSet[entry]), JSON.stringify([ruleSet[entry], entry]))
-    },
+    // What the grammar covers, token by token, whatever the layers above
+    // make of the tokens.
     isValid: [() => {
-            const [m, entry] = jsMatcher()
-
             /** @type {(s: string, expected: boolean) => void} */
             const expect = (s, expected) => {
-                const cp = toArray(stringToCodePointList(s))
-                const mr = descentParserCpOnly(m, entry, cp)
-                const success = mr.success && mr.idx === cp.length
-                assertEq(success, expected, JSON.stringify([s, mr]))
+                assertEq(covers(s), expected, s)
             }
 
             expect('"', false)
@@ -549,128 +95,6 @@ export const proof = {
             expect('//12\n', true)
             expect('/*12*/', true)
             expect('/* 1*2 */', true)
-        }
-    ],
-    tokenizer: [
-        () => {
-            const [m, entry] = jsMatcher()
-            const cp = toArray(stringToCodePointList('tr'))
-            const mr = descentParserCpOnly(m, entry, cp)
-            const seq = mr.ast.sequence[0]
-            assert(!(seq instanceof Array), JSON.stringify(mr))
-            assertEq(seq.tag, 'id', JSON.stringify(mr))
-        },
-        () => {
-            const [m, entry] = jsMatcher()
-            const cp = toArray(stringToCodePointList('"tr"'))
-            const mr = descentParserCpOnly(m, entry, cp)
-            const seq = mr.ast.sequence[0]
-            assert(!(seq instanceof Array), JSON.stringify(mr))
-            assertEq(seq.tag, 'string', JSON.stringify(mr))
-        },
-        () => {
-            const [m, entry] = jsMatcher()
-            const cp = toArray(stringToCodePointList('56.7e+5'))
-            const mr = descentParserCpOnly(m, entry, cp)
-            const seq = mr.ast.sequence[0]
-            assert(!(seq instanceof Array), JSON.stringify(mr))
-            assertEq(seq.tag, 'number', JSON.stringify(mr))
-        },
-        () => {
-            const [m, entry] = jsMatcher()
-            const cp = toArray(stringToCodePointList('56n'))
-            const mr = descentParserCpOnly(m, entry, cp)
-            const seq = mr.ast.sequence[0]
-            assert(!(seq instanceof Array), JSON.stringify(mr))
-            assertEq(seq.tag, 'number', JSON.stringify(mr))
-        },
-        () => {
-            const [m, entry] = jsMatcher()
-            const cp = toArray(stringToCodePointList('*'))
-            const mr = descentParserCpOnly(m, entry, cp)
-            const seq = mr.ast.sequence[0]
-            assert(!(seq instanceof Array), JSON.stringify(mr))
-            assertEq(seq.tag, '*', JSON.stringify(mr))
-        },
-        () => {
-            const [m, entry] = jsMatcher()
-            const cp = toArray(stringToCodePointList('**'))
-            const mr = descentParserCpOnly(m, entry, cp)
-            const seq = mr.ast.sequence[0]
-            assert(!(seq instanceof Array), JSON.stringify(mr))
-            assertEq(seq.tag, '**', JSON.stringify(mr))
-        },
-        () => {
-            const [m, entry] = jsMatcher()
-            const cp = toArray(stringToCodePointList('=>'))
-            const mr = descentParserCpOnly(m, entry, cp)
-            const seq = mr.ast.sequence[0]
-            assert(!(seq instanceof Array), JSON.stringify(mr))
-            assertEq(seq.tag, '=>', JSON.stringify(mr))
-        },
-        () => {
-            const [m, entry] = jsMatcher()
-            const cp = toArray(stringToCodePointList('=='))
-            const mr = descentParserCpOnly(m, entry, cp)
-            const seq = mr.ast.sequence[0]
-            assert(!(seq instanceof Array), JSON.stringify(mr))
-            assert(!(seq.tag !== '=='), JSON.stringify(mr))
-        },
-        () => {
-            const [m, entry] = jsMatcher()
-            const cp = toArray(stringToCodePointList('==='))
-            const mr = descentParserCpOnly(m, entry, cp)
-            const seq = mr.ast.sequence[0]
-            assert(!(seq instanceof Array), JSON.stringify(mr))
-            assert(!(seq.tag !== '==='), JSON.stringify(mr))
-        },
-        () => {
-            const [m, entry] = jsMatcher()
-            const cp = toArray(stringToCodePointList('='))
-            const mr = descentParserCpOnly(m, entry, cp)
-            const seq = mr.ast.sequence[0]
-            assert(!(seq instanceof Array), JSON.stringify(mr))
-            assertEq(seq.tag, '=', JSON.stringify(mr))
-        },
-        () => {
-            const [m, entry] = jsMatcher()
-            const cp = toArray(stringToCodePointList(' '))
-            const mr = descentParserCpOnly(m, entry, cp)
-            const seq = mr.ast.sequence[0]
-            assert(!(seq instanceof Array), JSON.stringify(mr))
-            assertEq(seq.tag, ' ', JSON.stringify(mr))
-        },
-        () => {
-            const [m, entry] = jsMatcher()
-            const cp = toArray(stringToCodePointList('\n'))
-            const mr = descentParserCpOnly(m, entry, cp)
-            const seq = mr.ast.sequence[0]
-            assert(!(seq instanceof Array), JSON.stringify(mr))
-            assertEq(seq.tag, '\n', JSON.stringify(mr))
-        },
-        () => {
-            const [m, entry] = jsMatcher()
-            const cp = toArray(stringToCodePointList('/\n'))
-            const mr = descentParserCpOnly(m, entry, cp)
-            const seq = mr.ast.sequence[0]
-            assert(!(seq instanceof Array), JSON.stringify(mr))
-            assertEq(seq.tag, '/', JSON.stringify(mr))
-        },
-        () => {
-            const [m, entry] = jsMatcher()
-            const cp = toArray(stringToCodePointList('//\n'))
-            const mr = descentParserCpOnly(m, entry, cp)
-            const seq = mr.ast.sequence[0]
-            assert(!(seq instanceof Array), JSON.stringify(mr))
-            assertEq(seq.tag, 'comment', JSON.stringify(mr))
-        },
-        () => {
-            const [m, entry] = jsMatcher()
-            const cp = toArray(stringToCodePointList('/*1*/'))
-            const mr = descentParserCpOnly(m, entry, cp)
-            const seq = mr.ast.sequence[0]
-            assert(!(seq instanceof Array), JSON.stringify(mr))
-            assertEq(seq.tag, 'comment', JSON.stringify(mr))
         }
     ],
     djs: [
@@ -1464,9 +888,10 @@ export const proof = {
         },
     ],
     // Regression coverage for large inputs: both a file with many short tokens and a
-    // single very long token used to overflow the JS call stack, because fjs/bnf/descent's
-    // matcher recursed once per grammar step. It now runs on an explicit frame stack, so
-    // the whole-file jsGrammar() match is safe at any input length.
+    // single very long token used to overflow the JS call stack, when the matcher
+    // recursed once per grammar step. The LL(1) machine runs on an explicit frame
+    // stack and the tokenizer resumes it once per token, so a file of any length
+    // is a loop, and a token of any length one match.
     largeInputs: [
         () => {
             // many short whitespace tokens: the reported repro (`' '.repeat(5000)`)
@@ -1499,7 +924,7 @@ export const proof = {
             assertEq(result.length, 3000 * 2 + 1)
         },
         () => {
-            // a single long token: a 5 KB string literal — overflows unless the descent
+            // a single long token: a 5 KB string literal — overflows unless the
             // matcher itself is iterative
             const value = 'a'.repeat(5000)
             const result = tokenizeString(`"${value}"`)

--- a/fjs/djs/tokenizer/todo/tokenize-string-derive.md
+++ b/fjs/djs/tokenizer/todo/tokenize-string-derive.md
@@ -1,62 +1,34 @@
-## tokenize-string-derive. `tokenizeString` re-implements `tokenizeJs`; `toJsTokens` re-implements `toJsTokenWithMetadata`
+## tokenize-string-derive. `tokenizeString` is proof-only and lives in the production module
 
 **Priority:** P4
 **Status:** open
 
 ### Problem
 
-Two metadata-free copies of metadata-aware pipelines live in
-`fjs/djs/tokenizer/module.f.mjs`:
+`tokenizeString` in `fjs/djs/tokenizer/module.f.mjs` is a projection of
+`tokenizeJs` — the tokens with their positions dropped, as one string, or
+`error` where the stream holds an error token — and its sole consumer is
+`fjs/djs/tokenizer/proof.f.mjs`. It still lives in the production module,
+and pulls `stringifyAsTree` and `sort` from `fjs/djs/serializer` into the
+tokenizer's import graph purely to format test output.
+`fjs/js/tokenizer/proof.f.mjs` already shows the right shape for its
+tokenizer: a proof-local stringifier over the production tokenizer.
 
-1. `tokenizeString` (`:464-486`) vs `tokenizeJs` (`:501-531`): the same
-   pipeline in the same order — empty-input short circuit →
-   `descentParser(jsGrammar())` → `codePointsWithMetadata` → match →
-   `getTokensFromAstRule` → the `'unterminated'`/`'numError'` structural-error
-   probe → `filter(filterFunc)` + `concat(…)([''])` →
-   `stateScan(scanFunc)(['', null, []])` → `flatMap(toJsToken*)` → append
-   `eof`. The differences are only the error representation (`return 'error'`
-   vs an error token with metadata) and the final `stringify`.
-
-2. `toJsTokens` (`:410-418`) vs `toJsTokenWithMetadata` (`:422-431`) — the
-   "a `/*` comment containing a newline also emits an `nl`" rule, twice:
-
-   ```js
-   if (token.kind === '/*') {
-       const hasNl = token.value.includes('\n') || token.value.includes('\r')
-       if (hasNl) return [token, { kind: 'nl' }]
-   }
-   ```
-
-The module already contains the needed lifting idiom one screen lower, for
-the DJS layer: `mapDjsTokenWithMetadata` (`:601-608`) derives the
-metadata-aware scanner from the plain one by mapping metadata over the
-produced tokens. The JS layer just doesn't use it.
-
-There is also a separation-of-concerns problem: `tokenizeString` is
-proof-only (`fjs/djs/tokenizer/proof.f.mjs` is its sole consumer) yet it
-lives in the production module and pulls `stringifyAsTree`/`sort` from
-`fjs/djs/serializer` into the tokenizer's import graph purely to format test
-output. `fjs/js/tokenizer/proof.f.mjs:12` already shows the right shape for
-its tokenizer: a proof-local stringifier over the production tokenizer.
+The two duplications this issue used to name — a second copy of the
+pipeline behind `tokenizeString`, and the `/*`-with-newline rule spelled
+twice — went with the port to the LL(1) backend: there is one pipeline,
+`tokenizeJs`, and the rule is stated once in its fold.
 
 ### Proposal
 
-- Keep `tokenizeJs` as the only pipeline. Derive the token-only view by
-  projection: `tokenizeString` becomes (proof-local)
-  `stringify(toArray(map(({ token }) => token)(tokenizeJs(cp)(''))))`, with
-  the `'error'` result recovered from the single `{ kind: 'error' }` token.
-- Derive `toJsTokenWithMetadata` from `toJsTokens` (or both from one
-  `hasNlComment` helper), mirroring `mapDjsTokenWithMetadata`.
-- Move `tokenizeString` (and the serializer imports it drags in) to
-  `proof.f.mjs`.
+Move `tokenizeString` and the serializer imports it drags in to
+`proof.f.mjs`; the ~90 proof cases that call it stay as they are.
 
 ### Tasks
 
-- [ ] Unify the `/*`-with-newline rule; delete one of the twin functions.
-- [ ] Rewrite `tokenizeString` as a projection of `tokenizeJs`; move it to
-      the proof; drop the serializer imports from the tokenizer module.
-- [ ] `tsc`, `fjs t` — the ~90 `tokenizeString` proof cases pass
-      unchanged.
+- [ ] Move `tokenizeString` to the proof; drop the serializer imports from
+      the tokenizer module.
+- [ ] `tsc`, `fjs t` — the `tokenizeString` proof cases pass unchanged.
 
 ### Related
 

--- a/fjs/todo/ebnf-migration.md
+++ b/fjs/todo/ebnf-migration.md
@@ -405,15 +405,16 @@ consumer port"), never by number, so a renumbering here cannot strand them.
    `descent` is the first evidence the backend decision holds; if it does not,
    this stage is where the plan is revised, not forced.
 
-   The djs tokenizer's public exports that expose the descent backend —
-   `jsMatcher`, which builds a `descentParserRuleSet`, and
-   `descentParserCpOnly`, which returns a `DescentMatchResult` — are the
-   port's to replace with their LL(1) equivalents, under whatever names fit.
-   Their only importer is the tokenizer's own proof, updated in the same PR.
-   That is a change to `fjs/djs/tokenizer`'s own public API and the port
-   declares it as such; the "one breaking change" above is a statement about
-   `fjs/bnf/` paths, not about a consumer's surface where it had exposed the
-   backend it is leaving.
+   The djs tokenizer's public exports that exposed the descent backend —
+   `jsGrammar`, `jsMatcher`, which built a `descentParserRuleSet`, and
+   `descentParserCpOnly`, which returned a `DescentMatchResult` — were the
+   port's to retire, and it did, with no LL(1) equivalents: the grammar is
+   [`fjs/ebnf/lib/js`](../ebnf/lib/js/module.f.mjs) and a consumer that
+   wants it imports it there. Their only importer was the tokenizer's own
+   proof, updated in the same PR. That was a change to `fjs/djs/tokenizer`'s
+   own public API and the port declared it as such; the "one breaking
+   change" above is a statement about `fjs/bnf/` paths, not about a
+   consumer's surface where it had exposed the backend it left.
 7. **Delete `fjs/bnf/`.** With it: the retired issues, `descentEquivalence` in
    its two-backend form, and the classical half of the README split. Finish
    the issue moves, each taking its inbound links with it. Repoint every
@@ -447,8 +448,10 @@ consumer port"), never by number, so a renumbering here cannot strand them.
 - [ ] Stage 4: `ebnf/token_symbol/` with proof.
 - [ ] Stage 5: `ebnf/lib/json` and `ebnf/lib/datajs` with proofs; the
       cross-front-end comparison proof group; bnf-grammar-single-owner moved.
-- [ ] Stage 6: the token layer; the djs tokenizer and parser grammars made
-      LL(1); both ported; the descent backend without consumers.
+- [ ] Stage 6: the token layer (done: the resumable parser); the djs
+      tokenizer grammar made LL(1) and the tokenizer ported (done); the
+      parser grammar made LL(1) and the parser ported; the descent backend
+      without consumers.
 - [ ] Stage 7: delete `fjs/bnf/`; move the remaining issues; split the README;
       repoint every inbound link and reference from outside `fjs/bnf/`.
       `**BREAKING CHANGES:**`.


### PR DESCRIPTION
The fourth task of `fjs/djs/todo/ebnf-ll1-port.md`: the tokenizer port (#1925, the grammar it reads, is merged). With it, the djs parser is the last consumer of `fjs/bnf` outside that module.

**The layers**, each an LL(1) grammar or a fold over the layer below, nothing else parsing:

```text
code points ==the token grammar, one token at a time==> lexemes
            ==fold: trivia merged, words classified, boundaries checked==> JsToken stream
            ==fold: keywords demoted, `-` folded into a number==> DjsToken stream
```

- The grammar is `fjs/ebnf/lib/js`, read by the LL(1) backend resumed where the last token ended. A token's text is the input it spans, and its position is carried along rather than attached to every code point; nothing walks a token's tree but the one question a block comment leaves open, whether it closed, and that walk is a loop, since the content is right-recursive and a comment may be long.
- The fold above the grammar does what the grammar cannot: a run of trivia is one token, `nl` where the run holds a newline and anchored at the first, `ws` otherwise, exactly as before; a word is a keyword or an identifier; a number is a `number` or a `bigint`; and a number directly followed by a word or a number, no trivia between — `123abc`, `1nabc`, `00` — is `invalid number` at the token that should not be there. The classical grammar refused those inside the number with a branch that consumed the offending character; an LL(1) grammar cannot, and the token stream shows the same fact one layer up.
- Errors keep their anchors: a token the grammar refuses is `invalid token` from where it began to the end of input; a number cut short (`1.`, `0e`) is `invalid number` at the character where digits were expected, no end; a block comment the input ends inside is `*/ expected` from its `/*`. The grammar stops at the token it refuses, so the fold runs over what came before first, and the refused token is reported only where nothing before it was wrong.

**The proof corpus passes unchanged.** Every `tokenizeString`, `tokenize` and `errorAt` expectation the descent tokenizer met — tokens, positions, error anchors and spans, the 20,000-character comment and the 10,000-character identifier — the LL(1) tokenizer meets, with no expectation edited. The proof loses only what named the descent backend: the comparison group #1925 added, which retires with the classical grammar it compared, the `tokenizer` group that read kinds off the descent AST (the grammar's own proof pins them now), and `isValid`, which now asks the grammar whether it covers a text token by token.

**One behavioural difference**, on inputs with two errors: the error is now the first in document order. The descent tokenizer checked an unterminated comment anywhere in the file before a malformed number anywhere in it, and a refused token anywhere before both; so `123abc /* x` reported `*/ expected` and now reports `invalid number` at the `a`, and a malformed number before a refused token reports the number rather than the token. No proof pinned the old order.

Checks: `tsc`, `node ./fjs/module.mjs t` (5543, the parser and transpiler included), `npm run gen` (no change), `node --test` with 100% coverage — the new module needed no proof beyond the corpus.

Changelog:
- **BREAKING CHANGES:** `fjs/djs/tokenizer` no longer exports `jsGrammar`, `jsMatcher` and `descentParserCpOnly`, which exposed the descent backend it has left. The grammar is `fjs/ebnf/lib/js`; a consumer that wants it imports it there. Their only importer was the tokenizer's own proof.
- `fjs/djs/tokenizer`: where a text holds more than one lexical error — a malformed number, an unterminated block comment, a token the grammar refuses — the error reported is the first in document order, where it used to be the refused token first, then the comment, then the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CZRKbBvWAYpYtgVpUa3UH