### PR TITLE
git/tag: a tag as a second pass over the header block

### DIFF
--- a/fjs/git/README.md
+++ b/fjs/git/README.md
@@ -23,6 +23,12 @@ come.
   for a repository's id width: a reader that reads what `git fsck` would
   flag, a `validate` that refuses it the way `fsck` does, `mode` as the
   number an entry's digits spell, and a writer.
+- [`oid/`](oid/module.f.mjs) — an object id between its two spellings, the
+  raw bytes a tree entry holds and the hex text a header holds.
+- [`tag/`](tag/module.f.mjs) — a tag as a second pass over the header
+  block: `object`, `type`, `tag` and `tagger` as functions over the header
+  list, read by position as Git reads them, and a `validate` that refuses
+  what `git fsck` does.
 - `types.ts` — `Bytes`, the type of a field the format leaves unbounded,
   `Oid` and `OidBytes`, the one fixed-width field and its width, and
   `ObjectType`.

--- a/fjs/git/header/module.f.mjs
+++ b/fjs/git/header/module.f.mjs
@@ -21,7 +21,7 @@
  */
 
 import { assert, assertNotNullish } from '../../asserts/module.f.mjs'
-import { byte, byteArray, byteLength, byteParser, not, symbols, symbolsOf } from '../../ebnf/byte/module.f.mjs'
+import { ascii, byte, byteArray, byteLength, byteParser, not, symbols, symbolsOf } from '../../ebnf/byte/module.f.mjs'
 import { eof, repeatFrom0, repeatFrom1, set } from '../../ebnf/module.f.mjs'
 import { flat, flatMap } from '../../types/list/module.f.mjs'
 
@@ -77,6 +77,22 @@ export const tryRead = input => {
     if (r[0] === 'error') { return null }
     const [[hs, , message]] = r[1]
     return { headers: hs.map(headerOf), message: symbolsOf(message) }
+}
+
+/**
+ * The value of the header at `i` where its key is `key`, or `null`: a
+ * commit and a tag are read by position, as Git reads them — `tree` first
+ * in one, `object` first in the other — and the same key elsewhere is a
+ * header Git does not know.
+ *
+ * @type {(p: Payload, i: number, key: string) => Nullable<Bytes>}
+ */
+export const valueAt = (p, i, key) => {
+    if (i >= p.headers.length) { return null }
+    const [k, v] = p.headers[i]
+    const a = byteArray(k)
+    const b = ascii(key)
+    return a.length === b.length && a.every((x, j) => x === b[j]) ? v : null
 }
 
 /**

--- a/fjs/git/header/module.f.mjs
+++ b/fjs/git/header/module.f.mjs
@@ -80,6 +80,18 @@ export const tryRead = input => {
 }
 
 /**
+ * Whether a header's key is `key`, compared as bytes: the well-known keys
+ * are ASCII, and a key is bytes.
+ *
+ * @type {(h: Header, key: string) => boolean}
+ */
+export const keyIs = ([k], key) => {
+    const a = byteArray(k)
+    const b = ascii(key)
+    return a.length === b.length && a.every((x, j) => x === b[j])
+}
+
+/**
  * The value of the header at `i` where its key is `key`, or `null`: a
  * commit and a tag are read by position, as Git reads them — `tree` first
  * in one, `object` first in the other — and the same key elsewhere is a
@@ -89,11 +101,19 @@ export const tryRead = input => {
  */
 export const valueAt = (p, i, key) => {
     if (i >= p.headers.length) { return null }
-    const [k, v] = p.headers[i]
-    const a = byteArray(k)
-    const b = ascii(key)
-    return a.length === b.length && a.every((x, j) => x === b[j]) ? v : null
+    const h = p.headers[i]
+    return keyIs(h, key) ? h[1] : null
 }
