### PR TITLE
ebnf/token_symbol: token names as symbols, moved from bnf

### DIFF
--- a/fjs/djs/todo/ebnf-ll1-port.md
+++ b/fjs/djs/todo/ebnf-ll1-port.md
@@ -127,8 +127,8 @@ reads values, not text.
 
 - [x] `ebnf/ll1`: a parser resumable at an index, with proof; the loop over
       it is the consumer's, as that module's README says.
-- [ ] `ebnf/token_symbol/` moved, with proof; ebnf-migration's stage 4 half
-      ticked.
+- [x] `ebnf/token_symbol/` moved, with proof — a symbol is a rule, and
+      there is no capacity to check; ebnf-migration's stage 4 half ticked.
 - [x] `literals`, the prefix tree over a word list, in `fjs/ebnf` with
       proof; the punctuators of JavaScript build as one LL(1) rule.
 - [x] Tokenizer grammar in EBNF beside the classical one, LL(1), with the

--- a/fjs/djs/tokenizer/todo/error-message-specificity.md
+++ b/fjs/djs/tokenizer/todo/error-message-specificity.md
@@ -1,87 +1,79 @@
-## error-message-specificity. tokenizer only reports one generic error, not the old tokenizer's specific ones
+## error-message-specificity. The tokenizer reports three messages and stops at the first
 
 **Priority:** P4
 **Status:** open
 
 ### Problem
 
-The old tokenizer (`fjs/djs/tokenizer`, deleted when this grammar-based one
-replaced it) reported ~10 distinct, specific messages depending on what
-went wrong — `'invalid number'`,
-`'unexpected character'`, `'" are missing'`, `'unescaped character'`,
-`'invalid hex value'`, `'*/ expected'`, `'invalid token'` — each at the
-exact position of the failing character, and it kept tokenizing afterward,
-so the parser still saw whatever valid tokens came later.
+The tokenizer before the grammar-based ones reported ~10 distinct messages
+depending on what went wrong — `'invalid number'`, `'unexpected
+character'`, `'" are missing'`, `'unescaped character'`, `'invalid hex
+value'`, `'*/ expected'`, `'invalid token'` — each at the exact position
+of the failing character, and it kept tokenizing afterward, so the parser
+still saw whatever valid tokens came later.
 
-`fjs/djs/tokenizer/module.f.mjs`'s grammar (`descentParser`) has no
-cut/commit mechanism — it either parses the whole input as tokens or fails
-as one unit. This is why `numError`/`unterminated` exist at all (see
-`multilineContent`'s comment in `module.f.mjs`): they turn what would be a
-hard grammar failure into an always-succeeding, specially-tagged match, so
-the descent parser doesn't fall back to matching stray characters as
-unrelated operator tokens.
+`fjs/djs/tokenizer/module.f.mjs` reads the one-token grammar
+[`fjs/ebnf/lib/js`](../../../ebnf/lib/js/module.f.mjs) through the LL(1)
+backend, resumed once per token, and reports three messages, each
+anchored where the module doc says: `invalid number` for a number cut
+short or directly followed by a word or a number; `*/ expected` for a
+block comment the input ends inside; and `invalid token` for everything
+else the grammar refuses — an unterminated string, a bad escape, a
+character no token begins with — spanning from where the token began to
+the end of input. The backend reports a refusal as the index it stopped
+at and nothing else, so the fold above it cannot tell an unterminated
+string from a bad escape, and the first error is the whole output.
 
-As a result, `tokenizeJs`/`tokenize` in `fjs/djs/tokenizer/module.f.mjs`
-collapse every failure mode — malformed numbers, unterminated strings,
-unterminated comments, unrecognized characters, anything the grammar can't
-fully parse — into a single `{kind: 'error', message: 'invalid token'}`,
-and tokenization stops there instead of continuing. Position accuracy was
-fixed when the DJS-level wrapper landed (via `len` and `metadataAfterTag`),
-but message specificity and continuation were explicitly deferred —
-confirmed with the user before that work, since closing this gap properly
-is a much bigger, separate undertaking than the metadata/swap work was.
-
-This is a real DX regression for anyone editing malformed DJS source: they
-now get "invalid token" wherever the file happens to become unparseable,
-instead of a message that tells them what's actually wrong (missing closing
-quote vs. bad number vs. bad escape, etc.), and nothing after the first
-problem gets checked.
-
-No current test depends on this (confirmed during the tokenizer-swap
-research: `fjs/djs/parser/proof.f.mjs` had zero tests exercising an actual
-tokenizer-emitted error token), so there's no urgency — this is tracked so
-it doesn't get silently forgotten, not because something is broken today.
+Position accuracy holds — the tokenizer's proof pins every anchor and
+span — and no consumer reads the messages: `fjs/djs/parser` freezes on
+the first error and reports it as `unexpected token`. This is tracked so
+the DX regression is not silently forgotten, not because something is
+broken today.
 
 ### Proposal
 
 Two separable improvements, either could land independently:
 
