### PR TITLE
edag: 28 schema pins moved to where they are checked

### DIFF
--- a/fjs/AGENTS.md
+++ b/fjs/AGENTS.md
@@ -111,10 +111,12 @@ the last thing in a function body compiles. Put any statement after it and the
 same line is TS2344.
 
 So a proof entry that *ends* with its typedefs checks nothing from there on.
-That is what `fjs/edag/proof.f.mjs`'s `consistency` is — a body of nothing but
-typedefs, all 28 of its `Assert<Check<…>>` pins green whatever they claim —
-and `fjs/effects/proof.f.mjs`'s `signatures`, whose last eight go the same
-way. Where a typedef is followed by an `assert` call, as in
+`fjs/effects/proof.f.mjs`'s `signatures` is the standing example: its last
+eight `Assert<Equal<…>>` have no statement after them and are green whatever
+they claim. `fjs/edag/proof.f.mjs`'s `consistency` was the extreme of it — a
+body of nothing but typedefs, so all 28 of its `Assert<Check<…>>` pins were
+inert — which is why those now sit at module scope in `fjs/edag/types.ts`.
+Where a typedef is followed by an `assert` call, as in
 `fjs/ebnf/ll1/proof.f.mjs`'s `constParameter`, it is checked and does its job.
 
 **Prefer module scope in a `.ts` file**, where a type alias is resolved

--- a/fjs/edag/proof.f.mjs
+++ b/fjs/edag/proof.f.mjs
@@ -10,14 +10,10 @@
  * which `comma` is now the sole route to; it pins the operand array's
  * element schema, and claims nothing about what a `,` means.
  *
- * @import { Assert } from '../asserts/types.ts'
  * @import { ValidationError } from '../rtti/common/types.ts'
- * @import { Check, Check3, Unknown } from '../rtti/ts/types.ts'
+ * @import { Unknown } from '../rtti/ts/types.ts'
  * @import { StringMap } from '../types/object/types.ts'
  * @import {
- *  _exp,
- *  _optionLambda,
- *  _optionPropertyLambda,
  *  array,
  *  call,
  *  comma,
@@ -40,33 +36,8 @@
  * } from './module.f.mjs'
  * @import {
  *  Array,
- *  Call,
- *  Comma,
- *  Dot,
  *  Exp,
- *  Exps,
- *  Items,
- *  NumberCast,
  *  Object,
- *  Op0,
- *  Op0Id,
- *  Op1,
- *  Op1Id,
- *  Op12,
- *  Op12Id,
- *  Op2,
- *  Op2Id,
- *  Op3,
- *  Op3Id,
- *  OptionCall,
- *  OptionDot,
- *  OptionLambda,
- *  OptionPropertyLambda,
- *  Primitive,
- *  Properties,
- *  Property,
- *  PropertyLambda,
- *  Spread,
  * } from './types.ts'
  */
 
