### PR TITLE
git/oid: the id an object has at the repository's width

### DIFF
--- a/fjs/crypto/sha1/proof.f.mjs
+++ b/fjs/crypto/sha1/proof.f.mjs
@@ -1,17 +1,9 @@
-/**
- * @import { Vec } from '../../types/bit_vec/types.ts'
- * @import { List } from '../../types/list/types.ts'
- * @import { ObjectType } from '../../git/types.ts'
- */
-
 import { assertEq } from '../../asserts/module.f.mjs'
-import { write as writeEnvelope } from '../../git/object/module.f.mjs'
-import { commitPayload, mergePayload, modesTree, rootTree, sha256Commit, sha256Tree, tagPayload } from '../../git/testlib.f.mjs'
 import { utf8 } from '../../text/module.f.mjs'
-import { maxLength, msb, repeat, u8ListToVec, uint, vec } from '../../types/bit_vec/module.f.mjs'
+import { maxLength, repeat, uint, vec } from '../../types/bit_vec/module.f.mjs'
 import { flip } from '../../types/function/module.f.mjs'
-import { map, toArray } from '../../types/list/module.f.mjs'
-import { computeSync, sha256 } from '../sha2/module.f.mjs'
+import { map } from '../../types/list/module.f.mjs'
+import { computeSync } from '../sha2/module.f.mjs'
 import { sha1 } from './module.f.mjs'
 
 const compute = computeSync(sha1)
@@ -23,20 +15,6 @@ const a = vec(8n)(0x61n)
 
 /** @type {(n: bigint) => bigint} */
 const as = n => uint(compute([flip(repeat)(a)(n)]))
-
-const toVec = u8ListToVec(msb)
-
-/**
- * The id Git gives an object: the hash of the envelope ahead of the
- * payload, as {@link writeEnvelope} lays them out.
- *
- * @type {(hash: (list: List<Vec>) => Vec) => (type: ObjectType, payload: readonly number[]) => bigint}
- */
-const idOf = hash => (type, payload) => uint(hash([toVec(toArray(writeEnvelope(type, payload)))]))
-
-const gitId = idOf(compute)
-
-const gitId256 = idOf(computeSync(sha256))
 
 export const proof = {
     // The byte counts a consumer reads, pinned against the bit lengths.
@@ -91,17 +69,6 @@ export const proof = {
         assertEq(uint(sha1.end(sha1.append(full)(state))), uint(compute([a, full])))
         assertEq(uint(compute([a, full])), uint(compute([full, a])))
     },
-    // The checked-in Git objects, each with the id Git computed over
-    // `<type> SP <size> NUL <payload>`: the hash gives Git's answer.
-    git: {
-        commit: () => assertEq(gitId('commit', commitPayload), 0xd2bc56a53b2d6d7c1dc0860dec10435ed479b22dn),
-        merge: () => assertEq(gitId('commit', mergePayload), 0x9880b6949363a320bb2a534e6de86d72d2206a14n),
-        tag: () => assertEq(gitId('tag', tagPayload), 0xb79a8e25df6a75ef83c047b329e730d92ad59decn),
-        rootTree: () => assertEq(gitId('tree', rootTree), 0xb007dac9ff840a9f5f9eaa68747d0c91b44c556bn),
-        modesTree: () => assertEq(gitId('tree', modesTree), 0x5c1f5cdc3637a09fa100a2055ed273b7d91f3d80n),
-        // The other width, from `sha2`, over the objects a SHA-256
-        // repository wrote: the same envelope, the same fold, the other hash.
-        sha256Commit: () => assertEq(gitId256('commit', sha256Commit), 0x8031c3b5f0c291f374148e59909ea8a8f83538e9a412bac9b1f8072e6e6be27fn),
-        sha256Tree: () => assertEq(gitId256('tree', sha256Tree), 0x2f1e8b790adef60b1b58a9fe37ff415972da0e5abd333e171a4f999484eb42b0n),
-    },
+    // The checked-in Git objects, with the ids Git computed, are the proof
+    // of `fjs/git/oid`'s `of`, which is where this hash meets an object.
 }

