### PR TITLE
djs/parser: the module grammar, LL(1), beside the classical one

### DIFF
--- a/fjs/djs/parser/grammar/module.f.mjs
+++ b/fjs/djs/parser/grammar/module.f.mjs
@@ -34,11 +34,14 @@
  *   follows, so a trailing comma is a comma nothing follows; the classical
  *   grammar rested it on a failed repetition round rewinding.
  *
- * The alphabet is one symbol per token kind, the five framing keywords
- * — which the tokenizer emits as identifiers — with symbols of their own,
- * from `fjs/ebnf/token_symbol`; `eof` has none, since the backend
+ * The alphabet is the classical parser's own, `_ordinaryTokenNames` in
+ * `../module.f.mjs` — one name per token kind, the five framing keywords
+ * with names of their own, since the tokenizer emits them as identifiers —
+ * encoded by `fjs/ebnf/token_symbol`; `eof` has none, since the backend
  * synthesizes the end of input. A symbol is a rule of one symbol, so a
- * terminal is the symbol a token is encoded to and nothing else.
+ * terminal is the symbol a token is encoded to and nothing else. The port
+ * turns the import around: the names move here, and the parser reads them
+ * from the grammar.
  *
  * @module
  *
@@ -52,25 +55,7 @@
 import { assert } from '../../../asserts/module.f.mjs'
 import { eof, option, repeatFrom0 } from '../../../ebnf/module.f.mjs'
 import { encoding } from '../../../ebnf/token_symbol/module.f.mjs'
-
-/**
- * The framing keywords, which the tokenizer emits as `id` tokens carrying
- * the word. None is reserved: outside its framing position each is an
- * ordinary identifier, which {@link identifier} says.
- */
-export const framingKeywords = /** @type {const} */ (['import', 'const', 'export', 'default', 'from'])
-
-/**
- * The alphabet: one name per `DjsToken` kind except `eof`, then the
- * framing keywords. Append-only, as every registered alphabet is.
- */
-export const names = /** @type {const} */ ([
-    'true', 'false', 'null', 'undefined',
-    '{', '}', ':', ',', '[', ']', '.', '=', ';',
-    'string', 'number', 'error', 'id', 'bigint',
-    'ws', 'nl', '//', '/*',
-    ...framingKeywords,
-])
+import { _framingKeywords as framingKeywords, _ordinaryTokenNames as names } from '../module.f.mjs'
 
 const alphabet = encoding(names)
 