@@ -166,41 +137,6 @@ const op3Ids = /** @type {const} */ (['?:'])
 const desugarOptionalAt = o => o !== null && o !== undefined ? o.at : undefined
 
 export const proof = {
-    /**
-     * Each RTTI constant in `./module.f.mjs` matches its declared type in
-     * `./types.ts`. These are compile-time checks; the function body only has
-     * to exist so the typedefs have a local scope.
-     */
-    consistency: () => {
-        /** @typedef {Assert<Check3<Exp, typeof _exp, typeof exp>>} _ExpAssert */
-        /** @typedef {Assert<Check<Primitive, typeof primitive>>} _Primitive */
-        /** @typedef {Assert<Check<Exps, typeof exps>>} _Exps */
-        /** @typedef {Assert<Check<Spread, typeof spread>>} _Spread */
-        /** @typedef {Assert<Check<Items, typeof items>>} _Items */
-        /** @typedef {Assert<Check<Array, typeof array>>} _Array */
-        /** @typedef {Assert<Check<Property, typeof property>>} _Property */
-        /** @typedef {Assert<Check<Properties, typeof properties>>} _Properties */
-        /** @typedef {Assert<Check<Object, typeof object>>} _Object */
-        /** @typedef {Assert<Check<NumberCast, typeof numberCast>>} _NumberCast */
-        /** @typedef {Assert<Check3<OptionLambda, typeof _optionLambda, typeof optionLambda>>} _OptionLambda */
-        /** @typedef {Assert<Check3<OptionPropertyLambda, typeof _optionPropertyLambda, typeof optionPropertyLambda>>} _OptionPropertyLambda */
-        /** @typedef {Assert<Check<PropertyLambda, typeof propertyLambda>>} _PropertyLambda */
-        /** @typedef {Assert<Check<Call, typeof call>>} _Call */
-        /** @typedef {Assert<Check<Dot, typeof dot>>} _Dot */
-        /** @typedef {Assert<Check<OptionDot, typeof optionDot>>} _OptionDot */
-        /** @typedef {Assert<Check<OptionCall, typeof optionCall>>} _OptionCall */
-        /** @typedef {Assert<Check<Comma, typeof comma>>} _Comma */
-        /** @typedef {Assert<Check<Op0Id, typeof op0Id>>} _Op0Id */
-        /** @typedef {Assert<Check<Op0, typeof op0>>} _Op0 */
-        /** @typedef {Assert<Check<Op1Id, typeof op1Id>>} _Op1Id */
-        /** @typedef {Assert<Check<Op1, typeof op1>>} _Op1 */
-        /** @typedef {Assert<Check<Op2Id, typeof op2Id>>} _Op2Id */
-        /** @typedef {Assert<Check<Op2, typeof op2>>} _Op2 */
-        /** @typedef {Assert<Check<Op12Id, typeof op12Id>>} _Op12Id */
-        /** @typedef {Assert<Check<Op12, typeof op12>>} _Op12 */
-        /** @typedef {Assert<Check<Op3Id, typeof op3Id>>} _Op3Id */
-        /** @typedef {Assert<Check<Op3, typeof op3>>} _Op3 */
-    },
     primitive: {
         ok: () => {
             assertOk(v(null))

--- a/fjs/edag/types.ts
+++ b/fjs/edag/types.ts
@@ -9,7 +9,41 @@
  */
 
 import type { Assert } from '../asserts/types.ts'
+import type { Check, Check3 } from '../rtti/ts/types.ts'
 import type { Equal } from '../types/ts/types.ts'
+import type {
+    _exp,
+    _optionLambda,
+    _optionPropertyLambda,
+    array,
+    call,
+    comma,
+    dot,
+    exp,
+    exps,
+    items,
+    numberCast,
+    object,
+    op0,
+    op0Id,
+    op1,
+    op1Id,
+    op12,
+    op12Id,
+    op2,
+    op2Id,
+    op3,
+    op3Id,
+    optionCall,
+    optionDot,
+    optionLambda,
+    optionPropertyLambda,
+    primitive,
+    properties,
+    property,
+    propertyLambda,
+    spread,
+} from './module.f.mjs'
 
 // exp
 
@@ -123,13 +157,12 @@ export type OptionPropertyLambda =
 // the two option states share — which is what both of these used to do, and
 // what `module.f.mjs`'s `regionProductions` now does once for the schema.
 //
-// These are here and not in `proof.f.mjs` because a `@typedef` there is
-// checked only where a statement follows it in the same block. That file's
-// `consistency` entry is nothing but typedefs, so all 28 of its pins are
-// green whatever they claim. A module-scope alias in a `.ts` file is
-// resolved either way; `../nanvm/types.ts` is the worked case, `../AGENTS.md`
-// §1.4 states the rule, and `../../todo/inert-type-level-proofs.md` moves
-// the rest.
+// These came here ahead of the schema pins below, for the reason those
+// followed: a `@typedef` in `proof.f.mjs` is checked only where a statement
+// follows it in the same block, and the `consistency` entry that held them
+// was nothing but typedefs. A module-scope alias in a `.ts` file is resolved
+// either way — `../AGENTS.md` §1.4 states the rule, and
+// `../../todo/inert-type-level-proofs.md` moves what is left elsewhere.
 
 type _OptionInsideOptionProperty = Assert<Equal<OptionLambda extends OptionPropertyLambda ? true : false, true>>
 type _PropertyInsideOptionProperty = Assert<Equal<PropertyLambda extends OptionPropertyLambda ? true : false, true>>
@@ -139,11 +172,10 @@ type _PropertyInsideOptionProperty = Assert<Equal<PropertyLambda extends OptionP
 // than a silent change of what the grammar admits.
 //
 // The shared segment is not theirs to pin, in either direction. An arm
-// gained or lost there lands on both sides of the `Exclude` and cancels, so
-// all three stay green — measured both ways, zero errors in this file. The
-// pin for the shared segment is `_OptionLambda`, the schema against the
-// type, which is inert where it sits in `proof.f.mjs`; see
-// `../../todo/inert-type-level-proofs.md`.
+// gained or lost there lands on both sides of the `Exclude` and cancels,
+// so all three stay green — measured both ways, zero errors from these.
+// The pin for the shared segment is `_OptionLambda` below, the schema
+// against the type, which either change makes disagree.
 type _OptionPropertyAdds = Assert<Equal<
     Exclude<OptionPropertyLambda, OptionLambda>,
     | readonly['|?.()', Exp]
@@ -218,3 +250,44 @@ export type Op12 =
 export type Op3Id = '?:'
 
 export type Op3 = readonly[Op3Id, Exp, Exp, Exp]
+
+// Each RTTI constant in `./module.f.mjs` matches its declared type above.
+//
+// These were `proof.f.mjs`'s `consistency` entry, whose body was nothing but
+// typedefs — so none of them bound to anything and all 28 were green whatever
+// they claimed (`../AGENTS.md` §1.4, `../../todo/inert-type-level-proofs.md`).
+// At module scope in a `.ts` file an alias is resolved on sight, so each one
+// below was falsified once and seen to fail before being restored.
+//
+// `Check3` is for the three schemas that are thunks behind a `Phantom`: it
+// checks the raw thunk as well as the wrapped export, since checking only the
+// wrapped one is a tautology — `Ts<>` short-circuits to the annotation.
+
+type _ExpAssert = Assert<Check3<Exp, typeof _exp, typeof exp>>
+type _Primitive = Assert<Check<Primitive, typeof primitive>>
+type _Exps = Assert<Check<Exps, typeof exps>>
+type _Spread = Assert<Check<Spread, typeof spread>>
+type _Items = Assert<Check<Items, typeof items>>
+type _Array = Assert<Check<Array, typeof array>>
+type _Property = Assert<Check<Property, typeof property>>
+type _Properties = Assert<Check<Properties, typeof properties>>
+type _Object = Assert<Check<Object, typeof object>>
+type _NumberCast = Assert<Check<NumberCast, typeof numberCast>>
+type _OptionLambda = Assert<Check3<OptionLambda, typeof _optionLambda, typeof optionLambda>>
+type _OptionPropertyLambda = Assert<Check3<OptionPropertyLambda, typeof _optionPropertyLambda, typeof optionPropertyLambda>>
+type _PropertyLambda = Assert<Check<PropertyLambda, typeof propertyLambda>>
+type _Call = Assert<Check<Call, typeof call>>
+type _Dot = Assert<Check<Dot, typeof dot>>
+type _OptionDot = Assert<Check<OptionDot, typeof optionDot>>
+type _OptionCall = Assert<Check<OptionCall, typeof optionCall>>
+type _Comma = Assert<Check<Comma, typeof comma>>
+type _Op0Id = Assert<Check<Op0Id, typeof op0Id>>
+type _Op0 = Assert<Check<Op0, typeof op0>>
+type _Op1Id = Assert<Check<Op1Id, typeof op1Id>>
+type _Op1 = Assert<Check<Op1, typeof op1>>
+type _Op2Id = Assert<Check<Op2Id, typeof op2Id>>
+type _Op2 = Assert<Check<Op2, typeof op2>>
+type _Op12Id = Assert<Check<Op12Id, typeof op12Id>>
+type _Op12 = Assert<Check<Op12, typeof op12>>
+type _Op3Id = Assert<Check<Op3Id, typeof op3Id>>
+type _Op3 = Assert<Check<Op3, typeof op3>>

--- a/todo/inert-type-level-proofs.md
+++ b/todo/inert-type-level-proofs.md
@@ -1,4 +1,4 @@
-## inert-type-level-proofs. 70 `Assert<…>` typedefs in proofs check nothing
+## inert-type-level-proofs. 42 `Assert<…>` typedefs in proofs check nothing
 
 **Priority:** P2
 **Status:** open
@@ -47,11 +47,11 @@ with `Assert<Equal<1, 2>>` and keeping the name so references still resolve,
 the 9 multi-line ones by replacing their first type argument — and `tsc` run
 over the falsified tree. A checked one reports TS2344 at its own line; an
 inert one says nothing. Of **125 across 23 files, 55 are checked and 70 are
-inert**, in ten files:
+inert**, in ten files. `fjs/edag/proof.f.mjs`'s 28 have since moved, leaving
+**42 in nine files**:
 
 | file | inert |
 | --- | --: |
-| `fjs/edag/proof.f.mjs` | 28 |
 | `fjs/rtti/ts/proof.f.mjs` | 9 |
 | `fjs/edag/amnesia/proof.f.mjs`, `fjs/effects/proof.f.mjs` | 8 each |
 | `fjs/types/object/proof.f.mjs`, `fjs/djs/parser/grammar/proof.f.mjs` | 4 each |
@@ -124,17 +124,21 @@ number moved.
 - [x] Correct `fjs/AGENTS.md` §3.2 and §1.4: §3.2 no longer calls a
       function-local typedef the normal home for a proof, and §1.4 states the
       binding rule, the measured table, and where a proof belongs.
-- [ ] Move all 28 inert `fjs/edag/proof.f.mjs` assertions into
-      `fjs/edag/types.ts`, falsifying each once to prove the moved form fails. Three chain-state
-      pins are already there, added beside the unions they are about when
-      `regionProductions` landed: `OptionLambda` and `PropertyLambda` are
-      inside `OptionPropertyLambda`, and the wider state adds exactly three
-      arms. Each was falsified once and went red. They overlap
-      `_OptionLambda` and `_OptionPropertyLambda` without replacing them —
-      those pin the schema against the type, these pin the types to each
-      other.
-- [ ] The same for the other nine files in the table, a directory at a time.
-      Six files the first count named have nothing inert and need no work.
+- [x] Move all 28 inert `fjs/edag/proof.f.mjs` assertions into
+      `fjs/edag/types.ts`, falsifying each once to prove the moved form
+      fails. Done: moved verbatim, all 28 flagged when falsified together,
+      and the `consistency` entry removed since it would assert nothing.
+      `types.ts` reaches the schema values through an `import type` from
+      `module.f.mjs` — a type-only cycle, no runtime import, so the file
+      stays type source. Three chain-state pins were already there, added
+      beside the unions they are about when `regionProductions` landed. They
+      overlap `_OptionLambda` and `_OptionPropertyLambda` without replacing
+      them: those pin the schema against the type, these pin the types to
+      each other.
+- [ ] The same for the nine files left in the table, a directory at a time,
+      starting with `fjs/edag/amnesia/proof.f.mjs`'s 8 to finish the
+      directory. Six files the first count named have nothing inert and need
+      no work.
 - [ ] `tsc` and `fjs test` clean after each, and the sweep's inert count
       down by the number moved.
 


### PR DESCRIPTION
Against `main`, now that [#1986](https://github.com/functionalscript/functionalscript/pull/1986) and the rest of the stack have merged. Two commits, four files. The `fjs/edag/proof.f.mjs` task of `todo/inert-type-level-proofs.md`.

**What was wrong.** `proof.f.mjs`'s `consistency` entry was a body of nothing but typedefs, so none of them bound to a statement and all 28 `Assert<Check<…>>` pins were green whatever they claimed. These are the pins `types.ts`'s own header says keep it and the rtti schema from drifting, and they would not have noticed if it had.

**The move.** All 28 go verbatim to module scope in `types.ts`, where a type alias resolves on sight.

**The thing I checked before moving anything.** Every pin is `Check<SomeType, typeof someSchemaValue>`, pairing a type in `types.ts` with a value in `module.f.mjs`, so `types.ts` has to reach back into the module it describes. That is a cycle, and `types.ts` is the published type API that must hold no runtime implementation.

An `import type` settles both: the cycle is type-only and no runtime import is emitted, so the file stays type source as §3.2 requires. I probed it with one true pin and one deliberately false one before touching the real thing, and only the false one reported TS2344.

**Proved bitten, not merely moved.** All 28 falsified at once, each claim replaced by `Assert<Equal<1, 2>>` with the name kept, then one `tsc` run: 28 flagged, none missed. The repository sweep agrees independently — single-line inert falls from 62 to 34, with `fjs/edag/proof.f.mjs` off the list entirely.

| | before | after |
|---|--:|--:|
| inert, single-line | 62 | 34 |
| inert, total | 70 | 42 |
| files with inert pins | 10 | 9 |

**What goes with them.** The `consistency` entry, since it would now assert nothing, and the 28 `@import` names it alone used. The suite drops one test relative to its base: that entry ran and counted as passing while checking nothing, which is the defect in miniature.

**The containment comment is finished here too.** The three chain-state pins cover the three arms the wider state adds and the two containments; the shared segment is unpinned in either direction, since a change there lands on both sides of the `Exclude` and cancels. With `_OptionLambda` now in this file, that is the pin covering it, and I measured both directions at this head: an arm added to `OptionLambda` gives 2 errors and an arm removed gives 2.

**The second commit** repoints `fjs/AGENTS.md` §1.4, which described `consistency` in the present tense as its worked example of the inert form. `fjs/effects/proof.f.mjs`'s `signatures` carries it now; `consistency` stays as the past extreme with a pointer to where its pins went.

**Checks.** `tsc -p .` clean on the 7.0.2 CI pins and on 6.0.2. `node ./fjs/module.mjs t`: 5751 passed, 0 failed. `npm run gen`: stable.

Changelog: no public API change. The pins are `_`-prefixed private aliases, no exported name changes, and the schema is untouched.

`fjs/edag/amnesia/proof.f.mjs`'s 8 remain and finish the directory. I left them for their own change: some pin local inference rather than a published type, so whether each has a `types.ts` home is a judgment worth reviewing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L983nybNdxpxnFpJfoq7Y