--- a/fjs/crypto/todo/sha1.md
+++ b/fjs/crypto/todo/sha1.md
@@ -42,8 +42,8 @@ blocks. The standard's
 test vectors are its proof, and the checked-in Git fixtures in
 [`fjs/git/testlib.f.mjs`](../../git/testlib.f.mjs) — each carrying the id
 Git computed over `<type> SP <size> NUL <payload>` — are the proof of the
-`oid` function that chooses the width. Landed; what remains is that function,
-and the detection.
+`oid` function that chooses the width. Both landed; what remains is the
+detection.
 
 Collision detection, if the policy issue asks for it, is a second step in
 the same module, and a second export: `sha1dc` computes the same hash
@@ -64,7 +64,7 @@ picks for the store.
 
 - [x] `fjs/crypto/sha1/module.f.mjs`, with the FIPS 180-4 vectors, and the
       checked-in fixtures' ids at both widths in its proof.
-- [ ] `fjs/git/oid`: an `of(type, payload)` that hashes an object at the
+- [x] `fjs/git/oid`: an `of(type, payload)` that hashes an object at the
       repository's width, SHA-1 or SHA-256, and the fixtures' ids as its
       proof.
 - [ ] Collision detection beside the hash, once

--- a/fjs/crypto/todo/sha1.md
+++ b/fjs/crypto/todo/sha1.md
@@ -62,11 +62,12 @@ picks for the store.
 
 ### Tasks
 
-- [x] `fjs/crypto/sha1/module.f.mjs`, with the FIPS 180-4 vectors, and the
-      checked-in fixtures' ids at both widths in its proof.
+- [x] `fjs/crypto/sha1/module.f.mjs`, with the FIPS 180-4 vectors as its
+      proof; the checked-in fixtures' ids moved to `fjs/git/oid`'s proof
+      with the function below, where the hash meets an object.
 - [x] `fjs/git/oid`: an `of(type, payload)` that hashes an object at the
-      repository's width, SHA-1 or SHA-256, and the fixtures' ids as its
-      proof.
+      repository's width, SHA-1 or SHA-256, and the fixtures' ids at both
+      widths as its proof.
 - [ ] Collision detection beside the hash, once
       [`todo/git-sha1-collisions.md`](../../../todo/git-sha1-collisions.md)
       decides it is the floor; the SHAttered PDFs as the proof it refuses.

--- a/fjs/git/README.md
+++ b/fjs/git/README.md
@@ -34,7 +34,9 @@ what a grammar can and cannot do for the formats.
   `mergetag` by key, the last read as a tag by the tag module, and a
   `validate`.
 - [`oid/`](oid/module.f.mjs) — an object id between its two spellings, the
-  raw bytes a tree entry holds and the hex text a header holds.
+  raw bytes a tree entry holds and the hex text a header holds, and `of`,
+  the id an object has at the repository's width: SHA-1 at 20 bytes,
+  SHA-256 at 32.
 - [`loose/`](loose/module.f.mjs) — a loose object file read through the
   host's `inflate` effect and past its envelope: the one place a real
   repository meets the decoder.
@@ -290,15 +292,14 @@ Each is a limit stated, refused where it is crossed, and none approximated:
   supplies them from `node:zlib` at the host boundary, and
   [`loose/`](loose/module.f.mjs) is its caller. A FunctionalScript inflater
   is [`todo/inflate.md`](../../todo/inflate.md).
-- **An id computed.** Reading an object needs no hash; addressing or
-  verifying one does, and both hashes are here —
+- **An id checked.** Reading an object needs no hash; addressing or
+  verifying one does, and `oid`'s `of` computes it at either width —
   [`fjs/crypto/sha1`](../crypto/sha1/module.f.mjs) for today's
   repositories, [`fjs/crypto/sha2`](../crypto/sha2/module.f.mjs) for
-  SHA-256 ones, each proven on the checked-in objects' ids — but nothing
-  in this module calls them yet: the function from an object to its id at
-  the repository's width is the rest of
-  [`fjs/crypto/todo/sha1.md`](../crypto/todo/sha1.md), and what a trust
-  layer does about a hash that can collide is
+  SHA-256 ones, proven on the checked-in objects' ids — but no reader
+  here checks the id it was given against the object it read: that is
+  the store's business, [`todo/object-store.md`](todo/object-store.md),
+  and what a trust layer does about a hash that can collide is
   [`todo/git-sha1-collisions.md`](../../todo/git-sha1-collisions.md).
 - **Packfiles**, where most objects in a real clone live, so the loose
   reader alone reads a fresh clone poorly: [`todo/packfiles.md`](todo/packfiles.md).