-1. **Per-failure-type messages.** Extend the `numError`/`unterminated`-style
-   tagging to distinguish *why* a token is invalid — e.g. separate tags for
-   "digits expected after `.`" vs. "digits expected after `e`" vs. "disallowed
-   trailing char" (the `fracPart`/`expPart`/trailing-check branches in
-   `module.f.mjs`'s `number` rule already structurally know which case fired;
-   right now they're all folded into one `numError` tag). Do the same for
-   `string` (currently a hard grammar failure, not a tagged one — would need
-   the same always-succeeds-but-tagged treatment `multilineContent` uses) and
-   for genuinely unrecognized characters (currently just falls through to
-   `len !== cp.length`).
-2. **Continue tokenizing after an error.** Requires restructuring away from
-   "parse the whole input as one grammar match" toward something that can
-   resume after a recognized failure point — a bigger architectural change,
-   possibly re-running the tokenizer from the next plausible token boundary
-   after emitting an error token. Needs its own design pass; not sketched
-   here.
+1. **Per-failure-type messages.** The grammar already spells one refusal
+   as an accepting branch — a block comment's `unterminated: ''` — so that
+   the fold can name it, and a string's failure modes can be spelled the
+   same way: a branch for the closing quote, one for a newline or the end
+   of input inside the string, one for a bad escape, each a rule the
+   backend's one symbol of lookahead selects, so the grammar stays LL(1).
+   The fold then reads the branch and reports `'" are missing'` or
+   `'invalid escape'` at the character. A number cut short is already
+   its own message; `invalid token` would be left for a character no token
+   begins with. The alternative — the backend reporting which rule it was
+   in when it stopped — is a change to `fjs/ebnf/ll1`'s `MatchResult`
+   that every reader of a failure index would carry; the branches cost
+   nothing outside this grammar.
+2. **Continue tokenizing after an error.** The token layer already resumes
+   the parser once per token, so continuing is resuming at the next
+   plausible boundary — the character after the refused token's first,
+   or after the closing quote a string rule found — and emitting an error
+   token before going on. What is missing is the boundary choice and a
+   token stream that may hold more than one error, which
+   `fjs/djs/parser`'s `splitEof` today reads as the one error token that
+   ends the stream. Needs its own design pass; not sketched here.
 
-Start with (1) if this becomes worth doing — it's additive to the existing
-tagging technique and doesn't require an architecture change. (2) is likely
-not worth it unless a real use case (e.g. an editor/LSP wanting multiple
-diagnostics per file) shows up.
+Start with (1) if this becomes worth doing — it is a grammar change and a
+fold change, both local. (2) is likely not worth it unless a real use case
+(e.g. an editor/LSP wanting multiple diagnostics per file) shows up.
 
 ### Tasks
 
 - [ ] Decide if this is worth doing at all — re-check whether any consumer
       (editor tooling, error-reporting UX) actually needs it before
       investing here.
