### PR TITLE
git/ident: who and when, as a second pass over a header's value

### DIFF
--- a/fjs/git/README.md
+++ b/fjs/git/README.md
@@ -15,6 +15,10 @@ come.
   share, and the message after it: a generic grammar over `key SP value LF`
   lines with continuation, a reader to a header list, and a writer that
   returns the block byte for byte.
+- [`ident/`](ident/module.f.mjs) — an `author`, `committer` or `tagger`
+  value, `name SP <email> SP time SP tz`, read as a second pass over the
+  bytes a header holds: a `try*` reader that refuses what the grammar does
+  not cover, and a writer.
 - `types.ts` — `Bytes`, the type of a field the format leaves unbounded,
   and `ObjectType`.
 

--- a/fjs/git/ident/module.f.mjs
+++ b/fjs/git/ident/module.f.mjs
@@ -17,18 +17,16 @@
  *
  * @module
  *
- * @import { Meta } from '../../ebnf/ast/types.ts'
- * @import { Byte } from '../../ebnf/byte/types.ts'
  * @import { Nullable } from '../../types/nullable/types.ts'
  * @import { Bytes } from '../types.ts'
  * @import { Ident } from './types.ts'
  */
 
 import { assert } from '../../asserts/module.f.mjs'
-import { byteArray, byteParser, not, symbols } from '../../ebnf/byte/module.f.mjs'
+import { ascii, byteArray, byteParser, not, symbols, symbolsOf } from '../../ebnf/byte/module.f.mjs'
 import { eof, range, repeatFrom0, repeatFrom1, set, times } from '../../ebnf/module.f.mjs'
-import { codePointListToString, stringToCodePointList } from '../../text/utf16/module.f.mjs'
-import { flat, toArray } from '../../types/list/module.f.mjs'
+import { codePointListToString } from '../../text/utf16/module.f.mjs'
+import { flat } from '../../types/list/module.f.mjs'
 
 const sp = /** @type {const} */ (0x20)
 
@@ -52,12 +50,6 @@ const zone = /** @type {const} */ ([set('+-'), times(4)(digit)])
 export const ident = /** @type {const} */ ([name, '<', email, '>', ' ', time, ' ', zone, eof])
 
 const parse = byteParser(ident)
