### PR TITLE
datajs: whitespace names what it accepts, and rejects everything else

### DIFF
--- a/fjs/media/datajs/todo/parser-serializer.md
+++ b/fjs/media/datajs/todo/parser-serializer.md
@@ -167,9 +167,15 @@ states and the reader's proof pins:
   positions with no condition attached, and is otherwise insignificant. The
   four permitted characters are JSON's, and they are the whole rule: outside a
   string literal a character is whitespace or part of a token, and one that is
-  neither is **refused**. Derive the rejected set from that rather than from a
-  list — measured against ECMAScript it is 21 characters, and every hand-written
-  list of them in this repository has been short.
+  neither is **refused**. Derive what is refused from that rather than from a
+  list: everything outside a token is, `@` as much as U+2028, so there is no
+  finite set to write down. The 21 worth naming are the delta — the characters
+  ECMAScript treats as whitespace and DataJS does not — and they are enumerated
+  once, in
+  [the corpus derivation](../../../../spec/datajs/todo/conformance-vectors.md),
+  because each owes a vector. Every *normative* list of them written by hand
+  here has been short, this plan's included, which is why the rule states what
+  it accepts.
 
 #### 3. Parser
 

--- a/fjs/media/datajs/todo/parser-serializer.md
+++ b/fjs/media/datajs/todo/parser-serializer.md
@@ -168,8 +168,9 @@ states and the reader's proof pins:
   four permitted characters are JSON's, and they are the whole rule: outside a
   string literal a character is whitespace or part of a token, and one that is
   neither is **refused**. Derive what is refused from that rather than from a
-  list: everything outside a token is, `@` as much as U+2028, so there is no
-  finite set to write down. The 21 worth naming are the delta — the characters
+  list: everything outside a token is, `@` as much as U+2028, so the list is the
+  input alphabet minus the tokens — finite, since the input is code units, and
+  no more worth writing than the alphabet itself. The 21 worth naming are the delta — the characters
   ECMAScript treats as whitespace and DataJS does not — and they are enumerated
   once, in
   [the corpus derivation](../../../../spec/datajs/todo/conformance-vectors.md),

--- a/fjs/media/datajs/todo/parser-serializer.md
+++ b/fjs/media/datajs/todo/parser-serializer.md
@@ -165,9 +165,11 @@ states and the reader's proof pins:
   and `infinity`. `-NaN`, `-undefined`, `-true` and a bare `-` have no rule.
 - **Whitespace is required after `const`, `export` and `default`**, at three
   positions with no condition attached, and is otherwise insignificant. The
-  four permitted characters are JSON's; every other character JavaScript
-  treats as whitespace or a line terminator (U+2028, U+2029, NBSP, FF, VT,
-  BOM) is **refused** wherever it appears outside a string.
+  four permitted characters are JSON's, and they are the whole rule: outside a
+  string literal a character is whitespace or part of a token, and one that is
+  neither is **refused**. Derive the rejected set from that rather than from a
+  list — measured against ECMAScript it is 21 characters, and every hand-written
+  list of them in this repository has been short.
 
 #### 3. Parser
 

--- a/spec/datajs/README.md
+++ b/spec/datajs/README.md
@@ -131,11 +131,12 @@ Whitespace is exactly JSON's: **space** (U+0020), **tab** (U+0009), **LF**
 except that the special property-key sequence `["__proto__"]` is one token and
 must contain exactly those characters without whitespace or escapes.
 
-Those four and no others. Every other character is **rejected** outside a
-string literal, whatever JavaScript may treat as whitespace or a line
-terminator. Enumerating what a reader accepts is the whole rule, and it is
-four characters long; enumerating what it refuses would import a taxonomy no
-implementer of a data format should have to know.
+Those four and no others: **nothing else is whitespace**, whatever JavaScript
+may treat as one. Outside a string literal a character is whitespace or part
+of a token, and one that is neither is **rejected**. Enumerating what a reader
+accepts is the whole rule, and it is four characters long; enumerating what it
+refuses would import a taxonomy no implementer of a data format should have to
+know.
 
 Whitespace is **required after `const`, after `export`, and after `default`**.
 Three positions, with no condition attached to any of them. Elsewhere it is