-- [ ] If yes: tag specific failure reasons in the `number`/`string`/comment
-      grammar rules (extending the `numError`/`unterminated` pattern).
-- [ ] Update `tokenizeJs`'s error branch to surface the specific message
-      instead of always `'invalid token'`.
+- [ ] If yes: spell the string's failure modes as accepting branches of
+      `fjs/ebnf/lib/js`'s `string` rule, as the block comment's
+      `unterminated` is, and name each in `tokenizeJs`'s fold.
 - [ ] Separately evaluate whether continuation-after-error is actually
       needed, given `fjs/djs/parser` already freezes on the first error and
       doesn't do multi-error collection today.
 
 ### Related
 
-- `fjs/djs/tokenizer/module.f.mjs` — `numError`/`unterminated` tagging,
-  `tokenizeJs`'s error branch.
+- `fjs/djs/tokenizer/module.f.mjs` — the fold that names the three errors.
+- [`fjs/ebnf/lib/js`](../../../ebnf/lib/js/module.f.mjs) — the grammar,
+  with the `unterminated` branch the proposal extends.

--- a/fjs/ebnf/token_symbol/README.md
+++ b/fjs/ebnf/token_symbol/README.md
@@ -1,0 +1,62 @@
+# Token Symbols
+
+Symbols for the layer above a tokenizer: the tokenizer consumes code points
+and emits tokens, and the parser above it consumes one input symbol per
+token ([`../ll1`](../ll1/README.md), "A token layer resumes the parser").
+Token categories may map to single ASCII symbols and single-character
+operators to themselves, but a multi-character operator (`>>>=`) and a
+keyword (`instanceof`) have no such symbol. `encoding()` hands them one.
+
+The `token_symbol/` piece of [ebnf-migration](../../todo/ebnf-migration.md),
+moved from `fjs/bnf/token_symbol` with two things rethought on the way:
+
+- **A symbol is a rule.** A number is a rule of one symbol in the EBNF
+  front end, so the value `encode` returns is at once what a tokenizer
+  emits and the terminal a grammar names the token by. The classical
+  module returned a bare symbol that had to be wrapped as a range before a
+  rule could name it, and a symbol and a range were both plain numbers, so
+  passing one where the other belonged was no type error.
+- **No capacity.** The classical range ran to the last symbol of a packed
+  codec, and a list longer than that was refused. The EBNF domain is the
+  non-negative safe integers, and no array is long enough to carry an
+  alphabet past that ceiling, so there is nothing to check.
+
+## Symbol range
+
+From `0x110000`, one past the last Unicode scalar value, upward: a token
+symbol is numerically disjoint from a code point even though the two
+alphabets belong to different layers — the layers meet in error messages
+and debugging output, where one number space is worth more than 1.1M extra
+symbols nobody needs. The end of input is not a symbol of either alphabet
+and needs none from this space.
+
+## Why a registered alphabet
+
+The alternative was an *intrinsic* encoding: derive the symbol from the
+string alone by packing its characters positionally, so no alphabet has to
+be registered and decoding needs no table. It was rejected because packing
+bounds a name's length — `instanceof` does not fit any base a symbol can
+hold — and an intrinsic encoding for operators plus a registered one for
+keywords would mean two mechanisms and two ways for a symbol to be wrong,
+for no gain over the one that covers both.
+
+This also settles a question the parser design left open: keywords **can**
+be distinct terminal symbols, because a registered name has no length
+limit. Only the number of names is bounded, and by the array, not by this
+module.
+
+## Why positional assignment
+
+Symbols come from a name's index in the list. The alternative was hashing
+the name with a seed and rejecting the encoding on a collision, which makes
+symbols independent of list order — appending or reordering names preserves
+them.
+
+Positional assignment won on simplicity: construction always succeeds for a
+valid list, there is no seed to manage and no collision to retry, and
+decoding is an array index rather than a registered reverse table. The cost
+is that the list is append-only — inserting or reordering names shifts every
+symbol after the edit. That is acceptable because nothing persists a token
+symbol: symbols are built with the grammar, live as long as a parse, and are
+never serialized. Should they ever be written to a file, order independence
+would matter and the hash strategy is the way back.