-
-/** @type {(leaves: readonly Meta<Byte>[]) => readonly number[]} */
-const symbolsOf = leaves => leaves.map(({ symbol }) => symbol)
-
-/** @type {(s: string) => readonly number[]} */
-const ascii = s => toArray(stringToCodePointList(s))
 
 /**
  * Whether a digit string is canonical decimal — no leading zero ahead of

--- a/fjs/git/ident/module.f.mjs
+++ b/fjs/git/ident/module.f.mjs
@@ -1,0 +1,126 @@
+/**
+ * An ident: the value of an `author`, `committer` or `tagger` header,
+ * `name SP < email > SP time SP tz`, read as a second pass over the bytes
+ * the header block cut out.
+ *
+ * The SP before `<` cannot be a symbol of the rule: the name's repetition
+ * may end in SP, so `' <'` after it is a first/follow conflict the backend
+ * refuses. The name is read up to `<`, and the reader requires its last
+ * byte to be SP and drops it, refusing a name that does not end in one.
+ * `eof` closes the rule, so trailing bytes are refused rather than left.
+ *
+ * Git's own reader is lenient, and old history holds idents without an
+ * email or with a malformed zone. This reader is a `try*`: an ident the
+ * grammar does not cover is refused, not repaired, and the raw header
+ * stays in the header list either way. Which of those forms are worth
+ * accepting is decided when one is met, as an issue naming the object.
+ *
+ * @module
+ *
+ * @import { Meta } from '../../ebnf/ast/types.ts'
+ * @import { Byte } from '../../ebnf/byte/types.ts'
+ * @import { Nullable } from '../../types/nullable/types.ts'
+ * @import { Bytes } from '../types.ts'
+ * @import { Ident } from './types.ts'
+ */
+
+import { assert } from '../../asserts/module.f.mjs'
+import { byteArray, byteParser, not, symbols } from '../../ebnf/byte/module.f.mjs'
+import { eof, range, repeatFrom0, repeatFrom1, set, times } from '../../ebnf/module.f.mjs'
+import { codePointListToString, stringToCodePointList } from '../../text/utf16/module.f.mjs'
+import { flat, toArray } from '../../types/list/module.f.mjs'
+
+const sp = /** @type {const} */ (0x20)
+
+const lf = /** @type {const} */ (0x0A)
+
+const lt = /** @type {const} */ (0x3C)
+
+const gt = /** @type {const} */ (0x3E)
+
+const digit = range('09')
+
+const name = repeatFrom0(not(set('<\n')))
+
+const email = repeatFrom0(not(set('>\n')))
+
+const time = repeatFrom1(digit)
+
+const zone = /** @type {const} */ ([set('+-'), times(4)(digit)])
+
+/** The ident rule, to the end of the value. */
+export const ident = /** @type {const} */ ([name, '<', email, '>', ' ', time, ' ', zone, eof])
+
+const parse = byteParser(ident)
+
+/** @type {(leaves: readonly Meta<Byte>[]) => readonly number[]} */
+const symbolsOf = leaves => leaves.map(({ symbol }) => symbol)
+
+/** @type {(s: string) => readonly number[]} */
+const ascii = s => toArray(stringToCodePointList(s))
+
+/**
+ * Whether a digit string is canonical decimal — no leading zero ahead of
+ * another digit — so that what is read is what {@link write} spells.
+ *
+ * @type {(digits: readonly number[]) => boolean}
+ */
+const canonical = digits => digits.length === 1 || digits[0] !== 0x30
+
+/** @type {(digits: readonly number[]) => bigint} */
+const decimal = digits => digits.reduce((n, d) => n * 10n + BigInt(d - 0x30), 0n)
+
+/**
+ * Reads an ident, or refuses it: no `<` or `>`, a name that does not end
+ * in SP, a time that is not canonical decimal, a zone that is not a sign
+ * and four digits, or anything after the zone.
+ *
+ * @throws If an item of the value is not a byte.
+ *
+ * @type {(value: Bytes) => Nullable<Ident>}
+ */
+export const tryRead = value => {
+    const r = parse(symbols(value))
+    if (r[0] === 'error') { return null }
+    const [[n, , e, , , t, , [sign, z]]] = r[1]
+    const spaced = symbolsOf(n)
+    const digits = symbolsOf(t)
+    return spaced.length !== 0 && spaced[spaced.length - 1] === sp && canonical(digits)
+        ? {
+            name: spaced.slice(0, -1),
+            email: symbolsOf(e),
+            time: decimal(digits),
+            tz: codePointListToString([sign.symbol, ...symbolsOf(z)]),
+        }
+        : null
+}
+
+/**
+ * Whether `tz` is a zone as the format spells it: a sign and four digits.
+ *
+ * @type {(tz: string) => boolean}
+ */
+const isZone = tz => {
+    const c = ascii(tz)
+    return c.length === 5 && (c[0] === 0x2B || c[0] === 0x2D) && c.slice(1).every(d => d >= 0x30 && d <= 0x39)
+}
+
+/**
+ * An ident's bytes, as a header value: the inverse of {@link tryRead},
+ * byte for byte.
+ *
+ * @throws On an ident the format cannot spell — a name holding `<` or LF,
+ * an email holding `>` or LF, a negative time, a zone that is not a sign
+ * and four digits — or a name or email holding a number that is no byte.
+ *
+ * @type {(i: Ident) => Bytes}
+ */
+export const write = ({ name, email, time, tz }) => {
+    const n = byteArray(name)
+    const e = byteArray(email)
+    assert(n.every(b => b !== lt && b !== lf), ['not a name', n])
+    assert(e.every(b => b !== gt && b !== lf), ['not an email', e])
+    assert(time >= 0n, ['not a time', time])
+    assert(isZone(tz), ['not a zone', tz])
+    return flat([n, [sp, lt], e, [gt, sp], ascii(`${time} ${tz}`)])
+}

