### PR TITLE
datajs/vectors: prose is shown as spaced, so the space is single

### DIFF
--- a/fjs/media/datajs/vectors/matrix/module.f.mjs
+++ b/fjs/media/datajs/vectors/matrix/module.f.mjs
@@ -168,8 +168,17 @@ const nameChars = `${lower}${upper}${digits}/+-._:`
 /** @type {(allowed: string) => (s: string) => boolean} */
 const onlyFrom = allowed => s => [...s].every(c => allowed.includes(c))
 
-/** @type {(s: string) => boolean} */
-const isProse = onlyFrom(proseChars)
+/**
+ * Prose the cell shows as written, which for the space means *as spaced*.
+ * A table cell trims its edges and the rendering collapses a run, so
+ * `reader  only` reaches a reader as `reader only` — the words intact and
+ * the spacing not, which is still the table saying something the corpus
+ * did not. The space is the last allowed character whose *repetition*
+ * renders differently, so single-spacing closes whitespace entirely.
+ *
+ * @type {(s: string) => boolean}
+ */
+const isProse = s => onlyFrom(proseChars)(s) && s.trim() === s && !s.includes('  ')
 
 /** @type {(s: string) => boolean} */
 const isName = onlyFrom(nameChars)

--- a/fjs/media/datajs/vectors/matrix/module.f.mjs
+++ b/fjs/media/datajs/vectors/matrix/module.f.mjs
@@ -168,6 +168,9 @@ const nameChars = `${lower}${upper}${digits}/+-._:`
 /** @type {(allowed: string) => (s: string) => boolean} */
 const onlyFrom = allowed => s => [...s].every(c => allowed.includes(c))
 
+/** @type {(s: string) => boolean} */
+const proseCharsOnly = onlyFrom(proseChars)
+
 /**
  * Prose the cell shows as written, which for the space means *as spaced*.
  * A table cell trims its edges and the rendering collapses a run, so
@@ -178,7 +181,7 @@ const onlyFrom = allowed => s => [...s].every(c => allowed.includes(c))
  *
  * @type {(s: string) => boolean}
  */
-const isProse = s => onlyFrom(proseChars)(s) && s.trim() === s && !s.includes('  ')
+const isProse = s => proseCharsOnly(s) && s.trim() === s && !s.includes('  ')
 
 /** @type {(s: string) => boolean} */
 const isName = onlyFrom(nameChars)

--- a/fjs/media/datajs/vectors/matrix/proof.f.mjs
+++ b/fjs/media/datajs/vectors/matrix/proof.f.mjs
@@ -161,6 +161,13 @@ export const proof = {
         refuses(one('rea`der', 'acc`ept', v('a', 'x')),
             `the role rea\`der: "rea\`der" ${name}`,
             `the set acc\`ept of rea\`der: "acc\`ept" ${name}`)
+        // a space is allowed, but a table cell trims its edges and the
+        // rendering collapses a run, so the words survive and the spacing
+        // does not — the last allowed character whose repetition renders
+        // differently
+        refuses(reason('reader  only'), `the reason for y in serializer: "reader  only" ${prose}`)
+        refuses(reason(' reader only'), `the reason for y in serializer: " reader only" ${prose}`)
+        refuses(reason('reader only '), `the reason for y in serializer: "reader only " ${prose}`)
         // a cell that shows nothing is an unanswered cell wearing the look of
         // an answered one, and a space is an allowed character, so the
         // characters alone cannot catch it


### PR DESCRIPTION
A carried review finding from #1978, which merged before the fix could be pushed — its branch was in the merge queue and refuses updates. `doc/SESSION.md` says a finding left unaddressed by a merged pull request is addressed in the next one, and with the stack empty that is a focused follow-up against `main`. The thread is [#1978 (comment)](https://github.com/functionalscript/functionalscript/pull/1978#discussion_r3986649069).

**The defect.** A not-applicable reason made only of allowed characters could still reach a reader as different text. A Markdown table cell trims its edges and the rendering collapses a run of spaces, so `reader  only` displays as `reader only` — the words intact and the spacing not, which is still the table showing something the corpus did not write, with `matrix` returning `ok`.

The blank check landed in `7f4e46d` used `trim()` for one job, catching an entirely blank reason, and I had read it as covering whitespace generally. It does not.

**The fix.** Prose is single-spaced: no edge space, no run of two.

```js
const proseCharsOnly = onlyFrom(proseChars)

const isProse = s => proseCharsOnly(s) && s.trim() === s && !s.includes('  ')
```

That closes whitespace entirely, since the ASCII space is the only whitespace character the rule admits — a tab, a newline and a non-breaking space are already outside it. Names need nothing, having no space to spend.

**Why it is its own rule rather than another character.** This is the third kind of defect in a row on that generator, and the three are worth distinguishing:

| the corpus wrote | why the whitelist missed it |
| - | - |
| `<!-- x -->` | a character the list did not have — fixed by the list |
| `:warning:` | allowed characters in a **shape** |
| `reader  only` | an allowed character in a **repetition** |

A character whitelist answers neither of the last two on its own, which is what I got wrong when I said it closed the question for good.

**Proof.** Three cases pinned — a double space, a leading space, a trailing space — and both halves of the check are mutation-proved: dropping either the edge test or the run test fails the `unrenderable` proof and nothing else. The existing case asserting that an ordinary sentence still renders is unchanged and still passes, so the rule has not tightened into refusing real prose.

**Second commit, from review.** Adding the two tests had turned `isProse` from a partial application into a lambda, so every reason rebuilt `onlyFrom(proseChars)` over a module constant. `a3a946fb` hoists it back to module scope beside `isName`, which is the form shown above. No behaviour change.

Checks: `tsc`, `node ./fjs/module.mjs t` (5747), `npm run cov` 100%, `npm run gen` with no drift.

Changelog:
- `fjs/media/datajs/vectors/matrix`: a reason with an edge space or a repeated space is refused, since a table cell does not show it as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CZRKbBvWAYpYtgVpUa3UH