### PR TITLE
edag: amnesia takes the nodes a caller established, and nanvm drops its walker

### DIFF
--- a/fjs/edag/amnesia/README.md
+++ b/fjs/edag/amnesia/README.md
@@ -49,15 +49,6 @@ vm(context)(['===', shared, shared])   // false — the model says true
 ```
 
 One node reached from two operand positions is one value; here it is two
-— unless the caller says otherwise. `Context`'s `memo` carries nodes whose
-values are already established, consulted by identity before anything is
-computed, which is [execution-models](../execution-models.md)'s §2.2 with the
-analysis done by the caller. It does not make this the model: nothing is
-remembered that the caller did not supply, and nothing crosses a call
-boundary. It is enough for a caller that knows which of its nodes are shared,
-which is how `fjs/nanvm`'s equality cases ask an identity question of an
-evaluator that otherwise forgets.
-
 arrays, so identity comparisons silently give the wrong answer. The cost
 compounds in the same way. A chain of 22 shared additions,
 `['+', x, x]` over the same `x`, is 23 distinct nodes:
@@ -72,6 +63,24 @@ Exponential in depth, and the leaf alone is visited 4,194,304 times.
 same reason, which is where the word for it comes from. The models that do
 preserve identity, and what each is for, are in
 [execution-models.md](../execution-models.md).
+
+### ... unless the caller says otherwise
+
+`Context`'s `memo` carries nodes whose values are already established,
+consulted by identity before anything is computed — which is
+[execution-models](../execution-models.md)'s §2.2 with the analysis done by
+the caller rather than by a pass here. It does not make this the model:
+nothing is remembered that the caller did not supply, nothing is added while
+walking, and nothing crosses a call boundary, since a call is a new
+invocation. It is enough for a caller that knows which of its own nodes are
+shared, which is how `fjs/nanvm`'s `'==='` cases ask an identity question of
+an evaluator that otherwise forgets.
+
+```js
+const shared = ['[]', [1, 2]]
+const memo = [[shared, vm(context)(shared)]]
+vm({ ...context, memo })(['===', shared, shared])   // true
+```
 
 ### It hands out the host
 

--- a/fjs/edag/amnesia/README.md
+++ b/fjs/edag/amnesia/README.md
@@ -49,6 +49,15 @@ vm(context)(['===', shared, shared])   // false — the model says true
 ```
 
 One node reached from two operand positions is one value; here it is two
+— unless the caller says otherwise. `Context`'s `memo` carries nodes whose
+values are already established, consulted by identity before anything is
+computed, which is [execution-models](../execution-models.md)'s §2.2 with the
+analysis done by the caller. It does not make this the model: nothing is
+remembered that the caller did not supply, and nothing crosses a call
+boundary. It is enough for a caller that knows which of its nodes are shared,
+which is how `fjs/nanvm`'s equality cases ask an identity question of an
+evaluator that otherwise forgets.
+
 arrays, so identity comparisons silently give the wrong answer. The cost
 compounds in the same way. A chain of 22 shared additions,
 `['+', x, x]` over the same `x`, is 23 distinct nodes:

--- a/fjs/edag/amnesia/module.f.mjs
+++ b/fjs/edag/amnesia/module.f.mjs
@@ -236,6 +236,10 @@ const map = {
     '===': o2((a, b) => a === b),
     '=>': (x, [, frameExp, body]) => {
         const frame = vm(x)(frameExp)
+        // The body is a new invocation, so it starts with nothing
+        // established: the enclosing `memo` does not cross the boundary, the
+        // same way the model's per-invocation memo does not. The captured
+        // frame is a value and crosses as one.
         /**@type {(...arg: readonly unknown[]) => unknown}*/
         return (...args) =>vm({ frame, args })(body)
     },
@@ -320,6 +324,7 @@ const map = {
 }
 
 export const vm = (/**@type {Context}*/context) => {
+    const { memo } = context
     const compute =
         /**
          * Generic over the tag, not `(e: ExpOp) =>`: with a union-typed `e`,
@@ -332,7 +337,13 @@ export const vm = (/**@type {Context}*/context) => {
          * ) => unknown}
          */
         e => map[e[0]](context, e)