--- a/fjs/git/oid/module.f.mjs
+++ b/fjs/git/oid/module.f.mjs
@@ -1,20 +1,28 @@
 /**
- * An object id between its two spellings: the raw bytes a tree entry holds
- * and the hex text a header holds. Neither knows the repository's id width;
- * a hex of any even length reads to the id it spells, and the width is a
- * check `validate` makes on the object, against the width it is given.
+ * An object id between its two spellings, and from the object it names.
+ * The spellings are the raw bytes a tree entry holds and the hex text a
+ * header holds; neither knows the repository's id width, since a hex of
+ * any even length reads to the id it spells, and the width is a check
+ * `validate` makes on the object, against the width it is given. The id
+ * itself is {@link of}: the hash of the object's bytes at the width the
+ * repository uses, SHA-1 or SHA-256, which is the one place this module
+ * knows the width means a hash.
  *
  * @module
  *
+ * @import { Vec } from '../../types/bit_vec/types.ts'
  * @import { Nullable } from '../../types/nullable/types.ts'
- * @import { Bytes, Oid, OidBytes } from '../types.ts'
+ * @import { Bytes, ObjectType, Oid, OidBytes } from '../types.ts'
  */
 
 import { assert } from '../../asserts/module.f.mjs'
+import { sha1 } from '../../crypto/sha1/module.f.mjs'
+import { computeSync, sha256 } from '../../crypto/sha2/module.f.mjs'
 import { byteArray } from '../../ebnf/byte/module.f.mjs'
 import { hexDigitCodePoint, hexDigitValue } from '../../text/ascii/module.f.mjs'
-import { length, msb, tryU8ListToVec, u8List } from '../../types/bit_vec/module.f.mjs'
+import { length, msb, tryU8ListToVec, u8List, u8ListToVec } from '../../types/bit_vec/module.f.mjs'
 import { toArray } from '../../types/list/module.f.mjs'
+import { write } from '../object/module.f.mjs'
 
 const toVec = tryU8ListToVec(msb)
 