--- a/fjs/git/ident/proof.f.mjs
+++ b/fjs/git/ident/proof.f.mjs
@@ -1,0 +1,102 @@
+/**
+ * @import { Ident } from './types.ts'
+ */
+
+import { assert, assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
+import { codePointListToString } from '../../text/utf16/module.f.mjs'
+import { toArray } from '../../types/list/module.f.mjs'
+import { tryRead as readPayload } from '../header/module.f.mjs'
+import { commitPayload, hole, latin1 } from '../testlib.f.mjs'
+import { tryRead, write } from './module.f.mjs'
+
+const sp = /** @type {const} */ (0x20)
+
+const lt = /** @type {const} */ (0x3C)
+
+const gt = /** @type {const} */ (0x3E)
+
+/** @type {(value: readonly number[]) => Ident} */
+const read = value => {
+    const i = tryRead(value)
+    assert(i !== null)
+    return i
+}
+
+/** @type {(i: Ident) => readonly [string, string, bigint, string]} */
+const text = ({ name, email, time, tz }) =>
+    [codePointListToString(name), codePointListToString(email), time, tz]
+
+/** @type {(value: readonly number[]) => void} */
+const roundTrip = value => assertStructurallySame(toArray(write(read(value))), value)
+
+export const proof = {
+    // The author and the committer of a real commit, read out of its
+    // header list — the second pass over what the first one cut out — and
+    // written back to the same bytes.
+    commit: () => {
+        const p = readPayload(commitPayload)
+        assert(p !== null)
+        const author = toArray(p.headers[3][1])
+        const committer = toArray(p.headers[4][1])
+        assertStructurallySame(text(read(author)),
+            ['Sergey Shandar', 'sergey-shandar@users.noreply.github.com', 1789011254n, '+0000'])
+        assertStructurallySame(text(read(committer)), ['GitHub', 'noreply@github.com', 1789011254n, '+0000'])
+        roundTrip(author)
+        roundTrip(committer)
+    },
+    // A name may hold spaces and `>`, an email `<`; both are bytes, not
+    // text; a name may be empty, and a time may be `0`.
+    forms: () => {
+        assertStructurallySame(text(read(latin1('A B> <x<y> 5 -0530'))), ['A B>', 'x<y', 5n, '-0530'])
+        assertStructurallySame(text(read(latin1(' <> 0 +0000'))), ['', '', 0n, '+0000'])
+        const i = read([0xE9, sp, lt, 0xFF, gt, sp, ...latin1('12 +0100')])
+        assertStructurallySame([toArray(i.name), toArray(i.email), i.time, i.tz], [[0xE9], [0xFF], 12n, '+0100'])
+        for (const v of ['A B> <x<y> 5 -0530', ' <> 0 +0000', 'Alice  <a@b> 1 +0000']) {
+            roundTrip(latin1(v))
+        }
+    },
+    // A time past the safe integers is a bigint, read and written exactly.
+    bigTime: () => {
+        const i = read(latin1('a <b> 123456789012345678901234567890 +0000'))
+        assertEq(i.time, 123456789012345678901234567890n)
+        roundTrip(latin1('a <b> 123456789012345678901234567890 +0000'))
+    },
+    // Each refusal, one per condition: the SP before `<`, the brackets,
+    // the time's spelling, the zone's, trailing bytes, LF anywhere.
+    refused: () => {
+        for (const v of [
+            '',
+            'Alice<a@b> 1 +0000',       // no SP before `<`
+            'Alice <a@b 1 +0000',       // no `>`
+            'Alice a@b> 1 +0000',       // no `<`
+            'Alice <a@b> 01 +0000',     // not canonical decimal
+            'Alice <a@b> x +0000',      // not a time
+            'Alice <a@b> 1 0000',       // no sign
+            'Alice <a@b> 1 +000',       // three digits
+            'Alice <a@b> 1 +00000',     // five digits
+            'Alice <a@b> 1 +0000 ',     // trailing byte
+            'Alice <a@b> 1 +0000junk',
+            'Ali\nce <a@b> 1 +0000',
+            'Alice <a\n@b> 1 +0000',
+            'Alice <a@b>  1 +0000',     // two SP before the time
+        ]) {
+            assertEq(tryRead(latin1(v)), null)
+        }
+    },
+    // The writer refuses what the format cannot spell.
+    write: {
+        throw: {
+            ltInName: () => write({ name: latin1('a<b'), email: [], time: 0n, tz: '+0000' }),
+            lfInName: () => write({ name: latin1('a\nb'), email: [], time: 0n, tz: '+0000' }),
+            gtInEmail: () => write({ name: [], email: latin1('a>b'), time: 0n, tz: '+0000' }),
+            lfInEmail: () => write({ name: [], email: latin1('a\nb'), time: 0n, tz: '+0000' }),
+            negativeTime: () => write({ name: [], email: [], time: -1n, tz: '+0000' }),
+            zoneNoSign: () => write({ name: [], email: [], time: 0n, tz: '0000' }),
+            zoneShort: () => write({ name: [], email: [], time: 0n, tz: '+000' }),
+            zoneLetters: () => write({ name: [], email: [], time: 0n, tz: '+00a0' }),
+            nonByteInName: () => write({ name: [0x100], email: [], time: 0n, tz: '+0000' }),
+            holeInEmail: () => write({ name: [], email: hole, time: 0n, tz: '+0000' }),
+            readHole: () => tryRead(hole),
+        },
+    },
+}

--- a/fjs/git/ident/types.ts
+++ b/fjs/git/ident/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Type-level API of an ident: who, and when.
+ *
+ * @module
+ */
+
+import type { Bytes } from '../types.ts'
+
+/**
+ * The value of an `author`, `committer` or `tagger` header, read: the name
+ * without the SP that separates it from `<`, the email without its angle
+ * brackets, the time as the seconds it counts, and the zone as it was
+ * spelled, a sign and four digits. The name and the email are bytes, in
+ * whatever encoding the object's author used; the zone is ASCII by the
+ * format, so it is text.
+ */
+export type Ident = {
+    readonly name: Bytes
+    readonly email: Bytes
+    readonly time: bigint
+    readonly tz: string
+}

--- a/todo/git-objects.md
+++ b/todo/git-objects.md
@@ -384,7 +384,9 @@ approximated:
       shipped as [`fjs/git/header/`](../fjs/git/header/module.f.mjs), with
       the writer; the proof reads a real signed merge commit of this
       repository and writes it back byte for byte.
-- [ ] `fjs/git/ident/`: the ident grammar as a `try*` over a header value.
+- [x] `fjs/git/ident/`: the ident grammar as a `try*` over a header value —
+      shipped as [`fjs/git/ident/`](../fjs/git/ident/module.f.mjs), with
+      the writer.
 - [ ] `fjs/git/commit/`, `fjs/git/tag/`, `fjs/git/tree/`: grammar, mappings,
       `validate`, and the writer for each, parameterized by the id width.
 - [ ] Proofs over real objects: capture a handful with `git cat-file` once


### PR DESCRIPTION
Stacked on [#1935](https://github.com/functionalscript/functionalscript/pull/1935), whose branch it targets (its earlier base, #1926, has merged). The third implementation piece of [`todo/git-objects.md`](https://github.com/functionalscript/functionalscript/blob/claude/git-ident/todo/git-objects.md): the value of an `author`, `committer` or `tagger` header, read as the design's second pass over the bytes the header block cut out.

## `fjs/git/ident/`

`name SP <email> SP time SP tz`, over the bytes of one header's value:

- **The SP before `<` is the reader's, not the grammar's.** The name's repetition may end in SP, so `' <'` after it is a first/follow conflict the backend refuses (verified in #1916's review). The name is read up to `<`, and the reader requires its last byte to be SP and drops it, refusing a name that does not end in one. `eof` closes the rule, so trailing bytes are refused rather than left.
- **A `try*`, as the design says.** Git's own reader is lenient and old history holds idents without an email or with a malformed zone; this one refuses what the grammar does not cover, and the raw header stays in the header list either way. Which forms are worth accepting is decided when one is met.
- **Values as the design types them.** `name` and `email` are bytes, in whatever encoding the author used; `time` is a bigint from canonical decimal, so a leading zero ahead of another digit is refused as the envelope's size is; `tz` is text, a sign and four digits, ASCII by the format.
- **`write` is the inverse, byte for byte**, and refuses what the format cannot spell: `<` or LF in a name, `>` or LF in an email, a negative time, a zone that is not a sign and four digits, a non-byte or a hole in either byte field.
- **Its byte helpers are the alphabet's.** `symbolsOf` and `ascii` are imported from `fjs/ebnf/byte`, where #1935 puts them, rather than copied.

## Proof

100% line, branch and function coverage. The `commit` case reads both idents of the real commit fixture out of its header list — the layering the design describes, one pass over the other's output — and writes them back unchanged. Beside it: a name holding spaces and `>`, an email holding `<`, an empty name, a time of `0`, a time past the safe integers, bytes above `0x7F`; fourteen refusals one per condition; and eleven writer panics.

Also checks the ident task off in `todo/git-objects.md` and lists the module in `fjs/git/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdU8wW4oihFS1gj4dUAcPS