### PR TITLE
djs/parser: spell the paragraph separator as an escape

### DIFF
--- a/fjs/media/datajs/parser/proof.f.mjs
+++ b/fjs/media/datajs/parser/proof.f.mjs
@@ -212,7 +212,7 @@ export const proof = {
         refused('\ufeffexport default 1;', 'unexpected symbol at 0')
         refused('export\u00a0default 1;', 'unexpected symbol at 6')
         refused('export default\u2028 1;', 'unexpected symbol at 14')
-        refused('export default 1 ;', 'unexpected symbol at 16')
+        refused('export default 1\u2029;', 'unexpected symbol at 16')
         refused('export default 1;\f', 'unexpected symbol at 17')
         refused('export default 1;\v', 'unexpected symbol at 17')
     },


### PR DESCRIPTION
`fjs/media/datajs/parser/proof.f.mjs:215` held a literal U+2029 PARAGRAPH
SEPARATOR. It renders as nothing, so the line read as

    refused('export default 1 ;', 'unexpected symbol at 16')

-- an apparent stray space before the `;`, paired with an expected offset
of 16 that did not match it. It now reads

    refused('export default 1\u2029;', 'unexpected symbol at 16')

which is the style its three neighbours already use for their own unusual
code points (\ufeff, \u00a0, \u2028 on lines 212-214).

The string is byte-identical, so the case still exercises the same input
and the offset is unchanged.

`npm test` in the nix dev shell: 5642 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