@@ -52,6 +60,45 @@ export const tryFromHex = hex => {
 export const tryFromHexOf = oidBytes => hex => {
     const id = tryFromHex(hex)
     return id !== null && length(id) === BigInt(oidBytes) * 8n ? id : null
+}
+
+const chunkVec = u8ListToVec(msb)
+
+/**
+ * How many bytes of an object go into one `Vec` on the way to the hash:
+ * an object is as long as its author made it and a `Vec` holds 128 KiB,
+ * so the bytes are fed to the hash a piece at a time, each well under the
+ * bound and long enough that the pieces are few.
+ */
+const chunkBytes = /** @type {const} */ (65536)
+
+/**
+ * A byte array as the `Vec`s the hash takes, {@link chunkBytes} at a time
+ * and the last one shorter.
+ *
+ * @type {(bytes: readonly number[]) => readonly Vec[]}
+ */
+const chunks = bytes =>
+    Array.from({ length: Math.ceil(bytes.length / chunkBytes) }, (_, i) => chunkVec(bytes.slice(i * chunkBytes, (i + 1) * chunkBytes)))
+
+/**
+ * The id Git gives an object, at the repository's width: the hash of
+ * `<type> SP <size> NUL <payload>`, as [`fjs/git/object`](../object/module.f.mjs)'s
+ * `write` lays it out — SHA-1 at 20 bytes, the width of every repository
+ * in use today, and SHA-256 at 32. The width is bound once, so a store
+ * that hashes every object it reads chooses the hash once.
+ *
+ * What the id vouches for is the hash's business: in a SHA-1 repository
+ * it is only as strong as SHA-1, and what a trust layer does about that
+ * is [`todo/git-sha1-collisions.md`](../../../todo/git-sha1-collisions.md).
+ *
+ * @throws If an item of the payload is not a byte, as `write` throws.
+ *
+ * @type {(oidBytes: OidBytes) => (type: ObjectType, payload: Bytes) => Oid}
+ */
+export const of = oidBytes => {
+    const hash = oidBytes === 20 ? computeSync(sha1) : computeSync(sha256)
+    return (type, payload) => hash(chunks(byteArray(write(type, payload))))
 }
 
 /**

--- a/fjs/git/oid/module.f.mjs
+++ b/fjs/git/oid/module.f.mjs
@@ -11,6 +11,7 @@
  * @module
  *
  * @import { Vec } from '../../types/bit_vec/types.ts'
+ * @import { List } from '../../types/list/types.ts'
  * @import { Nullable } from '../../types/nullable/types.ts'
  * @import { Bytes, ObjectType, Oid, OidBytes } from '../types.ts'
  */
@@ -21,7 +22,7 @@ import { computeSync, sha256 } from '../../crypto/sha2/module.f.mjs'
 import { byteArray } from '../../ebnf/byte/module.f.mjs'
 import { hexDigitCodePoint, hexDigitValue } from '../../text/ascii/module.f.mjs'
 import { length, msb, tryU8ListToVec, u8List, u8ListToVec } from '../../types/bit_vec/module.f.mjs'
-import { toArray } from '../../types/list/module.f.mjs'
+import { drop, take, toArray } from '../../types/list/module.f.mjs'
 import { write } from '../object/module.f.mjs'
 
 const toVec = tryU8ListToVec(msb)
@@ -73,13 +74,19 @@ const chunkVec = u8ListToVec(msb)
 const chunkBytes = /** @type {const} */ (65536)
 
 /**
- * A byte array as the `Vec`s the hash takes, {@link chunkBytes} at a time
- * and the last one shorter.
+ * An object's bytes as the `Vec`s the hash takes, {@link chunkBytes} at a
+ * time and the last one shorter, made as the hash asks for them: each is
+ * gathered from the front of the list and the rest of the list handed on
+ * for the next, so one chunk is held at a time and never the object as an
+ * array, and an object longer than an array would hold is hashed all the
+ * same.
  *
- * @type {(bytes: readonly number[]) => readonly Vec[]}
+ * @type {(bytes: Bytes) => List<Vec>}
  */
-const chunks = bytes =>
-    Array.from({ length: Math.ceil(bytes.length / chunkBytes) }, (_, i) => chunkVec(bytes.slice(i * chunkBytes, (i + 1) * chunkBytes)))
+const chunks = bytes => () => {
+    const head = toArray(take(chunkBytes)(bytes))
+    return head.length === 0 ? null : { first: chunkVec(head), tail: chunks(drop(chunkBytes)(bytes)) }
+}
 
 /**
  * The id Git gives an object, at the repository's width: the hash of
@@ -98,7 +105,7 @@ const chunks = bytes =>
  */
 export const of = oidBytes => {
     const hash = oidBytes === 20 ? computeSync(sha1) : computeSync(sha256)
-    return (type, payload) => hash(chunks(byteArray(write(type, payload))))
+    return (type, payload) => hash(chunks(write(type, payload)))
 }
 
 /**

--- a/fjs/git/oid/module.f.mjs
+++ b/fjs/git/oid/module.f.mjs
@@ -22,7 +22,7 @@ import { computeSync, sha256 } from '../../crypto/sha2/module.f.mjs'
 import { byteArray } from '../../ebnf/byte/module.f.mjs'
 import { hexDigitCodePoint, hexDigitValue } from '../../text/ascii/module.f.mjs'
 import { length, msb, tryU8ListToVec, u8List, u8ListToVec } from '../../types/bit_vec/module.f.mjs'
-import { drop, take, toArray } from '../../types/list/module.f.mjs'
+import { next, toArray } from '../../types/list/module.f.mjs'
 import { write } from '../object/module.f.mjs'
 
 const toVec = tryU8ListToVec(msb)
@@ -75,17 +75,31 @@ const chunkBytes = /** @type {const} */ (65536)
 
 /**
  * An object's bytes as the `Vec`s the hash takes, {@link chunkBytes} at a
- * time and the last one shorter, made as the hash asks for them: each is
- * gathered from the front of the list and the rest of the list handed on
- * for the next, so one chunk is held at a time and never the object as an
- * array, and an object longer than an array would hold is hashed all the
- * same.
+ * time and the last one shorter, made as the hash asks for them: one chunk
+ * is held at a time and never the object as an array, so an object longer
+ * than an array would hold is hashed all the same.
+ *
+ * The tail the gathering reached is what the next chunk starts from, not
+ * the list with a count dropped from its front: a dropped list walks the
+ * bytes it drops, and a chunk over a list dropped over a list would walk
+ * every byte before it, once per chunk, which is quadratic in the object.
+ * Every byte is walked once here.
  *
  * @type {(bytes: Bytes) => List<Vec>}
  */
 const chunks = bytes => () => {
-    const head = toArray(take(chunkBytes)(bytes))
-    return head.length === 0 ? null : { first: chunkVec(head), tail: chunks(drop(chunkBytes)(bytes)) }
+    let rest = bytes
+    let taken = 0
+    const gathered = Array.from({ length: chunkBytes }, () => {
+        const r = next(rest)
+        if (r === null) { return 0 }
+        rest = r.tail
+        taken += 1
+        return r.first
+    })
+    return taken === 0
+        ? null
+        : { first: chunkVec(taken === chunkBytes ? gathered : gathered.slice(0, taken)), tail: chunks(rest) }
 }
 
 /**

--- a/fjs/git/oid/proof.f.mjs
+++ b/fjs/git/oid/proof.f.mjs
@@ -4,7 +4,7 @@
 
 import { assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
 import { empty, length, maxLengthBytes, msb, u8List, vec } from '../../types/bit_vec/module.f.mjs'
-import { toArray } from '../../types/list/module.f.mjs'
+import { cycle, take, toArray } from '../../types/list/module.f.mjs'
 import { commitPayload, hole, latin1, mergePayload, modesTree, rootTree, sha256Commit, sha256Tree, tagPayload } from '../testlib.f.mjs'
 import { of, toHex, tryFromHex, tryFromHexOf } from './module.f.mjs'
 
@@ -84,10 +84,11 @@ export const proof = {
             assertEq(hex(of32('blob', [])), '473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813')
             assertEq(tryFromHexOf(32)(toHex(of20('blob', []))), null)
         },
-        // A payload longer than one chunk, and longer than a `Vec` holds:
-        // the hash sees every byte whatever the pieces.
+        // A payload longer than one chunk, and longer than a `Vec` holds,
+        // given as a lazy list that is never an array: the hash sees every
+        // byte whatever the pieces.
         long: () => {
-            const payload = Array.from({ length: 200_000 }, (_, i) => i & 0xFF)
+            const payload = take(200_000)(cycle(Array.from({ length: 256 }, (_, i) => i)))
             assertEq(hex(of20('blob', payload)), 'aa0916be0c6aa2ad2eb4173843f154cb9ac1ab5a')
         },
     },

--- a/fjs/git/oid/proof.f.mjs
+++ b/fjs/git/oid/proof.f.mjs
@@ -1,14 +1,25 @@
+/**
+ * @import { Oid } from '../types.ts'
+ */
+
 import { assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
 import { empty, length, maxLengthBytes, msb, u8List, vec } from '../../types/bit_vec/module.f.mjs'
 import { toArray } from '../../types/list/module.f.mjs'
-import { hole, latin1 } from '../testlib.f.mjs'
-import { toHex, tryFromHex, tryFromHexOf } from './module.f.mjs'
+import { commitPayload, hole, latin1, mergePayload, modesTree, rootTree, sha256Commit, sha256Tree, tagPayload } from '../testlib.f.mjs'
+import { of, toHex, tryFromHex, tryFromHexOf } from './module.f.mjs'
 
 /** @type {(hex: string) => readonly number[]} */
 const bytes = hex => {
     const id = tryFromHex(latin1(hex))
     return id === null ? [] : toArray(u8List(msb)(id))
 }
+
+/** @type {(id: Oid) => string} */
+const hex = id => String.fromCharCode(...toArray(toHex(id)))
+
+const of20 = of(20)
+
+const of32 = of(32)
 
 export const proof = {
     // A 20-byte id and a 32-byte one, and back to the same text.
@@ -54,9 +65,36 @@ export const proof = {
         assertEq(tryFromHex(latin1('0 ')), null)
         assertEq(tryFromHex([0x30, 0xE9]), null)
     },
+    // The checked-in Git objects, each with the id Git computed: SHA-1 at
+    // 20 bytes over the five a SHA-1 repository wrote, SHA-256 at 32 over
+    // the two a SHA-256 one wrote, and each refused at the other width by
+    // the reader, since the hash at the other width is some other id.
+    of: {
+        commit: () => assertEq(hex(of20('commit', commitPayload)), 'd2bc56a53b2d6d7c1dc0860dec10435ed479b22d'),
+        merge: () => assertEq(hex(of20('commit', mergePayload)), '9880b6949363a320bb2a534e6de86d72d2206a14'),
+        tag: () => assertEq(hex(of20('tag', tagPayload)), 'b79a8e25df6a75ef83c047b329e730d92ad59dec'),
+        rootTree: () => assertEq(hex(of20('tree', rootTree)), 'b007dac9ff840a9f5f9eaa68747d0c91b44c556b'),
+        modesTree: () => assertEq(hex(of20('tree', modesTree)), '5c1f5cdc3637a09fa100a2055ed273b7d91f3d80'),
+        sha256Commit: () => assertEq(hex(of32('commit', sha256Commit)), '8031c3b5f0c291f374148e59909ea8a8f83538e9a412bac9b1f8072e6e6be27f'),
+        sha256Tree: () => assertEq(hex(of32('tree', sha256Tree)), '2f1e8b790adef60b1b58a9fe37ff415972da0e5abd333e171a4f999484eb42b0'),
+        // The empty blob, the one id every Git user has seen, and a width
+        // is a width: the same bytes at the other give the other's id.
+        emptyBlob: () => {
+            assertEq(hex(of20('blob', [])), 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391')
+            assertEq(hex(of32('blob', [])), '473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813')
+            assertEq(tryFromHexOf(32)(toHex(of20('blob', []))), null)
+        },
+        // A payload longer than one chunk, and longer than a `Vec` holds:
+        // the hash sees every byte whatever the pieces.
+        long: () => {
+            const payload = Array.from({ length: 200_000 }, (_, i) => i & 0xFF)
+            assertEq(hex(of20('blob', payload)), 'aa0916be0c6aa2ad2eb4173843f154cb9ac1ab5a')
+        },
+    },
     throw: {
         nonByte: () => tryFromHex([0x100, 0x30]),
         hole: () => tryFromHex(hole),
+        notAByteInPayload: () => of20('blob', [0x100]),
         // A one-bit `Vec` is no id: spelled, it would pad to `80` and read
         // back as a byte.
         notWholeBytes: () => toHex(vec(1n)(1n)),


### PR DESCRIPTION
Stacked on #1958 (`claude/git-sha1`); only the commit above that branch is this PR.

Ships `of` in `fjs/git/oid/`, the second task of [`fjs/crypto/todo/sha1.md`](https://github.com/functionalscript/functionalscript/blob/claude/git-oid-of/fjs/crypto/todo/sha1.md) and the first place anything in `fjs/git` calls a hash.

- **`of(oidBytes)(type, payload)`** is the id Git gives an object: the hash of `<type> SP <size> NUL <payload>` as `fjs/git/object`'s `write` lays it out, SHA-1 at 20 bytes and SHA-256 at 32. The width is bound once, so a store that hashes every object it reads chooses the hash once. The bytes are fed to the hash 64 KiB at a time, so an object longer than a `Vec` is hashed whole and never held as one.
- **Proof**: every checked-in Git object's id at its width — the five a SHA-1 repository wrote through `of(20)`, the two a SHA-256 one wrote through `of(32)` — moved here from the sha1 proof, since this is where the hash meets an object; the empty blob at both widths, with the SHA-1 id refused as a SHA-256 one by the reader; a 200,000-byte payload, longer than one chunk and than a `Vec`, against the id Git computes; and a payload holding a non-byte, which throws as `write` throws. `fjs/crypto/sha1`'s proof keeps the standard's vectors and says where the Git ones went. 100% line, branch and function coverage.
- **Docs**: the git README lists `of` under `oid/`, and its "what is not here" now says the id is computed and what is still missing is the store's check of a given id against the object read, `fjs/git/todo/object-store.md`. The SHA-1 issue ticks its second task and keeps the third, collision detection, for `todo/git-sha1-collisions.md` to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdU8wW4oihFS1gj4dUAcPS

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdU8wW4oihFS1gj4dUAcPS)_