--- a/fjs/djs/parser/grammar/module.f.mjs
+++ b/fjs/djs/parser/grammar/module.f.mjs
@@ -1,0 +1,181 @@
+/**
+ * The djs module grammar over token symbols, spelled LL(1) for
+ * `fjs/ebnf/ll1`, beside the classical grammar in `../module.f.mjs` that
+ * the backtracking backend reads:
+ *
+ * ```text
+ * module ::= t import* const* export eof
+ * import ::= 'import' t id t 'from' t string t ';' t
+ * const  ::= 'const' t id t '=' t value t ';' t
+ * export ::= 'export' t 'default' t value t ';' t
+ * value  ::= primitive | id | array | object
+ * array  ::= '[' t [ items(value) ] ']'
+ * object ::= '{' t [ items(member) ] '}'
+ * member ::= key t ':' t value
+ * key    ::= id | string | '[' t string t ']'
+ * items  ::= item t [ ',' t [ items ] ]
+ * t      ::= (ws | nl | comment)*
+ * ```
+ *
+ * Three things are spelled differently from the classical grammar, each a
+ * conflict `../../todo/ebnf-ll1-port.md` measured:
+ *
+ * - **Trivia follows a token, never leads a rule.** Every token is
+ *   followed by `t`, so no rule begins with trivia and no two branches
+ *   begin with it; the classical grammar's statement terminator and the
+ *   module's final optional `;` both did.
+ * - **`;` ends every statement, the export included.** The newline
+ *   terminator is gone: it is the design `todo/parser-serializer-restructure.md`
+ *   decided for FunctionalScript (stage 5), it is what DataJS requires,
+ *   and deciding between a newline and a `;` reached through newlines
+ *   took unbounded lookahead.
+ * - **A list is right-recursive.** After an item and its comma, one
+ *   symbol of lookahead says whether an item or the closing bracket
+ *   follows, so a trailing comma is a comma nothing follows; the classical
+ *   grammar rested it on a failed repetition round rewinding.
+ *
+ * The alphabet is one symbol per token kind, the five framing keywords
+ * — which the tokenizer emits as identifiers — with symbols of their own,
+ * from `fjs/ebnf/token_symbol`; `eof` has none, since the backend
+ * synthesizes the end of input. A symbol is a rule of one symbol, so a
+ * terminal is the symbol a token is encoded to and nothing else.
+ *
+ * @module
+ *
+ * @import { Meta } from '../../../ebnf/ast/types.ts'
+ * @import { Rule } from '../../../ebnf/types.ts'
+ * @import { DjsTokenWithMetadata } from '../../tokenizer/types.ts'
+ * @import { _OrdinaryTokenName } from '../types.ts'
+ * @import { Items, Member, Value } from './types.ts'
+ */
+
+import { assert } from '../../../asserts/module.f.mjs'
+import { eof, option, repeatFrom0 } from '../../../ebnf/module.f.mjs'
+import { encoding } from '../../../ebnf/token_symbol/module.f.mjs'
+
+/**
+ * The framing keywords, which the tokenizer emits as `id` tokens carrying
+ * the word. None is reserved: outside its framing position each is an
+ * ordinary identifier, which {@link identifier} says.
+ */
+export const framingKeywords = /** @type {const} */ (['import', 'const', 'export', 'default', 'from'])
+
+/**
+ * The alphabet: one name per `DjsToken` kind except `eof`, then the
+ * framing keywords. Append-only, as every registered alphabet is.
+ */
+export const names = /** @type {const} */ ([
+    'true', 'false', 'null', 'undefined',
+    '{', '}', ':', ',', '[', ']', '.', '=', ';',
+    'string', 'number', 'error', 'id', 'bigint',
+    'ws', 'nl', '//', '/*',
+    ...framingKeywords,
+])
+
+const alphabet = encoding(names)
+
+/** The symbol of a token name: what a token is encoded to, and the terminal that names it. */
+export const sym = alphabet.encode
+
+/**
+ * One token as the parser's input: the symbol of its kind — of its word,
+ * for a framing keyword — with the whole token as metadata, so that a fold
+ * above still has its value and its position.
+ *
+ * `eof` has no symbol: a stream reaching here has had it split off, and
+ * one that has not is a caller's mistake, not bad input.
+ *
+ * @type {(t: DjsTokenWithMetadata) => Meta<DjsTokenWithMetadata>}
+ */
+export const symbolOf = t => {
+    const { token } = t
+    const keyword = token.kind === 'id' ? framingKeywords.find(k => k === token.value) : undefined
+    const name = keyword ?? token.kind
+    assert(name !== 'eof', ['eof token reached the parser alphabet', t])
+    return { symbol: sym(name), meta: t }
+}
+
+/** Trivia between any two tokens; it follows every token below. */
+export const trivia = repeatFrom0({
+    ws: sym('ws'),
+    nl: sym('nl'),
+    lineComment: sym('//'),
+    blockComment: sym('/*'),
+})
+
+/** Every word that may stand where an identifier is expected: none of the framing keywords is reserved. */
+export const identifier = /** @type {const} */ ({
+    id: sym('id'),
+    import: sym('import'),
+    const: sym('const'),
+    export: sym('export'),
+    default: sym('default'),
+    from: sym('from'),
+})
+
+/** A value that is one token. */
+export const primitive = /** @type {const} */ ({
+    null: sym('null'),
+    true: sym('true'),
+    false: sym('false'),
+    undefined: sym('undefined'),
+    number: sym('number'),
+    string: sym('string'),
+    bigint: sym('bigint'),
+})
+
+/**
+ * A comma-separated list of items, at least one, a trailing comma allowed.
+ *
+ * @type {<const I extends Rule>(item: I) => Items<I>}
+ */
+export const items = item => {
+    /** @type {Items<typeof item>} */
+    const list = () => ['const', [item, trivia, option([sym(','), trivia, option(list)])]]
+    return list
+}
+
+/** @type {Value} */
+export const value = () => ['const', { primitive, ref: identifier, array, object }]
+
+/** A property name: bare identifier, string literal, or a computed `["a"]`. */
+export const key = /** @type {const} */ ({
+    plain: identifier,
+    string: sym('string'),
+    computed: [sym('['), trivia, sym('string'), trivia, sym(']')],
+})
+
+/** @type {Member} */
+export const member = [key, trivia, sym(':'), trivia, value]
+
+export const array = /** @type {const} */ ([sym('['), trivia, option(items(value)), sym(']')])
+
+export const object = /** @type {const} */ ([sym('{'), trivia, option(items(member)), sym('}')])
+
+/** A statement's terminator: `;`, then the trivia after it. */
+const end = /** @type {const} */ ([sym(';'), trivia])
+
+export const importStatement = /** @type {const} */ ([
+    sym('import'), trivia, identifier, trivia, sym('from'), trivia, sym('string'), trivia, ...end,
+])
+
+export const constStatement = /** @type {const} */ ([
+    sym('const'), trivia, identifier, trivia, sym('='), trivia, value, trivia, ...end,
+])
+
+export const exportStatement = /** @type {const} */ ([
+    sym('export'), trivia, sym('default'), trivia, value, trivia, ...end,
+])
+
+/**
+ * The whole module: every `import` before every `const`, one
+ * `export default` last, each ended by `;`, and nothing but trivia around
+ * them. Ending on `eof` is what makes a trailing stray token a failure.
+ */
+export const djsModule = /** @type {const} */ ([
+    trivia,
+    repeatFrom0(importStatement),
+    repeatFrom0(constStatement),
+    exportStatement,
+    eof,
+])

