### PR TITLE
AGENTS: an assertion owes a mutation, not only a falsification

### DIFF
--- a/doc/REVIEWING.md
+++ b/doc/REVIEWING.md
@@ -99,9 +99,15 @@ observable — the runtime already refuses the invalid value, and the valid one
 was valid before — so do not ask for one; the simplest type that holds is the
 right one whether or not a walk is near the limit
 ([DESIGN.md §1](./DESIGN.md#1-simplicity-first)). Ask for the simplest type that states the
-contract, an `Assert<Equal<…>>` in the proof where the inference matters
-([fjs/AGENTS.md §1.4](../fjs/AGENTS.md#14-assert-type-level-facts-with-assertequal)),
-and a `todo/` for anything tighter.
+contract, an `Assert<Equal<…>>` where the claim matters, and a `todo/` for
+anything tighter. That assertion belongs at module scope in a `types.ts`,
+where an alias resolves whether or not anything follows it; ask for one in a
+proof only for a claim about a local inference, which is the case
+[fjs/AGENTS.md §1.4](../fjs/AGENTS.md#14-assert-type-level-facts-with-assertequal)
+carves out, and then only with a statement after it. That section also says
+what to ask of the assertion itself: falsified once to show it is evaluated,
+and, where its comment credits it with a mechanism, that mechanism broken once
+to show it reports.
 
 ## Bots
 

--- a/fjs/AGENTS.md
+++ b/fjs/AGENTS.md
@@ -140,6 +140,32 @@ write** — falsify it once, see it fail, restore it. A form copied from
 somewhere that works is not evidence, since what decides it is what follows
 the line, not the line.
 
+**That check is the first of two, and it is the weaker one.** Falsifying the
+claim asks whether the compiler evaluates the line at all. It says nothing
+about whether the line would notice the thing it is about breaking, and an
+assertion can pass the first test and fail the second: its claim resolves, its
+claim is true, and breaking the mechanism it names leaves it green.
+`fjs/rtti/ts/types.ts`'s `_UnionKeepsBranchCorrelation` was exactly that. It
+tested a value no answer admitted, correct one or broken one, so it held either
+way while reading as the pin for `TupleTs`'s per-member split.
+
+So **where an assertion's comment credits it with a mechanism, break that
+mechanism once and see the assertion report.** One mutation of the
+implementation, `tsc`, and read which line comes back: the named one, or
+nothing, which means the assertion is about something else than its comment
+says. Either fix the assertion or fix the comment; a row whose prose claims
+more than it holds is worse than one that claims nothing, because a reader
+stops looking. The three mutations behind
+[`fjs/rtti/ts/types.ts`](./rtti/ts/types.ts)'s `_RestTuple` header are the
+worked example, and the third of them is what caught that dead witness.
+
+This is a rule for an assertion you write or touch, not a standing audit. No
+sweep over the existing ones is planned: there is no enumeration of
+"mechanisms" to work through, so it is judgement per assertion with no
+definition of done, and [`../AGENTS.md` §6](../AGENTS.md#6-external-tools)
+prefers an honest unenforced rule to machinery that cannot say when it is
+finished.
+
 Some facts have nowhere else to be checked and so *require* an assertion. A
 `const` type parameter is the standing example: dropping the modifier widens
 every call site silently and `tsc` still passes, so the assertion is the only


### PR DESCRIPTION
Documentation only. Two edits, both consequences of #1993 and #1995.

## The gap

§1.4 already asks that a new `Assert` be falsified once and seen to fail. That check answers one question: does the compiler evaluate the line at all. #1995 showed it is not the whole question.

`fjs/rtti/ts/types.ts`'s `_UnionKeepsBranchCorrelation` passed it. It resolved, it held a true claim, and falsifying the claim reported it correctly. It still went green when the mechanism its comment credited it with was removed from `TupleTs`, because its witness was `readonly [1, true]`, a value neither the correct answer nor the broken one admits.

Two different questions, and an assertion can pass the first while failing the second:

| check | asks |
| --- | --- |
| falsify the assertion | is the line evaluated |
| break the mechanism it names | would the line notice |

## What §1.4 gains

Where an assertion's comment credits it with a mechanism, break that mechanism once and read which line reports. The named one, or nothing, which means the assertion is about something other than its prose says. Either the assertion or the comment is then wrong, and a row claiming more than it holds is worse than one claiming nothing, since a reader stops looking. The three mutations behind `_RestTuple`'s header are the worked example.

The scope is written into the rule on purpose: this is for an assertion you write or touch, not a standing audit. There is no enumeration of "mechanisms" to sweep, so a repository-wide pass would be judgement per assertion with no definition of done, which is the machinery root `AGENTS.md` §6 says to leave unbuilt. Saying so in the section makes the absence read as a decision rather than an oversight.

## What `REVIEWING.md` gains

Its type-level section told reviewers to ask for the assertion "in the proof". That predates #1993 and now reads as if a proof were the default home, when it is only right for the local inference §1.4 carves out. It now asks for module scope, names the exception and its statement-after requirement, and points at the two checks a reviewer can ask the author to have run.

## Checks

No source changes. `tsc -p .` exits 0, `fjs test` passes 5780 of 5780, and `npm run gen` produces no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXCZLTT4sRcrSc95AJviTk

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXCZLTT4sRcrSc95AJviTk)_