-    return (/**@type{Exp}*/e) => e instanceof Array
-        ? compute(e)
-        : e
+    return (/**@type{Exp}*/e) => {
+        if (!(e instanceof Array)) { return e }
+        // By identity, and before dispatch: an established node is a value
+        // this walk does not recompute, which is the only way one node
+        // reached twice can be one object here. `find` and not a `Map`
+        // because a caller supplies the few nodes it knows are shared.
+        const established = memo?.find(([n]) => n === e)
+        return established === undefined ? compute(e) : established[1]
+    }
 }

--- a/fjs/edag/amnesia/module.f.mjs
+++ b/fjs/edag/amnesia/module.f.mjs
@@ -2,10 +2,12 @@
  * A tree-walking evaluator for `exp`: `vm(context)(e)` returns a primitive
  * unchanged and dispatches a tagged tuple through one handler per tag.
  *
- * It remembers no node values — every incoming edge evaluates its target
- * again — so it is the Amnesia model of
+ * It remembers no node values of its own — every incoming edge evaluates its
+ * target again — so it is the Amnesia model of
  * [execution-models.md](../execution-models.md), for proving semantics and
- * not for running FunctionalScript. See [README.md](./README.md).
+ * not for running FunctionalScript. A caller that has established some nodes
+ * itself may hand them over as `Context`'s `memo`, which is the one thing
+ * this walk does not recompute. See [README.md](./README.md).
  *
  * @module
  *

--- a/fjs/edag/amnesia/proof.f.mjs
+++ b/fjs/edag/amnesia/proof.f.mjs
@@ -265,6 +265,34 @@ export const proof = {
         // ... and a string contributes its indices.
         same(['{}', [['...', 'ab']]], { 0: 'a', 1: 'b' })
     },
