### PR TITLE
git/header: write a value and a message as the lists they are

### DIFF
--- a/fjs/ebnf/byte/README.md
+++ b/fjs/ebnf/byte/README.md
@@ -7,9 +7,11 @@ grammar reads. It is the byte half of
 consumer, [git-objects](../../../todo/git-objects.md).
 
 - `module.f.mjs` — `byte`, `not`, `bytes`, `symbols`, `meta`, `byteParser`,
-  and, for a consumer holding numbers it means as bytes, `isByte`, the
-  alphabet's membership, and `byteArray`, a list as a dense array of bytes
-  with anything else refused, a hole included;
+  and, for a consumer that reads or writes bytes: `symbolsOf`, the bytes
+  under a tree's leaves; `ascii`, ASCII text as bytes; `isByte`, the
+  alphabet's membership; `byteArray`, a list as a dense array of bytes with
+  anything else refused, a hole included; and `byteLength`, the same check
+  as a count that walks a list once and never holds it;
 - `types.ts` — `Byte`, the metadata of a byte.
 
 ## What it is

--- a/fjs/ebnf/byte/module.f.mjs
+++ b/fjs/ebnf/byte/module.f.mjs
@@ -18,7 +18,8 @@
  *
  * @module
  *
- * @import { List } from '../../types/list/types.ts'
+ * @import { Accumulator, List } from '../../types/list/types.ts'
+ * @import { Nullable } from '../../types/nullable/types.ts'
  * @import { Ast, Meta } from '../ast/types.ts'
  * @import { Parser, RewriteSet } from '../ll1/types.ts'
  * @import { Rule, Set } from '../types.ts'
@@ -27,7 +28,7 @@
 
 import { assert } from '../../asserts/module.f.mjs'
 import { stringToCodePointList } from '../../text/utf16/module.f.mjs'
-import { toArray } from '../../types/list/module.f.mjs'
+import { toArray, tryFold } from '../../types/list/module.f.mjs'
 import { rangeEncode, remove, union } from '../module.f.mjs'
 import { toData } from '../data/module.f.mjs'
 import { parser } from '../ll1/module.f.mjs'
@@ -91,6 +92,52 @@ const symbol = b => ({ symbol: b, meta })
  * @type {(input: List<number>) => readonly Meta<Byte>[]}
  */
 export const symbols = input => byteArray(input).map(symbol)
+
+/**
+ * The bytes under the leaves of a byte grammar's tree: what a reader takes
+ * from a node whose rule matched bytes, one per leaf.
+ *
+ * @type {(leaves: readonly Meta<Byte>[]) => readonly number[]}
+ */
+export const symbolsOf = leaves => leaves.map(({ symbol }) => symbol)
+
+/**
+ * ASCII text as the bytes it spells, for a reader or a writer that holds a
+ * keyword as a string — `'commit'`, a header's key — and needs it as bytes.
+ *
+ * @throws If `s` is not ASCII: above `0x7F` a code point and its bytes
+ * part ways, and no text spells such a byte here.
+ *
+ * @type {(s: string) => readonly number[]}
+ */
+export const ascii = s => {
+    const a = toArray(stringToCodePointList(s))
+    assert(a.every(c => c < 0x80), ['not ASCII', s])
+    return a
+}
+
+/**
+ * Counting a list of bytes: one more per item, and the fold stops at an
+ * item that is no byte.
+ *
+ * @type {Accumulator<number, number, number>}
+ */
+const byteCount = {
+    init: 0,
+    update: (b, n) => isByte(b) ? n + 1 : null,
+    end: n => n,
+}
+
+/**
+ * The length of a list of bytes, walked once and never held as an array,
+ * so a list as long as a list can be is counted as it is; `null` where an
+ * item is no byte, a hole included, since the walk meets a hole as
+ * `undefined`. For a consumer that holds a `List<number>` it means as bytes
+ * and must refuse one that is not, without holding it.
+ *
+ * @type {(input: List<number>) => Nullable<number>}
+ */
+export const byteLength = tryFold(byteCount)
 
 /** Any one byte: the byte universe as a terminal. */
 export const byte = rangeEncode(0, 0xFF)