--- a/spec/datajs/README.md
+++ b/spec/datajs/README.md
@@ -131,10 +131,11 @@ Whitespace is exactly JSON's: **space** (U+0020), **tab** (U+0009), **LF**
 except that the special property-key sequence `["__proto__"]` is one token and
 must contain exactly those characters without whitespace or escapes.
 
-Every other character JavaScript treats as whitespace or a line terminator is
-**rejected**: U+2028, U+2029, no-break space, form feed, vertical tab, and a
-byte order mark, wherever they appear outside a string literal. Accepting them
-would import a taxonomy no implementer of a data format should have to know.
+Those four and no others. Every other character is **rejected** outside a
+string literal, whatever JavaScript may treat as whitespace or a line
+terminator. Enumerating what a reader accepts is the whole rule, and it is
+four characters long; enumerating what it refuses would import a taxonomy no
+implementer of a data format should have to know.
 
 Whitespace is **required after `const`, after `export`, and after `default`**.
 Three positions, with no condition attached to any of them. Elsewhere it is

--- a/spec/datajs/todo/conformance-vectors.md
+++ b/spec/datajs/todo/conformance-vectors.md
@@ -213,11 +213,14 @@ The five parts:
     while passing every other vector here. `normalize` pins that `/` comes back
     unescaped, but that is a different role and closes nothing for this one.
     **And the raw non-ASCII character is not one vector but nineteen**, because
-    every character §Whitespace refuses *between* tokens is ordinary content
-    *inside* a string, and only a vector says so. That reject side enumerates
-    21; two of them, U+000B and U+000C, stay rejects inside a string under a
-    different rule — they are below U+0020, where the raw-control rule reaches
-    them — so the contextual inverse is the other nineteen: U+2028, U+2029,
+    a character §Whitespace refuses *between* tokens can be ordinary content
+    *inside* a string, and only a vector says so. What it refuses between
+    tokens is everything outside a token, `@` as much as U+2028, so the set
+    worth vectors here is the delta from ECMAScript's whitespace, which the
+    reject side enumerates: 21 characters. Two of them, U+000B and U+000C, stay
+    rejects inside a string under a different rule — they are below U+0020,
+    where the raw-control rule reaches them — so the contextual inverse is the
+    other nineteen: U+2028, U+2029,
     U+FEFF and the sixteen `Space_Separator` characters other than U+0020. A
     reader consulting one whitespace table in both contexts refuses all
     nineteen while passing every vector above, and a reader refusing only the

--- a/spec/datajs/todo/conformance-vectors.md
+++ b/spec/datajs/todo/conformance-vectors.md
@@ -580,7 +580,8 @@ The five parts:
   reader can accept a raw LF as string content while rejecting the other three
   correctly. Then the characters JavaScript
   treats as whitespace or a line terminator and DataJS does not, of which there
-  are **21**, not the six the spec enumerates: U+000B, U+000C, U+2028, U+2029,
+  are **21**, a set §Whitespace deliberately does not list: U+000B, U+000C,
+  U+2028, U+2029,
   U+FEFF, and the sixteen `Space_Separator` characters other than U+0020 —
   U+00A0, U+1680, U+2000–U+200A, U+202F, U+205F and U+3000. **All 21 get
   vectors**, not one per shape. An earlier draft took six of the sixteen `Zs`
@@ -939,13 +940,16 @@ The five parts:
     `+`, no leading or trailing point, no separators, no leading zeros.
   - **Identifiers** — §Identifiers' ASCII-only rule, which excludes both a
     non-ASCII letter and the `\uXXXX` spelling of an ASCII one.