--- a/fjs/djs/parser/grammar/proof.f.mjs
+++ b/fjs/djs/parser/grammar/proof.f.mjs
@@ -1,7 +1,10 @@
 /**
+ * @import { Assert } from '../../../asserts/types.ts'
  * @import { Meta } from '../../../ebnf/ast/types.ts'
  * @import { Rule } from '../../../ebnf/types.ts'
+ * @import { Equal } from '../../../types/ts/types.ts'
  * @import { DjsTokenWithMetadata } from '../../tokenizer/types.ts'
+ * @import { Items } from './types.ts'
  */
 
 import { assertEq, assertStructurallySame } from '../../../asserts/module.f.mjs'
@@ -12,7 +15,7 @@ import { toArray } from '../../../types/list/module.f.mjs'
 import { tokenize } from '../../tokenizer/module.f.mjs'
 import { _ordinaryTokenNames as names } from '../module.f.mjs'
 import {
-    array, constStatement, djsModule, exportStatement, identifier, importStatement, key, member,
+    array, constStatement, djsModule, exportStatement, identifier, importStatement, items, key, member,
     object, primitive, sym, symbolOf, trivia, value,
 } from './module.f.mjs'
 
@@ -107,6 +110,12 @@ export const proof = {
         assertStructurallySame(read('export default {1: 2};'), ['error', 'number'])
         assertStructurallySame(read('export default;'), ['error', ';'])
         assertStructurallySame(read('export default "abc;'), ['error', 'error'])
+    },
+    // `items` keeps the item's type: a tuple written at the call stays the
+    // tuple, which is what its `const` type parameter is for. Compile-time.
+    itemsInference: () => {
+        const list = items([42, 43])
+        /** @typedef {Assert<Equal<typeof list, Items<readonly [42, 43]>>>} _ItemsKeepTheTuple */
     },
     // Statements end with `;`, so a repetition of any statement is LL(1)
     // too — the order is the module's rule, not lookahead's.

--- a/fjs/djs/parser/grammar/proof.f.mjs
+++ b/fjs/djs/parser/grammar/proof.f.mjs
@@ -10,9 +10,10 @@ import { repeatFrom0 } from '../../../ebnf/module.f.mjs'
 import { stringToList } from '../../../text/utf16/module.f.mjs'
 import { toArray } from '../../../types/list/module.f.mjs'
 import { tokenize } from '../../tokenizer/module.f.mjs'
+import { _ordinaryTokenNames as names } from '../module.f.mjs'
 import {
     array, constStatement, djsModule, exportStatement, identifier, importStatement, key, member,
-    names, object, primitive, sym, symbolOf, trivia, value,
+    object, primitive, sym, symbolOf, trivia, value,
 } from './module.f.mjs'
 
 // The value names itself, and the tree of a whole module is too deep a

