### PR TITLE
git/commit: a commit as a second pass over the header block

### DIFF
--- a/fjs/git/README.md
+++ b/fjs/git/README.md
@@ -23,6 +23,10 @@ come.
   for a repository's id width: a reader that reads what `git fsck` would
   flag, a `validate` that refuses it the way `fsck` does, `mode` as the
   number an entry's digits spell, and a writer.
+- [`commit/`](commit/module.f.mjs) — a commit as a second pass over the
+  header block: `tree`, `parent`, `author` and `committer` by position,
+  `encoding`, `gpgsig` and `mergetag` by key, the last read as a tag by
+  the tag module, and a `validate` that refuses what `git fsck` does.
 - [`oid/`](oid/module.f.mjs) — an object id between its two spellings, the
   raw bytes a tree entry holds and the hex text a header holds.
 - [`tag/`](tag/module.f.mjs) — a tag as a second pass over the header

--- a/fjs/git/commit/module.f.mjs
+++ b/fjs/git/commit/module.f.mjs
@@ -1,0 +1,211 @@
+/**
+ * A commit: the header block with `tree`, then `parent` zero or more
+ * times, then `author` and `committer`, read by position as Git reads
+ * them; `encoding`, `gpgsig` and `mergetag` by key, wherever they sit;
+ * then the message.
+ *
+ * The header block's grammar is the first pass and this module the second:
+ * {@link tryRead} and {@link write} are the block's, since a commit adds
+ * no syntax to it, and the well-known fields are functions over the header
+ * list, total on a commit {@link validate} has accepted and a panic on one
+ * it has not. A `mergetag` value is a whole tag object, and
+ * {@link mergetags} hands it to the tag reader — one more pass over the
+ * same alphabet, as the design says. A commit with a bad `tree` id or no
+ * `committer` is read and written byte for byte; `validate` is where it is
+ * refused, as `git fsck` refuses it.
+ *
+ * @module
+ *
+ * @import { Nullable } from '../../types/nullable/types.ts'
+ * @import { Result } from '../../types/result/types.ts'
+ * @import { Ident } from '../ident/types.ts'
+ * @import { Tag } from '../tag/types.ts'
+ * @import { Bytes, Oid, OidBytes } from '../types.ts'
+ * @import { Commit } from './types.ts'
+ */
+
+import { assert, assertNotNullish } from '../../asserts/module.f.mjs'
+import { length as bitLength } from '../../types/bit_vec/module.f.mjs'
+import { error, ok } from '../../types/result/module.f.mjs'
+import { tryRead as readPayload, valueAt, valuesOf, write as writePayload } from '../header/module.f.mjs'
+import { tryRead as readIdent } from '../ident/module.f.mjs'
+import { tryFromHex } from '../oid/module.f.mjs'
+import { tryRead as readTag, validate as validateTag } from '../tag/module.f.mjs'
+
+/**
+ * Reads a commit, or refuses it: the header block's reader, since a
+ * commit is the block and nothing more. What the headers hold is not
+ * looked at; see {@link validate}.
+ *
+ * @type {(input: Bytes) => Nullable<Commit>}
+ */
+export const tryRead = readPayload
+
+/**
+ * A commit's bytes, every header as read: the header block's writer.
+ *
+ * @type {(c: Commit) => Bytes}
+ */
+export const write = writePayload
+
+/**
+ * The values of the `parent` headers: from the second header on, as many
+ * as are `parent` in a row.
+ *
+ * @type {(c: Commit) => readonly Bytes[]}
+ */
+const parentValues = c => {
+    /** @type {(i: number) => readonly Bytes[]} */
+    const from = i => {
+        const v = valueAt(c, i, 'parent')
+        return v === null ? [] : [v, ...from(i + 1)]
+    }
+    return from(1)
+}
+
+/**
+ * The id the `tree` header names: the first header, a hex id.
+ *
+ * @throws On a commit {@link validate} refuses: no `tree` header first,
+ * or one that is not a hex id.
+ *
+ * @type {(c: Commit) => Oid}
+ */
+export const tree = c => {
+    const value = valueAt(c, 0, 'tree')
+    assertNotNullish(value, 'no tree')
+    const id = tryFromHex(value)
+    assert(id !== null, ['not a tree id', value])
+    return id
+}
+
+/**
+ * The ids the `parent` headers name, in order: none for a root commit,
+ * two or more for a merge.
+ *
+ * @throws On a commit {@link validate} refuses: a `parent` header that is
+ * not a hex id.
+ *
+ * @type {(c: Commit) => readonly Oid[]}
+ */
+export const parents = c => parentValues(c).map(value => {
+    const id = tryFromHex(value)
+    assert(id !== null, ['not a parent id', value])
+    return id
+})
+
+/**
+ * The ident the header at `i` holds, where its key is `key`.
+ *
+ * @throws Where the header is not there, or holds what is not an ident.
+ *
+ * @type {(c: Commit, i: number, key: string) => Ident}
+ */
+const identAt = (c, i, key) => {
+    const value = valueAt(c, i, key)
+    assertNotNullish(value, `no ${key}`)
+    const ident = readIdent(value)
+    assert(ident !== null, [`not an ${key}`, value])
+    return ident
+}
+
+/**
+ * Who wrote the change and when: the `author` header, after the parents.
+ *
+ * @throws On a commit {@link validate} refuses: no `author` header after
+ * the parents, or one that is not an ident.
+ *
+ * @type {(c: Commit) => Ident}
+ */
+export const author = c => identAt(c, 1 + parentValues(c).length, 'author')
+
+/**
+ * Who made the commit and when: the `committer` header, after `author`.
+ *
+ * @throws On a commit {@link validate} refuses: no `committer` header
+ * after `author`, or one that is not an ident.
+ *
+ * @type {(c: Commit) => Ident}
+ */
+export const committer = c => identAt(c, 2 + parentValues(c).length, 'committer')
+
+/**
+ * The value of the first header of a key, or `null` where there is none.
+ *
+ * @type {(c: Commit, key: string) => Nullable<Bytes>}
+ */
+const first = (c, key) => valuesOf(c, key)[0] ?? null
+
+/**
+ * The encoding the `encoding` header names, as bytes, or `null` where
+ * there is none — the message is UTF-8 then, by convention.
+ *
+ * @type {(c: Commit) => Nullable<Bytes>}
+ */
+export const encoding = c => first(c, 'encoding')
+
+/**
+ * The signature the `gpgsig` header holds, its armor as bytes with the
+ * continuation lines joined by LF, or `null` where the commit is not
+ * signed.
+ *
+ * @type {(c: Commit) => Nullable<Bytes>}
+ */
+export const gpgsig = c => first(c, 'gpgsig')
+
+/**
+ * The tags the `mergetag` headers carry, one per signed tag the commit
+ * merged, each a whole tag object read out of the header's value.
+ *
+ * @throws On a commit {@link validate} refuses: a `mergetag` value that
+ * is not a tag.
+ *
+ * @type {(c: Commit) => readonly Tag[]}
+ */
+export const mergetags = c => valuesOf(c, 'mergetag').map(value => {
+    const tag = readTag(value)
+    assert(tag !== null, ['not a mergetag', value])
+    return tag
+})
+
+/**
+ * Whether a header value is a hex id `oidBytes` wide.
+ *
+ * @type {(oidBytes: OidBytes) => (value: Bytes) => boolean}
+ */
+const isId = oidBytes => value => {
+    const id = tryFromHex(value)
+    return id !== null && bitLength(id) === BigInt(oidBytes) * 8n
+}
+
+/**
+ * Vouches for a commit as `git fsck` does, or refuses it, saying why: no
+ * `tree` header first or one that is not a hex id of the repository's
+ * width, a `parent` header that is not one, no `author` header after the
+ * parents or no `committer` after it, or either holding what is not an
+ * ident. One check `fsck` does not make, since it never looks inside:
+ * a `mergetag` value must be a tag this module's sibling vouches for, so
+ * that {@link mergetags} is total. What `fsck` only notes passes: any
+ * other header, a message holding NUL.
+ *
+ * Separate from {@link tryRead} on purpose: a reader reads what it can,
+ * and only this says no.
+ *
+ * @type {(oidBytes: OidBytes) => (c: Commit) => Result<Commit, string>}
+ */
+export const validate = oidBytes => c => {
+    const id = isId(oidBytes)
+    const treeValue = valueAt(c, 0, 'tree')
+    if (treeValue === null) { return error('no tree') }
+    if (!id(treeValue)) { return error('not a tree id') }
+    const ps = parentValues(c)
+    if (!ps.every(id)) { return error('not a parent id') }
+    const authorValue = valueAt(c, 1 + ps.length, 'author')
+    if (authorValue === null) { return error('no author') }
+    if (readIdent(authorValue) === null) { return error('not an author') }
+    const committerValue = valueAt(c, 2 + ps.length, 'committer')
+    if (committerValue === null) { return error('no committer') }
+    if (readIdent(committerValue) === null) { return error('not a committer') }
+    const tags = valuesOf(c, 'mergetag').map(readTag)
+    return tags.every(t => t !== null && validateTag(oidBytes)(t)[0] === 'ok') ? ok(c) : error('not a mergetag')
+}

