### PR TITLE
Update nixpkgs commit reference across Nix configurations

### DIFF
--- a/fjs/ci/config/module.f.mjs
+++ b/fjs/ci/config/module.f.mjs
@@ -146,7 +146,7 @@ export const nixpkgs = /** @type {const} */({
     owner: 'NixOS',
     repo: 'nixpkgs',
     ref: 'nixos-26.05',
-    commit: '6aefcda9401be8acc2b74244fb3b37520ea1f0a8',
+    commit: 'd58a46e3bc02d91ebe04667f8397752a749c0024',
 })
 
 // Wasmtime and Wasmer are installed by their own setup actions, so these are

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -3,7 +3,7 @@
     "nixpkgs": {
       "locked": {
         "lastModified": 1789009968,
-        "narHash": "sha256-rK92Q3Fc5uAeHrq7+59dyVtq3qVshuPqAY6uXjkqcPM=",
+        "narHash": "sha256-GB16oaxpsrnGNnGIE+0uYBqMRzB9X6FYDUvjvnJAYew=",
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "d58a46e3bc02d91ebe04667f8397752a749c0024",

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788921488,
-        "narHash": "sha256-8+xWRxEkD6l217cIUdRxfeUGS9lQX0hVtUuNVsBaDzk=",
+        "lastModified": 1789009968,
+        "narHash": "sha256-rK92Q3Fc5uAeHrq7+59dyVtq3qVshuPqAY6uXjkqcPM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6aefcda9401be8acc2b74244fb3b37520ea1f0a8",
+        "rev": "d58a46e3bc02d91ebe04667f8397752a749c0024",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6aefcda9401be8acc2b74244fb3b37520ea1f0a8",
+        "rev": "d58a46e3bc02d91ebe04667f8397752a749c0024",
         "type": "github"
       }
     },

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -1,5 +1,5 @@
 {
-    inputs.nixpkgs.url = "github:NixOS/nixpkgs/6aefcda9401be8acc2b74244fb3b37520ea1f0a8";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/d58a46e3bc02d91ebe04667f8397752a749c0024";
     inputs.rust-overlay.url = "github:oxalica/rust-overlay/6ae57a71bcb0bebc7a66cc2bd76942c4cf649167";
     inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
     outputs = { nixpkgs, rust-overlay, ... }: let

--- a/nix/node22/flake.lock
+++ b/nix/node22/flake.lock
@@ -3,7 +3,7 @@
     "nixpkgs": {
       "locked": {
         "lastModified": 1789009968,
-        "narHash": "sha256-rK92Q3Fc5uAeHrq7+59dyVtq3qVshuPqAY6uXjkqcPM=",
+        "narHash": "sha256-GB16oaxpsrnGNnGIE+0uYBqMRzB9X6FYDUvjvnJAYew=",
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "d58a46e3bc02d91ebe04667f8397752a749c0024",

--- a/nix/node22/flake.lock
+++ b/nix/node22/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788921488,
-        "narHash": "sha256-8+xWRxEkD6l217cIUdRxfeUGS9lQX0hVtUuNVsBaDzk=",
+        "lastModified": 1789009968,
+        "narHash": "sha256-rK92Q3Fc5uAeHrq7+59dyVtq3qVshuPqAY6uXjkqcPM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6aefcda9401be8acc2b74244fb3b37520ea1f0a8",
+        "rev": "d58a46e3bc02d91ebe04667f8397752a749c0024",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6aefcda9401be8acc2b74244fb3b37520ea1f0a8",
+        "rev": "d58a46e3bc02d91ebe04667f8397752a749c0024",
         "type": "github"
       }
     },

--- a/nix/node22/flake.nix
+++ b/nix/node22/flake.nix
@@ -1,5 +1,5 @@
 {
-    inputs.nixpkgs.url = "github:NixOS/nixpkgs/6aefcda9401be8acc2b74244fb3b37520ea1f0a8";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/d58a46e3bc02d91ebe04667f8397752a749c0024";
     outputs = { nixpkgs, ... }: {
         devShells.aarch64-linux.default = let
             pkgs = import nixpkgs {

--- a/nix/node24/flake.lock
+++ b/nix/node24/flake.lock
@@ -3,7 +3,7 @@
     "nixpkgs": {
       "locked": {
         "lastModified": 1789009968,
-        "narHash": "sha256-rK92Q3Fc5uAeHrq7+59dyVtq3qVshuPqAY6uXjkqcPM=",
+        "narHash": "sha256-GB16oaxpsrnGNnGIE+0uYBqMRzB9X6FYDUvjvnJAYew=",
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "d58a46e3bc02d91ebe04667f8397752a749c0024",

--- a/nix/node24/flake.lock
+++ b/nix/node24/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788921488,
-        "narHash": "sha256-8+xWRxEkD6l217cIUdRxfeUGS9lQX0hVtUuNVsBaDzk=",
+        "lastModified": 1789009968,
+        "narHash": "sha256-rK92Q3Fc5uAeHrq7+59dyVtq3qVshuPqAY6uXjkqcPM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6aefcda9401be8acc2b74244fb3b37520ea1f0a8",
+        "rev": "d58a46e3bc02d91ebe04667f8397752a749c0024",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6aefcda9401be8acc2b74244fb3b37520ea1f0a8",
+        "rev": "d58a46e3bc02d91ebe04667f8397752a749c0024",
         "type": "github"
       }
     },

--- a/nix/node24/flake.nix
+++ b/nix/node24/flake.nix
@@ -1,5 +1,5 @@
 {
-    inputs.nixpkgs.url = "github:NixOS/nixpkgs/6aefcda9401be8acc2b74244fb3b37520ea1f0a8";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/d58a46e3bc02d91ebe04667f8397752a749c0024";
     outputs = { nixpkgs, ... }: {
         devShells.aarch64-linux.default = let
             pkgs = import nixpkgs {


### PR DESCRIPTION
## Summary
Updates the nixpkgs commit reference to a newer version across all Nix configuration files and CI configuration.

## Key Changes
- Updated nixpkgs commit from `6aefcda9401be8acc2b74244fb3b37520ea1f0a8` to `d58a46e3bc02d91ebe04667f8397752a749c0024` in:
  - `nix/flake.nix`
  - `nix/node22/flake.nix`
  - `nix/node24/flake.nix`
  - `fjs/ci/config/module.f.mjs` (CI configuration)
- Corresponding flake.lock files updated with new lastModified timestamp and narHash values

## Details
This change updates the pinned nixpkgs version used across the project's Nix development environments and CI pipeline. The update ensures consistent package versions across all Nix configurations (main, Node 22, and Node 24 variants).

https://claude.ai/code/session_014U9oFRxLjbVgiGkJHbS8XP