### PR TITLE
git/walk: the width check reaches tryEntries and tryEntry, so they declare it

### DIFF
--- a/fjs/git/walk/module.f.mjs
+++ b/fjs/git/walk/module.f.mjs
@@ -183,6 +183,9 @@ export const peel = (read, oidBytes) => {
  * it refuses one without, so this reads that tree and does not judge the
  * commit again.
  *
+ * @throws On an id that is not `oidBytes` wide, since the walk starts at
+ * {@link peel} and that is its check.
+ *
  * @template {Operation} O
  * @param {Read<O>} read
  * @param {OidBytes} oidBytes
@@ -260,6 +263,10 @@ const componentStep = at => ({ name, last }) => ({ entries }) => {
  * The entry's own object is not read, so the caller reads the blob with
  * the same `Read` and a submodule entry comes back rather than a missing
  * object.
+ *
+ * @throws On an id that is not `oidBytes` wide, since the walk starts at
+ * {@link peel} and that is its check. A path of no components is the one
+ * that does not: it answers `null` before the id is read.
  *
  * @template {Operation} O
  * @param {Read<O>} read


### PR DESCRIPTION
Picks up the one review comment from #1989 that its merge did not carry, and
declares the break that went in with it.

#1989 merged at `70c7bca6`, one commit before the fix for
[this P1 on `peel`'s width check](https://github.com/functionalscript/functionalscript/pull/1989#discussion_r3992617211).
Two things are therefore in `main` unfinished.

**The `@throws` was on `peel` only.** `peel` asserts the id it is given is
`oidBytes` wide. `tryEntries` and `tryEntry` hand the caller's id straight to
it and inherit the throw, and neither said so. Both now carry an `@throws`.
That is the whole diff: seven lines of JSDoc, no code change.

Which calls actually throw, measured against an 8-bit id at `oidBytes` 20
rather than reasoned about:

```
tryEntries THREW: not an id of the width,255
tryEntry one component THREW: not an id of the width,255
tryEntry empty path: no throw
```

The last line is why `tryEntry`'s `@throws` carries a sentence the other two
do not. A path of no components returns `null` before `rootOf(id)` is
reached, so the id is never read and the assertion never runs.

**The break shipped undeclared.** `peel`'s assertion is itself in `main`, at
`653f1bba`. It throws where the old code called the supplied `Read` and
answered its effect, and `Oid` carries no width, so nothing catches the mix
at compile time. I added a `**BREAKING CHANGES:**` item to #1989's
description in answer to the review, but the merge commit `37e14461` carries
the earlier text, whose `Changelog:` section names only `git/repo`. Nothing
derives a break from a diff, and `0.49.0` is already published, so the
declaration has to land on a pull request in the open window or the next
release picks a patch number for a release that breaks. This is that pull
request, and the section below is the declaration.

Changelog:
- **BREAKING CHANGES:** `git/walk`: `peel`, and `tryEntries` and `tryEntry`
  through it, throw on an id that is not `oidBytes` wide, where they used to
  call the supplied `Read` and answer its effect. `Oid` carries no width, so
  no type catches the mix, and a SHA-256 id was getting a plausible answer
  out of a SHA-1 walk. Pass the id at the width the repository uses, which
  is `git/store`'s `oidBytes`. A path of no components still answers `null`
  before the id is read, so `tryEntry` does not throw there. The check
  itself shipped in #1989; this declares it.
- `git/tag`, `git/commit`: a tag whose `type` value holds an LF, and a commit
  whose `parent` names the same id as its own `tree`, are refused, as Git's
  own parse refuses them. Also shipped in #1989, and not breaking — they
  narrow what two readers accept to what Git accepts — but worth a release
  note

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdU8wW4oihFS1gj4dUAcPS

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdU8wW4oihFS1gj4dUAcPS)_