-  - **Whitespace** — §Whitespace, which narrows twice, and where the *spec's
-    own list* is the trap. Its rule is general and correct: whitespace is
-    exactly JSON's four characters, so **every other character JavaScript
-    treats as whitespace or a line terminator** is rejected. The six it then
-    names after a colon are illustrations, and measured against ECMAScript the
-    real set is 21 — the colon list omits every `Space_Separator` character
-    but U+00A0. Derive from the rule; the six are not a set to copy. §Whitespace
+  - **Whitespace** — §Whitespace, which narrows twice, and where a list was
+    the trap. Its rule is general and correct: whitespace is exactly JSON's
+    four characters, so **every other character JavaScript treats as
+    whitespace or a line terminator** is rejected. The section used to name
+    six of them after a colon as illustrations; measured against ECMAScript
+    the real set is 21, the colon list having omitted every `Space_Separator`
+    character but U+00A0, and the list is now deleted rather than corrected —
+    §Whitespace enumerates what it accepts and nothing else. Derive the 21
+    from the rule; there is no list to copy and there was never a set to copy
+    from. §Whitespace
     also *requires* whitespace in three places — after `const`, after `export`
     and after `default` — **unconditionally in all three**, whatever follows.
     Not "before an identifier-starting value after `default`", which is the

--- a/spec/datajs/todo/conformance-vectors.md
+++ b/spec/datajs/todo/conformance-vectors.md
@@ -944,9 +944,10 @@ The five parts:
     the trap. Its rule is general and correct: whitespace is exactly JSON's
     four characters, so **every other character JavaScript treats as
     whitespace or a line terminator** is rejected. The section used to name
-    six of them after a colon as illustrations; measured against ECMAScript
-    the real set is 21, the colon list having omitted every `Space_Separator`
-    character but U+00A0, and the list is now deleted rather than corrected —
+    six of them after a colon, in normative text, so a reader could take the
+    six for the set whatever they were meant as; measured against ECMAScript
+    the real set is 21, that list having omitted every `Space_Separator`
+    character but U+00A0, and it is now deleted rather than corrected —
     §Whitespace enumerates what it accepts and nothing else. Derive the 21
     from the rule; there is no list to copy and there was never a set to copy
     from. §Whitespace

--- a/spec/datajs/todo/conformance-vectors.md
+++ b/spec/datajs/todo/conformance-vectors.md
@@ -588,7 +588,9 @@ The five parts:
   reasoning that an implementation reaching that class at all reaches all of
   it. Review was right that nothing guarantees it, and this paragraph carries
   the disproof in its own first sentence: **the spec's own list of these
-  characters omitted fifteen of them**. A hand-written whitespace table with a
+  characters omitted fifteen of them** — which is why that list is now
+  deleted rather than corrected, the rule naming the four accepted
+  characters and nothing else. A hand-written whitespace table with a
   hole in it is not a hypothetical here — it is the thing that made this
   section necessary — and a reader whose table stops at U+2000 accepts U+200A
   while passing every sampled vector. So: U+000B, U+000C, U+2028, U+2029,
@@ -1621,13 +1623,15 @@ or the spec, not only into a thread.
    serializer falls outside those two, so "any other non-plain object" has no
    case to decide, and the serializer-reject vector it was to unblock does not
    exist because that set does not either.