--- a/fjs/ebnf/byte/proof.f.mjs
+++ b/fjs/ebnf/byte/proof.f.mjs
@@ -14,7 +14,7 @@ import { fromArrayLike } from '../../types/list/module.f.mjs'
 import { unwrap } from '../../types/result/module.f.mjs'
 import { eof, range, rangeEncode, repeatFrom0, repeatFrom1, set, times, unicodeMax } from '../module.f.mjs'
 import { mapping } from '../ll1/module.f.mjs'
-import { byte, byteArray, byteParser, bytes, isByte, meta, not, symbols } from './module.f.mjs'
+import { ascii as asciiBytes, byte, byteArray, byteLength, byteParser, bytes, isByte, meta, not, symbols, symbolsOf } from './module.f.mjs'
 
 /** @type {(s: string) => readonly number[]} */
 const ascii = s => [...s].map(c => c.charCodeAt(0))
@@ -110,6 +110,32 @@ export const proof = {
             hole: () => byteArray(/** @type {List<number>} */ (hole)),
             nonByte: () => byteArray([0x100]),
         },
+    },
+    // The bytes under a tree's leaves: the inverse of `symbols`.
+    symbolsOf: () => {
+        assertStructurallySame(symbolsOf(symbols([0, 0x7F, 0xFF])), [0, 0x7F, 0xFF])
+        assertStructurallySame(symbolsOf([]), [])
+    },
+    // ASCII text as bytes, and nothing above it.
+    ascii: {
+        text: () => {
+            assertStructurallySame(asciiBytes('tree '), [0x74, 0x72, 0x65, 0x65, 0x20])
+            assertStructurallySame(asciiBytes(''), [])
+        },
+        throw: {
+            latin1: () => asciiBytes('é'),
+            astral: () => asciiBytes('😀'),
+        },
+    },
+    // A count that walks once and holds nothing, `null` at the first item
+    // that is no byte.
+    byteLength: () => {
+        assertEq(byteLength([]), 0)
+        assertEq(byteLength([0, 0xFF]), 2)
+        assertEq(byteLength(fromArrayLike(new Uint8Array(1000))), 1000)
+        assertEq(byteLength([0, 0x100, 0]), null)
+        assertEq(byteLength([0.5]), null)
+        assertEq(byteLength(/** @type {List<number>} */ (hole)), null)
     },
     byteParser: {
         // A grammar over every rule form — a string, a number, `not`,

--- a/fjs/git/header/module.f.mjs
+++ b/fjs/git/header/module.f.mjs
@@ -13,15 +13,15 @@
  *
  * @module
  *
- * @import { Ast, Meta } from '../../ebnf/ast/types.ts'
+ * @import { Ast } from '../../ebnf/ast/types.ts'
  * @import { Byte } from '../../ebnf/byte/types.ts'
  * @import { Nullable } from '../../types/nullable/types.ts'
  * @import { Bytes } from '../types.ts'
  * @import { Header, Payload } from './types.ts'
  */
 
-import { assert } from '../../asserts/module.f.mjs'
-import { byte, byteArray, byteParser, not, symbols } from '../../ebnf/byte/module.f.mjs'
+import { assert, assertNotNullish } from '../../asserts/module.f.mjs'
+import { byte, byteArray, byteLength, byteParser, not, symbols, symbolsOf } from '../../ebnf/byte/module.f.mjs'
 import { eof, repeatFrom0, repeatFrom1, set } from '../../ebnf/module.f.mjs'
 import { flat, flatMap } from '../../types/list/module.f.mjs'
 
@@ -52,9 +52,6 @@ export const headers = repeatFrom0(header)
 export const payload = /** @type {const} */ ([headers, '\n', repeatFrom0(byte), eof])
 
 const parse = byteParser(payload)
-
-/** @type {(leaves: readonly Meta<Byte>[]) => readonly number[]} */
-const symbolsOf = leaves => leaves.map(({ symbol }) => symbol)
 
 /**
  * A header's node folded to the header: the key's bytes, and the value's,
@@ -91,19 +88,34 @@ export const tryRead = input => {
 const valueBytes = flatMap(b => b === lf ? [lf, sp] : [b])
 
 /**
+ * A list a caller means as bytes, walked once to refuse an item that is no
+ * byte, and handed back as the list it is, never held: a value may be as
+ * long as a `mergetag`'s and a message as long as its author wrote, and
+ * the writer puts neither ceiling on them that an array would.
+ *
+ * @throws If an item is not a byte.
+ *
+ * @type {(bytes: Bytes) => Bytes}
+ */
+const checked = bytes => {
+    assertNotNullish(byteLength(bytes), 'not bytes')
+    return bytes
+}
+
+/**
  * @throws On a key the format cannot spell — empty, or holding SP or LF —
  * since {@link tryRead} would read what was written as a different header,
  * and on a key or a value holding a number that is no byte, or a hole. A
  * header comes from a read or from a caller that built one, and the type
- * cannot say which numbers it holds, so the writer checks, through
- * `byteArray` from the alphabet.
+ * cannot say which numbers it holds, so the writer checks: the key as an
+ * array, since its bytes are looked at, the value as the list it is.
  *
  * @type {(h: Header) => Bytes}
  */
 const headerBytes = ([k, v]) => {
     const key = byteArray(k)
     assert(key.length !== 0 && key.every(b => b !== sp && b !== lf), ['not a header key', key])
-    return flat([key, [sp], valueBytes(byteArray(v)), [lf]])
+    return flat([key, [sp], valueBytes(checked(v)), [lf]])
 }
 
 /**
@@ -116,4 +128,4 @@ const headerBytes = ([k, v]) => {
  * @type {(p: Payload) => Bytes}
  */
 export const write = ({ headers, message }) =>
-    flat([flat(headers.map(headerBytes)), [lf], byteArray(message)])
+    flat([flat(headers.map(headerBytes)), [lf], checked(message)])

--- a/fjs/git/header/proof.f.mjs
+++ b/fjs/git/header/proof.f.mjs
@@ -4,7 +4,7 @@
 
 import { assert, assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
 import { codePointListToString } from '../../text/utf16/module.f.mjs'
-import { toArray } from '../../types/list/module.f.mjs'
+import { fromArrayLike, toArray } from '../../types/list/module.f.mjs'
 import { commitPayload, hole, latin1 } from '../testlib.f.mjs'
 import { tryRead, write } from './module.f.mjs'
 
@@ -88,6 +88,17 @@ export const proof = {
     // and comes back as it went; a key the format cannot spell is refused
     // by the writer, since it would be read as a different header.
     write: {
+        // A value and a message are written as the lists they are, never
+        // held as arrays: a lazy list goes in, and the bytes come out.
+        lazy: () => {
+            const lazy = latin1('x\ny').map(b => b)
+            const out = write({
+                headers: [[latin1('k'), fromArrayLike(new Uint8Array(lazy))]],
+                message: fromArrayLike(new Uint8Array(latin1('m'))),
+            })
+            assert(!(out instanceof Array))
+            assertStructurallySame(toArray(out), latin1('k x\n y\n\nm'))
+        },
         value: () => {
             /** @type {(v: string) => void} */
             const same = v => {

--- a/fjs/git/object/module.f.mjs
+++ b/fjs/git/object/module.f.mjs
@@ -13,19 +13,16 @@
  *
  * @module
  *
- * @import { Meta } from '../../ebnf/ast/types.ts'
- * @import { Byte } from '../../ebnf/byte/types.ts'
- * @import { Accumulator } from '../../types/list/types.ts'
  * @import { Nullable } from '../../types/nullable/types.ts'
  * @import { Bytes, ObjectType } from '../types.ts'
  * @import { Envelope } from './types.ts'
  */
 
 import { assertNotNullish } from '../../asserts/module.f.mjs'
-import { byteParser, isByte, not, symbols } from '../../ebnf/byte/module.f.mjs'
+import { ascii, byteLength, byteParser, not, symbols, symbolsOf } from '../../ebnf/byte/module.f.mjs'
 import { range, repeatFrom1, set } from '../../ebnf/module.f.mjs'
-import { codePointListToString, stringToCodePointList } from '../../text/utf16/module.f.mjs'
-import { concat, drop, take, toArray, tryFold } from '../../types/list/module.f.mjs'
+import { codePointListToString } from '../../text/utf16/module.f.mjs'
+import { concat, drop, take } from '../../types/list/module.f.mjs'
 
 const { isSafeInteger } = Number
 
@@ -62,42 +59,16 @@ const parse = byteParser(envelope)
 const prefixLength = /** @type {const} */ (32)
 
 /**
- * Counting a list of bytes: one more per item, and the fold stops at an
- * item that is no byte. `Bytes` is a list of numbers, and a number that is
- * no byte is a caller's mistake the format could not carry, so it is
- * refused rather than read or written as a plausible object.
- *
- * @type {Accumulator<number, number, number>}
- */
-const byteCount = {
-    init: 0,
-    update: (b, n) => isByte(b) ? n + 1 : null,
-    end: n => n,
-}
-
-/**
- * The length of a list of bytes, walked once and never held as an array,
- * so a payload as long as a list can be is counted as it is; `null` where
- * an item is no byte.
- *
- * @type {(bytes: Bytes) => Nullable<number>}
- */
-const byteLength = tryFold(byteCount)
-
-/**
- * The length of a list a caller means as bytes.
+ * The length of a list a caller means as bytes, walked once and never
+ * held: `Bytes` is a list of numbers, and a number that is no byte is a
+ * caller's mistake the format could not carry, so it is refused rather
+ * than read or written as a plausible object.
  *
  * @throws If an item is not a byte.
  *
  * @type {(bytes: Bytes) => number}
  */
 const length = bytes => assertNotNullish(byteLength(bytes), 'not bytes')
-
-/** @type {(leaves: readonly Meta<Byte>[]) => readonly number[]} */
-const symbolsOf = leaves => leaves.map(({ symbol }) => symbol)
-
-/** @type {(s: string) => readonly number[]} */
-const ascii = s => toArray(stringToCodePointList(s))
 
 /**
  * The type a word names, or `null`: the four are ASCII, so the word is


### PR DESCRIPTION
A follow-up to [#1926](https://github.com/functionalscript/functionalscript/pull/1926), answering the two review findings that arrived as it merged. One commit; [#1931](https://github.com/functionalscript/functionalscript/pull/1931) is stacked on it.

## The header writer held what it wrote

`write` in `fjs/git/header` turned every value and the message into an array to check them, which put the array-length ceiling back on fields the design leaves unbounded — a `mergetag` value, a message as long as its author wrote. They are now walked once by `byteLength`, the count the envelope reader already used, and handed on as the lists they are, never held. Only the key is still an array, since its bytes are looked at for SP and LF. A `lazy` proof case writes a lazy value and a lazy message and checks the result is a list of the right bytes.

## Three helpers, one home

`symbolsOf` (the bytes under a tree's leaves), `ascii` (ASCII text as bytes, refused above `0x7F`) and `byteLength` (the lazy count) were each copied into the envelope, the header block and ident. They now live in `fjs/ebnf/byte` as exports, with proofs, and the three modules import them from there. `git/object` drops its local copies here; `git/ident` drops its own on #1931.

`tsc` passes, the byte adapter and both Git modules stay at 100% line, branch and function coverage, and the full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdU8wW4oihFS1gj4dUAcPS

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdU8wW4oihFS1gj4dUAcPS)_