### PR TITLE
AGENTS: a proof typedef is checked only where a statement follows it

### DIFF
--- a/fjs/AGENTS.md
+++ b/fjs/AGENTS.md
@@ -102,10 +102,36 @@ compiles no matter what the predicate resolved to. Such an entry in a `proof`
 object is doubly inert: the runner only invokes functions, so a boolean leaf is
 never counted as a test either.
 
-Some facts have nowhere else to be checked and so *require* one. A `const` type
-parameter is the standing example: dropping the modifier widens every call site
-silently and `tsc` still passes, so the assertion is the only thing standing
-between the signature and a schema quietly typed one notch too loose. See
+A JSDoc `@typedef` **at the end of a block** is inert for a different reason,
+and the reason is worth knowing because the form otherwise works. A JSDoc
+comment is bound to the statement that follows it; with no statement after it
+there is nothing to bind to, so the declaration is never created and its
+constraint is never resolved. `/** @typedef {Assert<Equal<1, 2>>} _Bad */` as
+the last thing in a function body compiles. Put any statement after it and the
+same line is TS2344.
+
+So a proof entry whose body is *nothing but* typedefs checks nothing at all —
+which is what `fjs/edag/proof.f.mjs`'s `consistency` is, and why all 28 of its
+`Assert<Check<…>>` pins are green whatever they claim. Where a typedef is
+followed by an `assert` call, as in `fjs/ebnf/ll1/proof.f.mjs`'s
+`constParameter`, it is checked and does its job.
+
+**Prefer module scope in a `.ts` file**, where a type alias is resolved
+whether or not anything follows or references it, so the claim cannot be
+silenced by an edit that moves a line.
+[`fjs/nanvm/types.ts`](./nanvm/types.ts) and
+[`fjs/types/array/types.ts`](./types/array/types.ts) are the worked cases.
+Keep a typedef in the proof only for a claim about a *local* inference that
+has no module-scope spelling — a `const` type parameter's effect at a call
+site is the standing example — and then make sure a statement follows it.
+[`todo/inert-type-level-proofs.md`](../todo/inert-type-level-proofs.md) tracks
+the ones already written the inert way.
+
+Some facts have nowhere else to be checked and so *require* an assertion. A
+`const` type parameter is the standing example: dropping the modifier widens
+every call site silently and `tsc` still passes, so the assertion is the only
+thing standing between the signature and a schema quietly typed one notch too
+loose. See
 [§3.2](#32-types), "Prefer a `const` type parameter to a cast at the call site".
 
 ### 1.5 Never use `try`/`catch`; test throwing with the `throw` key
@@ -334,9 +360,11 @@ implementation.
 
 No authored `.mjs` may contain a **file-scope** JSDoc `@typedef` — anywhere in
 the repository, whatever the directory or basename. Function-local typedefs are
-allowed, and are the normal home for compile-time proof types (see the
-`consistency` and `signatures` entries in `fjs/edag/proof.f.mjs` and
-`fjs/effects/proof.f.mjs`). A named file-scope type goes to one of:
+allowed. A compile-time proof written as one is checked only where a statement
+follows it, so it belongs at module scope in a `.ts` file unless the claim is
+about a local inference — see
+[§1.4](#14-assert-type-level-facts-with-assertequal). A named file-scope type
+goes to one of:
 
 - the sibling `types.ts` when it is part of the **public declaration closure** —
   public types, plus any private `_` helper a shipped public declaration

--- a/fjs/AGENTS.md
+++ b/fjs/AGENTS.md
@@ -110,11 +110,12 @@ constraint is never resolved. `/** @typedef {Assert<Equal<1, 2>>} _Bad */` as
 the last thing in a function body compiles. Put any statement after it and the
 same line is TS2344.
 
-So a proof entry whose body is *nothing but* typedefs checks nothing at all —
-which is what `fjs/edag/proof.f.mjs`'s `consistency` is, and why all 28 of its
-`Assert<Check<…>>` pins are green whatever they claim. Where a typedef is
-followed by an `assert` call, as in `fjs/ebnf/ll1/proof.f.mjs`'s
-`constParameter`, it is checked and does its job.
+So a proof entry that *ends* with its typedefs checks nothing from there on.
+That is what `fjs/edag/proof.f.mjs`'s `consistency` is — a body of nothing but
+typedefs, all 28 of its `Assert<Check<…>>` pins green whatever they claim —
+and `fjs/effects/proof.f.mjs`'s `signatures`, whose last eight go the same
+way. Where a typedef is followed by an `assert` call, as in
+`fjs/ebnf/ll1/proof.f.mjs`'s `constParameter`, it is checked and does its job.
 
 **Prefer module scope in a `.ts` file**, where a type alias is resolved
 whether or not anything follows or references it, so the claim cannot be

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -123,12 +123,13 @@ export type OptionPropertyLambda =
 // the two option states share — which is what both of these used to do, and
 // what `module.f.mjs`'s `regionProductions` now does once for the schema.
 //
-// These are here and not in `proof.f.mjs` because a `@typedef` inside a
-// function body is never checked — TypeScript does not evaluate the
-// constraint of a declaration nothing references, so that file's entire
-// `consistency` section is green whatever it claims. A module-scope alias in
-// a `.ts` file is checked; `../nanvm/types.ts` is the worked case and
-// `../../todo/inert-type-level-proofs.md` the issue that moves the rest.
+// These are here and not in `proof.f.mjs` because a `@typedef` there is
+// checked only where a statement follows it in the same block. That file's
+// `consistency` entry is nothing but typedefs, so all 28 of its pins are
+// green whatever they claim. A module-scope alias in a `.ts` file is
+// resolved either way; `../nanvm/types.ts` is the worked case, `../AGENTS.md`
+// §1.4 states the rule, and `../../todo/inert-type-level-proofs.md` moves
+// the rest.
 
 type _OptionInsideOptionProperty = Assert<Equal<OptionLambda extends OptionPropertyLambda ? true : false, true>>
 type _PropertyInsideOptionProperty = Assert<Equal<PropertyLambda extends OptionPropertyLambda ? true : false, true>>

--- a/fjs/nanvm/types.ts
+++ b/fjs/nanvm/types.ts
@@ -196,11 +196,13 @@ export type Group = Group1 | Group2 | Group12 | Group3
 // An operand count is a type error rather than a case that runs: a group's
 // count is which EDAG vocabulary its id is in, and `Case<N>` carries it.
 //
-// These are here and not in `proof.f.mjs` because a `@typedef` inside a
-// function body is never checked — TypeScript does not evaluate the
-// constraint of a declaration nothing references, so the same six assertions
-// written there passed with any claim at all. A module-scope alias in a
-// `.ts` file is checked; `../types/array/types.ts` is the precedent.
+// These are here and not in `proof.f.mjs` because a `@typedef` there is
+// checked only where a statement follows it in the same block: a JSDoc
+// comment binds to the next statement, and one with nothing after it is
+// never bound at all. Written as the tail of a proof entry, the same six
+// assertions passed with any claim. A module-scope alias in a `.ts` file is
+// resolved either way; `../types/array/types.ts` is the precedent and
+// `../AGENTS.md` §1.4 states the rule.
 
 type _Unary = Assert<Equal<Case<1>['args'], readonly [Value]>>
 type _Binary = Assert<Equal<Case<2>['args'], readonly [Value, Value]>>

--- a/todo/inert-type-level-proofs.md
+++ b/todo/inert-type-level-proofs.md
@@ -1,28 +1,36 @@
-## inert-type-level-proofs. 89 `Assert<…>` typedefs in proofs check nothing
+## inert-type-level-proofs. 62 `Assert<…>` typedefs in proofs check nothing
 
 **Priority:** P2
 **Status:** open
 
 ### Problem
 
-[`fjs/AGENTS.md` §3.2](../fjs/AGENTS.md) names a function-local JSDoc
+[`fjs/AGENTS.md` §3.2](../fjs/AGENTS.md) named a function-local JSDoc
 `@typedef` as "the normal home for compile-time proof types", pointing at the
 `consistency` and `signatures` entries in `fjs/edag/proof.f.mjs` and
-`fjs/effects/proof.f.mjs`. **TypeScript never evaluates them.** The constraint
-of a declaration nothing references is not resolved, so an `Assert<…>` written
-this way is green whatever it claims.
+`fjs/effects/proof.f.mjs`. Many of those are green whatever they claim.
 
-Two falsifications, each with `tsc` exiting 0 and printing nothing:
+**The mechanism, corrected.** This issue first said TypeScript never evaluates
+a function-local typedef, because "the constraint of a declaration nothing
+references is not resolved". That is not it, and the real rule is narrower and
+sharper: **a JSDoc comment binds to the statement that follows it.** With no
+statement after it there is nothing to bind to, the declaration is never
+created, and its constraint is never resolved. Measured on a scratch file:
 
-```js
-// fjs/edag/proof.f.mjs:177 — claims op1Id's schema matches Op1Id
-/** @typedef {Assert<Check<Op2Id, typeof op1Id>>} _Op1Id */   // Op2Id: still passes
-```
+| form | result |
+| --- | --- |
+| `@typedef` last in a block | inert |
+| any statement after it | TS2344 |
+| three in a row, nothing after | all three inert |
+| three in a row, one statement after | all three flagged |
+| one, a statement, then a trailing one | only the first flagged |
 
-```js
-// fjs/nanvm/proof.f.mjs (before #1776 moved these) — claims a unary case has one operand
-/** @typedef {Assert<Equal<Case<1>['args'], readonly[Value, Value]>>} _Unary */  // still passes
-```
+So a proof entry whose body is *nothing but* typedefs checks nothing, and one
+whose typedefs are followed by an `assert` call works exactly as intended.
+That is the whole difference, and it explains both of the original
+falsifications and why `fjs/ebnf/ll1/proof.f.mjs`'s `constParameter` — a
+typedef followed by `assertStructurallySame` — is genuinely load-bearing:
+falsifying it gives TS2344 at its own line.
 
 The same six assertions moved to module scope in `fjs/nanvm/types.ts` fail
 loudly (`TS2344: Type 'false' does not satisfy the constraint 'true'`) on the
@@ -31,21 +39,30 @@ for.
 
 This is the failure §1.4 already warns about in its other form: it forbids
 `true as _Predicate` because "the assertion compiles no matter what the
-predicate resolved to". A function-local typedef has the identical defect and
-is currently *recommended* — which is why it has spread to **89 typedefs
-across 15 files**:
+predicate resolved to".
 
-| file | count |
-| --- | --- |
-| `fjs/edag/proof.f.mjs` | 24 |
-| `fjs/rtti/parse/proof.f.mjs`, `fjs/rtti/proof.f.mjs`, `fjs/rtti/ts/proof.f.mjs` | 9 each |
-| `fjs/effects/proof.f.mjs`, `fjs/rtti/validate/proof.f.mjs` | 8 each |
-| `fjs/edag/amnesia/proof.f.mjs` | 5 |
-| `fjs/djs/parser/proof.f.mjs`, `fjs/types/object/proof.f.mjs` | 4 each |
-| `fjs/media/json/schema/proof.f.mjs`, `fjs/media/revision/proof.f.mjs`, `fjs/types/result/proof.f.mjs` | 2 each |
-| `fjs/js/keywords/proof.f.mjs`, `fjs/protocol/mcp/proof.f.mjs`, `fjs/types/nullable/proof.f.mjs` | 1 each |
+**The count, measured rather than grepped.** Every single-line `Assert`
+typedef in the repository was falsified at once — its claim replaced by
+`Assert<Equal<1, 2>>`, its name kept so references still resolve — and `tsc`
+run once. A checked one reports TS2344 at its own line; an inert one says
+nothing. Of **116 across 23 files, 54 are checked and 62 are inert**, in nine
+files:
 
-Each is a green leaf asserting nothing. Worse than an absent check: a leaf that
+| file | inert |
+| --- | --: |
+| `fjs/edag/proof.f.mjs` | 28 |
+| `fjs/rtti/ts/proof.f.mjs` | 9 |
+| `fjs/edag/amnesia/proof.f.mjs` | 8 |
+| `fjs/types/object/proof.f.mjs`, `fjs/djs/parser/grammar/proof.f.mjs` | 4 each |
+| `fjs/ebnf/byte/proof.f.mjs` | 3 |
+| `fjs/media/json/schema/proof.f.mjs`, `fjs/media/revision/proof.f.mjs`, `fjs/rtti/proof.f.mjs` | 2 each |
+
+The earlier table counted every typedef in a proof file, including the 54 that
+work. `fjs/effects/proof.f.mjs`, `fjs/rtti/parse/proof.f.mjs`,
+`fjs/rtti/validate/proof.f.mjs` and six others named there have none inert at
+all.
+
+Each inert one is a green leaf asserting nothing. Worse than an absent check: a leaf that
 cannot fail is indistinguishable from one that passes, and it survives the
 refactor that makes its claim false. The `fjs/edag` ones are the sharpest loss
 — they are the `Assert<Check<…>>` pins that the README says keep `types.ts` and
@@ -84,18 +101,25 @@ Per file the target differs, and the choice is the work:
   call site, say — has no `types.ts` home. It needs one written, or the
   claim needs restating as something a module-scope alias can hold.
 
+**Adding a statement after the run would also work**, and is worth naming so
+it is rejected on purpose rather than missed. It leaves the claim one
+reordering away from silent again, in a file whose other entries end with
+their typedefs, so it fixes the instance and not the hazard. Take it only
+where the entry already has statements and its typedefs merely drifted to the
+end.
+
 Do it per directory, so each lands with the `tsc` run that proves the
 moved form bites: falsify each assertion once, see it fail, restore it. An
-assertion moved without that check is the same inert leaf in a new place.
-
-Then correct §3.2 — a function-local `@typedef` is fine for an ordinary
-local type and is *not* a home for a proof — and add the rule to §1.4 beside
-the `true as _Predicate` prohibition it matches.
+assertion moved without that check is the same inert leaf in a new place. The
+whole-repository sweep above is the cheap version of that check and is worth
+re-running after each directory: the inert count should fall by exactly the
+number moved.
 
 ### Tasks
 
-- [ ] Correct `fjs/AGENTS.md` §3.2 and §1.4: a compile-time proof goes at
-      module scope in a `.ts` file, never in a function-local `@typedef`.
+- [x] Correct `fjs/AGENTS.md` §3.2 and §1.4: §3.2 no longer calls a
+      function-local typedef the normal home for a proof, and §1.4 states the
+      binding rule, the measured table, and where a proof belongs.
 - [ ] Move the 24 `fjs/edag/proof.f.mjs` assertions into `fjs/edag/types.ts`,
       falsifying each once to prove the moved form fails. Three chain-state
       pins are already there, added beside the unions they are about when
@@ -105,8 +129,11 @@ the `true as _Predicate` prohibition it matches.
       `_OptionLambda` and `_OptionPropertyLambda` without replacing them —
       those pin the schema against the type, these pin the types to each
       other.
-- [ ] The same for the remaining 14 files, a directory at a time.
-- [ ] `tsc` and `fjs test` clean after each.
+- [ ] The same for the remaining eight files in the table, a directory at a
+      time. Six files the first count named have nothing inert and need no
+      work.
+- [ ] `tsc` and `fjs test` clean after each, and the sweep's inert count
+      down by the number moved.
 
 ### Related
 

--- a/todo/inert-type-level-proofs.md
+++ b/todo/inert-type-level-proofs.md
@@ -1,4 +1,4 @@
-## inert-type-level-proofs. 62 `Assert<…>` typedefs in proofs check nothing
+## inert-type-level-proofs. 70 `Assert<…>` typedefs in proofs check nothing
 
 **Priority:** P2
 **Status:** open
@@ -41,26 +41,30 @@ This is the failure §1.4 already warns about in its other form: it forbids
 `true as _Predicate` because "the assertion compiles no matter what the
 predicate resolved to".
 
-**The count, measured rather than grepped.** Every single-line `Assert`
-typedef in the repository was falsified at once — its claim replaced by
-`Assert<Equal<1, 2>>`, its name kept so references still resolve — and `tsc`
-run once. A checked one reports TS2344 at its own line; an inert one says
-nothing. Of **116 across 23 files, 54 are checked and 62 are inert**, in nine
-files:
+**The count, measured rather than grepped.** Every `Assert` typedef in the
+repository was falsified — the 116 single-line ones by replacing the claim
+with `Assert<Equal<1, 2>>` and keeping the name so references still resolve,
+the 9 multi-line ones by replacing their first type argument — and `tsc` run
+over the falsified tree. A checked one reports TS2344 at its own line; an
+inert one says nothing. Of **125 across 23 files, 55 are checked and 70 are
+inert**, in ten files:
 
 | file | inert |
 | --- | --: |
 | `fjs/edag/proof.f.mjs` | 28 |
 | `fjs/rtti/ts/proof.f.mjs` | 9 |
-| `fjs/edag/amnesia/proof.f.mjs` | 8 |
+| `fjs/edag/amnesia/proof.f.mjs`, `fjs/effects/proof.f.mjs` | 8 each |
 | `fjs/types/object/proof.f.mjs`, `fjs/djs/parser/grammar/proof.f.mjs` | 4 each |
 | `fjs/ebnf/byte/proof.f.mjs` | 3 |
 | `fjs/media/json/schema/proof.f.mjs`, `fjs/media/revision/proof.f.mjs`, `fjs/rtti/proof.f.mjs` | 2 each |
 
-The earlier table counted every typedef in a proof file, including the 54 that
-work. `fjs/effects/proof.f.mjs`, `fjs/rtti/parse/proof.f.mjs`,
-`fjs/rtti/validate/proof.f.mjs` and six others named there have none inert at
-all.
+The first table counted every typedef in a proof file, including the 55 that
+work: `fjs/rtti/parse/proof.f.mjs`, `fjs/rtti/validate/proof.f.mjs`,
+`fjs/types/result/proof.f.mjs`, `fjs/types/nullable/proof.f.mjs`,
+`fjs/protocol/mcp/proof.f.mjs` and `fjs/js/keywords/proof.f.mjs` have none
+inert. `fjs/effects/proof.f.mjs` does, all eight, and every one is
+multi-line — its `signatures` entry ends with them, which is the inert shape
+exactly. §3.2 named that entry alongside `consistency` as a model to follow.
 
 Each inert one is a green leaf asserting nothing. Worse than an absent check: a leaf that
 cannot fail is indistinguishable from one that passes, and it survives the
@@ -120,8 +124,8 @@ number moved.
 - [x] Correct `fjs/AGENTS.md` §3.2 and §1.4: §3.2 no longer calls a
       function-local typedef the normal home for a proof, and §1.4 states the
       binding rule, the measured table, and where a proof belongs.
-- [ ] Move the 24 `fjs/edag/proof.f.mjs` assertions into `fjs/edag/types.ts`,
-      falsifying each once to prove the moved form fails. Three chain-state
+- [ ] Move all 28 inert `fjs/edag/proof.f.mjs` assertions into
+      `fjs/edag/types.ts`, falsifying each once to prove the moved form fails. Three chain-state
       pins are already there, added beside the unions they are about when
       `regionProductions` landed: `OptionLambda` and `PropertyLambda` are
       inside `OptionPropertyLambda`, and the wider state adds exactly three
@@ -129,9 +133,8 @@ number moved.
       `_OptionLambda` and `_OptionPropertyLambda` without replacing them —
       those pin the schema against the type, these pin the types to each
       other.
-- [ ] The same for the remaining eight files in the table, a directory at a
-      time. Six files the first count named have nothing inert and need no
-      work.
+- [ ] The same for the other nine files in the table, a directory at a time.
+      Six files the first count named have nothing inert and need no work.
 - [ ] `tsc` and `fjs test` clean after each, and the sweep's inert count
       down by the number moved.
 


### PR DESCRIPTION
Stacked on [#1985](https://github.com/functionalscript/functionalscript/pull/1985). Four files, all prose. First task of `todo/inert-type-level-proofs.md`.

**The problem.** §3.2 called a function-local JSDoc `@typedef` "the normal home for compile-time proof types" and cited the `consistency` entry in `fjs/edag/proof.f.mjs` and the `signatures` entry in `fjs/effects/proof.f.mjs` as the models. Every assertion in both is green whatever it claims, so the guidance was pointing at two examples of the defect.

**The mechanism is not what the issue said.** It claimed TypeScript never evaluates a function-local typedef, because "the constraint of a declaration nothing references is not resolved". That is too broad, and I only found out because I falsified one that was supposed to be inert and it went red.

| form | result |
| --- | --- |
| `@typedef` last in a block | inert |
| any statement after it | TS2344 |
| three in a row, nothing after | all three inert |
| three in a row, one statement after | all three flagged |
| one, a statement, then a trailing one | only the first flagged |

A JSDoc comment binds to the statement that follows it. With nothing after it there is nothing to bind to, so the declaration is never created and its constraint is never resolved. An intervening comment or blank line does not break the binding; only the absence of a following statement does.

That explains both halves. `consistency` and `signatures` each *end* with their typedefs. `fjs/ebnf/ll1/proof.f.mjs`'s `constParameter`, where an `assertStructurallySame` follows, is genuinely load-bearing — falsify it and you get TS2344 at its own line. AGENTS.md offers that one as the example of an assertion that makes a `const` modifier matter, and it is right to.

**So the count was an overcount.** I measured rather than grepped: every `Assert` typedef in the repository falsified, then one `tsc` run over the falsified tree. The 116 single-line ones by replacing the claim with `Assert<Equal<1, 2>>` and keeping the name so references still resolve; the 9 multi-line ones by replacing their first type argument.

| | total | checked | inert |
|---|--:|--:|--:|
| single-line | 116 | 54 | 62 |
| multi-line | 9 | 1 | 8 |
| **all** | **125** | **55** | **70** |

The 70 inert, by file:

| file | inert |
| --- | --: |
| `fjs/edag/proof.f.mjs` | 28 |
| `fjs/rtti/ts/proof.f.mjs` | 9 |
| `fjs/edag/amnesia/proof.f.mjs`, `fjs/effects/proof.f.mjs` | 8 each |
| `fjs/types/object/proof.f.mjs`, `fjs/djs/parser/grammar/proof.f.mjs` | 4 each |
| `fjs/ebnf/byte/proof.f.mjs` | 3 |
| `fjs/media/json/schema/proof.f.mjs`, `fjs/media/revision/proof.f.mjs`, `fjs/rtti/proof.f.mjs` | 2 each |

Six files the old table named have none inert at all, so the remaining work is nine files rather than fourteen.

**What changed.**

- §1.4 gains the binding rule, the table, and where a proof belongs: module scope in a `.ts` file, where an alias resolves whether or not anything follows or references it. A typedef stays in the proof only for a claim about a local inference with no module-scope spelling, and then needs a statement after it.
- §3.2 no longer calls a function-local typedef the normal home for a proof, and no longer cites `consistency` and `signatures` as models. It points at §1.4.
- The issue carries the corrected mechanism, the measured tables, and its first task ticked. Its proposal now also names the tempting cheap fix — add a statement after the run — and rejects it on purpose: it leaves the claim one reordering away from silent again. Its `fjs/edag` task asks for all 28 rather than the old table's 24.
- `fjs/nanvm/types.ts` and `fjs/edag/types.ts` each carried a comment giving the old explanation. Both now state the binding rule and point at §1.4 rather than restating a version of it.

**Checks.** `tsc -p .` clean on the 7.0.2 CI pins and on 6.0.2. `node ./fjs/module.mjs t`: 5729 passed, 0 failed. `npm run gen`: stable. No new lines over 80 columns.

No code changes, so no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L983nybNdxpxnFpJfoq7Y