--- a/fjs/ebnf/token_symbol/module.f.mjs
+++ b/fjs/ebnf/token_symbol/module.f.mjs
@@ -27,6 +27,8 @@ import { fromUndefined } from '../../types/nullable/module.f.mjs'
  * The symbol of the first registered name: `0x110000`, one past the last
  * Unicode scalar value, so a token symbol can never be mistaken for a code
  * point of the layer below.
+ *
+ * @type {number}
  */
 export const start = 0x110000
 

--- a/fjs/ebnf/token_symbol/module.f.mjs
+++ b/fjs/ebnf/token_symbol/module.f.mjs
@@ -1,0 +1,55 @@
+/**
+ * Encoding of multi-character token names as single input symbols.
+ *
+ * A parser built over a tokenizer consumes one symbol per token, so a
+ * multi-character operator (`>>>=`) and a keyword (`instanceof`) each need
+ * a symbol of their own. Names are registered as one fixed alphabet and
+ * take a symbol from their position in it, above the Unicode range, so a
+ * token symbol is never mistaken for a code point of the layer below. A
+ * number is a rule of one symbol in the EBNF front end, so the symbol a
+ * tokenizer emits is the terminal the grammar above names it by, with no
+ * wrapping between the two.
+ *
+ * Every list holds: a symbol is a non-negative safe integer, and no array
+ * is long enough to carry the alphabet past that ceiling, so there is no
+ * capacity to check. See `./README.md` for why the alphabet is registered
+ * and positional, and `./types.ts` for `Encoding<T>`.
+ *
+ * @module
+ *
+ * @import { Encoding } from './types.ts'
+ */
+
+import { assert } from '../../asserts/module.f.mjs'
+import { fromUndefined } from '../../types/nullable/module.f.mjs'
+
+/**
+ * The symbol of the first registered name: `0x110000`, one past the last
+ * Unicode scalar value, so a token symbol can never be mistaken for a code
+ * point of the layer below.
+ */
+export const start = 0x110000
+
+/**
+ * Builds an encoding over the complete list of token names.
+ *
+ * A name takes the symbol at its index in `names`, so the list is
+ * append-only: inserting or reordering names changes the symbols of
+ * everything after the edit.
+ *
+ * @throws When a name repeats — a repeated name has no single symbol to
+ * decode back to.
+ *
+ * @type {<T extends string>(names: readonly T[]) => Encoding<T>}
+ */
+export const encoding = names => {
+    assert(new Set(names).size === names.length, ['duplicate token name', names])
+    return {
+        encode: name => {
+            const index = names.indexOf(name)
+            assert(index !== -1, ['unregistered token name', name])
+            return start + index
+        },
+        decode: symbol => fromUndefined(names[symbol - start]),
+    }
+}