--- a/fjs/git/commit/module.f.mjs
+++ b/fjs/git/commit/module.f.mjs
@@ -10,10 +10,12 @@
  * list, total on a commit {@link validate} has accepted. On one it has
  * not, an accessor panics only where the field it reads is missing or
  * malformed — `tree` on a commit whose first header is no hex id,
- * `committer` on one with none — and reads what is there otherwise. A `mergetag` value is a whole tag object less its last LF,
- * which the header's framing took, and {@link mergetags} gives the LF back
- * and hands the tag to the tag reader — one more pass over the same
- * alphabet, as the design says. A commit with a bad `tree` id or no
+ * `committer` on one with none — and reads what is there otherwise. A
+ * `mergetag` value is a whole tag object less its last LF, which the
+ * header's framing took, and {@link mergetags} gives the LF back and hands
+ * the tag to the tag reader — one more pass over the same alphabet, as
+ * the design says; a tag that never ended in LF is the one the fold
+ * cannot keep, as it cannot for Git. A commit with a bad `tree` id or no
  * `committer` is read and written byte for byte; `validate` is where it is
  * refused, as Git refuses it.
  *
@@ -159,10 +161,19 @@ const lf = /** @type {const} */ (0x0A)
 
 /**
  * A `mergetag` value as the tag's bytes: Git folds a tag into the header
- * by putting SP before each of its lines, so the LF that ends the tag ends
- * the header too, and the header's reader takes it as framing. Given back
- * here, the value is the tag object whole, and the tag reader reads it as
- * it reads the tag's own file.
+ * by putting SP before each of its lines and completing the last, so the
+ * LF that ends the tag ends the header too, and the header's reader takes
+ * it as framing. Given back here, the value is the tag object whole, and
+ * the tag reader reads it as it reads the tag's own file.
+ *
+ * One tag the fold loses: a tag whose own bytes end without LF, which
+ * `git hash-object -t tag` writes and no tool of Git's does, folds to the
+ * same header as the same tag with one, and comes back with one, so the
+ * id of what {@link mergetags} gives is not the id it had. Git's own
+ * reading of the header, in `git verify-commit` and `git log
+ * --show-signature`, hashes the value with that LF and loses the same
+ * tag the same way; the fold is Git's, and the bytes here are the bytes
+ * Git reads back.
  *
  * @type {(value: Bytes) => Bytes}
  */

--- a/fjs/git/commit/module.f.mjs
+++ b/fjs/git/commit/module.f.mjs
@@ -12,7 +12,7 @@
  * {@link mergetags} hands it to the tag reader — one more pass over the
  * same alphabet, as the design says. A commit with a bad `tree` id or no
  * `committer` is read and written byte for byte; `validate` is where it is
- * refused, as `git fsck` refuses it.
+ * refused, as Git refuses it.
  *
  * @module
  *