--- a/fjs/djs/parser/grammar/proof.f.mjs
+++ b/fjs/djs/parser/grammar/proof.f.mjs
@@ -1,0 +1,118 @@
+/**
+ * @import { Meta } from '../../../ebnf/ast/types.ts'
+ * @import { Rule } from '../../../ebnf/types.ts'
+ * @import { DjsTokenWithMetadata } from '../../tokenizer/types.ts'
+ */
+
+import { assertEq, assertStructurallySame } from '../../../asserts/module.f.mjs'
+import { parser } from '../../../ebnf/ll1/module.f.mjs'
+import { repeatFrom0 } from '../../../ebnf/module.f.mjs'
+import { stringToList } from '../../../text/utf16/module.f.mjs'
+import { toArray } from '../../../types/list/module.f.mjs'
+import { tokenize } from '../../tokenizer/module.f.mjs'
+import {
+    array, constStatement, djsModule, exportStatement, identifier, importStatement, key, member,
+    names, object, primitive, sym, symbolOf, trivia, value,
+} from './module.f.mjs'
+
+// The value names itself, and the tree of a whole module is too deep a
+// type for `tsc` to unroll through `parser`'s return type (TS2589); the
+// rules are widened to `Rule` here, where only acceptance is read.
+const parseModule = parser(/** @type {Rule} */ (djsModule))
+
+/**
+ * The parser's input for a text: its tokens, the final `eof` split off.
+ *
+ * @type {(s: string) => readonly Meta<DjsTokenWithMetadata>[]}
+ */
+const symbols = s => {
+    const all = toArray(tokenize(stringToList(s))('a.js'))
+    const last = all[all.length - 1]
+    // a lexical failure is the stream's one token, an error and no `eof`
+    return (last !== undefined && last.token.kind === 'eof' ? all.slice(0, -1) : all).map(symbolOf)
+}
+
+/**
+ * What the grammar makes of a text: `ok`, or `error` at a token — named by
+ * its kind, or by its word where it is an identifier, or `end` where the
+ * input ran out.
+ *
+ * @type {(s: string) => readonly string[]}
+ */
+const read = s => {
+    const input = symbols(s)
+    const result = parseModule(input)
+    if (result[0] === 'ok') { return ['ok'] }
+    const at = input[result[1]]
+    if (at === undefined) { return ['error', 'end'] }
+    const { token } = at.meta
+    return ['error', token.kind === 'id' ? token.value : token.kind]
+}
+
+export const proof = {
+    // The grammar is LL(1): every rule builds, and so does the module.
+    ll1: () => {
+        parser(trivia)
+        parser(identifier)
+        parser(primitive)
+        parser(key)
+        parser(/** @type {Rule} */ (member))
+        parser(/** @type {Rule} */ (value))
+        parser(/** @type {Rule} */ (array))
+        parser(/** @type {Rule} */ (object))
+        parser(/** @type {Rule} */ (importStatement))
+        parser(/** @type {Rule} */ (constStatement))
+        parser(/** @type {Rule} */ (exportStatement))
+    },
+    // One symbol per name, all distinct, all above every code point; a
+    // framing keyword is not an identifier's symbol, and the token rides
+    // along as metadata.
+    alphabet: () => {
+        const all = names.map(sym)
+        assertEq(new Set(all).size, names.length)
+        assertEq(all.every(s => s > 0x10FFFF), true)
+        const word = symbolOf({ token: { kind: 'id', value: 'export' }, metadata: { path: 'a.js', line: 1, column: 1 } })
+        const id = symbolOf({ token: { kind: 'id', value: 'exports' }, metadata: { path: 'a.js', line: 1, column: 1 } })
+        assertEq(word.symbol, sym('export'))
+        assertEq(id.symbol, sym('id'))
+        assertEq(id.meta.token.kind, 'id')
+    },
+    accepted: () => {
+        assertStructurallySame(read('export default 1;'), ['ok'])
+        assertStructurallySame(read(' /* c */ export default [1, [2,], {a: 1, "b": 2, ["c"]: 3,},] ; // c\n'), ['ok'])
+        assertStructurallySame(read('import x from "m";\nconst a = [x];\nconst b = { a: a, };\nexport default [x, a, b];\n'), ['ok'])
+        assertStructurallySame(read('const export = 1;export default export;'), ['ok'])
+        assertStructurallySame(read('export default\n1\n;'), ['ok'])
+        assertStructurallySame(read('export default {};'), ['ok'])
+        assertStructurallySame(read('export default [];'), ['ok'])
+    },
+    // `;` ends every statement: a newline does not, and neither does the
+    // end of input. A newline is trivia, read past, so the failure is at
+    // what came instead of the `;` — the next statement, or the end.
+    terminator: () => {
+        assertStructurallySame(read('export default 1'), ['error', 'end'])
+        assertStructurallySame(read('export default 1\n'), ['error', 'end'])
+        assertStructurallySame(read('const a = 1\nexport default a;'), ['error', 'export'])
+        assertStructurallySame(read('import x from "m"\nconst a = x;\nexport default a;'), ['error', 'const'])
+        assertStructurallySame(read('export default 1;;'), ['error', ';'])
+    },
+    refused: () => {
+        assertStructurallySame(read(''), ['error', 'end'])
+        assertStructurallySame(read('export default [1,,2];'), ['error', ','])
+        assertStructurallySame(read('export default {,};'), ['error', ','])
+        assertStructurallySame(read('export default [1 2];'), ['error', 'number'])
+        assertStructurallySame(read('export default 1; const a = 2;'), ['error', 'const'])
+        assertStructurallySame(read('const a = 1; import x from "m"; export default a;'), ['error', 'import'])
+        assertStructurallySame(read('export default {1: 2};'), ['error', 'number'])
+        assertStructurallySame(read('export default;'), ['error', ';'])
+        assertStructurallySame(read('export default "abc;'), ['error', 'error'])
+    },
+    // Statements end with `;`, so a repetition of any statement is LL(1)
+    // too — the order is the module's rule, not lookahead's.
+    statements: () => {
+        parser(/** @type {Rule} */ (repeatFrom0({ importStatement, constStatement, exportStatement })))
+    },
+    throw: {
+        eofRejected: () => symbolOf({ token: { kind: 'eof' }, metadata: { path: 'a.js', line: 1, column: 1 } }),
+    },
+}