-3. **§Whitespace's enumeration.** Proposal for the spec: keep the rule and
-   replace the six-item colon list with the complete set it denotes — the 21
-   characters of ECMAScript's `WhiteSpace` and `LineTerminator` classes less
-   the four permitted, which is U+000B, U+000C, U+2028, U+2029, U+FEFF and the
-   sixteen `Space_Separator` characters other than U+0020 — since the corpus
-   enumerates all 21 anyway and a reader of the spec should not have to. The
-   alternative is to mark the six as illustrations and cite ECMAScript.
+3. **§Whitespace's enumeration — decided: enumerate what is accepted and
+   reject everything else.** The six-item list after the colon is deleted
+   rather than grown to 21. Naming four accepted characters is the whole
+   rule, and it cannot be short of anything; naming what is refused is the
+   taxonomy that same paragraph says an implementer should not have to know,
+   and it had been wrong by fifteen characters since it was written. The
+   corpus still enumerates all 21 rejects, because a reader delegating to a
+   JavaScript tokenizer over-accepts every one of them and only a vector
+   sees that.
 4. **The decoder seam — decided: there is none, and no set needs one.** DataJS
    works with correct UTF-8 and rejects everything else, so a malformed
    sequence is not an input the format processes and the corpus owes it no
@@ -2665,8 +2669,12 @@ The steps, in order; a step is one pull request unless it says otherwise:
       literals. `types.ts` dropped `SerializerReject` and the twelve recipes,
       and the three surviving serializer-side records take an ordinary
       `Unknown`. Coverage stayed at 100%.
-- [ ] **§Whitespace's enumeration in the spec**, per decision 3; its own
-      pull request.
+- [x] **§Whitespace's enumeration in the spec**, per decision 3: the
+      six-item list after the colon is gone, and the rule names the four
+      characters a reader accepts and rejects everything else. The vectors
+      needed no change — their `rule` already read "whitespace: exactly
+      space, tab, LF and CR", which is the accepting form the spec now
+      takes too.
 - [ ] **The decoder seam in the spec**, per decision 4: say that a document
       is correct UTF-8 and anything else is rejected, with no taxonomy of
       malformed sequences and nothing required of a decoder. Its own pull

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -316,8 +316,12 @@ key       ::= string | '["__proto__"]'
   The exact `["__proto__"]` key is one token and contains none. Those four and
   no others: outside a string literal a character is whitespace or part of a
   token, and one that is neither is rejected. Naming the rejected ones is the
-  taxonomy the specification declines to carry, and the list it used to carry
-  was wrong by fifteen characters.
+  taxonomy the specification declines to carry, and there is no finite set to
+  name anyway: `@` is rejected as much as U+2028. The 21 worth naming are the
+  delta from ECMAScript's whitespace, enumerated once in
+  [the corpus derivation](../spec/datajs/todo/conformance-vectors.md) because
+  each owes a vector; the normative list the specification used to carry was
+  short by fifteen of them.
 - **Whitespace is required after `const`, `export` and `default`**, with no
   condition, and optional between other tokens except within `["__proto__"]`.
   Two of the three were forced

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -313,8 +313,11 @@ key       ::= string | '["__proto__"]'
   without the `;`, followed by an appended line beginning with `[`, silently
   exports `1` instead of `[1]`; with the `;` it stays `[1]`.
 - **Whitespace is JSON's** — space, tab, LF, CR — insignificant between tokens.
-  The exact `["__proto__"]` key is one token and contains none. Other JS
-  whitespace (U+2028/U+2029, NBSP, FF, BOM) is rejected.
+  The exact `["__proto__"]` key is one token and contains none. Those four and
+  no others: outside a string literal a character is whitespace or part of a
+  token, and one that is neither is rejected. Naming the rejected ones is the
+  taxonomy the specification declines to carry, and the list it used to carry
+  was wrong by fifteen characters.
 - **Whitespace is required after `const`, `export` and `default`**, with no
   condition, and optional between other tokens except within `["__proto__"]`.
   Two of the three were forced

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -316,8 +316,9 @@ key       ::= string | '["__proto__"]'
   The exact `["__proto__"]` key is one token and contains none. Those four and
   no others: outside a string literal a character is whitespace or part of a
   token, and one that is neither is rejected. Naming the rejected ones is the