--- a/fjs/ebnf/token_symbol/proof.f.mjs
+++ b/fjs/ebnf/token_symbol/proof.f.mjs
@@ -1,0 +1,52 @@
+import { assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
+import { parser } from '../ll1/module.f.mjs'
+import { encoding, start } from './module.f.mjs'
+
+const names = /** @type {const} */ (['>>', '>>>=', 'instanceof'])
+
+export const proof = {
+    encode: () => {
+        const { encode } = encoding(names)
+        assertEq(encode('>>'), 0x110000)
+        assertEq(encode('instanceof'), 0x110002)
+        assertEq(start, 0x10FFFF + 1)
+    },
+    decode: [
+        () => {
+            const { decode } = encoding(names)
+            assertEq(decode(0x110000), '>>')
+            assertEq(decode(0x110002), 'instanceof')
+        },
+        () => {
+            const { decode } = encoding(names)
+            // past the end of the alphabet, a code point, the end of input
+            assertEq(decode(0x110003), null)
+            assertEq(decode(0x10FFFF), null)
+            assertEq(decode(-1), null)
+        },
+    ],
+    roundTrip: () => {
+        const { encode, decode } = encoding(names)
+        for (const name of names) {
+            assertEq(decode(encode(name)), name)
+        }
+    },
+    // A symbol is a rule of one symbol: the value a tokenizer emits is the
+    // terminal a grammar over the tokens names it by, and the backend reads
+    // the one from the other with nothing between.
+    rule: () => {
+        const { encode } = encoding(names)
+        const tok = { id: 'tok' }
+        const symbols = names.map(name => ({ symbol: encode(name), meta: tok }))
+        assertStructurallySame(parser([encode('>>'), encode('>>>=')])(symbols), ['ok', [[symbols[0], symbols[1]], 2]])
+        assertStructurallySame(parser(encode('instanceof'))(symbols), ['error', 0])
+    },
+    throw: {
+        duplicateName: () => { encoding(['a', 'b', 'a']) },
+        unregisteredName: () => {
+            /** @type {readonly string[]} */
+            const names = ['a']
+            encoding(names).encode('b')
+        },
+    },
+}

--- a/fjs/ebnf/token_symbol/proof.f.mjs
+++ b/fjs/ebnf/token_symbol/proof.f.mjs
@@ -36,7 +36,7 @@ export const proof = {
     // the one from the other with nothing between.
     rule: () => {
         const { encode } = encoding(names)
-        const tok = { id: 'tok' }
+        const tok = /** @type {const} */ ({ id: 'tok' })
         const symbols = names.map(name => ({ symbol: encode(name), meta: tok }))
         assertStructurallySame(parser([encode('>>'), encode('>>>=')])(symbols), ['ok', [[symbols[0], symbols[1]], 2]])
         assertStructurallySame(parser(encode('instanceof'))(symbols), ['error', 0])

--- a/fjs/ebnf/token_symbol/types.ts
+++ b/fjs/ebnf/token_symbol/types.ts
@@ -1,0 +1,26 @@
+/**
+ * Types for encoding multi-character token names as single input symbols.
+ *
+ * @module
+ */
+
+import type { Nullable } from '../../types/nullable/types.ts'
+
+/**
+ * A bidirectional map between a fixed alphabet of token names and the
+ * symbols reserved for them.
+ */
+export type Encoding<T extends string> = {
+    /**
+     * The symbol standing for `name`: what a tokenizer emits for the token,
+     * and, since a number is a rule of one symbol, the terminal a grammar
+     * over the tokens names it by — the same value in both places.
+     */
+    readonly encode: (name: T) => number
+    /**
+     * The name a symbol stands for, or `null` when the symbol belongs to no
+     * registered name — a code point, the end of input, or a symbol past
+     * the end of the alphabet.
+     */
+    readonly decode: (symbol: number) => Nullable<T>
+}

--- a/fjs/todo/ebnf-migration.md
+++ b/fjs/todo/ebnf-migration.md
@@ -445,7 +445,7 @@ consumer port"), never by number, so a renumbering here cannot strand them.
       rename-check-map retired with `bnf/map/rtti`.
 - [x] Stage 4: `ebnf/ll1/` with proof; the backend's side of the AST
       mapping.
-- [ ] Stage 4: `ebnf/token_symbol/` with proof.
+- [x] Stage 4: `ebnf/token_symbol/` with proof.
 - [ ] Stage 5: `ebnf/lib/json` and `ebnf/lib/datajs` with proofs; the
       cross-front-end comparison proof group; bnf-grammar-single-owner moved.
 - [ ] Stage 6: the token layer (done: the resumable parser); the djs

--- a/fjs/todo/ebnf-migration.md
+++ b/fjs/todo/ebnf-migration.md
@@ -335,9 +335,11 @@ rewritten against the surviving backend as they move.
 Every stage is additive, `bnf/` loses nothing until stage 7, and `tsc` and
 `fjs t` pass at each. **The stages are numbered for reference, not for
 order, and they prescribe no method.** The only constraints are the
-dependencies each module names in the layout — `token_symbol/` needs
-`unicode/`, `ll1/` needs `data/` and `map/`, a ported grammar needs
-whatever it imports, a deleted `bnf/` needs no consumer left on it — and
+dependencies each module names in the layout — `ll1/` needs `data/` and
+`map/`, a ported grammar needs whatever it imports, a deleted `bnf/` needs
+no consumer left on it; `token_symbol/` needs nothing, its `0x110000`
+start being its own, and reading that from `unicode/` is a repoint
+[unicode-rules](../bnf/todo/unicode-rules.md) tracks for after stage 3 — and
 the direction rule. Any order, overlap, split or merge of the stages that
 respects those is the developer's choice, and so is how each piece is
 built: whether a "move" is a copy, a re-export or a rewrite, whether an
@@ -378,8 +380,12 @@ consumer port"), never by number, so a renumbering here cannot strand them.
    nothing forbids it earlier. `ebnf/matcher/` was this stage's too, and is
    no longer anyone's: the backend shipped without it (the triage's
    `matcher/` row, **Amended**).
-4. **`ebnf/token_symbol/` and `ebnf/ll1/`.** `token_symbol`
-   copied, taking `unicodeRange` from `ebnf/unicode/`. `ll1` rewritten against
+4. **`ebnf/token_symbol/` and `ebnf/ll1/`.** `token_symbol` moved —
+   shipped as [`ebnf/token_symbol/`](../ebnf/token_symbol/README.md), a
+   symbol being a rule and the start `0x110000` spelled there; having it
+   read that from `ebnf/unicode/` is the repoint
+   [unicode-rules](../bnf/todo/unicode-rules.md) tracks, after stage 3,
+   which nothing waits on. `ll1` rewritten against
    the new IR — shipped as [`ebnf/ll1/`](../ebnf/ll1/README.md): flat nodes
    for every bound, a conflict error that names the rule, and the AST
    mapping as a rewrite set folded into the parse. Of the two things the
@@ -445,7 +451,8 @@ consumer port"), never by number, so a renumbering here cannot strand them.
       rename-check-map retired with `bnf/map/rtti`.
 - [x] Stage 4: `ebnf/ll1/` with proof; the backend's side of the AST
       mapping.
-- [x] Stage 4: `ebnf/token_symbol/` with proof.
+- [x] Stage 4: `ebnf/token_symbol/` with proof; its start is its own
+      until [unicode-rules](../bnf/todo/unicode-rules.md)'s repoint.
 - [ ] Stage 5: `ebnf/lib/json` and `ebnf/lib/datajs` with proofs; the
       cross-front-end comparison proof group; bnf-grammar-single-owner moved.
 - [ ] Stage 6: the token layer (done: the resumable parser); the djs


### PR DESCRIPTION
Stacked on #1927. The `ebnf/token_symbol/` move of `fjs/djs/todo/ebnf-ll1-port.md` and of ebnf-migration's stage 4: the alphabet the djs parser reads, moved so that its port keeps no import into `fjs/bnf`. `bnf/token_symbol` stays as it is until stage 7, as the plan has it.

Two things rethought on the way, per the plan's "triage, not copy":

- **A symbol is a rule.** A number is a rule of one symbol in the EBNF front end, so the value `encode` returns is at once what a tokenizer emits and the terminal a grammar names the token by. The classical module returned a bare symbol that had to be wrapped as a range before a rule could name it, and a symbol and a range were both plain numbers, so passing one where the other belonged was no type error. The proof feeds `encode`'s values to the LL(1) parser as both input and grammar.
- **No capacity.** The classical range ran to the last symbol of the packed codec and refused a longer list. The EBNF domain is the non-negative safe integers, and no array is long enough to carry an alphabet past that ceiling, so there is nothing to check and `capacity` is gone.

Symbols start at `0x110000`, above every code point, as before; the alphabet stays registered and positional, and the README carries both arguments over. Nothing imports the module yet; the parser port does.

Checks: `tsc`, `node ./fjs/module.mjs t` (5550), `npm run gen` (no change), `node --test` with 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CZRKbBvWAYpYtgVpUa3UH

---
_Generated by [Claude Code](https://claude.ai/code/session_014CZRKbBvWAYpYtgVpUa3UH)_