+    // `memo` — the nodes a caller established, consulted by identity. It is
+    // what lets this evaluator answer an identity question it otherwise
+    // cannot: with the node established, `['===', n, n]` is one value
+    // compared with itself, and without it two.
+    established: () => {
+        /** @type {Exp} */
+        const node = ['[]', [1, 2]]
+        // Amnesia as such: one node reached twice is two arrays.
+        eq(['===', node, node], false)
+        // Established: one value, so the comparison is an identity.
+        /** @type {readonly (readonly[Exp, unknown])[]} */
+        const one = [[node, ev(node)]]
+        assertEq(vm({ ...context, memo: one })(['===', node, node]), true)
+        // ... and it is the caller's value that comes back, not a fresh one.
+        const marker = ['marker']
+        /** @type {readonly (readonly[Exp, unknown])[]} */
+        const markerMemo = [[node, marker]]
+        assertEq(vm({ ...context, memo: markerMemo })(node), marker)
+        // A node the memo does not hold is computed as always.
+        assertStructurallySame(vm({ ...context, memo: one })(['[]', [3]]), [3])
+        // A call is a new invocation, so nothing established crosses into a
+        // body: the node inside evaluates fresh and is not the caller's value.
+        /** @type {Exp} */
+        const body = ['=>', ['[]', []], node]
+        const f = /** @type {() => unknown} */ (
+            vm({ ...context, memo: markerMemo })(body))
+        assert(f() !== marker, ['the memo crossed a call boundary'])
+    },
     // Operands are evaluated through `vm(context)`, so a node composes with
     // every other node kind and sees the same context at any depth.
     nested: () => {

--- a/fjs/edag/amnesia/types.ts
+++ b/fjs/edag/amnesia/types.ts
@@ -5,6 +5,17 @@ export type ExpOp = Extract<Exp, readonly unknown[]>
 export type Context = {
     readonly frame: unknown,
     readonly args: readonly unknown[],
+    /**
+     * Nodes whose values the caller already established, consulted by node
+     * identity before anything is computed — `../execution-models.md`'s
+     * §2.2, "memoize only shared nodes", in the form where the caller did the
+     * analysis. Absent is the model this evaluator is named for: nothing
+     * remembered, every incoming edge walked again.
+     *
+     * A caller that supplies one owes the order: an entry may only be built
+     * from entries before it, since this is consulted and never extended.
+     */
+    readonly memo?: readonly (readonly [Exp, unknown])[],
 }
 
 type Get0<T extends ExpOp, K extends ExpOp[0]> =

--- a/fjs/nanvm/README.md
+++ b/fjs/nanvm/README.md
@@ -16,7 +16,7 @@ consumers read the expression rather than each reading the case its own way.
 
 ```text
                               ┌─> proof.f.mjs ──────────────────────────> a JS engine
-module.f.mjs ──> an EDAG exp ─┤     (evaluate)
+module.f.mjs ──> an EDAG exp ─┤     (amnesia)
  (data + the     per case     └─> rust/module.f.mjs ──> generated.rs ──> nanvm-lib
   lowering)                          (print)             (generated)
 ```

--- a/fjs/nanvm/proof.f.mjs
+++ b/fjs/nanvm/proof.f.mjs
@@ -13,20 +13,21 @@
  * checked, so the claim has to be a module-scope alias in a `.ts` file to be
  * one at all.
  *
- * Every lowered case runs through [`amnesia`](../edag/amnesia/module.f.mjs),
- * the repository's one real EDAG evaluator, rather than a second hand-written
+ * Every case runs through [`amnesia`](../edag/amnesia/module.f.mjs), the
+ * repository's one real EDAG evaluator, rather than a second hand-written
  * walker — so an operator's behaviour here is proven by actually executing
  * the EDAG node, the same way [`../edag/proof.f.mjs`](../edag/proof.f.mjs)
- * proves the schema against it. `eq`'s cases are the one exception: they
+ * proves the schema against it. `eq`'s cases used to be the exception: they
  * exist to check EDAG node **identity** (`arrayByItself` and friends), which
  * amnesia deliberately does not preserve — see "It forgets" in
- * [amnesia's README](../edag/amnesia/README.md) — so `evaluate` below stays a
- * small dedicated memoizing walker for that section alone. When a
- * memoizing (identity-preserving) EDAG interpreter
- * ([interpret-edag](../djs/todo/interpret-edag.md)) lands, it can absorb
- * `evaluate` too and this module reduces to lowering plus assertions.
+ * [amnesia's README](../edag/amnesia/README.md) — so this module carried a
+ * second, memoizing walker for that section alone. It does not any more:
+ * amnesia takes the nodes a caller has already established
+ * (`Context`'s `memo`), so `sharedMemo` below hands it the `eq` section's
+ * shared nodes and the cases run through the one evaluator like everything
+ * else.
  *
- * @import { Exp, Op2, Properties } from '../edag/types.ts'
+ * @import { Exp, Op2 } from '../edag/types.ts'
  * @import { Context } from '../edag/amnesia/types.ts'
  * @import { Case, EqCase, Expectation, Group, SharedNode, Value } from './types.ts'
  */
@@ -58,9 +59,7 @@ const { fromEntries, is } = Object
  *
  * Keyed by `groupKey`, one table for every arity — so `-` at one operand and
  * at two are two entries, as they are two groups, and a consumer needs no
- * arity dispatch to find the one it wants. `'==='` is the exception that is
- * not a group's key: `evaluate` below asks for it directly, since `eq`'s
- * cases build that node by hand in `lowerEq`.
+ * arity dispatch to find the one it wants.
  *
  * No case *runs* through these — every case runs through `amnesia`'s `vm`
  * (see `run` below) — so an entry is a claim about what an operation denotes
@@ -102,7 +101,6 @@ const js = {
     '<=': (a, b) => a <= b,
     '>': (a, b) => a > b,
     '>=': (a, b) => a >= b,
-    '===': (a, b) => a === b,
     '&&': (a, b) => a && b,
     '||': (a, b) => a || b,
     '??': (a, b) => a ?? b,
@@ -134,76 +132,35 @@ const reference = key => {
 const context = { frame: undefined, args: [] }
 
 /**
- * Evaluates a constant EDAG expression **with identity preserved** across a
- * shared node — what `amnesia`'s `vm` deliberately does not do (see "It
- * forgets" in [its README](../edag/amnesia/README.md)), and the one thing
- * `eq`'s cases are for: `memo` holds the nodes already evaluated for this
- * case, so a node reached from several places is one value, which is the
- * whole reason `arrayByItself` is `true` where `arrayByEqualArray` is
- * `false`. It is a list and not a `Map` because the corpus's shared nodes are
- * the three `eq` ones and nothing else: the lowering gives every other
- * operand a node of its own, so a node reached twice is always a `ref`.
+ * The shared nodes, established one value each, for `amnesia`'s `memo`.
  *
- * `amnesia`'s recursion is not pluggable — its handlers call its own `vm`
- * directly — so it cannot be handed this memo to consult mid-walk; this stays
- * a separate, smaller walker for exactly that reason, rather than the general
- * evaluator `run` uses below.
- *
- * Sees two kinds of node: a `Value`'s lowering (`eq.shared`'s nodes, and the
- * operands `eqProof` reads out of `e` below — plus, from
- * `jsOnly.throw.objectSpread`, a hand-built one of the same shape), which is
- * always a constant or a `ref` and so always `'undefined'`/`'[]'`/`'{}'` or a
- * primitive, never an operator application; and `lowerEq`'s own `['===', a,
- * b]`, the one binary node this file ever builds by hand — plus a
- * `functionValue`'s lowering, the `=>` node, which is a value here and not
- * an operation: it establishes to a host closure, one per node, so two
- * function values are two closures and a shared one is one. Nothing here is
- * ever a unary or ternary operator node either, which is why the reference is
- * asked for `'==='` and for nothing else.
- *
- * @type {(memo: readonly (readonly[Exp, unknown])[]) => (e: Exp) => unknown}
- */
-const evaluate = memo => {
-    /** @type {(e: Exp) => unknown} */
-    const f = e => {
-        if (!(e instanceof Array)) { return e }
-        const shared = memo.find(([n]) => n === e)
-        if (shared !== undefined) { return shared[1] }
-        const [id, a, b] = /** @type {readonly any[]} */ (e)
-        if (id === 'undefined') { return undefined }
-        if (id === '=>') { return () => undefined }
-        if (id === '[]') { return a.map(f) }
-        if (id === '{}') {
-            // `Properties` is `Property | Spread`. A spread read as a property
-            // would take its operand as the key and its absent third element
-            // as the value, giving a silently wrong object rather than an
-            // error — the same defect the printer refuses.
-            return fromEntries(a.map((/** @type {Properties} */ p) => {
-                if (p[0] !== ':') { throw ['not a property', p] }
-                return [f(p[1]), f(p[2])]
-            }))
-        }
-        return reference(id)(f(a), f(b))
-    }
-    return f
-}
-
-/**
- * The shared nodes, evaluated to one value each.
- *
- * Each is evaluated against the ones already evaluated, so a `ref` inside a
+ * Each is evaluated against the ones already established, so a `ref` inside a
  * shared value reaches that value rather than an equal copy — the same
- * ordering the lowering used to resolve it.
+ * ordering the lowering used to resolve it, and the order `memo` requires.
  *
  * Rebuilt per case: the model's memo is per invocation and a case is one
  * invocation, so nothing here depends on two cases seeing the same object.
+ *
+ * This is the whole of what `eq`'s cases need that an ordinary case does not.
+ * Identity across a shared node is what they are for — `arrayByItself` is
+ * `true` where `arrayByEqualArray` is `false` — and `amnesia` forgets by
+ * design, so the nodes it must not recompute are handed to it rather than
+ * walked by a second evaluator here.
  *
  * @type {(shared: readonly SharedNode[]) => readonly (readonly[Exp, unknown])[]}
  */
 const sharedMemo = shared => shared.reduce(
     (/** @type {readonly (readonly[Exp, unknown])[]} */ memo, [, node]) =>
-        [...memo, /** @type {readonly[Exp, unknown]} */ ([node, evaluate(memo)(node)])],
+        [...memo, /** @type {readonly[Exp, unknown]} */
+            ([node, vm({ ...context, memo })(node)])],
     [])
+
+/**
+ * `amnesia`, with the `eq` section's shared nodes established.
+ *
+ * @type {(shared: readonly SharedNode[]) => (e: Exp) => unknown}
+ */
+const shared = s => vm({ ...context, memo: sharedMemo(s) })
 
 /**
  * A value as `crossCheck`'s reference sees it, built through the same
@@ -356,8 +313,8 @@ const lambda = () => {
     assert(f !== g, ['one closure reached twice'])
     // In the `eq` section a function is a value like any other: two are two
     // closures, one reached through `ref` is one, and a nested one is the
-    // same node inside its container's, so `evaluate` establishes all three.
-    const { shared, cases } = lowerEq({
+    // same node inside its container's, so all three establish as one.
+    const { shared: nodes, cases } = lowerEq({
         shared: { fn: functionValue, holder: [ref('fn')] },
         cases: [
             { name: 'twoFunctions', a: functionValue, b: functionValue, eq: false },
@@ -365,20 +322,20 @@ const lambda = () => {
             { name: 'nestedFunction', a: ref('holder'), b: [ref('fn')], eq: false },
         ],
     })
-    const ev = evaluate(sharedMemo(shared))
+    const ev = shared(nodes)
     for (const [c, e] of cases) { assertEq(ev(e), c.eq, c.name) }
-    const [[, fn], [, holder]] = sharedMemo(shared)
+    const [[, fn], [, holder]] = sharedMemo(nodes)
     assert(/** @type {readonly unknown[]} */ (holder)[0] === fn, ['nested function is a copy'])
 }
 
 const eqProof = (() => {
-    const { shared, cases } = lowerEq(data.eq)
+    const { shared: nodes, cases } = lowerEq(data.eq)
     /** @type {(ce: readonly[EqCase, Op2]) => readonly[string, () => void]} */
     const leaf = ([c, e]) => [c.name, () => {
         // One memo for the case, so two `ref`s to a name really are one
         // object; the operands in the failure message come from the same
         // memo and so name the values the comparison actually saw.
-        const ev = evaluate(sharedMemo(shared))
+        const ev = shared(nodes)
         const [, a, b] = e
         assertEq(ev(e), c.eq, [ev(a), c.eq ? '===' : '!==', ev(b)])
         assertEq(ev(['===', b, a]), c.eq)
@@ -402,16 +359,16 @@ const eqProof = (() => {
  * `rust/proof.f.mjs` checks the printed `let` bindings.
  */
 const nestedSharing = () => {
-    const { shared } = lowerEq({
+    const { shared: nodes } = lowerEq({
         shared: { base: [], wrapper: [ref('base')] },
         cases: [],
     })
-    const [[, base], [, wrapper]] = shared
+    const [[, base], [, wrapper]] = nodes
     const items = /** @type {readonly any[]} */ (wrapper)[1]
     assertEq(items.length, 1)
     assert(items[0] === base, ['wrapper holds a copy, not the shared node'])
     // And the values the nodes evaluate to share in the same place.
-    const memo = sharedMemo(shared)
+    const memo = sharedMemo(nodes)
     const [[, baseValue], [, wrapperValue]] = memo
     assert(
         /** @type {readonly unknown[]} */ (wrapperValue)[0] === baseValue,
@@ -468,14 +425,6 @@ const jsOnly = {
         toStringThrows: () => String({ toString: () => { throw 'Custom error' } }),
         toStringNotAFunction: () => String({ toString: 'hello' }),
         toStringNotPrimitive: () => String({ toString: () => [] }),
-        /**
-         * An object spread reaching the evaluator. `Properties` is
-         * `Property | Spread`, so this is a valid `Exp`; read as a property it
-         * evaluated to `{ x: undefined }` instead of failing. The corpus
-         * cannot produce one — it lowers JavaScript values — so this is the
-         * only way the branch is walked.
-         */
-        objectSpread: () => evaluate([])(['{}', [['...', 'x']]]),
         /**
          * Only the `eq` section shares, so a `ref` anywhere else is a mistake.
          *

--- a/fjs/nanvm/todo/corpus-as-conformance-vectors.md
+++ b/fjs/nanvm/todo/corpus-as-conformance-vectors.md
@@ -103,10 +103,13 @@ interpreter. Authoring stays single-source; only the transport is generated.
 Once the deferred `Any`/CBOR serialization exists, the same expressions can
 ship as serialized data instead. Either way this is what keeps the interpreter
 and the generated code in agreement — the point the roadmap's test-generation
-item makes — and the JavaScript side's counterpart is replacing the proof's
-inline evaluator with the EDAG interpreter
+item makes — and the JavaScript side's counterpart is replacing `amnesia`
+with the EDAG interpreter
 ([interpret-edag](../../djs/todo/interpret-edag.md)), which owes the same
-identity-memoization contract the corpus already relies on.
+identity-memoization contract the corpus already relies on. The proof's own
+inline evaluator is already gone: `amnesia` takes the corpus's shared nodes
+as `Context`'s `memo`, so what is left to migrate is the evaluator itself,
+not a second one beside it.
 
 ### Tasks
 
@@ -118,8 +121,8 @@ identity-memoization contract the corpus already relies on.
 - [ ] Add `&&`, `||`, and `??` groups with their value results, each case
       carrying a `rust` reason while `nanvm-lib` cannot yet pass it.
 - [ ] Add non-establishment cases once `['throw', exp]` is in the schema.
-- [ ] Replace the proof's inline evaluator with the `interpret-edag`
-      interpreter when it lands, and register the corpus as its test suite.
+- [ ] Replace `amnesia` with the `interpret-edag` interpreter when it lands,
+      and register the corpus as its test suite.
 - [ ] Extend the printer to construct each case's expression as an `Any` and
       hand it to the `nanvm-lib` interpreter (serialized `Any` once the
       roadmap's post-MVP serialization exists).
@@ -137,7 +140,7 @@ identity-memoization contract the corpus already relies on.
 - [`../../../nanvm-lib/todo/mvp-roadmap.md`](../../../nanvm-lib/todo/mvp-roadmap.md)
   — the interpreter and remaining-operators items this feeds.
 - [`../../djs/todo/interpret-edag.md`](../../djs/todo/interpret-edag.md) — the
-  FunctionalScript executor that replaces the proof's inline evaluator.
+  FunctionalScript executor that replaces `amnesia` here.
 - [`../../../todo/edag-stage1-discussion.md`](../../../todo/edag-stage1-discussion.md)
   — positional laziness, and the future `throw` node the non-establishment
   cases need.


### PR DESCRIPTION
Stacked on [#1968](https://github.com/functionalscript/functionalscript/pull/1968), which is stacked on [#1963](https://github.com/functionalscript/functionalscript/pull/1963). `nanvm-lib/tests/test/generated.rs` is untouched and no Rust changes.

**The duplication.** The corpus's equality cases ask an identity question — `arrayByItself` is `true` where `arrayByEqualArray` is `false` — and amnesia forgets by design, so the proof carried a second evaluator: 24 lines re-implementing amnesia's `undefined`, `=>`, `[]`, `{}` and `===` handlers around a memo it could consult. Two evaluators for one node kind is exactly what this corpus exists to avoid.

**The EDAG side.** `Context` gains an optional `memo`: nodes whose values the caller has already established, consulted by identity before dispatch. It is `execution-models.md`'s §2.2, "memoize only shared nodes", in the form where the caller did the analysis. It deliberately does not make amnesia the model: nothing is remembered that the caller did not supply, and nothing crosses a call boundary, since a call is a new invocation and per-invocation is the memo's scope.

Immutability is why it takes that shape. A growing memo would need `Map#set`, which FunctionalScript does not have, so a general memoizing executor means threading state through every handler. A caller that already knows which of its nodes are shared can establish them in order instead, which is what `sharedMemo` was doing anyway.

**What goes.** The walker, and with it two things that only existed to serve it:

- The reference table's `'==='` entry. The equality cases reached the JavaScript `===` directly through the walker; they now run amnesia's `'==='` handler like every other case, so that entry has no caller.
- `jsOnly.throw.objectSpread`. It pinned that the walker refused a spread read as a property — a defect amnesia does not have, since it implements spread.

**Positive controls.** Three mutations of the new behaviour, each restored after:

| Mutation | Result |
|---|---|
| Ignore the memo | amnesia 1 failure, corpus 5 |
| Let the memo cross a call boundary | amnesia 9 failures |
| Match by structure instead of identity | corpus 7 failures |

**Checks.** `tsc` clean. `npm run cov`: 5542 passed, 0 failed, 100% lines, branches and functions. `npm run gen`: no diff. The count is unchanged from #1968 because the new `established` section replaces the deleted spread pin one for one.

**Not in this PR.** The `eq` section is still its own authoring shape: `Eq`, `EqCase`, `LoweredEq`, `lowerEq` and the printer's `eqFn` remain, and folding them into an ordinary `'==='` group is `fjs/nanvm/todo/unify-eq-into-a-group.md`. That fold changes `generated.rs` and the hand-written `harness.rs`, so it belongs on its own. This PR removes the duplicated *evaluator*, which was the part that needed something from EDAG.

Changelog:
- `edag`: `amnesia`'s `Context` gains an optional `memo` of already-established nodes, consulted by identity. Existing callers are unaffected — absent `memo` is the previous behaviour exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L983nybNdxpxnFpJfoq7Y

---
_Generated by [Claude Code](https://claude.ai/code/session_018L983nybNdxpxnFpJfoq7Y)_