-  taxonomy the specification declines to carry, and there is no finite set to
-  name anyway: `@` is rejected as much as U+2028. The 21 worth naming are the
+  taxonomy the specification declines to carry, and it is the whole input
+  alphabet minus the tokens rather than a short list: `@` is rejected as much as
+  U+2028. The 21 worth naming are the
   delta from ECMAScript's whitespace, enumerated once in
   [the corpus derivation](../spec/datajs/todo/conformance-vectors.md) because
   each owes a vector; the normative list the specification used to carry was


### PR DESCRIPTION
Stacked on [#2003](https://github.com/functionalscript/functionalscript/pull/2003).

The rule was right and the list after it was wrong.

§Whitespace said every other character JavaScript treats as whitespace or a line terminator is rejected, and then named six. The rule denotes twenty-one. The list gave one of the sixteen `Space_Separator` characters, the no-break space, and omitted U+1680, the ten from U+2000 to U+200A, U+202F, U+205F and U+3000.

So it is deleted rather than grown to twenty-one. Four accepted characters is the whole rule and cannot be short of anything. A list of the refused is exactly the taxonomy the same paragraph says an implementer should not have to know, and it had been wrong by fifteen characters since it was written.

## The corpus keeps all twenty-one

A conforming reader gets them for free by accepting four and refusing the rest, so those vectors are not there for it. They are there for a reader that delegates to a JavaScript tokenizer, which over-accepts every one, and only a vector sees that. The issue records the whole class being sampled at six once, on the reasoning that an implementation reaching the class reaches all of it — which this very list disproved.

## No vector changed

Their `rule` already read `whitespace: exactly space, tab, LF and CR`. That is the accepting form, which the spec now takes too, so the two were already saying the same thing from different ends.

## Four rounds of review, and each was the same failure one step wider

- **The rewrite rejected every valid document.** Deleting the list is right; scoping the sentence to whitespace is what I dropped while doing it. "Every other character is rejected outside a string literal" is literally every character — the letters in `export`, the digit, the semicolon — and as normative text it contradicted the token grammar directly below. It now says that *nothing else is whitespace*, and that outside a string literal a character is whitespace or part of a token, so one that is neither is refused.
- **The issue still told contributors how to read the deleted list.** Its derivation described §Whitespace as naming six characters after a colon and advised treating them as illustrations, and a sentence above called the real set 21 rather than "the six the spec enumerates". Both now say what happened instead of what to do about it, with the colon list appearing only in the past tense.
- **Two active plans carried their own copies.** Deleting the specification's list does nothing while the documents directing the implementation have one, and both did: five characters in the coordinating plan, six in the canonical one, each incomplete in exactly the same way. Both now state the rule in the accepting form and say why there is no list to copy. One of them also called the 21 "the rejected set", which treats a delta as a whole: `@` is refused exactly as U+2028 is, so the refused characters are the whole input alphabet minus the tokens. A later round corrected the form that claim first took here: the reader fixes its input alphabet to UTF-16 code units, so the complement is **finite**, and saying otherwise told an implementer a false constraint in support of a conclusion that does not need it. What is true is that the list is the alphabet minus the tokens and no more worth writing out than the alphabet itself, which is why the rule states what it accepts.
- **And the three descriptions of the deleted list disagreed with each other.** The derivation called the six illustrations while both plans called the same text a normative list short by fifteen. Where it stood is the fact that matters, because it is why deleting beat correcting: the six sat in normative text directly after the `rejected:` statement, so a reader could take them for the set whatever the author meant. All three say that now.

That is four places the same list had to be removed or redescribed, which is the argument for the accepting form over a corrected one: a corrected list is one more thing that can go stale, and this one went stale identically every time.

## Checks

`tsc` clean, `node --test` green at 5880 with the stack merged in, coverage 100% on lines, branches and functions, `npm run gen` current.

Two steps left in the issue after this: the serializer's input domain, which is still your call, and the hand-over that deletes the file. The decoder seam is written whenever you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzayQtZmCzP9rtExwHXtF2

---
_Generated by [Claude Code](https://claude.ai/code)_