--- a/fjs/djs/parser/grammar/types.ts
+++ b/fjs/djs/parser/grammar/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Type-level API of the djs module grammar: the shapes its helpers build
+ * and the value, which names itself and so is spelled here, as `JsonValue`
+ * is in `fjs/ebnf/lib/json/types.ts` — a named type a `const` binding may
+ * be annotated with.
+ *
+ * @module
+ */
+
+import type { Option, Rule } from '../../../ebnf/types.ts'
+import type { identifier, key, primitive, trivia } from './module.f.mjs'
+
+/**
+ * A comma-separated list of `Item`s, at least one, a trailing comma
+ * allowed: an item and its trivia, then optionally a comma, its trivia, and
+ * the rest of the list — or nothing after the comma, which is the trailing
+ * one. Right-recursive, so that one symbol of lookahead decides whether a
+ * comma is followed by an item or by the closing bracket.
+ */
+export type Items<Item extends Rule> = () => readonly ['const', readonly [
+    Item,
+    typeof trivia,
+    Option<readonly [number, typeof trivia, Option<Items<Item>>]>,
+]]
+
+/** An opening symbol, trivia, an optional list, and the closing symbol. */
+export type Container<Item extends Rule> = readonly [number, typeof trivia, Option<Items<Item>>, number]
+
+/** A key, trivia, `:`, trivia, and a value. */
+export type Member = readonly [typeof key, typeof trivia, number, typeof trivia, Value]
+
+/**
+ * A value: a primitive token, a reference, an array of values, or an
+ * object of members — a `const` thunk whose payload names the thunk, which
+ * is what lets a type alias name itself.
+ */
+export type Value = () => readonly ['const', {
+    readonly primitive: typeof primitive
+    readonly ref: typeof identifier
+    readonly array: Container<Value>
+    readonly object: Container<Member>
+}]

--- a/fjs/djs/parser/proof.f.mjs
+++ b/fjs/djs/parser/proof.f.mjs
@@ -14,7 +14,7 @@ import {
 } from './module.f.mjs'
 import { tokenize } from '../tokenizer/module.f.mjs'
 import { parser } from '../../ebnf/ll1/module.f.mjs'
-import { djsModule as ebnfModule, names as ebnfNames, symbolOf } from './grammar/module.f.mjs'
+import { djsModule as ebnfModule, symbolOf } from './grammar/module.f.mjs'
 import { toArray } from '../../types/list/module.f.mjs'
 import { sort } from '../../types/object/module.f.mjs'
 import { stringToList } from '../../text/utf16/module.f.mjs'