@@ -172,33 +172,37 @@ export const mergetags = c => valuesOf(c, 'mergetag').map(value => {
  * NUL in any header, no `tree` header first or one that is not a hex id
  * of the repository's width, a `parent` header that is not one, no
  * `author` header after the parents or no `committer` after it, or either
- * holding what is not an ident, or a NUL in the message — the last a
- * warning to `fsck` and a refusal under `--strict`, which is how Git
- * writes an object. One check `fsck` does not make, since it never looks
- * inside: a `mergetag` value must be a tag this module's sibling vouches
- * for, so that {@link mergetags} is total. What `fsck` only notes passes:
- * any other header.
+ * holding what is not an ident, or a NUL in the message. All but the last
+ * are what `git fsck` reports as an error; a NUL in the message is one it
+ * only warns of, as `nulInCommit`, and this refuses it, since no tool of
+ * Git's writes one and a message is read as text. One check `fsck` does
+ * not make, since it never looks inside: a `mergetag` value must be a tag
+ * this module's sibling vouches for, so that {@link mergetags} is total.
+ * What `fsck` only notes and Git writes passes: any other header.
  *
  * Separate from {@link tryRead} on purpose: a reader reads what it can,
  * and only this says no.
  *
  * @type {(oidBytes: OidBytes) => (c: Commit) => Result<Commit, string>}
  */
-export const validate = oidBytes => c => {
-    if (hasNulHeader(c)) { return error('NUL in header') }
+export const validate = oidBytes => {
     const id = tryFromHexOf(oidBytes)
-    const treeValue = valueAt(c, 0, 'tree')
-    if (treeValue === null) { return error('no tree') }
-    if (id(treeValue) === null) { return error('not a tree id') }
-    const ps = parentValues(c)
-    if (!ps.every(v => id(v) !== null)) { return error('not a parent id') }
-    const authorValue = valueAt(c, 1 + ps.length, 'author')
-    if (authorValue === null) { return error('no author') }
-    if (readIdent(authorValue) === null) { return error('not an author') }
-    const committerValue = valueAt(c, 2 + ps.length, 'committer')
-    if (committerValue === null) { return error('no committer') }
-    if (readIdent(committerValue) === null) { return error('not a committer') }
-    const tags = valuesOf(c, 'mergetag').map(readTag)
-    if (!tags.every(t => t !== null && validateTag(oidBytes)(t)[0] === 'ok')) { return error('not a mergetag') }
-    return includes(0)(c.message) ? error('NUL in message') : ok(c)
+    const tagOk = validateTag(oidBytes)
+    return c => {
+        if (hasNulHeader(c)) { return error('NUL in header') }
+        const treeValue = valueAt(c, 0, 'tree')
+        if (treeValue === null) { return error('no tree') }
+        if (id(treeValue) === null) { return error('not a tree id') }
+        const ps = parentValues(c)
+        if (!ps.every(v => id(v) !== null)) { return error('not a parent id') }
+        const authorValue = valueAt(c, 1 + ps.length, 'author')
+        if (authorValue === null) { return error('no author') }
+        if (readIdent(authorValue) === null) { return error('not an author') }
+        const committerValue = valueAt(c, 2 + ps.length, 'committer')
+        if (committerValue === null) { return error('no committer') }
+        if (readIdent(committerValue) === null) { return error('not a committer') }
+        const tags = valuesOf(c, 'mergetag').map(readTag)
+        if (!tags.every(t => t !== null && tagOk(t)[0] === 'ok')) { return error('not a mergetag') }
+        return includes(0)(c.message) ? error('NUL in message') : ok(c)
+    }
 }

--- a/fjs/git/commit/module.f.mjs
+++ b/fjs/git/commit/module.f.mjs
@@ -26,8 +26,9 @@
 
 import { assert, assertNotNullish } from '../../asserts/module.f.mjs'
 import { length as bitLength } from '../../types/bit_vec/module.f.mjs'
+import { includes } from '../../types/list/module.f.mjs'
 import { error, ok } from '../../types/result/module.f.mjs'
-import { tryRead as readPayload, valueAt, valuesOf, write as writePayload } from '../header/module.f.mjs'
+import { hasNulHeader, keyIs, tryRead as readPayload, valueAt, valuesOf, write as writePayload } from '../header/module.f.mjs'
 import { tryRead as readIdent } from '../ident/module.f.mjs'
 import { tryFromHex } from '../oid/module.f.mjs'
 import { tryRead as readTag, validate as validateTag } from '../tag/module.f.mjs'
@@ -50,17 +51,16 @@ export const write = writePayload
 
 /**
  * The values of the `parent` headers: from the second header on, as many
- * as are `parent` in a row.
+ * as are `parent` in a row. A scan and a slice, not a recursion: Git puts
+ * no bound on the parents, and a merge of thousands is a commit `fsck`
+ * accepts.
  *
  * @type {(c: Commit) => readonly Bytes[]}
  */
 const parentValues = c => {
-    /** @type {(i: number) => readonly Bytes[]} */
-    const from = i => {
-        const v = valueAt(c, i, 'parent')
-        return v === null ? [] : [v, ...from(i + 1)]
-    }
-    return from(1)
+    const rest = c.headers.slice(1)
+    const end = rest.findIndex(h => !keyIs(h, 'parent'))
+    return (end === -1 ? rest : rest.slice(0, end)).map(([, v]) => v)
 }
 
 /**
@@ -179,14 +179,16 @@ const isId = oidBytes => value => {
 }
 
 /**
- * Vouches for a commit as `git fsck` does, or refuses it, saying why: no
- * `tree` header first or one that is not a hex id of the repository's
- * width, a `parent` header that is not one, no `author` header after the
- * parents or no `committer` after it, or either holding what is not an
- * ident. One check `fsck` does not make, since it never looks inside:
- * a `mergetag` value must be a tag this module's sibling vouches for, so
- * that {@link mergetags} is total. What `fsck` only notes passes: any
- * other header, a message holding NUL.
+ * Vouches for a commit as `git fsck` does, or refuses it, saying why: a
+ * NUL in any header, no `tree` header first or one that is not a hex id
+ * of the repository's width, a `parent` header that is not one, no
+ * `author` header after the parents or no `committer` after it, or either
+ * holding what is not an ident, or a NUL in the message — the last a
+ * warning to `fsck` and a refusal under `--strict`, which is how Git
+ * writes an object. One check `fsck` does not make, since it never looks
+ * inside: a `mergetag` value must be a tag this module's sibling vouches
+ * for, so that {@link mergetags} is total. What `fsck` only notes passes:
+ * any other header.
  *
  * Separate from {@link tryRead} on purpose: a reader reads what it can,
  * and only this says no.
@@ -194,6 +196,7 @@ const isId = oidBytes => value => {
  * @type {(oidBytes: OidBytes) => (c: Commit) => Result<Commit, string>}
  */
 export const validate = oidBytes => c => {
+    if (hasNulHeader(c)) { return error('NUL in header') }
     const id = isId(oidBytes)
     const treeValue = valueAt(c, 0, 'tree')
     if (treeValue === null) { return error('no tree') }
@@ -207,5 +210,6 @@ export const validate = oidBytes => c => {
     if (committerValue === null) { return error('no committer') }
     if (readIdent(committerValue) === null) { return error('not a committer') }
     const tags = valuesOf(c, 'mergetag').map(readTag)
-    return tags.every(t => t !== null && validateTag(oidBytes)(t)[0] === 'ok') ? ok(c) : error('not a mergetag')
+    if (!tags.every(t => t !== null && validateTag(oidBytes)(t)[0] === 'ok')) { return error('not a mergetag') }
+    return includes(0)(c.message) ? error('NUL in message') : ok(c)
 }

--- a/fjs/git/commit/module.f.mjs
+++ b/fjs/git/commit/module.f.mjs
@@ -7,10 +7,13 @@
  * The header block's grammar is the first pass and this module the second:
  * {@link tryRead} and {@link write} are the block's, since a commit adds
  * no syntax to it, and the well-known fields are functions over the header
- * list, total on a commit {@link validate} has accepted and a panic on one
- * it has not. A `mergetag` value is a whole tag object, and
- * {@link mergetags} hands it to the tag reader — one more pass over the
- * same alphabet, as the design says. A commit with a bad `tree` id or no
+ * list, total on a commit {@link validate} has accepted. On one it has
+ * not, an accessor panics only where the field it reads is missing or
+ * malformed — `tree` on a commit whose first header is no hex id,
+ * `committer` on one with none — and reads what is there otherwise. A `mergetag` value is a whole tag object less its last LF,
+ * which the header's framing took, and {@link mergetags} gives the LF back
+ * and hands the tag to the tag reader — one more pass over the same
+ * alphabet, as the design says. A commit with a bad `tree` id or no
  * `committer` is read and written byte for byte; `validate` is where it is
  * refused, as Git refuses it.
  *
@@ -25,7 +28,7 @@
  */
 
 import { assert, assertNotNullish } from '../../asserts/module.f.mjs'
-import { includes } from '../../types/list/module.f.mjs'
+import { concat, includes } from '../../types/list/module.f.mjs'
 import { error, ok } from '../../types/result/module.f.mjs'
 import { hasNulHeader, keyIs, tryRead as readPayload, valueAt, valuesOf, write as writePayload } from '../header/module.f.mjs'
 import { tryRead as readIdent } from '../ident/module.f.mjs'
@@ -152,9 +155,23 @@ export const encoding = c => first(c, 'encoding')
  */
 export const gpgsig = c => first(c, 'gpgsig')
 
+const lf = /** @type {const} */ (0x0A)
+
+/**
+ * A `mergetag` value as the tag's bytes: Git folds a tag into the header
+ * by putting SP before each of its lines, so the LF that ends the tag ends
+ * the header too, and the header's reader takes it as framing. Given back
+ * here, the value is the tag object whole, and the tag reader reads it as
+ * it reads the tag's own file.
+ *
+ * @type {(value: Bytes) => Bytes}
+ */
+const tagOf = value => concat(value)([lf])
+
 /**
  * The tags the `mergetag` headers carry, one per signed tag the commit
- * merged, each a whole tag object read out of the header's value.
+ * merged, each a whole tag object read out of the header's value: the
+ * tag's bytes, byte for byte, with the LF the framing took given back.
  *
  * @throws On a commit {@link validate} refuses: a `mergetag` value that
  * is not a tag.
@@ -162,7 +179,7 @@ export const gpgsig = c => first(c, 'gpgsig')
  * @type {(c: Commit) => readonly Tag[]}
  */
 export const mergetags = c => valuesOf(c, 'mergetag').map(value => {
-    const tag = readTag(value)
+    const tag = readTag(tagOf(value))
     assert(tag !== null, ['not a mergetag', value])
     return tag
 })
@@ -201,7 +218,7 @@ export const validate = oidBytes => {
         const committerValue = valueAt(c, 2 + ps.length, 'committer')
         if (committerValue === null) { return error('no committer') }
         if (readIdent(committerValue) === null) { return error('not a committer') }
-        const tags = valuesOf(c, 'mergetag').map(readTag)
+        const tags = valuesOf(c, 'mergetag').map(value => readTag(tagOf(value)))
         if (!tags.every(t => t !== null && tagOk(t)[0] === 'ok')) { return error('not a mergetag') }
         return includes(0)(c.message) ? error('NUL in message') : ok(c)
     }

--- a/fjs/git/commit/module.f.mjs
+++ b/fjs/git/commit/module.f.mjs
@@ -25,12 +25,11 @@
  */
 
 import { assert, assertNotNullish } from '../../asserts/module.f.mjs'
-import { length as bitLength } from '../../types/bit_vec/module.f.mjs'
 import { includes } from '../../types/list/module.f.mjs'
 import { error, ok } from '../../types/result/module.f.mjs'
 import { hasNulHeader, keyIs, tryRead as readPayload, valueAt, valuesOf, write as writePayload } from '../header/module.f.mjs'
 import { tryRead as readIdent } from '../ident/module.f.mjs'
-import { tryFromHex } from '../oid/module.f.mjs'
+import { tryFromHex, tryFromHexOf } from '../oid/module.f.mjs'
 import { tryRead as readTag, validate as validateTag } from '../tag/module.f.mjs'
 
 /**
@@ -169,16 +168,6 @@ export const mergetags = c => valuesOf(c, 'mergetag').map(value => {
 })
 
 /**
- * Whether a header value is a hex id `oidBytes` wide.
- *
- * @type {(oidBytes: OidBytes) => (value: Bytes) => boolean}
- */
-const isId = oidBytes => value => {
-    const id = tryFromHex(value)
-    return id !== null && bitLength(id) === BigInt(oidBytes) * 8n
-}
-
-/**
  * Vouches for a commit as `git fsck` does, or refuses it, saying why: a
  * NUL in any header, no `tree` header first or one that is not a hex id
  * of the repository's width, a `parent` header that is not one, no
@@ -197,12 +186,12 @@ const isId = oidBytes => value => {
  */
 export const validate = oidBytes => c => {
     if (hasNulHeader(c)) { return error('NUL in header') }
-    const id = isId(oidBytes)
+    const id = tryFromHexOf(oidBytes)
     const treeValue = valueAt(c, 0, 'tree')
     if (treeValue === null) { return error('no tree') }
-    if (!id(treeValue)) { return error('not a tree id') }
+    if (id(treeValue) === null) { return error('not a tree id') }
     const ps = parentValues(c)
-    if (!ps.every(id)) { return error('not a parent id') }
+    if (!ps.every(v => id(v) !== null)) { return error('not a parent id') }
     const authorValue = valueAt(c, 1 + ps.length, 'author')
     if (authorValue === null) { return error('no author') }
     if (readIdent(authorValue) === null) { return error('not an author') }

--- a/fjs/git/commit/proof.f.mjs
+++ b/fjs/git/commit/proof.f.mjs
@@ -1,0 +1,145 @@
+/**
+ * @import { Oid } from '../types.ts'
+ * @import { Commit } from './types.ts'
+ */
+
+import { assert, assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
+import { codePointListToString } from '../../text/utf16/module.f.mjs'
+import { toArray } from '../../types/list/module.f.mjs'
+import { toHex } from '../oid/module.f.mjs'
+import { name, object, tagger, type } from '../tag/module.f.mjs'
+import { commitPayload, latin1, mergePayload } from '../testlib.f.mjs'
+import { author, committer, encoding, gpgsig, mergetags, parents, tree, tryRead, validate, write } from './module.f.mjs'
+
+/** @type {(input: readonly number[]) => Commit} */
+const read = input => {
+    const c = tryRead(input)
+    assert(c !== null)
+    return c
+}
+
+/** @type {(lines: readonly string[]) => Commit} */
+const commit = lines => read(latin1(lines.join('\n')))
+
+/** @type {(bytes: readonly number[]) => string} */
+const text = codePointListToString
+
+/** @type {(id: Oid) => string} */
+const hex = id => text(toArray(toHex(id)))
+
+const validate20 = validate(20)
+
+const treeId = 'c5711460da9d5ae7158a951d9d924385419b13ca'
+
+const parentId = '30317689cb0aaba4f927c1980d80e286c69dce85'
+
+const who = 'A <a@b> 1 +0000'
+
+/** The headers every rule below starts from: a commit `git fsck` accepts. */
+const lines = [`tree ${treeId}`, `parent ${parentId}`, `author ${who}`, `committer ${who}`, '', 'm']
+
+/** @type {(i: number, line: string) => Commit} */
+const replaced = (i, line) => commit(lines.map((l, j) => j === i ? line : l))
+
+/** @type {(i: number) => Commit} */
+const without = i => commit(lines.filter((_, j) => j !== i))
+
+export const proof = {
+    // The real signed merge commit of this repository: tree, two parents,
+    // author, committer, its signature, no encoding and no mergetag;
+    // vouched for, and written back to the same bytes.
+    merge: () => {
+        const c = read(commitPayload)
+        assertEq(hex(tree(c)), treeId)
+        assertStructurallySame(parents(c).map(hex), [parentId, '261b9142dfe024d8e8e009b0e97f6e52ea981c8d'])
+        assertEq(text(toArray(author(c).name)), 'Sergey Shandar')
+        assertEq(author(c).time, 1789011254n)
+        assertEq(text(toArray(committer(c).email)), 'noreply@github.com')
+        assertEq(committer(c).tz, '+0000')
+        assertEq(encoding(c), null)
+        const sig = gpgsig(c)
+        assert(sig !== null)
+        assertEq(text(toArray(sig)).split('\n').length, 17)
+        assertStructurallySame(mergetags(c), [])
+        assertStructurallySame(validate20(c), ['ok', c])
+        assertStructurallySame(toArray(write(c)), commitPayload)
+    },
+    // A merge of a signed tag, as Git wrote it: the tag comes back whole
+    // out of the `mergetag` header, its own signature in its message, and
+    // names the second parent.
+    mergetag: () => {
+        const c = read(mergePayload)
+        assertEq(hex(tree(c)), '3a3e4ab4cfbdacbc05f5721ad4aa7877a8004de4')
+        const [t] = mergetags(c)
+        assert(t !== undefined)
+        assertEq(mergetags(c).length, 1)
+        assertEq(hex(object(t)), hex(parents(c)[1]))
+        assertEq(type(t), 'commit')
+        assertEq(text(toArray(name(t))), 'vt')
+        const by = tagger(t)
+        assert(by !== null)
+        assertEq(by.time, 1700000100n)
+        assertEq(committer(c).time, 1700000200n)
+        const message = text(toArray(t.message)).split('\n')
+        assertStructurallySame([message[0], message[1], message[6]], ['Topic tag', '-----BEGIN SSH SIGNATURE-----', '-----END SSH SIGNATURE-----'])
+        assert(gpgsig(c) !== null)
+        assertStructurallySame(validate20(c), ['ok', c])
+        assertStructurallySame(toArray(write(c)), mergePayload)
+    },
+    // A root commit has no parent; `author` and `committer` sit right after
+    // the tree. An `encoding` is read by key.
+    root: () => {
+        const c = commit([`tree ${treeId}`, `author ${who}`, `committer ${who}`, 'encoding latin1', '', ''])
+        assertStructurallySame(parents(c), [])
+        assertEq(text(toArray(author(c).name)), 'A')
+        assertEq(text(toArray(committer(c).name)), 'A')
+        assertStructurallySame(toArray(encoding(c) ?? []), latin1('latin1'))
+        assertEq(gpgsig(c), null)
+        assertStructurallySame(validate20(c), ['ok', c])
+    },
+    // The other id width, and each width refuses the other's id.
+    sha256: () => {
+        const c = commit([`tree ${'ab'.repeat(32)}`, `parent ${'cd'.repeat(32)}`, `author ${who}`, `committer ${who}`, '', ''])
+        assertStructurallySame(validate(32)(c), ['ok', c])
+        assertStructurallySame(validate20(c), ['error', 'not a tree id'])
+        assertStructurallySame(validate(32)(commit(lines)), ['error', 'not a tree id'])
+    },
+    // What `fsck` only notes passes: a header between committer and the
+    // end, a `parent` after author, which is another header, not a parent.
+    noted: () => {
+        const extra = commit([...lines.slice(0, 4), 'note x', ...lines.slice(4)])
+        assertStructurallySame(validate20(extra), ['ok', extra])
+        const late = commit([...lines.slice(0, 4), `parent ${parentId}`, ...lines.slice(4)])
+        assertStructurallySame(validate20(late), ['ok', late])
+        assertEq(parents(late).length, 1)
+    },
+    // Each refusal, one per rule, on a commit the reader reads.
+    validate: () => {
+        assertStructurallySame(validate20(without(0)), ['error', 'no tree'])
+        assertStructurallySame(validate20(commit(['', ''])), ['error', 'no tree'])
+        assertStructurallySame(validate20(replaced(0, `tree ${treeId.slice(1)}`)), ['error', 'not a tree id'])
+        assertStructurallySame(validate20(replaced(1, `parent ${parentId}0`)), ['error', 'not a parent id'])
+        assertStructurallySame(validate20(replaced(1, 'parent zz')), ['error', 'not a parent id'])
+        assertStructurallySame(validate20(without(2)), ['error', 'no author'])
+        assertStructurallySame(validate20(commit(lines.slice(0, 2).concat(['', '']))), ['error', 'no author'])
+        assertStructurallySame(validate20(replaced(2, 'author A <a@b> 1')), ['error', 'not an author'])
+        assertStructurallySame(validate20(without(3)), ['error', 'no committer'])
+        assertStructurallySame(validate20(replaced(3, `author ${who}`)), ['error', 'no committer'])
+        assertStructurallySame(validate20(replaced(3, 'committer A <a@b> x +0000')), ['error', 'not a committer'])
+        const bad = commit([...lines.slice(0, 4), 'mergetag object zz', ' type commit', ' tag t', ' ', ' m', ...lines.slice(4)])
+        assertStructurallySame(validate20(bad), ['error', 'not a mergetag'])
+        const notATag = commit([...lines.slice(0, 4), 'mergetag object', ...lines.slice(4)])
+        assertStructurallySame(validate20(notATag), ['error', 'not a mergetag'])
+    },
+    // The well-known fields panic on a commit `validate` refuses.
+    throw: {
+        noTree: () => tree(without(0)),
+        notATreeId: () => tree(replaced(0, 'tree zz')),
+        notAParentId: () => parents(replaced(1, 'parent zz')),
+        noAuthor: () => author(without(2)),
+        notAnAuthor: () => author(replaced(2, 'author A')),
+        noCommitter: () => committer(without(3)),
+        notACommitter: () => committer(replaced(3, 'committer A')),
+        notAMergetag: () => mergetags(commit([...lines.slice(0, 4), 'mergetag x', ...lines.slice(4)])),
+    },
+}

--- a/fjs/git/commit/proof.f.mjs
+++ b/fjs/git/commit/proof.f.mjs
@@ -130,6 +130,23 @@ export const proof = {
         assertStructurallySame(validate20(bad), ['error', 'not a mergetag'])
         const notATag = commit([...lines.slice(0, 4), 'mergetag object', ...lines.slice(4)])
         assertStructurallySame(validate20(notATag), ['error', 'not a mergetag'])
+        // A NUL in any header is refused before anything else is looked at;
+        // one in the message, after everything else.
+        assertStructurallySame(validate20(replaced(3, `committer ${who}\0`)), ['error', 'NUL in header'])
+        assertStructurallySame(validate20(commit([...lines.slice(0, 4), 'no\0te x', ...lines.slice(4)])), ['error', 'NUL in header'])
+        assertStructurallySame(validate20(commit(['\0 x', '', ''])), ['error', 'NUL in header'])
+        assertStructurallySame(validate20(replaced(5, 'm\0')), ['error', 'NUL in message'])
+        assertStructurallySame(validate20(commit([...lines.slice(0, 4), 'mergetag x', '', 'm\0'])), ['error', 'not a mergetag'])
+    },
+    // Git puts no bound on the parents: a merge of eight thousand is read,
+    // vouched for, and walked without a stack to run out of.
+    octopus: () => {
+        const ps = Array.from({ length: 8000 }, (_, i) => `parent ${i.toString(16).padStart(40, '0')}`)
+        const c = commit([`tree ${treeId}`, ...ps, `author ${who}`, `committer ${who}`, '', 'm'])
+        assertEq(parents(c).length, 8000)
+        assertEq(hex(parents(c)[7999]), '1f3f'.padStart(40, '0'))
+        assertEq(text(toArray(committer(c).name)), 'A')
+        assertStructurallySame(validate20(c), ['ok', c])
     },
     // The well-known fields panic on a commit `validate` refuses.
     throw: {

--- a/fjs/git/commit/proof.f.mjs
+++ b/fjs/git/commit/proof.f.mjs
@@ -7,8 +7,8 @@ import { assert, assertEq, assertStructurallySame } from '../../asserts/module.f
 import { codePointListToString } from '../../text/utf16/module.f.mjs'
 import { toArray } from '../../types/list/module.f.mjs'
 import { toHex } from '../oid/module.f.mjs'
-import { name, object, tagger, type } from '../tag/module.f.mjs'
-import { commitPayload, latin1, mergePayload } from '../testlib.f.mjs'
+import { name, object, tagger, type, write as writeTag } from '../tag/module.f.mjs'
+import { commitPayload, latin1, mergePayload, tagPayload } from '../testlib.f.mjs'
 import { author, committer, encoding, gpgsig, mergetags, parents, tree, tryRead, validate, write } from './module.f.mjs'
 
 /** @type {(input: readonly number[]) => Commit} */
@@ -90,6 +90,18 @@ export const proof = {
         assertStructurallySame(validate20(c), ['ok', c])
         assertStructurallySame(toArray(write(c)), mergePayload)
     },
+    // A tag folded into a `mergetag` header as Git folds it — SP before
+    // each line, so the tag's last LF ends the header — comes back byte
+    // for byte, all 432 of them, and not one short.
+    folded: () => {
+        const folded = `mergetag ${text(tagPayload).slice(0, -1).replaceAll('\n', '\n ')}`
+        const c = commit([...lines.slice(0, 4), folded, ...lines.slice(4)])
+        assertStructurallySame(validate20(c), ['ok', c])
+        const [t] = mergetags(c)
+        assert(t !== undefined)
+        assertStructurallySame(toArray(writeTag(t)), tagPayload)
+        assertEq(tagPayload.length, 432)
+    },
     // A root commit has no parent; `author` and `committer` sit right after
     // the tree. An `encoding` is read by key.
     root: () => {
@@ -116,6 +128,10 @@ export const proof = {
         const late = commit([...lines.slice(0, 4), `parent ${parentId}`, ...lines.slice(4)])
         assertStructurallySame(validate20(late), ['ok', late])
         assertEq(parents(late).length, 1)
+        // A header list that ends in its parents: the run reaches the end.
+        const last = commit([...lines.slice(0, 2), '', ''])
+        assertEq(parents(last).length, 1)
+        assertEq(hex(parents(last)[0]), parentId)
     },
     // Each refusal, one per rule, on a commit the reader reads.
     validate: () => {

--- a/fjs/git/commit/proof.f.mjs
+++ b/fjs/git/commit/proof.f.mjs
@@ -35,7 +35,11 @@ const parentId = '30317689cb0aaba4f927c1980d80e286c69dce85'
 
 const who = 'A <a@b> 1 +0000'
 
-/** The headers every rule below starts from: a commit `git fsck` accepts. */
+/**
+ * The headers every rule below starts from: a commit `git fsck` accepts.
+ *
+ * @type {readonly string[]}
+ */
 const lines = [`tree ${treeId}`, `parent ${parentId}`, `author ${who}`, `committer ${who}`, '', 'm']
 
 /** @type {(i: number, line: string) => Commit} */

--- a/fjs/git/commit/proof.f.mjs
+++ b/fjs/git/commit/proof.f.mjs
@@ -29,11 +29,11 @@ const hex = id => text(toArray(toHex(id)))
 
 const validate20 = validate(20)
 
-const treeId = 'c5711460da9d5ae7158a951d9d924385419b13ca'
+const treeId = /** @type {const} */ ('c5711460da9d5ae7158a951d9d924385419b13ca')
 
-const parentId = '30317689cb0aaba4f927c1980d80e286c69dce85'
+const parentId = /** @type {const} */ ('30317689cb0aaba4f927c1980d80e286c69dce85')
 
-const who = 'A <a@b> 1 +0000'
+const who = /** @type {const} */ ('A <a@b> 1 +0000')
 
 /**
  * The headers every rule below starts from: a commit `git fsck` accepts.

--- a/fjs/git/commit/types.ts
+++ b/fjs/git/commit/types.ts
@@ -1,0 +1,16 @@
+/**
+ * Type-level API of a commit.
+ *
+ * @module
+ */
+
+import type { Payload } from '../header/types.ts'
+
+/**
+ * A commit is its header list and its message, and nothing else: the
+ * shape a tag has too, read by the same grammar. `tree`, `parent`,
+ * `author` and `committer` are the headers Git reads by position,
+ * `encoding`, `gpgsig` and `mergetag` the ones it reads by key, and the
+ * functions of `./module.f.mjs` read them off the list.
+ */
+export type Commit = Payload

--- a/fjs/git/header/module.f.mjs
+++ b/fjs/git/header/module.f.mjs
@@ -106,6 +106,15 @@ export const valueAt = (p, i, key) => {
 }
 
 /**
+ * The values of every header whose key is `key`, in order: the headers
+ * Git reads by key rather than position, `encoding`, `gpgsig` and
+ * `mergetag` among them, wherever they sit in the list.
+ *
+ * @type {(p: Payload, key: string) => readonly Bytes[]}
+ */
+export const valuesOf = (p, key) => p.headers.flatMap(h => keyIs(h, key) ? [h[1]] : [])
+
+/**
  * Whether a NUL sits in any header, key or value: the grammar reads one,
  * since a key is any byte but SP and LF and a value any byte at all, and
  * `git fsck` refuses the object as `nulInHeader`, so the `validate` of a

--- a/fjs/git/header/proof.f.mjs
+++ b/fjs/git/header/proof.f.mjs
@@ -6,7 +6,7 @@ import { assert, assertEq, assertStructurallySame } from '../../asserts/module.f
 import { codePointListToString } from '../../text/utf16/module.f.mjs'
 import { fromArrayLike, toArray } from '../../types/list/module.f.mjs'
 import { commitPayload, hole, latin1 } from '../testlib.f.mjs'
-import { hasNulHeader, keyIs, tryRead, valueAt, write } from './module.f.mjs'
+import { hasNulHeader, keyIs, tryRead, valueAt, valuesOf, write } from './module.f.mjs'
 
 /** @type {(input: readonly number[]) => Payload} */
 const read = input => {
@@ -104,6 +104,17 @@ export const proof = {
         assert(hasNulHeader(read([0x61, 0x20, 0, 0x0A, 0x0A])))
         assert(hasNulHeader(read([0x61, 0, 0x20, 0x78, 0x0A, 0x0A])))
         assert(hasNulHeader(read(latin1('a x\nb y\n \0\n\n'))))
+    },
+    // Every header of a key, in order, wherever it sits; none is none.
+    valuesOf: () => {
+        const p = read(commitPayload)
+        assertStructurallySame(valuesOf(p, 'parent').map(toArray), [
+            latin1('30317689cb0aaba4f927c1980d80e286c69dce85'),
+            latin1('261b9142dfe024d8e8e009b0e97f6e52ea981c8d'),
+        ])
+        assertEq(valuesOf(p, 'gpgsig').length, 1)
+        assertStructurallySame(valuesOf(p, 'encoding'), [])
+        assertStructurallySame(valuesOf(p, 'paren'), [])
     },
     // Each refusal: no empty line before the end, a header without SP, a
     // first line beginning with SP, a header without LF.

--- a/fjs/git/header/todo/header-only-object.md
+++ b/fjs/git/header/todo/header-only-object.md
@@ -5,7 +5,7 @@
 
 ### Problem
 
-The header block's grammar in [`fjs/git/header`](../header/module.f.mjs)
+The header block's grammar in [`fjs/git/header`](../module.f.mjs)
 reads `headers`, one empty line, and the message to the end, so a commit
 or a tag whose bytes end right after its last header's LF — no empty
 line, no message — is refused by `tryRead` with `null`. Git accepts such
@@ -38,5 +38,5 @@ waits for a consumer that meets such an object.
 
 ### Related
 
-- [`fjs/git/README.md`](../README.md) — the header block, and reading
+- [`fjs/git/README.md`](../../README.md) — the header block, and reading
   versus vouching.

--- a/fjs/git/oid/module.f.mjs
+++ b/fjs/git/oid/module.f.mjs
@@ -58,13 +58,16 @@ export const tryFromHexOf = oidBytes => hex => {
  * An id's hex spelling, two small-letter digits a byte: the inverse of
  * {@link tryFromHex}, and what Git writes.
  *
- * @throws On a `Vec` that is not whole bytes: `Oid` is the type's name for
- * one that is, and a caller can build any `Vec`, so the spelling refuses
- * rather than pad the last byte and spell an id that reads back wider.
+ * @throws On a `Vec` that is not whole bytes, or is empty: `Oid` is the
+ * type's name for one that is neither, and a caller can build any `Vec`,
+ * so the spelling refuses rather than pad the last byte and spell an id
+ * that reads back wider, or spell nothing, which {@link tryFromHex} does
+ * not read.
  *
  * @type {(oid: Oid) => Bytes}
  */
 export const toHex = oid => {
-    assert(length(oid) % 8n === 0n, ['not whole bytes', oid])
+    const bits = length(oid)
+    assert(bits !== 0n && bits % 8n === 0n, ['not whole bytes', oid])
     return toArray(toBytes(oid)).flatMap(b => [hexDigitCodePoint(b >> 4), hexDigitCodePoint(b & 15)])
 }

--- a/fjs/git/oid/proof.f.mjs
+++ b/fjs/git/oid/proof.f.mjs
@@ -1,5 +1,5 @@
 import { assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
-import { length, maxLengthBytes, msb, u8List, vec } from '../../types/bit_vec/module.f.mjs'
+import { empty, length, maxLengthBytes, msb, u8List, vec } from '../../types/bit_vec/module.f.mjs'
 import { toArray } from '../../types/list/module.f.mjs'
 import { hole, latin1 } from '../testlib.f.mjs'
 import { toHex, tryFromHex, tryFromHexOf } from './module.f.mjs'
@@ -60,5 +60,7 @@ export const proof = {
         // A one-bit `Vec` is no id: spelled, it would pad to `80` and read
         // back as a byte.
         notWholeBytes: () => toHex(vec(1n)(1n)),
+        // No bytes is no id either: `tryFromHex` reads no hex of none.
+        empty: () => toHex(empty),
     },
 }

--- a/fjs/git/tag/module.f.mjs
+++ b/fjs/git/tag/module.f.mjs
@@ -103,7 +103,9 @@ const isComponent = component =>
  */
 const components = name => {
     const slashes = name.flatMap((b, i) => b === slash ? [i] : [])
+    /** @type {readonly number[]} */
     const starts = [0, ...slashes.map(i => i + 1)]
+    /** @type {readonly number[]} */
     const ends = [...slashes, name.length]
     return starts.map((start, i) => name.slice(start, ends[i]))
 }

--- a/fjs/git/tag/proof.f.mjs
+++ b/fjs/git/tag/proof.f.mjs
@@ -22,7 +22,7 @@ const tag = lines => read(latin1(lines.join('\n')))
 /** @type {(bytes: readonly number[]) => string} */
 const text = codePointListToString
 
-const id = '9fed27590671460cacf76884f17cd2a4b17f7220'
+const id = /** @type {const} */ ('9fed27590671460cacf76884f17cd2a4b17f7220')
 
 const validate20 = validate(20)
 

--- a/fjs/git/testlib.f.mjs
+++ b/fjs/git/testlib.f.mjs
@@ -171,3 +171,52 @@ export const tagPayload = latin1([
     '+AQ=',
     '-----END SSH SIGNATURE-----',
     '',].join('\n'))
+
+/**
+ * A merge of a signed tag, as `git cat-file commit` prints it: written by
+ * Git 2.43 in the same scratch repository as {@link tagPayload}, with the
+ * tag it merged carried whole in a `mergetag` header, one of its
+ * continuation lines empty, and the commit's own SSH signature in
+ * `gpgsig`. Its id is `9880b6949363a320bb2a534e6de86d72d2206a14`, over
+ * 1354 bytes. The lines are joined by LF, and the last one is empty
+ * because the message ends in LF.
+ *
+ * @type {readonly number[]}
+ */
+export const mergePayload = latin1([
+    'tree 3a3e4ab4cfbdacbc05f5721ad4aa7877a8004de4',
+    'parent 6f9b6538ae436d8f14a748463c8d2d348d5ed134',
+    'parent c7571226b6d0c9fe865510e72c935f157425a651',
+    'author Proof <proof@example.com> 1700000200 +0100',
+    'committer Proof <proof@example.com> 1700000200 +0100',
+    'mergetag object c7571226b6d0c9fe865510e72c935f157425a651',
+    ' type commit',
+    ' tag vt',
+    ' tagger Proof <proof@example.com> 1700000100 +0100',
+    ' ',
+    ' Topic tag',
+    ' -----BEGIN SSH SIGNATURE-----',
+    ' U1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgrLzsfFISF4by8Q+FKz27YpkK1USsBB+m',
+    ' amu1QkJnbDsAAAADZ2l0AAAAAAAAAAZzaGE1MTIAAABTAAAAC3NzaC1lZDI1NTE5AAAAQEuKvuyn',
+    ' 58HE2hZtPeJlmZmDOBqs1eIBIflKZ3g3/A0DUSmnv3VihiiIkcTkhcWrrtkxwfT++0eVHwpAtevU',
+    ' SQc=',
+    ' -----END SSH SIGNATURE-----',
+    'gpgsig -----BEGIN SSH SIGNATURE-----',
+    ' U1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgrLzsfFISF4by8Q+FKz27YpkK1USsBB+m',
+    ' amu1QkJnbDsAAAADZ2l0AAAAAAAAAAZzaGE1MTIAAABTAAAAC3NzaC1lZDI1NTE5AAAAQOkgfUZ0',
+    ' PYhR8NUO38KbMwUG6hmeXlshRAhlMR8uXXcck2TAgQ4vyj0xeLm47mHwTm0GBA0ukY2+AQEZrm9m',
+    ' UAw=',
+    ' -----END SSH SIGNATURE-----',
+    '',
+    'Merge tag \'vt\'',
+    '',
+    'Topic tag',
+    '',
+    '# -----BEGIN SSH SIGNATURE-----',
+    '# U1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgrLzsfFISF4by8Q+FKz27YpkK1USsBB+m',
+    '# amu1QkJnbDsAAAADZ2l0AAAAAAAAAAZzaGE1MTIAAABTAAAAC3NzaC1lZDI1NTE5AAAAQEuKvuyn',
+    '# 58HE2hZtPeJlmZmDOBqs1eIBIflKZ3g3/A0DUSmnv3VihiiIkcTkhcWrrtkxwfT++0eVHwpAtevU',
+    '# SQc=',
+    '# -----END SSH SIGNATURE-----',
+    '# gpg verification failed.',
+    '',].join('\n'))

--- a/fjs/git/todo/header-only-object.md
+++ b/fjs/git/todo/header-only-object.md
@@ -1,0 +1,42 @@
+## A commit or a tag with no empty line: headers to the end of the object
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+The header block's grammar in [`fjs/git/header`](../header/module.f.mjs)
+reads `headers`, one empty line, and the message to the end, so a commit
+or a tag whose bytes end right after its last header's LF — no empty
+line, no message — is refused by `tryRead` with `null`. Git accepts such
+an object: `git hash-object -t commit` writes it and `git fsck` reports
+nothing, since `fsck` reads the headers it needs and stops. None of
+Git's own writers make one — `commit-tree` and `mktag` always write the
+empty line — so one comes from a hand-made object or another tool, and
+old history may hold some.
+
+### Proposal
+
+Read it, and write it back byte for byte, which is the part that needs a
+decision: `Payload` has one `message`, and an empty message after an empty
+line and no empty line at all are two objects with one value under that
+type. Either the empty line becomes optional in the grammar and
+`message` becomes `Nullable<Bytes>`, `null` for the object with no empty
+line, which is a change to `Payload` every reader shares; or the reader
+accepts the form and the writer normalises it, which breaks the
+byte-for-byte promise the signature work relies on. The first is right
+and the second is not; the first is a breaking change to `Payload` and
+waits for a consumer that meets such an object.
+
+### Tasks
+
+- [ ] `payload` with the empty line and the message optional, LL(1) as
+      the block is: after the headers comes LF or the end of input.
+- [ ] `message: Nullable<Bytes>`, and the writer that puts back no empty
+      line for `null`.
+- [ ] A fixture made with `git hash-object`, read and written back.
+
+### Related
+
+- [`fjs/git/README.md`](../README.md) — the header block, and reading
+  versus vouching.

--- a/todo/git-objects.md
+++ b/todo/git-objects.md
@@ -408,12 +408,16 @@ approximated:
       [`fjs/git/oid/`](../fjs/git/oid/module.f.mjs) for the hex spelling
       of an id; the proof reads a tag Git signed and writes it back byte
       for byte.
-- [ ] `fjs/git/commit/`: known fields as functions over the header list,
-      `mergetag` through the tag reader, `validate`, and the writer.
+- [x] `fjs/git/commit/`: known fields as functions over the header list,
+      `mergetag` through the tag reader, `validate`, and the writer —
+      shipped as [`fjs/git/commit/`](../fjs/git/commit/module.f.mjs); the
+      proof reads this repository's signed merge commit and a merge of a
+      signed tag, and writes both back byte for byte.
 - [ ] Proofs over real objects: capture a handful with `git cat-file` once
-      — a merge commit with `gpgsig` and `mergetag`, a tree with every
-      mode, a SHA-256 object — and check them in as byte
-      literals; nothing in code calls `git`.
+      — a tree with every mode, a SHA-256 object — and check them in as
+      byte literals; nothing in code calls `git`. Done so far: a signed
+      merge commit, a merge with `mergetag` and `gpgsig`, a signed tag, a
+      root tree with three of the five modes.
 - [ ] Inflate at the boundary: a `.mjs` adapter over `node:zlib` as an
       effect; file the FunctionalScript inflater as its own issue.
 - [ ] File SHA-1, packfiles, refs and the object-store walk as their own


### PR DESCRIPTION
Ships `fjs/git/commit/`, the last object type of [`todo/git-objects.md`](https://github.com/functionalscript/functionalscript/blob/claude/git-commit/todo/git-objects.md).

- **A commit adds no syntax to the header block**, so `tryRead` and `write` are the block's, and the module is the second pass the design describes. `tree`, `parents`, `author` and `committer` are read by position, as Git reads them: `tree` first, `parent` as many times as it repeats, then the two idents. `encoding`, `gpgsig` and `mergetags` are read by key, wherever they sit. All are total on a commit `validate` has accepted; on one it has not, an accessor panics only where the field it reads is missing or malformed. The optional ones are `null` or empty where absent.
- **`mergetags`** hands each `mergetag` value to the tag module's reader, one more pass over the same alphabet. Git folds a tag into the header by putting SP before each of its lines and completing the last, so the LF that ends the tag ends the header too and the header's framing takes it; `mergetags` gives it back, and the tag comes back byte for byte, its own signature in its message, with the id Git gave it recomputable from what `write` returns. The one tag the fold loses, one whose own bytes never ended in LF, is lost for Git's own reader of the header too, and the doc says so.
- **`validate(oidBytes)`** refuses what `git fsck` refuses, saying why: a NUL in any header, no `tree` first or one that is not a hex id of the repository's width, a `parent` that is not one, no `author` after the parents or no `committer` after it, either holding what is not an ident. One check `fsck` does not make, since it never looks inside: a `mergetag` must be a tag the tag module vouches for, so that `mergetags` is total. A NUL in the message, which `fsck` only warns of, is refused too, since no tool of Git's writes one. What `fsck` only notes passes, any other header included.
- **`valuesOf` in `fjs/git/header/`**: every header of a key, in order, the by-key lookup beside `valueAt`.
- **Proof**: this repository's signed merge commit (two parents, a sixteen-line `gpgsig`), and a merge of a signed tag that Git 2.43 wrote in a scratch repository, with the tag in `mergetag`, one of its continuation lines empty, and the merge's own signature in `gpgsig`. Both read, their fields checked, vouched for, and written back to the same bytes. The checked-in 432-byte tag folded into a `mergetag` as Git folds it comes back as the same 432 bytes. Beside them: a root commit with `encoding`, both id widths, a merge of eight thousand parents, what `fsck` only notes, each `validate` refusal, and each field's panic. All git modules at 100% line, branch and function coverage.
- **Filed**: `fjs/git/header/todo/header-only-object.md`, a commit or tag with no empty line, which Git accepts and the header block's grammar refuses; reading it changes `Payload` and is its own PR.
- **Left open on #1940 when it merged**, fixed here: `toHex` in `fjs/git/oid` refuses the empty `Vec`, as it refuses one that is not whole bytes; the component boundaries in `fjs/git/tag` and the tag proof's id are pinned.

Checks the commit task off in the design and lists the module in `fjs/git/README.md`. Left on the design's list: a tree fixture with every mode and a SHA-256 object, the inflate adapter, and the issues to file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdU8wW4oihFS1gj4dUAcPS