### PR TITLE
djs/serializer: end every statement with ;

### DIFF
--- a/fjs/djs/README.md
+++ b/fjs/djs/README.md
@@ -36,8 +36,8 @@ See [examples/input.f.mjs](./examples/input.f.mjs).
   ```
   Serialization
   ```js
-  const _0=[3]
-  export default {a:_0,b:_0}
+  const _0=[3];
+  export default {a:_0,b:_0};
   ```
 - [x] import
   ```js

--- a/fjs/djs/proof.f.mjs
+++ b/fjs/djs/proof.f.mjs
@@ -80,7 +80,7 @@ export const proof = {
         const [state, code] = virtual({ ...emptyState, root })(compile(['input.f.js', 'output.f.js']))
         assertEq(exitCode(code), 0)
         const content = readOutput(state.root, 'output.f.js')
-        assertEq(content, 'export default 42')
+        assertEq(content, 'export default 42;')
     },
     jsonOutput: () => {
         const root = { 'input.f.js': [utf8('export default 42')] }
@@ -156,7 +156,7 @@ export const proof = {
         // input spelling — so the emitter's output is an input that means the
         // same value, and compiling it again is the identity.
         moduleRoundTrip: () => {
-            const source = 'export default {["__proto__"]:{"a":42}}'
+            const source = 'export default {["__proto__"]:{"a":42}};'
             const output = compileSource(source)('output.f.js')
             assertEq(output, source)
             assertEq(compileSource(output)('output.f.js'), source)
@@ -176,7 +176,7 @@ export const proof = {
             const root = { 'proto.json': [utf8('{"__proto__":5}')] }
             const [state, code] = virtual({ ...emptyState, root })(compile(['proto.json', 'a.js']))
             assertEq(exitCode(code), 0, state.stderr)
-            assertEq(readOutput(state.root, 'a.js'), 'export default {["__proto__"]:5}')
+            assertEq(readOutput(state.root, 'a.js'), 'export default {["__proto__"]:5};')
         },
         // …and back, byte for byte: a JSON document survives the loop
         // `proto.json → a.js → out.json` with no `["__proto__"]:` artifact,
@@ -187,7 +187,7 @@ export const proof = {
             const [state, code] = virtual({ ...emptyState, root })(compile(['proto.json', 'a.js']))
             assertEq(exitCode(code), 0, state.stderr)
             const module = readOutput(state.root, 'a.js')
-            assertEq(module, 'export default {["__proto__"]:{"a":42}}')
+            assertEq(module, 'export default {["__proto__"]:{"a":42}};')
             assertEq(compileSource(module)('out.json'), document)
         },
         // The extension speaks for the file named on the command line and for

--- a/fjs/djs/serializer/module.f.mjs
+++ b/fjs/djs/serializer/module.f.mjs
@@ -201,7 +201,12 @@ const addRef = djs => refs => {
 
 /**
  * Serializes a value as a JavaScript module: a shared value becomes a `const`,
- * and a `__proto__` key is written in the computed form the language requires.
+ * a `__proto__` key is written in the computed form the language requires,
+ * and every statement ends with `;`, the export included — the terminator
+ * DataJS requires after each statement
+ * ([spec](../../../spec/datajs/README.md)), and the one
+ * `todo/parser-serializer-restructure.md` settles on for FunctionalScript
+ * (stage 5), so what is written here parses wherever a module is read.
  *
  * @type {(sort: _MapEntries) => (djs: Unknown) => string}
  */
@@ -214,10 +219,10 @@ export const stringify = sort => djs => {
     /** @type {(entry: Unknown) => List<string>} */
     const constSerialize = entry => {
         const refCounter = assertNotNullish(refs.get(entry))
-        return flat([['const c'], numberSerialize(refCounter[0]), [' = '], serializeWithConst(sort)(refs)(entry)(entry), ['\n']])
+        return flat([['const c'], numberSerialize(refCounter[0]), [' = '], serializeWithConst(sort)(refs)(entry)(entry), [';\n']])
     }
     const constStrings = flatMap(constSerialize)(consts)
-    const rootStrings = listConcat(['export default '])(serializeWithConst(sort)(refs)(djs)(djs))
+    const rootStrings = flat([['export default '], serializeWithConst(sort)(refs)(djs)(djs), [';']])
     return concat(listConcat(constStrings)(rootStrings))
 }
 

--- a/fjs/djs/serializer/proof.f.mjs
+++ b/fjs/djs/serializer/proof.f.mjs
@@ -5,6 +5,9 @@ import { setProperty } from '../../media/json/module.f.mjs'
 import { assertEq } from '../../asserts/module.f.mjs'
 
 export const proof = {
+    // The module form: a shared value hoisted to a `const`, every statement
+    // ended by `;` — the export's too, as DataJS requires and as the module
+    // reader will — and one statement per line.
     stringify: [
         {
             testPrimitives: () => {
@@ -45,13 +48,13 @@ export const proof = {
                 const obj = { "a": 1, "c": 2n, "b": [undefined, null, true, false] }
                 const djs = [obj, obj, 1]
                 const res = stringify(sort)(djs)
-                if (res !== 'const c2 = {"a":1,"b":[undefined,null,true,false],"c":2n}\nexport default [c2,c2,1]') { throw res }
+                if (res !== 'const c2 = {"a":1,"b":[undefined,null,true,false],"c":2n};\nexport default [c2,c2,1];') { throw res }
             },
             testIdentity: () => {
                 const obj = { "a": 1, "c": 2n, "b": [undefined, null, true, false] }
                 const djs = [obj, obj, 1]
                 const res = stringify(identity)(djs)
-                if (res !== 'const c2 = {"a":1,"c":2n,"b":[undefined,null,true,false]}\nexport default [c2,c2,1]') { throw res }
+                if (res !== 'const c2 = {"a":1,"c":2n,"b":[undefined,null,true,false]};\nexport default [c2,c2,1];') { throw res }
             },
         }
     ],
@@ -63,12 +66,12 @@ export const proof = {
         // property, so the module emitter must use it.
         module: () => {
             const res = stringify(sort)(fromEntries([['__proto__', 3]]))
-            assertEq(res, 'export default {["__proto__"]:3}')
+            assertEq(res, 'export default {["__proto__"]:3};')
         },
         moduleShared: () => {
             const shared = fromEntries([['__proto__', 3]])
             const res = stringify(sort)([shared, shared])
-            assertEq(res, 'const c0 = {["__proto__"]:3}\nexport default [c0,c0]')
+            assertEq(res, 'const c0 = {["__proto__"]:3};\nexport default [c0,c0];')
         },
         // JSON output: `JSON.parse` has no prototype special case, so the plain
         // spelling already round-trips — and the computed form is not JSON.

--- a/spec/README.md
+++ b/spec/README.md
@@ -501,9 +501,9 @@ export default [b, b, a]
 ```
 
 ```js
-const c0 = {"x":1}
-const c1 = [c0,c0]
-export default [c1,c1,c0]
+const c0 = {"x":1};
+const c1 = [c0,c0];
+export default [c1,c1,c0];
 ```
 
 See


### PR DESCRIPTION
Stacked on #1930 → #1929. The first half of the parser port's breaking change, landed on its own so that the port PR is the port alone.

`stringify`, the module form, now writes `;` after each `const` and after the export — `const c0 = {"x":1};\nexport default [c0,c0];` — the terminator DataJS requires after every statement ([spec](spec/datajs/README.md)) and the one `todo/parser-serializer-restructure.md` settles on for FunctionalScript (stage 5: `;` after each statement, the final one included). The port that follows makes the module reader require it, so what the serializer writes has to carry it first; the classical parser already accepts it, which is why this can land ahead. The layout stays one statement per line, and `stringifyAsTree`, the JSON form, does not change.

The two examples that show emitted modules (`spec/README.md`, `fjs/djs/README.md`) and the round-trip expectations in `fjs/djs/proof.f.mjs` follow.

Checks: `tsc`, `node ./fjs/module.mjs t` (5559), `npm run gen` (no change), `node --test` with 100% coverage.

Changelog:
- **BREAKING CHANGES:** `fjs/djs/serializer`'s `stringify` ends every statement with `;`, the export included: `export default 42;` where it wrote `export default 42`. `fjs compile`'s module output changes the same way. `stringifyAsTree` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CZRKbBvWAYpYtgVpUa3UH