+
+/**
+ * Whether a NUL sits in any header, key or value: the grammar reads one,
+ * since a key is any byte but SP and LF and a value any byte at all, and
+ * `git fsck` refuses the object as `nulInHeader`, so the `validate` of a
+ * commit and of a tag both ask.
+ *
+ * @type {(p: Payload) => boolean}
+ */
+export const hasNulHeader = p => p.headers.some(([k, v]) => byteArray(k).includes(0) || byteArray(v).includes(0))
 
 /**
  * A value's bytes as written: an LF in a value begins a continuation

--- a/fjs/git/header/proof.f.mjs
+++ b/fjs/git/header/proof.f.mjs
@@ -6,7 +6,7 @@ import { assert, assertEq, assertStructurallySame } from '../../asserts/module.f
 import { codePointListToString } from '../../text/utf16/module.f.mjs'
 import { fromArrayLike, toArray } from '../../types/list/module.f.mjs'
 import { commitPayload, hole, latin1 } from '../testlib.f.mjs'
-import { tryRead, write } from './module.f.mjs'
+import { tryRead, valueAt, write } from './module.f.mjs'
 
 /** @type {(input: readonly number[]) => Payload} */
 const read = input => {
@@ -74,6 +74,18 @@ export const proof = {
         assertStructurallySame(p.headers, [[[0xE9], [0xFF]]])
         assertStructurallySame(toArray(p.message), [0xC3, 0])
         roundTrip(input)
+    },
+    // A header by position and key: the value where both match, `null`
+    // where the key is elsewhere or the position is past the end.
+    valueAt: () => {
+        const p = read(commitPayload)
+        assertStructurallySame(valueAt(p, 0, 'tree'), latin1('c5711460da9d5ae7158a951d9d924385419b13ca'))
+        assertStructurallySame(valueAt(p, 2, 'parent'), latin1('261b9142dfe024d8e8e009b0e97f6e52ea981c8d'))
+        assertEq(valueAt(p, 1, 'tree'), null)
+        assertEq(valueAt(p, 0, 'tre'), null)
+        assertEq(valueAt(p, 0, 'trees'), null)
+        assertEq(valueAt(p, 6, 'gpgsig'), null)
+        assertEq(valueAt(read(latin1('\n')), 0, 'tree'), null)
     },
     // Each refusal: no empty line before the end, a header without SP, a
     // first line beginning with SP, a header without LF.

--- a/fjs/git/header/proof.f.mjs
+++ b/fjs/git/header/proof.f.mjs
@@ -6,7 +6,7 @@ import { assert, assertEq, assertStructurallySame } from '../../asserts/module.f
 import { codePointListToString } from '../../text/utf16/module.f.mjs'
 import { fromArrayLike, toArray } from '../../types/list/module.f.mjs'
 import { commitPayload, hole, latin1 } from '../testlib.f.mjs'
-import { tryRead, valueAt, write } from './module.f.mjs'
+import { hasNulHeader, keyIs, tryRead, valueAt, write } from './module.f.mjs'
 
 /** @type {(input: readonly number[]) => Payload} */
 const read = input => {
@@ -86,6 +86,24 @@ export const proof = {
         assertEq(valueAt(p, 0, 'trees'), null)
         assertEq(valueAt(p, 6, 'gpgsig'), null)
         assertEq(valueAt(read(latin1('\n')), 0, 'tree'), null)
+    },
+    // A key as bytes against a name: the same bytes, and nothing shorter,
+    // longer or other.
+    keyIs: () => {
+        assert(keyIs([latin1('tree'), []], 'tree'))
+        assert(!keyIs([latin1('tre'), []], 'tree'))
+        assert(!keyIs([latin1('trees'), []], 'tree'))
+        assert(!keyIs([latin1('tref'), []], 'tree'))
+        assert(!keyIs([[0xE9, 0x72, 0x65, 0x65], []], 'tree'))
+    },
+    // A NUL in a key or a value, wherever the header sits; none in a
+    // real commit, and one in the message is not a header's.
+    hasNulHeader: () => {
+        assert(!hasNulHeader(read(commitPayload)))
+        assert(!hasNulHeader(read(latin1('\n\0'))))
+        assert(hasNulHeader(read([0x61, 0x20, 0, 0x0A, 0x0A])))
+        assert(hasNulHeader(read([0x61, 0, 0x20, 0x78, 0x0A, 0x0A])))
+        assert(hasNulHeader(read(latin1('a x\nb y\n \0\n\n'))))
     },
     // Each refusal: no empty line before the end, a header without SP, a
     // first line beginning with SP, a header without LF.

--- a/fjs/git/ident/module.f.mjs
+++ b/fjs/git/ident/module.f.mjs
@@ -77,6 +77,9 @@ const decimal = digits => digits.reduce((n, d) => n * 10n + BigInt(d - 0x30), 0n
  */
 export const maxTime = 9223372036854775807n
 
+/** The digits {@link maxTime} has: a time spelled with more is later. */
+const maxTimeDigits = 19
+
 /**
  * Reads an ident, or refuses it: no `<` or `>`, a name that does not end
  * in SP, a `>` in the name or a `<` in the email, a time that is not
@@ -93,12 +96,15 @@ export const tryRead = value => {
     const [[n, , e, , , t, , [sign, z]]] = r[1]
     const spaced = symbolsOf(n)
     const digits = symbolsOf(t)
-    const time = decimal(digits)
-    return spaced.length !== 0 && spaced[spaced.length - 1] === sp && canonical(digits) && time <= maxTime
+    // The digits are judged before they are folded: a run of a hundred
+    // thousand is refused for its spelling or its length, never folded
+    // into the number it would be.
+    const timely = canonical(digits) && digits.length <= maxTimeDigits && decimal(digits) <= maxTime
+    return spaced.length !== 0 && spaced[spaced.length - 1] === sp && timely
         ? {
             name: spaced.slice(0, -1),
             email: symbolsOf(e),
-            time,
+            time: decimal(digits),
             tz: codePointListToString([sign.symbol, ...symbolsOf(z)]),
         }
         : null

--- a/fjs/git/ident/module.f.mjs
+++ b/fjs/git/ident/module.f.mjs
@@ -75,10 +75,10 @@ const decimal = digits => digits.reduce((n, d) => n * 10n + BigInt(d - 0x30), 0n
  * time into a signed 64-bit integer, and `git fsck` refuses a later one
  * as `badDateOverflow`.
  */
-export const maxTime = 9223372036854775807n
+export const maxTime = /** @type {const} */ (9223372036854775807n)
 
 /** The digits {@link maxTime} has: a time spelled with more is later. */
-const maxTimeDigits = 19
+const maxTimeDigits = /** @type {const} */ (19)
 
 /**
  * Reads an ident, or refuses it: no `<` or `>`, a name that does not end

--- a/fjs/git/ident/module.f.mjs
+++ b/fjs/git/ident/module.f.mjs
@@ -10,8 +10,9 @@
  * `eof` closes the rule, so trailing bytes are refused rather than left.
  *
  * Git's own reader is lenient, and old history holds idents without an
- * email or with a malformed zone. This reader is a `try*`: an ident the
- * grammar does not cover is refused, not repaired, and the raw header
+ * email or with a malformed zone. This reader is a `try*`, and reads what
+ * `git fsck` vouches for: an ident the grammar does not cover, or whose
+ * time Git cannot hold, is refused, not repaired, and the raw header
  * stays in the header list either way. Which of those forms are worth
  * accepting is decided when one is met, as an issue naming the object.
  *
@@ -38,9 +39,16 @@ const gt = /** @type {const} */ (0x3E)
 
 const digit = range('09')
 
-const name = repeatFrom0(not(set('<\n')))
+/**
+ * A name or an email: any byte but the brackets and LF, as `git fsck`
+ * reads them — a `>` in the name or a `<` in the email is a bad name or
+ * a bad email there, and here is no ident.
+ */
+const field = repeatFrom0(not(set('<>\n')))
 
-const email = repeatFrom0(not(set('>\n')))
+const name = field
+
+const email = field
 
 const time = repeatFrom1(digit)
 
@@ -63,9 +71,17 @@ const canonical = digits => digits.length === 1 || digits[0] !== 0x30
 const decimal = digits => digits.reduce((n, d) => n * 10n + BigInt(d - 0x30), 0n)
 
 /**
+ * The latest time an ident may hold, `INT64_MAX` seconds: Git reads a
+ * time into a signed 64-bit integer, and `git fsck` refuses a later one
+ * as `badDateOverflow`.
+ */
+export const maxTime = 9223372036854775807n
+
+/**
  * Reads an ident, or refuses it: no `<` or `>`, a name that does not end
- * in SP, a time that is not canonical decimal, a zone that is not a sign
- * and four digits, or anything after the zone.
+ * in SP, a `>` in the name or a `<` in the email, a time that is not
+ * canonical decimal or is later than {@link maxTime}, a zone that is not
+ * a sign and four digits, or anything after the zone.
  *
  * @throws If an item of the value is not a byte.
  *
@@ -77,11 +93,12 @@ export const tryRead = value => {
     const [[n, , e, , , t, , [sign, z]]] = r[1]
     const spaced = symbolsOf(n)
     const digits = symbolsOf(t)
-    return spaced.length !== 0 && spaced[spaced.length - 1] === sp && canonical(digits)
+    const time = decimal(digits)
+    return spaced.length !== 0 && spaced[spaced.length - 1] === sp && canonical(digits) && time <= maxTime
         ? {
             name: spaced.slice(0, -1),
             email: symbolsOf(e),
-            time: decimal(digits),
+            time,
             tz: codePointListToString([sign.symbol, ...symbolsOf(z)]),
         }
         : null
@@ -101,18 +118,19 @@ const isZone = tz => {
  * An ident's bytes, as a header value: the inverse of {@link tryRead},
  * byte for byte.
  *
- * @throws On an ident the format cannot spell — a name holding `<` or LF,
- * an email holding `>` or LF, a negative time, a zone that is not a sign
- * and four digits — or a name or email holding a number that is no byte.
+ * @throws On an ident the format cannot spell — a name or an email holding
+ * `<`, `>` or LF, a time negative or later than {@link maxTime}, a zone
+ * that is not a sign and four digits — or a name or email holding a
+ * number that is no byte.
  *
  * @type {(i: Ident) => Bytes}
  */
 export const write = ({ name, email, time, tz }) => {
     const n = byteArray(name)
     const e = byteArray(email)
-    assert(n.every(b => b !== lt && b !== lf), ['not a name', n])
-    assert(e.every(b => b !== gt && b !== lf), ['not an email', e])
-    assert(time >= 0n, ['not a time', time])
+    assert(n.every(b => b !== lt && b !== gt && b !== lf), ['not a name', n])
+    assert(e.every(b => b !== lt && b !== gt && b !== lf), ['not an email', e])
+    assert(time >= 0n && time <= maxTime, ['not a time', time])
     assert(isZone(tz), ['not a zone', tz])
     return flat([n, [sp, lt], e, [gt, sp], ascii(`${time} ${tz}`)])
 }

--- a/fjs/git/ident/proof.f.mjs
+++ b/fjs/git/ident/proof.f.mjs
@@ -7,7 +7,7 @@ import { codePointListToString } from '../../text/utf16/module.f.mjs'
 import { toArray } from '../../types/list/module.f.mjs'
 import { tryRead as readPayload } from '../header/module.f.mjs'
 import { commitPayload, hole, latin1 } from '../testlib.f.mjs'
-import { tryRead, write } from './module.f.mjs'
+import { maxTime, tryRead, write } from './module.f.mjs'
 
 const sp = /** @type {const} */ (0x20)
 
@@ -44,22 +44,24 @@ export const proof = {
         roundTrip(author)
         roundTrip(committer)
     },
-    // A name may hold spaces and `>`, an email `<`; both are bytes, not
+    // A name may hold spaces, an email `@` and dots; both are bytes, not
     // text; a name may be empty, and a time may be `0`.
     forms: () => {
-        assertStructurallySame(text(read(latin1('A B> <x<y> 5 -0530'))), ['A B>', 'x<y', 5n, '-0530'])
+        assertStructurallySame(text(read(latin1('A B. <x.y@z> 5 -0530'))), ['A B.', 'x.y@z', 5n, '-0530'])
         assertStructurallySame(text(read(latin1(' <> 0 +0000'))), ['', '', 0n, '+0000'])
         const i = read([0xE9, sp, lt, 0xFF, gt, sp, ...latin1('12 +0100')])
         assertStructurallySame([toArray(i.name), toArray(i.email), i.time, i.tz], [[0xE9], [0xFF], 12n, '+0100'])
-        for (const v of ['A B> <x<y> 5 -0530', ' <> 0 +0000', 'Alice  <a@b> 1 +0000']) {
+        for (const v of ['A B. <x.y@z> 5 -0530', ' <> 0 +0000', 'Alice  <a@b> 1 +0000']) {
             roundTrip(latin1(v))
         }
     },
-    // A time past the safe integers is a bigint, read and written exactly.
+    // A time past the safe integers is a bigint, read and written exactly,
+    // up to the latest Git can hold; one second later is refused.
     bigTime: () => {
-        const i = read(latin1('a <b> 123456789012345678901234567890 +0000'))
-        assertEq(i.time, 123456789012345678901234567890n)
-        roundTrip(latin1('a <b> 123456789012345678901234567890 +0000'))
+        const i = read(latin1(`a <b> ${maxTime} +0000`))
+        assertEq(i.time, 9223372036854775807n)
+        roundTrip(latin1(`a <b> ${maxTime} +0000`))
+        assertEq(tryRead(latin1(`a <b> ${maxTime + 1n} +0000`)), null)
     },
     // Each refusal, one per condition: the SP before `<`, the brackets,
     // the time's spelling, the zone's, trailing bytes, LF anywhere.
@@ -69,6 +71,8 @@ export const proof = {
             'Alice<a@b> 1 +0000',       // no SP before `<`
             'Alice <a@b 1 +0000',       // no `>`
             'Alice a@b> 1 +0000',       // no `<`
+            'A> B <a@b> 1 +0000',       // `>` in the name
+            'Alice <a<b> 1 +0000',      // `<` in the email
             'Alice <a@b> 01 +0000',     // not canonical decimal
             'Alice <a@b> x +0000',      // not a time
             'Alice <a@b> 1 0000',       // no sign
@@ -87,10 +91,13 @@ export const proof = {
     write: {
         throw: {
             ltInName: () => write({ name: latin1('a<b'), email: [], time: 0n, tz: '+0000' }),
+            gtInName: () => write({ name: latin1('a>b'), email: [], time: 0n, tz: '+0000' }),
             lfInName: () => write({ name: latin1('a\nb'), email: [], time: 0n, tz: '+0000' }),
+            ltInEmail: () => write({ name: [], email: latin1('a<b'), time: 0n, tz: '+0000' }),
             gtInEmail: () => write({ name: [], email: latin1('a>b'), time: 0n, tz: '+0000' }),
             lfInEmail: () => write({ name: [], email: latin1('a\nb'), time: 0n, tz: '+0000' }),
             negativeTime: () => write({ name: [], email: [], time: -1n, tz: '+0000' }),
+            lateTime: () => write({ name: [], email: [], time: maxTime + 1n, tz: '+0000' }),
             zoneNoSign: () => write({ name: [], email: [], time: 0n, tz: '0000' }),
             zoneShort: () => write({ name: [], email: [], time: 0n, tz: '+000' }),
             zoneLetters: () => write({ name: [], email: [], time: 0n, tz: '+00a0' }),

--- a/fjs/git/ident/proof.f.mjs
+++ b/fjs/git/ident/proof.f.mjs
@@ -62,6 +62,11 @@ export const proof = {
         assertEq(i.time, 9223372036854775807n)
         roundTrip(latin1(`a <b> ${maxTime} +0000`))
         assertEq(tryRead(latin1(`a <b> ${maxTime + 1n} +0000`)), null)
+        // A time of many digits is refused for its length or its spelling
+        // before it is folded into a number: twenty digits, and a zero
+        // ahead of a hundred thousand nines.
+        assertEq(tryRead(latin1(`a <b> ${'1'.repeat(20)} +0000`)), null)
+        assertEq(tryRead(latin1(`a <b> 0${'9'.repeat(100000)} +0000`)), null)
     },
     // Each refusal, one per condition: the SP before `<`, the brackets,
     // the time's spelling, the zone's, trailing bytes, LF anywhere.

--- a/fjs/git/oid/module.f.mjs
+++ b/fjs/git/oid/module.f.mjs
@@ -19,9 +19,6 @@ const toVec = tryU8ListToVec(msb)
 
 const toBytes = u8List(msb)
 
-/** @type {(v: Nullable<number>) => v is number} */
-const isValue = v => v !== null
-
 /**
  * Reads an id from its hex spelling, or refuses it: a byte that is no hex
  * digit, an odd count of them, none, or more than a `Vec` holds. Either
@@ -34,7 +31,10 @@ const isValue = v => v !== null
  */
 export const tryFromHex = hex => {
     const digits = byteArray(hex)
-    const values = digits.map(hexDigitValue).filter(isValue)
+    const values = digits.flatMap(b => {
+        const v = hexDigitValue(b)
+        return v === null ? [] : [v]
+    })
     if (values.length !== digits.length || values.length === 0 || values.length % 2 !== 0) { return null }
     return toVec(values.filter((_, i) => i % 2 === 0).map((h, i) => h * 16 + values[2 * i + 1]))
 }

--- a/fjs/git/oid/module.f.mjs
+++ b/fjs/git/oid/module.f.mjs
@@ -1,0 +1,47 @@
+/**
+ * An object id between its two spellings: the raw bytes a tree entry holds
+ * and the hex text a header holds. Neither knows the repository's id width;
+ * a hex of any even length reads to the id it spells, and the width is a
+ * check `validate` makes on the object, against the width it is given.
+ *
+ * @module
+ *
+ * @import { Nullable } from '../../types/nullable/types.ts'
+ * @import { Bytes, Oid } from '../types.ts'
+ */
+
+import { byteArray } from '../../ebnf/byte/module.f.mjs'
+import { hexDigitCodePoint, hexDigitValue } from '../../text/ascii/module.f.mjs'
+import { msb, u8List, u8ListToVec } from '../../types/bit_vec/module.f.mjs'
+import { toArray } from '../../types/list/module.f.mjs'
+
+const toVec = u8ListToVec(msb)
+
+const toBytes = u8List(msb)
+
+/** @type {(v: Nullable<number>) => v is number} */
+const isValue = v => v !== null
+
+/**
+ * Reads an id from its hex spelling, or refuses it: a byte that is no hex
+ * digit, an odd count of them, or none. Either case of letter is read, as
+ * Git reads it, though Git writes the small one; {@link toHex} writes it.
+ *
+ * @throws If an item of the hex is not a byte.
+ *
+ * @type {(hex: Bytes) => Nullable<Oid>}
+ */
+export const tryFromHex = hex => {
+    const digits = byteArray(hex)
+    const values = digits.map(hexDigitValue).filter(isValue)
+    if (values.length !== digits.length || values.length === 0 || values.length % 2 !== 0) { return null }
+    return toVec(values.filter((_, i) => i % 2 === 0).map((h, i) => h * 16 + values[2 * i + 1]))
+}
+
+/**
+ * An id's hex spelling, two small-letter digits a byte: the inverse of
+ * {@link tryFromHex}, and what Git writes.
+ *
+ * @type {(oid: Oid) => Bytes}
+ */
+export const toHex = oid => toArray(toBytes(oid)).flatMap(b => [hexDigitCodePoint(b >> 4), hexDigitCodePoint(b & 15)])

--- a/fjs/git/oid/module.f.mjs
+++ b/fjs/git/oid/module.f.mjs
@@ -7,12 +7,12 @@
  * @module
  *
  * @import { Nullable } from '../../types/nullable/types.ts'
- * @import { Bytes, Oid } from '../types.ts'
+ * @import { Bytes, Oid, OidBytes } from '../types.ts'
  */
 
 import { byteArray } from '../../ebnf/byte/module.f.mjs'
 import { hexDigitCodePoint, hexDigitValue } from '../../text/ascii/module.f.mjs'
-import { msb, tryU8ListToVec, u8List } from '../../types/bit_vec/module.f.mjs'
+import { length, msb, tryU8ListToVec, u8List } from '../../types/bit_vec/module.f.mjs'
 import { toArray } from '../../types/list/module.f.mjs'
 
 const toVec = tryU8ListToVec(msb)
@@ -37,6 +37,20 @@ export const tryFromHex = hex => {
     })
     if (values.length !== digits.length || values.length === 0 || values.length % 2 !== 0) { return null }
     return toVec(values.filter((_, i) => i % 2 === 0).map((h, i) => h * 16 + values[2 * i + 1]))
+}
+
+/**
+ * {@link tryFromHex} at the repository's width: an id of any other width
+ * is refused too, which is the check every header that names an object
+ * makes, in a commit's `validate` and a tag's alike.
+ *
+ * @throws If an item of the hex is not a byte.
+ *
+ * @type {(oidBytes: OidBytes) => (hex: Bytes) => Nullable<Oid>}
+ */
+export const tryFromHexOf = oidBytes => hex => {
+    const id = tryFromHex(hex)
+    return id !== null && length(id) === BigInt(oidBytes) * 8n ? id : null
 }
 
 /**

--- a/fjs/git/oid/module.f.mjs
+++ b/fjs/git/oid/module.f.mjs
@@ -10,6 +10,7 @@
  * @import { Bytes, Oid, OidBytes } from '../types.ts'
  */
 
+import { assert } from '../../asserts/module.f.mjs'
 import { byteArray } from '../../ebnf/byte/module.f.mjs'
 import { hexDigitCodePoint, hexDigitValue } from '../../text/ascii/module.f.mjs'
 import { length, msb, tryU8ListToVec, u8List } from '../../types/bit_vec/module.f.mjs'
@@ -57,6 +58,13 @@ export const tryFromHexOf = oidBytes => hex => {
  * An id's hex spelling, two small-letter digits a byte: the inverse of
  * {@link tryFromHex}, and what Git writes.
  *
+ * @throws On a `Vec` that is not whole bytes: `Oid` is the type's name for
+ * one that is, and a caller can build any `Vec`, so the spelling refuses
+ * rather than pad the last byte and spell an id that reads back wider.
+ *
  * @type {(oid: Oid) => Bytes}
  */
-export const toHex = oid => toArray(toBytes(oid)).flatMap(b => [hexDigitCodePoint(b >> 4), hexDigitCodePoint(b & 15)])
+export const toHex = oid => {
+    assert(length(oid) % 8n === 0n, ['not whole bytes', oid])
+    return toArray(toBytes(oid)).flatMap(b => [hexDigitCodePoint(b >> 4), hexDigitCodePoint(b & 15)])
+}

--- a/fjs/git/oid/module.f.mjs
+++ b/fjs/git/oid/module.f.mjs
@@ -12,10 +12,10 @@
 
 import { byteArray } from '../../ebnf/byte/module.f.mjs'
 import { hexDigitCodePoint, hexDigitValue } from '../../text/ascii/module.f.mjs'
-import { msb, u8List, u8ListToVec } from '../../types/bit_vec/module.f.mjs'
+import { msb, tryU8ListToVec, u8List } from '../../types/bit_vec/module.f.mjs'
 import { toArray } from '../../types/list/module.f.mjs'
 
-const toVec = u8ListToVec(msb)
+const toVec = tryU8ListToVec(msb)
 
 const toBytes = u8List(msb)
 
@@ -24,8 +24,9 @@ const isValue = v => v !== null
 
 /**
  * Reads an id from its hex spelling, or refuses it: a byte that is no hex
- * digit, an odd count of them, or none. Either case of letter is read, as
- * Git reads it, though Git writes the small one; {@link toHex} writes it.
+ * digit, an odd count of them, none, or more than a `Vec` holds. Either
+ * case of letter is read, as Git reads it, though Git writes the small
+ * one; {@link toHex} writes it.
  *
  * @throws If an item of the hex is not a byte.
  *

--- a/fjs/git/oid/proof.f.mjs
+++ b/fjs/git/oid/proof.f.mjs
@@ -1,5 +1,5 @@
 import { assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
-import { length, maxLengthBytes, msb, u8List } from '../../types/bit_vec/module.f.mjs'
+import { length, maxLengthBytes, msb, u8List, vec } from '../../types/bit_vec/module.f.mjs'
 import { toArray } from '../../types/list/module.f.mjs'
 import { hole, latin1 } from '../testlib.f.mjs'
 import { toHex, tryFromHex, tryFromHexOf } from './module.f.mjs'
@@ -57,5 +57,8 @@ export const proof = {
     throw: {
         nonByte: () => tryFromHex([0x100, 0x30]),
         hole: () => tryFromHex(hole),
+        // A one-bit `Vec` is no id: spelled, it would pad to `80` and read
+        // back as a byte.
+        notWholeBytes: () => toHex(vec(1n)(1n)),
     },
 }

--- a/fjs/git/oid/proof.f.mjs
+++ b/fjs/git/oid/proof.f.mjs
@@ -1,0 +1,42 @@
+import { assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
+import { length, msb, u8List } from '../../types/bit_vec/module.f.mjs'
+import { toArray } from '../../types/list/module.f.mjs'
+import { hole, latin1 } from '../testlib.f.mjs'
+import { toHex, tryFromHex } from './module.f.mjs'
+
+/** @type {(hex: string) => readonly number[]} */
+const bytes = hex => {
+    const id = tryFromHex(latin1(hex))
+    return id === null ? [] : toArray(u8List(msb)(id))
+}
+
+export const proof = {
+    // A 20-byte id and a 32-byte one, and back to the same text.
+    widths: () => {
+        assertStructurallySame(bytes('00ff10a5' + '0'.repeat(32)), [0, 0xFF, 0x10, 0xA5, ...Array(16).fill(0)])
+        const sha256 = 'ab'.repeat(31) + '01'
+        const id = tryFromHex(latin1(sha256))
+        assertEq(id !== null && length(id), 256n)
+        assertEq(id !== null && String.fromCharCode(...toArray(toHex(id))), sha256)
+        const sha1 = '0123456789abcdef'.repeat(2) + 'fedcba98'
+        const i = tryFromHex(latin1(sha1))
+        assertEq(i !== null && String.fromCharCode(...toArray(toHex(i))), sha1)
+    },
+    // A capital letter reads as its small one; writing spells the small one.
+    capital: () => {
+        const id = tryFromHex(latin1('AbCdEf' + '0'.repeat(34)))
+        assertEq(id !== null && String.fromCharCode(...toArray(toHex(id))), 'abcdef' + '0'.repeat(34))
+    },
+    // Each refusal: no digits, an odd count, a byte that is no digit.
+    refused: () => {
+        assertEq(tryFromHex([]), null)
+        assertEq(tryFromHex(latin1('abc')), null)
+        assertEq(tryFromHex(latin1('0g')), null)
+        assertEq(tryFromHex(latin1('0 ')), null)
+        assertEq(tryFromHex([0x30, 0xE9]), null)
+    },
+    throw: {
+        nonByte: () => tryFromHex([0x100, 0x30]),
+        hole: () => tryFromHex(hole),
+    },
+}

--- a/fjs/git/oid/proof.f.mjs
+++ b/fjs/git/oid/proof.f.mjs
@@ -2,7 +2,7 @@ import { assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
 import { length, maxLengthBytes, msb, u8List } from '../../types/bit_vec/module.f.mjs'
 import { toArray } from '../../types/list/module.f.mjs'
 import { hole, latin1 } from '../testlib.f.mjs'
-import { toHex, tryFromHex } from './module.f.mjs'
+import { toHex, tryFromHex, tryFromHexOf } from './module.f.mjs'
 
 /** @type {(hex: string) => readonly number[]} */
 const bytes = hex => {
@@ -21,6 +21,18 @@ export const proof = {
         const sha1 = '0123456789abcdef'.repeat(2) + 'fedcba98'
         const i = tryFromHex(latin1(sha1))
         assertEq(i !== null && String.fromCharCode(...toArray(toHex(i))), sha1)
+    },
+    // At a width: the id of that width reads, any other is refused, and
+    // what is no hex at all is refused as before.
+    ofWidth: () => {
+        const sha1 = latin1('ab'.repeat(20))
+        const sha256 = latin1('ab'.repeat(32))
+        assertEq(tryFromHexOf(20)(sha1) !== null, true)
+        assertEq(tryFromHexOf(32)(sha1), null)
+        assertEq(tryFromHexOf(32)(sha256) !== null, true)
+        assertEq(tryFromHexOf(20)(sha256), null)
+        assertEq(tryFromHexOf(20)(latin1('ab'.repeat(19))), null)
+        assertEq(tryFromHexOf(20)(latin1('zz'.repeat(20))), null)
     },
     // A capital letter reads as its small one; writing spells the small one.
     capital: () => {

--- a/fjs/git/oid/proof.f.mjs
+++ b/fjs/git/oid/proof.f.mjs
@@ -1,5 +1,5 @@
 import { assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
-import { length, msb, u8List } from '../../types/bit_vec/module.f.mjs'
+import { length, maxLengthBytes, msb, u8List } from '../../types/bit_vec/module.f.mjs'
 import { toArray } from '../../types/list/module.f.mjs'
 import { hole, latin1 } from '../testlib.f.mjs'
 import { toHex, tryFromHex } from './module.f.mjs'
@@ -26,6 +26,13 @@ export const proof = {
     capital: () => {
         const id = tryFromHex(latin1('AbCdEf' + '0'.repeat(34)))
         assertEq(id !== null && String.fromCharCode(...toArray(toHex(id))), 'abcdef' + '0'.repeat(34))
+    },
+    // As many bytes as a `Vec` holds reads; one more is refused, not thrown.
+    ceiling: () => {
+        const most = Number(maxLengthBytes)
+        const id = tryFromHex(latin1('00'.repeat(most - 1) + '01'))
+        assertEq(id !== null && length(id), maxLengthBytes * 8n)
+        assertEq(tryFromHex(latin1('00'.repeat(most + 1))), null)
     },
     // Each refusal: no digits, an odd count, a byte that is no digit.
     refused: () => {

--- a/fjs/git/tag/module.f.mjs
+++ b/fjs/git/tag/module.f.mjs
@@ -22,7 +22,7 @@
  */
 
 import { assert, assertNotNullish } from '../../asserts/module.f.mjs'
-import { byteArray } from '../../ebnf/byte/module.f.mjs'
+import { ascii, byteArray } from '../../ebnf/byte/module.f.mjs'
 import { codePointListToString } from '../../text/utf16/module.f.mjs'
 import { length as bitLength } from '../../types/bit_vec/module.f.mjs'
 import { error, ok } from '../../types/result/module.f.mjs'
@@ -57,6 +57,59 @@ const typeOf = value => {
     const text = codePointListToString(byteArray(value))
     return objectTypes.find(t => t === text) ?? null
 }
+
+const dot = /** @type {const} */ (0x2E)
+
+const slash = /** @type {const} */ (0x2F)
+
+const at = /** @type {const} */ (0x40)
+
+const brace = /** @type {const} */ (0x7B)
+
+const del = /** @type {const} */ (0x7F)
+
+/** The bytes a ref name may not hold, besides the control characters. */
+const forbidden = ascii(' ~^:?*[\\')
+
+const lock = ascii('.lock')
+
+/**
+ * Whether two bytes sit next to each other in a name, in that order.
+ *
+ * @type {(name: readonly number[], a: number, b: number) => boolean}
+ */
+const holdsPair = (name, a, b) => name.some((x, i) => i !== 0 && name[i - 1] === a && x === b)
+
+/**
+ * Whether a component of a ref name, between slashes, is one: not empty,
+ * not beginning with `.`, not ending in `.lock`.
+ *
+ * @type {(component: readonly number[]) => boolean}
+ */
+const isComponent = component =>
+    component.length !== 0
+    && component[0] !== dot
+    && !(component.length >= lock.length && lock.every((b, i) => component[component.length - lock.length + i] === b))
+
+/**
+ * Whether a name is one `refs/tags/` takes, by the rules of
+ * `git check-ref-format`: no control character, no space and none of
+ * `~ ^ : ? * [ \`, no `..` and no `@{`, not `@` alone, not ending in `.`,
+ * and every component between slashes one {@link isComponent} takes.
+ * `git fsck` refuses a tag named otherwise as `badTagName`.
+ *
+ * @type {(name: readonly number[]) => boolean}
+ */
+const isTagName = name =>
+    name.every(b => b >= 0x20 && b !== del && !forbidden.includes(b))
+    && !holdsPair(name, dot, dot)
+    && !holdsPair(name, at, brace)
+    && !(name.length === 1 && name[0] === at)
+    && name[name.length - 1] !== dot
+    && name.reduce(
+        (cs, b) => b === slash ? [...cs, []] : [...cs.slice(0, -1), [...cs[cs.length - 1], b]],
+        /** @type {readonly (readonly number[])[]} */ ([[]]),
+    ).every(isComponent)
 
 /**
  * The id the `object` header names: the first header, a hex id.
@@ -125,9 +178,9 @@ export const tagger = t => {
  * Vouches for a tag as `git fsck` does, or refuses it, saying why: no
  * `object` header first or one that is not a hex id of the repository's
  * width, no `type` header second or one naming none of the four types, no
- * `tag` header third, or a `tagger` header fourth that is not an ident.
- * A missing `tagger` and a header after it are what `fsck` only notes,
- * so both pass.
+ * `tag` header third or one that is not a name `refs/tags/` takes, or a
+ * `tagger` header fourth that is not an ident. A missing `tagger` and a
+ * header after it are what `fsck` only notes, so both pass.
  *
  * Separate from {@link tryRead} on purpose: a reader reads what it can,
  * and only this says no.
@@ -142,7 +195,9 @@ export const validate = oidBytes => t => {
     const typeValue = valueAt(t, 1, 'type')
     if (typeValue === null) { return error('no type') }
     if (typeOf(typeValue) === null) { return error('unknown type') }
-    if (valueAt(t, 2, 'tag') === null) { return error('no tag name') }
+    const nameValue = valueAt(t, 2, 'tag')
+    if (nameValue === null) { return error('no tag name') }
+    if (!isTagName(byteArray(nameValue))) { return error('bad tag name') }
     const taggerValue = valueAt(t, 3, 'tagger')
     return taggerValue !== null && readIdent(taggerValue) === null ? error('not a tagger') : ok(t)
 }

--- a/fjs/git/tag/module.f.mjs
+++ b/fjs/git/tag/module.f.mjs
@@ -1,0 +1,148 @@
+/**
+ * A tag: the header block with `object`, `type`, `tag` and `tagger`, in
+ * that order and read by position as Git reads them, then the message.
+ * A signature, where there is one, is part of the message, from the line
+ * that begins its armor to the end, so nothing here knows about it.
+ *
+ * The header block's grammar is the first pass and this module the second:
+ * {@link tryRead} and {@link write} are the block's, since a tag adds no
+ * syntax to it, and the well-known fields are functions over the header
+ * list, total on a tag {@link validate} has accepted and a panic on one it
+ * has not. A tag with an unknown `type`, or with no `tagger` as very old
+ * tags have none, is read and written byte for byte; `validate` is where
+ * it is refused, as `git fsck` refuses it.
+ *
+ * @module
+ *
+ * @import { Nullable } from '../../types/nullable/types.ts'
+ * @import { Result } from '../../types/result/types.ts'
+ * @import { Ident } from '../ident/types.ts'
+ * @import { Bytes, ObjectType, Oid, OidBytes } from '../types.ts'
+ * @import { Tag } from './types.ts'
+ */
+
+import { assert, assertNotNullish } from '../../asserts/module.f.mjs'
+import { byteArray } from '../../ebnf/byte/module.f.mjs'
+import { codePointListToString } from '../../text/utf16/module.f.mjs'
+import { length as bitLength } from '../../types/bit_vec/module.f.mjs'
+import { error, ok } from '../../types/result/module.f.mjs'
+import { tryRead as readPayload, valueAt, write as writePayload } from '../header/module.f.mjs'
+import { tryRead as readIdent } from '../ident/module.f.mjs'
+import { objectTypes } from '../object/module.f.mjs'
+import { tryFromHex } from '../oid/module.f.mjs'
+
+/**
+ * Reads a tag, or refuses it: the header block's reader, since a tag is
+ * the block and nothing more. What the headers hold is not looked at; see
+ * {@link validate}.
+ *
+ * @type {(input: Bytes) => Nullable<Tag>}
+ */
+export const tryRead = readPayload
+
+/**
+ * A tag's bytes, every header as read: the header block's writer.
+ *
+ * @type {(t: Tag) => Bytes}
+ */
+export const write = writePayload
+
+/**
+ * The type the `type` header names, or `null` when it names none of the
+ * four.
+ *
+ * @type {(value: Bytes) => Nullable<ObjectType>}
+ */
+const typeOf = value => {
+    const text = codePointListToString(byteArray(value))
+    return objectTypes.find(t => t === text) ?? null
+}
+
+/**
+ * The id the `object` header names: the first header, a hex id.
+ *
+ * @throws On a tag {@link validate} refuses: no `object` header first, or
+ * one that is not a hex id.
+ *
+ * @type {(t: Tag) => Oid}
+ */
+export const object = t => {
+    const value = valueAt(t, 0, 'object')
+    assertNotNullish(value, 'no object')
+    const id = tryFromHex(value)
+    assert(id !== null, ['not an id', value])
+    return id
+}
+
+/**
+ * The type the `type` header names: the second header, one of the four.
+ *
+ * @throws On a tag {@link validate} refuses: no `type` header second, or
+ * one naming none of the four types.
+ *
+ * @type {(t: Tag) => ObjectType}
+ */
+export const type = t => {
+    const value = valueAt(t, 1, 'type')
+    assertNotNullish(value, 'no type')
+    const type = typeOf(value)
+    assert(type !== null, ['unknown type', value])
+    return type
+}
+
+/**
+ * The tag's name, the value of the `tag` header: the third header, bytes
+ * as the format leaves them.
+ *
+ * @throws On a tag {@link validate} refuses: no `tag` header third.
+ *
+ * @type {(t: Tag) => Bytes}
+ */
+export const name = t => {
+    const value = valueAt(t, 2, 'tag')
+    assertNotNullish(value, 'no tag name')
+    return value
+}
+
+/**
+ * Who made the tag and when, or `null` where the tag has no `tagger`
+ * header fourth, as very old tags have none.
+ *
+ * @throws On a tag {@link validate} refuses: a `tagger` header holding
+ * what is not an ident.
+ *
+ * @type {(t: Tag) => Nullable<Ident>}
+ */
+export const tagger = t => {
+    const value = valueAt(t, 3, 'tagger')
+    if (value === null) { return null }
+    const ident = readIdent(value)
+    assert(ident !== null, ['not a tagger', value])
+    return ident
+}
+
+/**
+ * Vouches for a tag as `git fsck` does, or refuses it, saying why: no
+ * `object` header first or one that is not a hex id of the repository's
+ * width, no `type` header second or one naming none of the four types, no
+ * `tag` header third, or a `tagger` header fourth that is not an ident.
+ * A missing `tagger` and a header after it are what `fsck` only notes,
+ * so both pass.
+ *
+ * Separate from {@link tryRead} on purpose: a reader reads what it can,
+ * and only this says no.
+ *
+ * @type {(oidBytes: OidBytes) => (t: Tag) => Result<Tag, string>}
+ */
+export const validate = oidBytes => t => {
+    const objectValue = valueAt(t, 0, 'object')
+    if (objectValue === null) { return error('no object') }
+    const id = tryFromHex(objectValue)
+    if (id === null || bitLength(id) !== BigInt(oidBytes) * 8n) { return error('not an id') }
+    const typeValue = valueAt(t, 1, 'type')
+    if (typeValue === null) { return error('no type') }
+    if (typeOf(typeValue) === null) { return error('unknown type') }
+    if (valueAt(t, 2, 'tag') === null) { return error('no tag name') }
+    const taggerValue = valueAt(t, 3, 'tagger')
+    return taggerValue !== null && readIdent(taggerValue) === null ? error('not a tagger') : ok(t)
+}

--- a/fjs/git/tag/module.f.mjs
+++ b/fjs/git/tag/module.f.mjs
@@ -10,7 +10,7 @@
  * list, total on a tag {@link validate} has accepted and a panic on one it
  * has not. A tag with an unknown `type`, or with no `tagger` as very old
  * tags have none, is read and written byte for byte; `validate` is where
- * it is refused, as `git fsck` refuses it.
+ * it is refused, as Git refuses it.
  *
  * @module
  *
@@ -112,7 +112,10 @@ const components = name => {
  * `~ ^ : ? * [ \`, no `..` and no `@{`, not ending in `.`,
  * and every component between slashes one {@link isComponent} takes. A
  * name that is `@` alone passes, since the ref it names is `refs/tags/@`
- * and not `@`. `git fsck` refuses a tag named otherwise as `badTagName`.
+ * and not `@`. `git fsck` only warns of a tag named otherwise, as
+ * `badTagName`, and exits clean; `git mktag`, strict by default, refuses to
+ * write it. This module refuses it too, since a name no ref takes names
+ * nothing.
  *
  * @type {(name: readonly number[]) => boolean}
  */
@@ -187,30 +190,35 @@ export const tagger = t => {
 }
 
 /**
- * Vouches for a tag as `git fsck` does, or refuses it, saying why: a NUL
- * in any header, no `object` header first or one that is not a hex id of
- * the repository's width, no `type` header second or one naming none of
- * the four types, no `tag` header third or one that is not a name
- * `refs/tags/` takes, or a `tagger` header fourth that is not an ident.
- * A missing `tagger` and a header after it are what `fsck` only notes,
- * so both pass.
+ * Vouches for a tag, or refuses it, saying why: a NUL in any header, no
+ * `object` header first or one that is not a hex id of the repository's
+ * width, no `type` header second or one naming none of the four types, no
+ * `tag` header third or one that is not a name `refs/tags/` takes, or a
+ * `tagger` header fourth that is not an ident. All but the name are what
+ * `git fsck` reports as an error; the name is one it only warns of, as
+ * `badTagName`, and `git mktag` refuses to write, and this refuses it as
+ * `mktag` does. What `fsck` only notes and Git writes passes: a missing
+ * `tagger`, a header after it.
  *
  * Separate from {@link tryRead} on purpose: a reader reads what it can,
  * and only this says no.
  *
  * @type {(oidBytes: OidBytes) => (t: Tag) => Result<Tag, string>}
  */
-export const validate = oidBytes => t => {
-    if (hasNulHeader(t)) { return error('NUL in header') }
-    const objectValue = valueAt(t, 0, 'object')
-    if (objectValue === null) { return error('no object') }
-    if (tryFromHexOf(oidBytes)(objectValue) === null) { return error('not an id') }
-    const typeValue = valueAt(t, 1, 'type')
-    if (typeValue === null) { return error('no type') }
-    if (typeOf(typeValue) === null) { return error('unknown type') }
-    const nameValue = valueAt(t, 2, 'tag')
-    if (nameValue === null) { return error('no tag name') }
-    if (!isTagName(byteArray(nameValue))) { return error('bad tag name') }
-    const taggerValue = valueAt(t, 3, 'tagger')
-    return taggerValue !== null && readIdent(taggerValue) === null ? error('not a tagger') : ok(t)
+export const validate = oidBytes => {
+    const id = tryFromHexOf(oidBytes)
+    return t => {
+        if (hasNulHeader(t)) { return error('NUL in header') }
+        const objectValue = valueAt(t, 0, 'object')
+        if (objectValue === null) { return error('no object') }
+        if (id(objectValue) === null) { return error('not an id') }
+        const typeValue = valueAt(t, 1, 'type')
+        if (typeValue === null) { return error('no type') }
+        if (typeOf(typeValue) === null) { return error('unknown type') }
+        const nameValue = valueAt(t, 2, 'tag')
+        if (nameValue === null) { return error('no tag name') }
+        if (!isTagName(byteArray(nameValue))) { return error('bad tag name') }
+        const taggerValue = valueAt(t, 3, 'tagger')
+        return taggerValue !== null && readIdent(taggerValue) === null ? error('not a tagger') : ok(t)
+    }
 }

--- a/fjs/git/tag/module.f.mjs
+++ b/fjs/git/tag/module.f.mjs
@@ -24,12 +24,11 @@
 import { assert, assertNotNullish } from '../../asserts/module.f.mjs'
 import { ascii, byteArray } from '../../ebnf/byte/module.f.mjs'
 import { codePointListToString } from '../../text/utf16/module.f.mjs'
-import { length as bitLength } from '../../types/bit_vec/module.f.mjs'
 import { error, ok } from '../../types/result/module.f.mjs'
 import { hasNulHeader, tryRead as readPayload, valueAt, write as writePayload } from '../header/module.f.mjs'
 import { tryRead as readIdent } from '../ident/module.f.mjs'
 import { objectTypes } from '../object/module.f.mjs'
-import { tryFromHex } from '../oid/module.f.mjs'
+import { tryFromHex, tryFromHexOf } from '../oid/module.f.mjs'
 
 /**
  * Reads a tag, or refuses it: the header block's reader, since a tag is
@@ -92,6 +91,21 @@ const isComponent = component =>
     && !(component.length >= lock.length && lock.every((b, i) => component[component.length - lock.length + i] === b))
 
 /**
+ * The components of a name, between its slashes: the bytes before the
+ * first, between each two, and after the last, so a name with none is one
+ * component and `a//b` has an empty one. Sliced once each, not grown byte
+ * by byte, since a name is as long as its author made it.
+ *
+ * @type {(name: readonly number[]) => readonly (readonly number[])[]}
+ */
+const components = name => {
+    const slashes = name.flatMap((b, i) => b === slash ? [i] : [])
+    const starts = [0, ...slashes.map(i => i + 1)]
+    const ends = [...slashes, name.length]
+    return starts.map((start, i) => name.slice(start, ends[i]))
+}
+
+/**
  * Whether a name is one `refs/tags/` takes, by the rules of
  * `git check-ref-format` over `refs/tags/<name>`: no control character,
  * no space and none of
@@ -107,10 +121,7 @@ const isTagName = name =>
     && !holdsPair(name, dot, dot)
     && !holdsPair(name, at, brace)
     && name[name.length - 1] !== dot
-    && name.reduce(
-        (cs, b) => b === slash ? [...cs, []] : [...cs.slice(0, -1), [...cs[cs.length - 1], b]],
-        /** @type {readonly (readonly number[])[]} */ ([[]]),
-    ).every(isComponent)
+    && components(name).every(isComponent)
 
 /**
  * The id the `object` header names: the first header, a hex id.
@@ -193,8 +204,7 @@ export const validate = oidBytes => t => {
     if (hasNulHeader(t)) { return error('NUL in header') }
     const objectValue = valueAt(t, 0, 'object')
     if (objectValue === null) { return error('no object') }
-    const id = tryFromHex(objectValue)
-    if (id === null || bitLength(id) !== BigInt(oidBytes) * 8n) { return error('not an id') }
+    if (tryFromHexOf(oidBytes)(objectValue) === null) { return error('not an id') }
     const typeValue = valueAt(t, 1, 'type')
     if (typeValue === null) { return error('no type') }
     if (typeOf(typeValue) === null) { return error('unknown type') }

--- a/fjs/git/tag/module.f.mjs
+++ b/fjs/git/tag/module.f.mjs
@@ -26,7 +26,7 @@ import { ascii, byteArray } from '../../ebnf/byte/module.f.mjs'
 import { codePointListToString } from '../../text/utf16/module.f.mjs'
 import { length as bitLength } from '../../types/bit_vec/module.f.mjs'
 import { error, ok } from '../../types/result/module.f.mjs'
-import { tryRead as readPayload, valueAt, write as writePayload } from '../header/module.f.mjs'
+import { hasNulHeader, tryRead as readPayload, valueAt, write as writePayload } from '../header/module.f.mjs'
 import { tryRead as readIdent } from '../ident/module.f.mjs'
 import { objectTypes } from '../object/module.f.mjs'
 import { tryFromHex } from '../oid/module.f.mjs'
@@ -93,10 +93,12 @@ const isComponent = component =>
 
 /**
  * Whether a name is one `refs/tags/` takes, by the rules of
- * `git check-ref-format`: no control character, no space and none of
- * `~ ^ : ? * [ \`, no `..` and no `@{`, not `@` alone, not ending in `.`,
- * and every component between slashes one {@link isComponent} takes.
- * `git fsck` refuses a tag named otherwise as `badTagName`.
+ * `git check-ref-format` over `refs/tags/<name>`: no control character,
+ * no space and none of
+ * `~ ^ : ? * [ \`, no `..` and no `@{`, not ending in `.`,
+ * and every component between slashes one {@link isComponent} takes. A
+ * name that is `@` alone passes, since the ref it names is `refs/tags/@`
+ * and not `@`. `git fsck` refuses a tag named otherwise as `badTagName`.
  *
  * @type {(name: readonly number[]) => boolean}
  */
@@ -104,7 +106,6 @@ const isTagName = name =>
     name.every(b => b >= 0x20 && b !== del && !forbidden.includes(b))
     && !holdsPair(name, dot, dot)
     && !holdsPair(name, at, brace)
-    && !(name.length === 1 && name[0] === at)
     && name[name.length - 1] !== dot
     && name.reduce(
         (cs, b) => b === slash ? [...cs, []] : [...cs.slice(0, -1), [...cs[cs.length - 1], b]],
@@ -175,12 +176,13 @@ export const tagger = t => {
 }
 
 /**
- * Vouches for a tag as `git fsck` does, or refuses it, saying why: no
- * `object` header first or one that is not a hex id of the repository's
- * width, no `type` header second or one naming none of the four types, no
- * `tag` header third or one that is not a name `refs/tags/` takes, or a
- * `tagger` header fourth that is not an ident. A missing `tagger` and a
- * header after it are what `fsck` only notes, so both pass.
+ * Vouches for a tag as `git fsck` does, or refuses it, saying why: a NUL
+ * in any header, no `object` header first or one that is not a hex id of
+ * the repository's width, no `type` header second or one naming none of
+ * the four types, no `tag` header third or one that is not a name
+ * `refs/tags/` takes, or a `tagger` header fourth that is not an ident.
+ * A missing `tagger` and a header after it are what `fsck` only notes,
+ * so both pass.
  *
  * Separate from {@link tryRead} on purpose: a reader reads what it can,
  * and only this says no.
@@ -188,6 +190,7 @@ export const tagger = t => {
  * @type {(oidBytes: OidBytes) => (t: Tag) => Result<Tag, string>}
  */
 export const validate = oidBytes => t => {
+    if (hasNulHeader(t)) { return error('NUL in header') }
     const objectValue = valueAt(t, 0, 'object')
     if (objectValue === null) { return error('no object') }
     const id = tryFromHex(objectValue)

--- a/fjs/git/tag/module.f.mjs
+++ b/fjs/git/tag/module.f.mjs
@@ -7,10 +7,13 @@
  * The header block's grammar is the first pass and this module the second:
  * {@link tryRead} and {@link write} are the block's, since a tag adds no
  * syntax to it, and the well-known fields are functions over the header
- * list, total on a tag {@link validate} has accepted and a panic on one it
- * has not. A tag with an unknown `type`, or with no `tagger` as very old
- * tags have none, is read and written byte for byte; `validate` is where
- * it is refused, as Git refuses it.
+ * list, total on a tag {@link validate} has accepted. On one it has not,
+ * an accessor panics only where the field it reads is missing or malformed
+ * — `object` on a tag whose first header is no hex id, `tagger` on one
+ * whose fourth is no ident — and reads what is there otherwise. A tag with an unknown
+ * `type`, or with no `tagger` as very old tags have none, is read and
+ * written byte for byte; `validate` is where it is refused, as Git refuses
+ * it.
  *
  * @module
  *

--- a/fjs/git/tag/proof.f.mjs
+++ b/fjs/git/tag/proof.f.mjs
@@ -91,16 +91,24 @@ export const proof = {
         assertStructurallySame(validate20(replaced(2, 'tagger A <a@b> 1 +0000')), ['error', 'no tag name'])
         assertStructurallySame(validate20(replaced(3, 'tagger A <a<b> 1 +0000')), ['error', 'not a tagger'])
         assertStructurallySame(validate20(replaced(3, 'tagger A <a@b> 9223372036854775808 +0000')), ['error', 'not a tagger'])
+        // A NUL in any header, the tagger's value or a header after it, is
+        // refused before anything else is looked at; one in the message is
+        // not a header's.
+        assertStructurallySame(validate20(replaced(3, 'tagger A <a@b> 1 +0000\0')), ['error', 'NUL in header'])
+        assertStructurallySame(validate20(tag([...lines.slice(0, 4), 'note \0', ...lines.slice(4)])), ['error', 'NUL in header'])
+        assertStructurallySame(validate20(tag([...lines.slice(0, 4), 'no\0te x', ...lines.slice(4)])), ['error', 'NUL in header'])
+        assertStructurallySame(validate20(tag(['', 'm\0'])), ['error', 'no object'])
+        assertStructurallySame(validate20(replaced(5, 'm\0'))[0], 'ok')
     },
     // A tag's name is a ref name: what `git check-ref-format` takes passes,
     // and each of its rules refuses.
     name: () => {
-        for (const n of ['v1.0', 'release/1.0', 'a@b', 'a.b.c', 'lock', 'x.locky', 'a{b', 'a/b/c', '\xE9']) {
+        for (const n of ['v1.0', 'release/1.0', 'a@b', 'a.b.c', 'lock', 'x.locky', 'a{b', 'a/b/c', '\xE9', '@']) {
             assertStructurallySame(validate20(replaced(2, `tag ${n}`))[0], 'ok')
         }
         for (const n of [
             '', 'a b', 'a~b', 'a^b', 'a:b', 'a?b', 'a*b', 'a[b', 'a\\b', 'a\x01b', 'a\x7Fb',
-            'a..b', 'a@{b', '@', 'a.', '.a', 'a/.b', 'a.lock', 'a.lock/b', 'a/', '/a', 'a//b',
+            'a..b', 'a@{b', 'a.', '.a', 'a/.b', 'a.lock', 'a.lock/b', 'a/', '/a', 'a//b',
         ]) {
             assertStructurallySame(validate20(replaced(2, `tag ${n}`)), ['error', 'bad tag name'])
         }

--- a/fjs/git/tag/proof.f.mjs
+++ b/fjs/git/tag/proof.f.mjs
@@ -89,6 +89,21 @@ export const proof = {
         assertStructurallySame(validate20(replaced(1, 'type commits')), ['error', 'unknown type'])
         assertStructurallySame(validate20(replaced(1, 'type Commit')), ['error', 'unknown type'])
         assertStructurallySame(validate20(replaced(2, 'tagger A <a@b> 1 +0000')), ['error', 'no tag name'])
+        assertStructurallySame(validate20(replaced(3, 'tagger A <a<b> 1 +0000')), ['error', 'not a tagger'])
+        assertStructurallySame(validate20(replaced(3, 'tagger A <a@b> 9223372036854775808 +0000')), ['error', 'not a tagger'])
+    },
+    // A tag's name is a ref name: what `git check-ref-format` takes passes,
+    // and each of its rules refuses.
+    name: () => {
+        for (const n of ['v1.0', 'release/1.0', 'a@b', 'a.b.c', 'lock', 'x.locky', 'a{b', 'a/b/c', '\xE9']) {
+            assertStructurallySame(validate20(replaced(2, `tag ${n}`))[0], 'ok')
+        }
+        for (const n of [
+            '', 'a b', 'a~b', 'a^b', 'a:b', 'a?b', 'a*b', 'a[b', 'a\\b', 'a\x01b', 'a\x7Fb',
+            'a..b', 'a@{b', '@', 'a.', '.a', 'a/.b', 'a.lock', 'a.lock/b', 'a/', '/a', 'a//b',
+        ]) {
+            assertStructurallySame(validate20(replaced(2, `tag ${n}`)), ['error', 'bad tag name'])
+        }
         assertStructurallySame(validate20(replaced(3, 'tagger A <a@b> 1 +000')), ['error', 'not a tagger'])
         assertStructurallySame(validate20(replaced(3, 'tagger A')), ['error', 'not a tagger'])
     },

--- a/fjs/git/tag/proof.f.mjs
+++ b/fjs/git/tag/proof.f.mjs
@@ -26,7 +26,11 @@ const id = '9fed27590671460cacf76884f17cd2a4b17f7220'
 
 const validate20 = validate(20)
 
-/** The headers every rule below starts from: a tag `git fsck` accepts. */
+/**
+ * The headers every rule below starts from: a tag `git fsck` accepts.
+ *
+ * @type {readonly string[]}
+ */
 const lines = [`object ${id}`, 'type commit', 'tag v1', 'tagger A <a@b> 1 +0000', '', 'm']
 
 /** @type {(i: number, line: string) => Tag} */
@@ -114,6 +118,11 @@ export const proof = {
         }
         assertStructurallySame(validate20(replaced(3, 'tagger A <a@b> 1 +000')), ['error', 'not a tagger'])
         assertStructurallySame(validate20(replaced(3, 'tagger A')), ['error', 'not a tagger'])
+        // A name is as long as its author made it, and is checked once over,
+        // not once per byte: twenty thousand bytes, and the same with slashes.
+        assertStructurallySame(validate20(replaced(2, `tag ${'n'.repeat(20000)}`))[0], 'ok')
+        assertStructurallySame(validate20(replaced(2, `tag ${'n/'.repeat(10000)}n`))[0], 'ok')
+        assertStructurallySame(validate20(replaced(2, `tag ${'n/'.repeat(10000)}`)), ['error', 'bad tag name'])
     },
     // The well-known fields panic on a tag `validate` refuses.
     throw: {

--- a/fjs/git/tag/proof.f.mjs
+++ b/fjs/git/tag/proof.f.mjs
@@ -1,0 +1,104 @@
+/**
+ * @import { Tag } from './types.ts'
+ */
+
+import { assert, assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
+import { codePointListToString } from '../../text/utf16/module.f.mjs'
+import { toArray } from '../../types/list/module.f.mjs'
+import { toHex } from '../oid/module.f.mjs'
+import { latin1, tagPayload } from '../testlib.f.mjs'
+import { name, object, tagger, tryRead, type, validate, write } from './module.f.mjs'
+
+/** @type {(input: readonly number[]) => Tag} */
+const read = input => {
+    const t = tryRead(input)
+    assert(t !== null)
+    return t
+}
+
+/** @type {(lines: readonly string[]) => Tag} */
+const tag = lines => read(latin1(lines.join('\n')))
+
+/** @type {(bytes: readonly number[]) => string} */
+const text = codePointListToString
+
+const id = '9fed27590671460cacf76884f17cd2a4b17f7220'
+
+const validate20 = validate(20)
+
+/** The headers every rule below starts from: a tag `git fsck` accepts. */
+const lines = [`object ${id}`, 'type commit', 'tag v1', 'tagger A <a@b> 1 +0000', '', 'm']
+
+/** @type {(i: number, line: string) => Tag} */
+const replaced = (i, line) => tag(lines.map((l, j) => j === i ? line : l))
+
+export const proof = {
+    // The real signed tag: four headers by position, the signature part
+    // of the message, vouched for, and written back to the same bytes.
+    signed: () => {
+        const t = read(tagPayload)
+        assertStructurallySame(t.headers.map(([k]) => text(toArray(k))), ['object', 'type', 'tag', 'tagger'])
+        assertEq(text(toArray(toHex(object(t)))), id)
+        assertEq(type(t), 'commit')
+        assertEq(text(toArray(name(t))), 'v2')
+        const who = tagger(t)
+        assert(who !== null)
+        assertEq(text(toArray(who.name)), 'Proof')
+        assertEq(text(toArray(who.email)), 'proof@example.com')
+        assertEq(who.time, 1700000000n)
+        assertEq(who.tz, '+0100')
+        const message = text(toArray(t.message)).split('\n')
+        assertEq(message[0], 'Version two, signed')
+        assertEq(message[1], '-----BEGIN SSH SIGNATURE-----')
+        assertEq(message[6], '-----END SSH SIGNATURE-----')
+        assertStructurallySame(validate20(t), ['ok', t])
+        assertStructurallySame(toArray(write(t)), tagPayload)
+    },
+    // A tag without `tagger`, as very old tags are: read, vouched for, and
+    // `tagger` is `null`.
+    old: () => {
+        const t = tag([`object ${id}`, 'type blob', 'tag old', '', ''])
+        assertEq(tagger(t), null)
+        assertEq(type(t), 'blob')
+        assertStructurallySame(validate20(t), ['ok', t])
+    },
+    // The other id width, and each width refuses the other's id.
+    sha256: () => {
+        const t = tag([`object ${'ab'.repeat(32)}`, 'type tree', 'tag x', '', ''])
+        assertStructurallySame(validate(32)(t), ['ok', t])
+        assertStructurallySame(validate20(t), ['error', 'not an id'])
+        assertStructurallySame(validate(32)(tag(lines)), ['error', 'not an id'])
+    },
+    // What `fsck` only notes passes: a header after `tagger`, and a
+    // capital letter in the id, which Git reads.
+    noted: () => {
+        const extra = tag([...lines.slice(0, 4), 'note x', ...lines.slice(4)])
+        assertStructurallySame(validate20(extra), ['ok', extra])
+        const capital = replaced(0, `object ${id.toUpperCase()}`)
+        assertStructurallySame(validate20(capital), ['ok', capital])
+        assertEq(text(toArray(toHex(object(capital)))), id)
+    },
+    // Each refusal, one per rule, on a tag the reader reads.
+    validate: () => {
+        assertStructurallySame(validate20(replaced(0, `type commit`)), ['error', 'no object'])
+        assertStructurallySame(validate20(tag(['', ''])), ['error', 'no object'])
+        assertStructurallySame(validate20(replaced(0, `object ${id.slice(1)}`)), ['error', 'not an id'])
+        assertStructurallySame(validate20(replaced(0, `object ${id.slice(2)}zz`)), ['error', 'not an id'])
+        assertStructurallySame(validate20(replaced(1, 'tag v1')), ['error', 'no type'])
+        assertStructurallySame(validate20(tag(lines.slice(0, 1).concat(['', '']))), ['error', 'no type'])
+        assertStructurallySame(validate20(replaced(1, 'type commits')), ['error', 'unknown type'])
+        assertStructurallySame(validate20(replaced(1, 'type Commit')), ['error', 'unknown type'])
+        assertStructurallySame(validate20(replaced(2, 'tagger A <a@b> 1 +0000')), ['error', 'no tag name'])
+        assertStructurallySame(validate20(replaced(3, 'tagger A <a@b> 1 +000')), ['error', 'not a tagger'])
+        assertStructurallySame(validate20(replaced(3, 'tagger A')), ['error', 'not a tagger'])
+    },
+    // The well-known fields panic on a tag `validate` refuses.
+    throw: {
+        noObject: () => object(tag(['', ''])),
+        notAnId: () => object(replaced(0, 'object zz')),
+        noType: () => type(tag(lines.slice(0, 1).concat(['', '']))),
+        unknownType: () => type(replaced(1, 'type Commit')),
+        noName: () => name(replaced(2, 'name v1')),
+        notATagger: () => tagger(replaced(3, 'tagger A')),
+    },
+}

--- a/fjs/git/tag/types.ts
+++ b/fjs/git/tag/types.ts
@@ -1,0 +1,16 @@
+/**
+ * Type-level API of a tag.
+ *
+ * @module
+ */
+
+import type { Payload } from '../header/types.ts'
+
+/**
+ * A tag is its header list and its message, and nothing else: the shape a
+ * commit has too, read by the same grammar. `object`, `type`, `tag` and
+ * `tagger` are the well-known headers, and the functions of
+ * `./module.f.mjs` read them off the list; a signature, where there is
+ * one, is part of the message.
+ */
+export type Tag = Payload

--- a/fjs/git/testlib.f.mjs
+++ b/fjs/git/testlib.f.mjs
@@ -146,3 +146,28 @@ export const rootTree = latin1([
     '100644 tsconfig.json\0'+'\x96\x7c\x99\xa5\x70\xc2\x9c\x68\x5f\x04\xbc\xe0\xc1\x16\xa1\xad\x9c\xd1\x6c\xaf',
     '100644 wrangler.jsonc\0'+'\xdf\x22\x8e\x28\x92\x18\x9a\x75\x03\xba\xbf\xdc\x4b\x65\x49\xbe\xe8\x75\x65\x2d',
 ].join(''))
+
+/**
+ * A signed tag, as `git cat-file tag` prints it: written by Git 2.43 in a
+ * scratch repository to a commit `9fed2759`, with an SSH signature, which
+ * Git puts in the message, from the line that begins its armor to the end.
+ * Its own id is `b79a8e25df6a75ef83c047b329e730d92ad59dec`, over 432
+ * bytes. The lines are joined by LF, and the last one is empty because
+ * the message ends in LF.
+ *
+ * @type {readonly number[]}
+ */
+export const tagPayload = latin1([
+    'object 9fed27590671460cacf76884f17cd2a4b17f7220',
+    'type commit',
+    'tag v2',
+    'tagger Proof <proof@example.com> 1700000000 +0100',
+    '',
+    'Version two, signed',
+    '-----BEGIN SSH SIGNATURE-----',
+    'U1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgrLzsfFISF4by8Q+FKz27YpkK1USsBB+m',
+    'amu1QkJnbDsAAAADZ2l0AAAAAAAAAAZzaGE1MTIAAABTAAAAC3NzaC1lZDI1NTE5AAAAQLLP2Pwo',
+    '7fTLqYbtbFsRGZ3ELHNIT5kjEj6FSogSns1sIp24JULk3FywiQc7vbzccgscl62ImMYfbjKtTYQ4',
+    '+AQ=',
+    '-----END SSH SIGNATURE-----',
+    '',].join('\n'))

--- a/todo/git-objects.md
+++ b/todo/git-objects.md
@@ -395,11 +395,17 @@ approximated:
       [`fjs/git/tree/`](../fjs/git/tree/module.f.mjs); the proof reads the
       root tree of a commit of this repository and writes it back byte for
       byte.
-- [ ] `fjs/git/commit/`, `fjs/git/tag/`: known fields as functions over the
-      header list, `validate`, and the writer for each.
+- [x] `fjs/git/tag/`: known fields as functions over the header list,
+      `validate`, and the writer — shipped as
+      [`fjs/git/tag/`](../fjs/git/tag/module.f.mjs), with
+      [`fjs/git/oid/`](../fjs/git/oid/module.f.mjs) for the hex spelling
+      of an id; the proof reads a tag Git signed and writes it back byte
+      for byte.
+- [ ] `fjs/git/commit/`: known fields as functions over the header list,
+      `mergetag` through the tag reader, `validate`, and the writer.
 - [ ] Proofs over real objects: capture a handful with `git cat-file` once
-      — a merge commit with `gpgsig` and `mergetag`, a signed tag, a tree
-      with every mode, a SHA-256 object — and check them in as byte
+      — a merge commit with `gpgsig` and `mergetag`, a tree with every
+      mode, a SHA-256 object — and check them in as byte
       literals; nothing in code calls `git`.
 - [ ] Inflate at the boundary: a `.mjs` adapter over `node:zlib` as an
       effect; file the FunctionalScript inflater as its own issue.

--- a/todo/git-objects.md
+++ b/todo/git-objects.md
@@ -78,8 +78,10 @@ The four payloads:
   what delimits the entry: nothing follows it but the next entry or the end.
 
 An `ident` is `name SP < email > SP time SP tz`: the name is any bytes but
-`<` and LF and may contain spaces; the email any bytes but `>`; `time` a
-decimal Unix timestamp; `tz` a sign and four digits.
+the brackets and LF and may contain spaces; the email the same; `time` a
+decimal Unix timestamp no later than `INT64_MAX`, the latest Git can hold;
+`tz` a sign and four digits. That is what `fsck_ident` reads, and what the
+reader reads.
 
 The object formats are specified across
 [gitformat-pack](https://git-scm.com/docs/gitformat-pack),
@@ -293,10 +295,13 @@ block is LF.
 
 **Ident** is a second layer over one header's value, the byte-level twin
 of the token layer in [`fjs/ebnf/ll1`](../fjs/ebnf/ll1/README.md): a grammar
-over the bytes of the value, `[repeatFrom0(not(set('<\n'))), '<',
-repeatFrom0(not(set('>\n'))), '>', ' ', digits, ' ', set('+-'),
-times(4)(digit), eof]`. The `eof` is what refuses trailing bytes, since a
-rule without it stops where it matches and leaves the rest. The SP before
+over the bytes of the value, `[repeatFrom0(not(set('<>\n'))), '<',
+repeatFrom0(not(set('<>\n'))), '>', ' ', digits, ' ', set('+-'),
+times(4)(digit), eof]` — a `>` in the name or a `<` in the email is a bad
+name or a bad email to `fsck_ident`, and here no ident — with the mapping
+refusing a time later than `INT64_MAX`, since the range is the ident's
+property and not the object's. The `eof` is what refuses trailing bytes,
+since a rule without it stops where it matches and leaves the rest. The SP before
 `<` cannot be a symbol of the rule — the name's repetition may end in SP,
 so `' <'` after it is a first/follow conflict the backend refuses — so the
 name is read up to `<` and the mapping requires its last byte to be SP and

--- a/todo/git-objects.md
+++ b/todo/git-objects.md
@@ -363,10 +363,12 @@ approximated:
   each an object, and streams nothing (its README, "Left for later"). For
   commits, tags and trees that is fine; it is the reason a blob is never
   handed to a parser.
-- **Semantic rules.** Required headers and their order, a duplicated
-  `tree`, a hex id of the wrong length, a timestamp out of range, the mode
-  set, the entry order: all after the parse, in one `validate` per object
-  type, refusing what it cannot vouch for and naming what it refused.
+- **Semantic rules.** Required headers and their order, a hex id of the
+  wrong length, a tag name that is no ref name, the mode set, the entry
+  order: all after the parse, in one `validate` per object type, refusing
+  what it cannot vouch for and naming what it refused. A timestamp out of
+  range is the ident reader's to refuse, since it is a property of the
+  ident and not of the object around it.
 - **Packfiles and `.idx`.** Length-framed throughout — varint sizes, delta
   chains, embedded zlib streams. A decoder in the `fjs/asn.1` style, and a
   later issue; most objects in a real repository live there, so the


### PR DESCRIPTION
The bottom of the git stack, against `main`; #1942, #1944 and #1947 sit on it in that order.

Ships `fjs/git/tag/`, the next task of the design after ident, and the small pieces a commit reader shares with it.

- **A tag adds no syntax to the header block**, so `tryRead` and `write` are the block's, and the module is the second pass the design describes: `object`, `type`, `name` and `tagger` as functions over the header list, read by position as Git reads them. They are total on a tag `validate` has accepted and panic on one it has not; `tagger` is `null` where the header is absent, as very old tags have none.
- **`validate(oidBytes)`** refuses what `git fsck` reports as an error, saying why: a NUL in any header, no `object` first or one that is not a hex id of the repository's width, no `type` second or one naming none of the four, no `tag` third, a `tagger` fourth that is not an ident. One thing `fsck` only warns of is refused too, as this module's own choice: a `tag` name that is no name `refs/tags/` takes, which `git mktag` refuses to write. What `fsck` only notes and Git writes passes: a missing `tagger`, a header after it. A tag with an unknown type is still read and written byte for byte.
- **`fjs/git/oid/`**: an id between its two spellings, the raw bytes a tree entry holds and the hex text a header holds. `tryFromHex` reads either case of letter, as Git does, refuses more bytes than a `Vec` holds with `null`, and `toHex` writes the small case; `tryFromHexOf` is the same at the repository's width, the check every `validate` that meets an id makes.
- **`keyIs`, `valueAt` and `hasNulHeader` in `fjs/git/header/`**: the byte comparison of a key, the positional lookup, and the NUL check that commit reuses.
- **The ident reader reads what `fsck_ident` reads.** A `>` in the name or a `<` in the email is no ident, and neither is a time later than `INT64_MAX`, exported as `maxTime`; a time's digits are judged before they are folded, so a long run costs nothing. The writer refuses the same.
- **Proof**: a tag Git 2.43 signed in a scratch repository, the signature in its message as the design says, read, its four fields checked, vouched for, and written back to the same 432 bytes. Beside it: a tag without `tagger`, both id widths, a case per `validate` rule and per ref-name rule, a name of twenty thousand bytes, and each field's panic. All git modules at 100% line, branch and function coverage.

Checks the tag task off in the design and lists the two modules in `fjs/git/README.md`.

Changelog:

- **BREAKING CHANGES:** `tryRead` in `fjs/git/ident` refuses three forms it read before, and `write` refuses to spell them: a `>` in the name, a `<` in the email, and a time later than `9223372036854775807`. They are what `git fsck` refuses as `badName`, `badEmail` and `badDateOverflow`. A caller that met one got an `Ident` and now gets `null`; an object holding one keeps its raw header in the header list, and a caller that wants to accept such a form reads it from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdU8wW4oihFS1gj4dUAcPS