@@ -253,9 +253,6 @@ export const proof = {
     // EBNF grammar accepts, or refuses at the terminator, since the fold is
     // not the grammar's.
     ebnf: {
-        alphabet: () => {
-            assertStructurallySame(ebnfNames, _ordinaryTokenNames)
-        },
         corpus: () => {
             const outcomes = inputs.map(s => {
                 const classical = classicalResult(s)

--- a/fjs/djs/parser/proof.f.mjs
+++ b/fjs/djs/parser/proof.f.mjs
@@ -102,8 +102,13 @@ const classicalResult = s => {
 }
 
 /**
- * Every literal input the proofs below hand to `parseFromTokens`, in their
- * order — the parser's corpus, which the comparison runs over whole.
+ * Every literal input the proofs below hand to `parseFromTokens` — the
+ * parser's corpus, which the comparison runs over whole. A second list
+ * rather than the proofs' own literals, which sit inside their closures;
+ * it retires with the comparison when the port lands, and until then a
+ * case added below is added here.
+ *
+ * @type {readonly string[]}
  */
 const inputs = [
     "export default missing",
@@ -240,7 +245,38 @@ const inputs = [
     "export default 1\n;",
     "const a = 1\n;\nexport default a",
     "const $0=[1];export default [$0,$0];",
-    "first/test.f.mjs",
+    "42",
+    "[1,2]",
+    "{\"a\":1}",
+    "const a = 1 export default a",
+    "export default 1 2",
+    "export default {a}",
+    "export default {:1}",
+    "import x from y\nexport default x",
+    "export x from \"m\"\nexport default 1",
+    "const = 1\nexport default 1",
+    "export default 1;;",
+    "const a = 1;;\nexport default a",
+    "const a = 1;\n;export default a",
+    ";export default 1",
+    "export default ;",
+    "export default 1\nconst b = 2",
+    "import x from \"m\"",
+    "const a = 1\nconst a = 2\nexport default a",
+    "import x from \"m\"\nimport x from \"n\"\nexport default x",
+    "import x from \"m\"\nconst x = 1\nexport default x",
+    "export default zzz",
+    "const a = zzz\nexport default a",
+    "export default [zzz]",
+    "export default {a: zzz}",
+    "export default {__proto__: 1}",
+    "export default {\"__proto__\": 1}",
+    "import x from \"m\"\nimport x from \"n\"\nimport y from \"o\"\nexport default y",
+    "const a = 1\nconst a = 2\nconst b = 3\nexport default b",
+    "const a = missing x",
+    "const a = missing",
+    "export default missing 1",
+    "const a = 1\nconst a = 2 x",
 ]
 
 export const proof = {

--- a/fjs/djs/parser/proof.f.mjs
+++ b/fjs/djs/parser/proof.f.mjs
@@ -1,5 +1,6 @@
 /**
  * @import { Assert } from '../../asserts/types.ts'
+ * @import { Rule } from '../../ebnf/types.ts'
  * @import { Equal } from '../../types/ts/types.ts'
  * @import { DjsToken, DjsTokenWithMetadata } from '../tokenizer/types.ts'
  * @import { _FramingKeyword, _OrdinaryTokenName } from './types.ts'
@@ -12,6 +13,8 @@ import {
     _tokenKindNames,
 } from './module.f.mjs'
 import { tokenize } from '../tokenizer/module.f.mjs'
+import { parser } from '../../ebnf/ll1/module.f.mjs'
+import { djsModule as ebnfModule, names as ebnfNames, symbolOf } from './grammar/module.f.mjs'
 import { toArray } from '../../types/list/module.f.mjs'
 import { sort } from '../../types/object/module.f.mjs'
 import { stringToList } from '../../text/utf16/module.f.mjs'
@@ -51,7 +54,227 @@ const proofKind = (kind, line) => ({ token: { kind }, metadata: { path: 'a.js', 
 /** @type {(value: string, line: number) => DjsTokenWithMetadata} */
 const proofId = (value, line) => ({ token: { kind: 'id', value }, metadata: { path: 'a.js', line, column: 1 } })
 
+// -- the EBNF module grammar reads the same documents -------------------------
+
+const parseEbnfModule = parser(/** @type {Rule} */ (ebnfModule))
+
+/**
+ * The EBNF grammar's reading of a text's tokens: `ok`, or `error` at a
+ * token — `terminator` where that token is the next statement's keyword or
+ * the end of input, which is where the `;` the EBNF grammar requires and
+ * the classical one does not would stand, a newline being trivia the
+ * grammar reads past.
+ *
+ * @type {(s: string) => 'ok' | 'error' | 'terminator'}
+ */
+const ebnfResult = s => {
+    const all = tokenizeString(s)
+    const last = all[all.length - 1]
+    // the final `eof` is split off; a lexical failure ends the stream at
+    // its error token instead, which no rule accepts
+    const tokens = last !== undefined && last.token.kind === 'eof' ? all.slice(0, -1) : all
+    if (tokens.some(({ token }) => token.kind === 'eof')) { return 'error' }
+    const result = parseEbnfModule(tokens.map(symbolOf))
+    if (result[0] === 'ok') { return 'ok' }
+    const at = tokens[result[1]]
+    if (at === undefined) { return 'terminator' }
+    const { token } = at
+    return token.kind === 'id' && (token.value === 'import' || token.value === 'const' || token.value === 'export')
+        ? 'terminator'
+        : 'error'
+}
+
+/**
+ * The classical parser's reading of a text: `ok`, a `grammar` failure —
+ * a token it cannot use, or the end of input — or a `fold` failure, one
+ * its grammar accepted and its fold refused: a name unbound or bound
+ * twice, a `__proto__` key.
+ *
+ * @type {(s: string) => 'ok' | 'grammar' | 'fold'}
+ */
+const classicalResult = s => {
+    const result = parseFromTokens(tokenizeString(s))
+    if (result[0] === 'ok') { return 'ok' }
+    const { message } = result[1]
+    return message === 'unexpected token' || message === 'unexpected end' || message === 'missing end-of-input token'
+        ? 'grammar'
+        : 'fold'
+}
+
+/**
+ * Every literal input the proofs below hand to `parseFromTokens`, in their
+ * order — the parser's corpus, which the comparison runs over whole.
+ */
+const inputs = [
+    "export default missing",
+    "const a = \"abc",
+    "const a = /* x",
+    "const export = 1\nexport default export",
+    "const from = 1\nexport default from",
+    "const import = 1\nexport default import",
+    "export default { from: 2, default: 3 }",
+    "export default { export: 1 }",
+    "export default null",
+    "export default true",
+    "export default false",
+    "export default undefined",
+    "export default 0.1",
+    "export default 1.1e+2",
+    "export default \"abc\"",
+    "export default []",
+    "export default [1]",
+    "export default [[]]",
+    "export default [0,[1,[2,[]]],3]",
+    "export default {}",
+    "export default [{}]",
+    "export default {\"a\":true,\"b\":false,\"c\":null,\"d\":undefined}",
+    "export default {\"a\":{\"b\":{\"c\":[\"d\"]}}}",
+    "export default {a: 1}",
+    "export default 1234567890n",
+    "export default [1234567890n]",
+    "export default [1,]",
+    "export default {\"a\":1,}",
+    "export default {[\"a\"]:1}",
+    "export default {a:1,\"b\":2,[\"c\"]:3,}",
+    "export default { [ /* c */ \n // c \n \"a\" /* c */ \n // c \n ] : 1 }",
+    "export default {[\"__proto__\"]:{\"a\":42}}",
+    "export default {[1]:2}",
+    "export default {[",
+    "export default {[\"a\"}",
+    "export default {[\"a\"",
+    "export default {[\"a\"]}",
+    "export default {__proto__:1}",
+    "export default {\"__proto__\":1}",
+    "export default {\"a\":1,__proto__:2}",
+    "export default {\"a\":1,\"__proto__\":2}",
+    "export default",
+    "export default \"123",
+    "export default \"\t\"",
+    "export default [,]",
+    "export default [1 2]",
+    "export default [1,,2]",
+    "export default []]",
+    "export default [\"a\"",
+    "export default [,1]",
+    "export default [:]",
+    "export default ]",
+    "export default {,}",
+    "export default {1:2}",
+    "export default {\"1\"2}",
+    "export default {\"1\"::2}",
+    "export default {\"1\":2,,\"3\":4",
+    "export default {}}",
+    "export default {\"1\":2",
+    "export default {,\"1\":2}",
+    "export default }",
+    "export default [{]}",
+    "export default {[}]",
+    "export default 10-5",
+    "export",
+    "const",
+    "const x",
+    "const x 5",
+    "import",
+    "import 5",
+    "import a",
+    "import a from",
+    "export default [",
+    "export default {",
+    "export default {\"a\"",
+    "export default {\"a\":",
+    "export default {\"a\":1 2}",
+    "export default {\"a\":1,",
+    " export default [ 0 , 1 , 2 ] ",
+    " export default { \"a\" : 0 , \"b\" : 1 } ",
+    "\nexport\ndefault\n[\n0\n,\n1\n,\n2\n]\n",
+    "\rexport\rdefault\r{\r\"a\"\r:\r0\r,\r\"b\"\r:\r1\r}\r",
+    "null",
+    "1",
+    "[]",
+    "{\"valid\":\"json\"}",
+    "a",
+    "",
+    "const a = 1\n",
+    "import a from \"a.f.js\" \n const b = 1 \n export default [a,b]",
+    "const b = 1 \n import a from \"a.f.js\" \n export default [a,b]",
+    "export default 1 \n const a = 2",
+    "module=null",
+    "export default a",
+    "export null",
+    "export default = null",
+    "const a = 1 \n const b = 2 \n export default 3",
+    "const a = 1 \n const b = 2 \n export default b",
+    "const a = 1 \n const b = 2 \n export default [b,a,b]",
+    "const a = 1 \n const b = 2 \n export default {\"1st\":b,\"2nd\":a,\"3rd\":b}",
+    "const a = 1 const b = 2 export default 3",
+    "const = 1 \n const b = 2 \n export default 3",
+    "const a = 1 \n const a = 2 \n export default 3",
+    "const a = 1",
+    "import a from \"test/test.f.mjs\" \n export default a",
+    "import a from \"first/test.f.mjs\" \n import b from \"second/test.f.mjs\" \n export default [b, a, b]",
+    "import a from \"test/test.f.mjs\" \n const b = null \n export default [b, a, b]",
+    "import a from \"test/test.f.mjs\" export default a",
+    "import a from \n export default a",
+    "import a \"test/test.f.mjs\" \n export default a",
+    "import from \"test/test.f.mjs\" \n export default a",
+    "import a from \"first/test.f.mjs\" \n import a from \"second/test.f.mjs\" \n export default [b, a, b]",
+    "import a from \"test/test.f.mjs\" \n const a = null \n export default null",
+    "export //comment \n default /* comment */ null //comment",
+    "export default {\"a\":1}",
+    "export default {a:1,a:2}",
+    "export default {[\"__proto__\"]: 1}",
+    "const a = 1\nexport default a",
+    "const a = 1\nconst b = 2\nexport default [a,b]",
+    "const a = a\nexport default a",
+    "import x from \"m\"\nexport default x",
+    "import x from \"m\"\nconst a = 1\nexport default a",
+    "import x from \"m\"\nimport y from \"n\"\nexport default [x,y]",
+    "// c\nexport default 1",
+    "/* c */ export default 1",
+    "\n\n export default 1 \n\n",
+    "const a = 1;\nexport default a",
+    "export default 1;",
+    "const a = 1;export default a",
+    "import x from \"m\";const a = [x];export default [x,a]",
+    "const a = 1 ; // c\nexport default a ;",
+    "export default 1\n;",
+    "const a = 1\n;\nexport default a",
+    "const $0=[1];export default [$0,$0];",
+    "first/test.f.mjs",
+]
+
 export const proof = {
+    // The EBNF module grammar in `./grammar`, over the same token symbols,
+    // reads the corpus as this parser does, but for the one difference it
+    // declares: `;` ends every statement. What this grammar accepts, the
+    // EBNF grammar accepts, or refuses at a newline or the end of input
+    // where the `;` belongs; what this grammar refuses, the EBNF grammar
+    // refuses; what this grammar accepts and the fold above it refuses, the
+    // EBNF grammar accepts, or refuses at the terminator, since the fold is
+    // not the grammar's.
+    ebnf: {
+        alphabet: () => {
+            assertStructurallySame(ebnfNames, _ordinaryTokenNames)
+        },
+        corpus: () => {
+            const outcomes = inputs.map(s => {
+                const classical = classicalResult(s)
+                const ebnf = ebnfResult(s)
+                switch (classical) {
+                    case 'ok':
+                    case 'fold': { assert(ebnf === 'ok' || ebnf === 'terminator', JSON.stringify([s, classical, ebnf])); break }
+                    // a refusal is a refusal wherever it lands: a document
+                    // cut short fails at the end of input in both grammars
+                    case 'grammar': { assert(ebnf !== 'ok', s); break }
+                }
+                return ebnf
+            })
+            // every class is populated, so the comparison compares something:
+            // documents both read, documents only the `;` separates, and
+            // documents both refuse
+            assert(outcomes.includes('ok') && outcomes.includes('terminator') && outcomes.includes('error'))
+        },
+    },
     /**
      * The parser alphabet in `./module.f.mjs` agrees with its type-level
      * description in `./types.ts`. These are compile-time checks; the function

--- a/fjs/djs/todo/ebnf-ll1-port.md
+++ b/fjs/djs/todo/ebnf-ll1-port.md
@@ -139,8 +139,10 @@ reads values, not text.
       `jsGrammar`, `jsMatcher` and `descentParserCpOnly` retired and
       declared. The comparison proof retired with the classical grammar;
       the tokenizer's corpus stands unchanged as the port's proof.
-- [ ] Parser grammar LL(1): trailing trivia, right-recursive or separated
-      list, the terminator per stage 5.
+- [x] Parser grammar LL(1), beside the classical one with the comparison
+      proof: [`fjs/djs/parser/grammar`](../parser/grammar/module.f.mjs) —
+      trivia after every token, a right-recursive list, `;` after every
+      statement per stage 5 of parser-serializer-restructure.
 - [ ] Parser on `ebnf/ll1`, on the `media/datajs` reader pattern.
 - [ ] ebnf-migration stage 6 ticked; `bnf/descent` without consumers.
 


### PR DESCRIPTION
Stacked on #1929 → #1927 → #1925. The parser grammar task of `fjs/djs/todo/ebnf-ll1-port.md`: the djs module grammar in EBNF beside the classical one, LL(1), with the comparison proof. The live parser does not change; the port is the next task.

**The grammar**, `fjs/djs/parser/grammar/module.f.mjs`, is over the token symbols of `fjs/ebnf/token_symbol`, one symbol per token kind and one per framing keyword, and resolves the three parser conflicts the port issue measured:

- **Trivia follows a token, never leads a rule.** Every token is followed by `t`, so no rule begins with trivia and no two branches begin with it; the classical statement terminator and the module's final optional `;` both did.
- **`;` ends every statement, the export included.** The newline terminator is gone. This is the design `todo/parser-serializer-restructure.md` decided for FunctionalScript (stage 5) and what DataJS requires, and deciding between a newline and a `;` reached through newlines took unbounded lookahead. Since a newline is trivia, a missing `;` is found at the next statement's keyword or at the end of input, which the proof pins.
- **A list is right-recursive**, `item t [ ',' t [ items ] ]`, so one symbol of lookahead tells a trailing comma from one an item follows; the classical grammar rested it on a failed repetition round rewinding.

**The comparison proof** lives with the classical parser and goes with it. Over every literal input of the parser's proofs, what the classical parser accepts, the EBNF grammar accepts or refuses only where the `;` belongs; what the classical grammar refuses, the EBNF grammar refuses; and what the classical grammar accepts and its fold refuses — an unbound name, a duplicate binding, a `__proto__` key — the EBNF grammar accepts, since the fold is not the grammar's. The grammar reads the parser's own `_framingKeywords` and `_ordinaryTokenNames`, so the two alphabets are one by construction; the grammar's proof asserts the symbols are distinct and the keyword/identifier split holds. A statement-only repetition also builds, which shows the `;` is what makes a module LL(1) and the order is the module's own rule.

Nothing here changes what `parseFromTokens` accepts. The port that follows does, and carries the breaking change: the newline terminator, the two examples under `fjs/djs/examples`, and the proofs that end statements at a newline.

Checks: `tsc`, `node ./fjs/module.mjs t` (5558), `npm run gen` (no change), `node --test` with 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CZRKbBvWAYpYtgVpUa3UH