### PR TITLE
git/walk: the width check is pinned by a proof, not only declared

### DIFF
--- a/fjs/git/walk/proof.f.mjs
+++ b/fjs/git/walk/proof.f.mjs
@@ -271,12 +271,22 @@ const name = latin1
 /** @type {(e: TreeEntry) => readonly [number, string, string]} */
 const seen = e => [mode(e), codePointListToString(e.name), hex(e.oid)]
 
-/** An id the hex digits of a number spell, at 20 bytes. */
-const idOf = /** @type {(k: number) => Oid} */ (k => {
-    const v = tryFromHex(latin1(hexOf(k)))
+/** The id a string of hex digits spells, at whatever width it is long. */
+const idAt = /** @type {(hex: string) => Oid} */ (hex => {
+    const v = tryFromHex(latin1(hex))
     assert(v !== null)
     return v
 })
+
+/** An id the hex digits of a number spell, at 20 bytes. */
+const idOf = /** @type {(k: number) => Oid} */ (k => idAt(hexOf(k)))
+
+/**
+ * An id of 32 bytes: the width a SHA-256 repository uses, and not this
+ * walk's. Which digits it spells says nothing, since the width is refused
+ * before any object is asked for.
+ */
+const wideId = idAt('8031c3b5f0c291f374148e59909ea8a8f83538e9a412bac9b1f8072e6e6be27f')
 
 /** The 40 hex digits a number spells, as an id is written. */
 const hexOf = /** @type {(k: number) => string} */ (k => k.toString(16).padStart(40, '0'))
@@ -487,5 +497,18 @@ export const proof = {
         const [log, r] = runHost(entryOf(commitId, [name('mod'), name('x')]))
         assertStructurallySame(r, ['ok', null])
         assertStructurallySame(log, [at(commitId), at(rootId)])
+    },
+    throw: {
+        // A 32-byte id in a 20-byte walk is a caller's bug, not an object
+        // that is not there. Over `liar`, which answers any id without
+        // looking at its width: the store's `Read` has the same check of
+        // its own, so a walk over that one would throw whatever this does.
+        // `tryEntries` and `tryEntry` start at `peel` and inherit its
+        // check, so the two below pin what they inherit, not a second one.
+        width: () => peel(liar, 20)(wideId),
+        entriesWidth: () => tryEntries(liar, 20)(wideId),
+        // With a component, since a path of none answers before the id is
+        // read and so is the one call of the three that does not throw.
+        entryWidth: () => tryEntry(liar, 20)(wideId, [name('a.txt')]),
     },
 }


### PR DESCRIPTION
Takes the review point on #2006 that its merge did not carry.

The review was right and the reasoning was exact: #2006 added three
`@throws` to `fjs/git/walk` and zero `throw:` entries to its proof, while the
identical check in `fjs/git/store` is pinned by `proof.throw.width`.
`fjs/AGENTS.md` §1.5 puts a throwing contract under a `throw` key. Declaring
a contract nothing enforces is a declaration that rots on the next edit.

**The trap, since it caught me.** The obvious proof is to run `peel` over the
proof's existing `Read`, which is the store's. That reader asserts the width
itself, at `fjs/git/store/module.f.mjs:126`, so a walk built on it throws
whichever of the two checks survives. I wrote that version first and it
passed with `peel`'s assert deleted — a test that pins nothing while looking
like it pins something. The cases here run over `liar` instead, the proof's
reader that answers any id without looking at its width, so the only check
left in the call is the one under test.

**Measured both ways rather than argued.** With the assert in place:

```
Number of tests: pass: 5859, fail: 0, total: 5859     exit 0
```

With `assert(length(id) === bits, ...)` deleted from `peel`:

```
proof.throw.width(): error
proof.throw.entriesWidth(): error
proof.throw.entryWidth(): error
Number of tests: pass: 5856, fail: 3, total: 5859     exit 1
```

Exactly the three, and nothing else moves. That is the property the review
asked for and the first version did not have.

`tryEntry`'s case passes a path of one component on purpose. A path of none
answers `null` before the id is read, so it is the one call of the three that
does not throw, which is what its `@throws` already says.

`idOf` now goes through a new `idAt`, which takes the hex rather than a
number, so the 32-byte id and the 20-byte ones are built one way instead of
two.

Coverage stays at 100% on lines, branches and functions.

No changelog entry: no observable behavior changes here. The break this pins
was declared on #2006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdU8wW4oihFS1gj4dUAcPS

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdU8wW4oihFS1gj4dUAcPS)_