### PR TITLE
git/refname: the ref-name rules leave the tag module for a shared one

### DIFF
--- a/fjs/git/README.md
+++ b/fjs/git/README.md
@@ -26,6 +26,11 @@ what a grammar can and cannot do for the formats.
   for a repository's id width: a reader that reads what `git fsck` would
   flag, a `validate` that refuses it the way `fsck` does, `mode` as the
   number an entry's digits spell, and a writer.
+- [`refname/`](refname/module.f.mjs) — what names a ref takes, by the rules
+  `git check-ref-format` applies: the byte rules over the whole name, and the
+  rule each component between slashes must pass. A tag's `tag` header is a
+  ref name, which is why the tag module asks, and `HEAD`, a loose ref and a
+  `packed-refs` line carry one too.
 - [`tag/`](tag/module.f.mjs) — a tag as a second pass over the header
   block: `object`, `type`, `tag` and `tagger` as functions over the header
   list, read by position as Git reads them, and a `validate`.

--- a/fjs/git/refname/module.f.mjs
+++ b/fjs/git/refname/module.f.mjs
@@ -1,0 +1,105 @@
+/**
+ * What names a ref takes, by the rules `git check-ref-format` applies.
+ *
+ * A ref name is bytes, not text: Git compares and stores it byte for byte,
+ * so the rules are stated over bytes here and no decoding happens on the
+ * way. The rules split in two, and which one a caller wants depends on
+ * whether it holds a whole ref name or a piece of one:
+ *
+ * - {@link isComponent} is the rule for one component, between slashes.
+ * - {@link isName} is the rule for a name below a known prefix, which is
+ *   every byte rule plus every component being one — `git fsck`'s reading
+ *   of a tag's `tag` header, where the ref is `refs/tags/<name>`.
+ *
+ * The rule for a *whole* ref name is neither of these: it adds that the
+ * name has at least two components and is not `@` alone, both of which are
+ * about the name's own shape rather than the bytes in it. It is not here
+ * because nothing in this repository reads a whole ref name yet;
+ * [`todo/refs.md`](../todo/refs.md) is the step that will.
+ *
+ * Measured against Git 2.43.0 rather than read off the manual page, since
+ * two of the rules are not where a reader would guess. `.lock` is refused
+ * at the end of *any* component, so `refs/a.lock/b` is refused; a trailing
+ * `.` is refused only at the end of the whole name, so `refs/heads/a./b`
+ * passes and `refs/heads/a/b.` does not. `@` is fine as a component and
+ * refused as a whole name: `refs/heads/@` and `refs/@/x` both pass.
+ *
+ * @module
+ */
+
+import { ascii } from '../../ebnf/byte/module.f.mjs'
+
+const dot = /** @type {const} */ (0x2E)
+
+const slash = /** @type {const} */ (0x2F)
+
+const at = /** @type {const} */ (0x40)
+
+const brace = /** @type {const} */ (0x7B)
+
+const del = /** @type {const} */ (0x7F)
+
+/** The bytes a ref name may not hold, besides the control characters. */
+const forbidden = ascii(' ~^:?*[\\')
+
+const lock = ascii('.lock')
+
+/**
+ * Whether two bytes sit next to each other in a name, in that order.
+ *
+ * @type {(name: readonly number[], a: number, b: number) => boolean}
+ */
+const holdsPair = (name, a, b) => name.some((x, i) => i !== 0 && name[i - 1] === a && x === b)
+
+/**
+ * Whether a component of a ref name, between slashes, is one: not empty,
+ * not beginning with `.`, not ending in `.lock`.
+ *
+ * @type {(component: readonly number[]) => boolean}
+ */
+export const isComponent = component =>
+    component.length !== 0
+    && component[0] !== dot
+    && !(component.length >= lock.length && lock.every((b, i) => component[component.length - lock.length + i] === b))
+
+/**
+ * The components of a name, between its slashes: the bytes before the
+ * first, between each two, and after the last, so a name with none is one
+ * component and `a//b` has an empty one. Sliced once each, not grown byte
+ * by byte, since a name is as long as its author made it.
+ *
+ * @type {(name: readonly number[]) => readonly (readonly number[])[]}
+ */
+export const components = name => {
+    const slashes = name.flatMap((b, i) => b === slash ? [i] : [])
+    /** @type {readonly number[]} */
+    const starts = [0, ...slashes.map(i => i + 1)]
+    /** @type {readonly number[]} */
+    const ends = [...slashes, name.length]
+    return starts.map((start, i) => name.slice(start, ends[i]))
+}
+
+/**
+ * Whether a name is one a ref takes below a prefix, by the rules of
+ * `git check-ref-format` over `<prefix>/<name>`: no control character, no
+ * space and none of `~ ^ : ? * [ \`, no `..` and no `@{`, not ending in
+ * `.`, and every component between slashes one {@link isComponent} takes.
+ *
+ * A name that is `@` alone passes, since the ref it names is
+ * `<prefix>/@` — `refs/heads/@` and `refs/tags/@` are both names
+ * `check-ref-format` accepts, and only a whole ref name of `@` is refused.
+ *
+ * This is the rule `git fsck` applies to a tag's `tag` header, where it
+ * only warns — as `badTagName` — and exits clean, and the rule
+ * `git mktag` applies, strict by default, where it refuses to write the
+ * object. A reader refuses it too, since a name no ref takes names
+ * nothing.
+ *
+ * @type {(name: readonly number[]) => boolean}
+ */
+export const isName = name =>
+    name.every(b => b >= 0x20 && b !== del && !forbidden.includes(b))
+    && !holdsPair(name, dot, dot)
+    && !holdsPair(name, at, brace)
+    && name[name.length - 1] !== dot
+    && components(name).every(isComponent)

--- a/fjs/git/refname/module.f.mjs
+++ b/fjs/git/refname/module.f.mjs
@@ -6,10 +6,11 @@
  * way. The rules split in two, and which one a caller wants depends on
  * whether it holds a whole ref name or a piece of one:
  *
- * - {@link isComponent} is the rule for one component, between slashes.
- * - {@link isName} is the rule for a name below a known prefix, which is
- *   every byte rule plus every component being one — `git fsck`'s reading
- *   of a tag's `tag` header, where the ref is `refs/tags/<name>`.
+ * {@link isName} is the rule for a name below a known prefix: every byte
+ * rule, plus every component between slashes being one. That is `git fsck`'s
+ * reading of a tag's `tag` header, where the ref is `refs/tags/<name>`. The
+ * per-component rule is not exported on its own, because nothing needs a
+ * component without the name around it.
  *
  * The rule for a *whole* ref name is neither of these: it adds that the
  * name has at least two components and is not `@` alone, both of which are
@@ -25,9 +26,11 @@
  * refused as a whole name: `refs/heads/@` and `refs/@/x` both pass.
  *
  * @module
+ *
+ * @import { Bytes } from '../types.ts'
  */
 
-import { ascii } from '../../ebnf/byte/module.f.mjs'
+import { ascii, byteArray } from '../../ebnf/byte/module.f.mjs'
 
 const dot = /** @type {const} */ (0x2E)
 
@@ -57,7 +60,7 @@ const holdsPair = (name, a, b) => name.some((x, i) => i !== 0 && name[i - 1] ===
  *
  * @type {(component: readonly number[]) => boolean}
  */
-export const isComponent = component =>
+const isComponent = component =>
     component.length !== 0
     && component[0] !== dot
     && !(component.length >= lock.length && lock.every((b, i) => component[component.length - lock.length + i] === b))
@@ -70,7 +73,7 @@ export const isComponent = component =>
  *
  * @type {(name: readonly number[]) => readonly (readonly number[])[]}
  */
-export const components = name => {
+const components = name => {
     const slashes = name.flatMap((b, i) => b === slash ? [i] : [])
     /** @type {readonly number[]} */
     const starts = [0, ...slashes.map(i => i + 1)]
@@ -85,6 +88,15 @@ export const components = name => {
  * space and none of `~ ^ : ? * [ \`, no `..` and no `@{`, not ending in
  * `.`, and every component between slashes one {@link isComponent} takes.
  *
+ * The name is read through {@link byteArray} first, so a caller that hands
+ * something that is no byte list panics rather than being told its value is
+ * a ref name. That is not belt and braces: `every` and `flatMap` step over
+ * a hole in a sparse array, so `new Array(1)` would satisfy every rule
+ * below without a single byte being looked at, and a value above `0xFF`
+ * satisfies them too since no rule has an upper bound. Both are a caller's
+ * bug rather than a name that is not one, and {@link byteArray} is where
+ * this repository already refuses them.
+ *
  * A name that is `@` alone passes, since the ref it names is
  * `<prefix>/@` — `refs/heads/@` and `refs/tags/@` are both names
  * `check-ref-format` accepts, and only a whole ref name of `@` is refused.
@@ -95,11 +107,15 @@ export const components = name => {
  * object. A reader refuses it too, since a name no ref takes names
  * nothing.
  *
- * @type {(name: readonly number[]) => boolean}
+ * @throws If `name` is not a list of bytes.
+ *
+ * @type {(name: Bytes) => boolean}
  */
-export const isName = name =>
-    name.every(b => b >= 0x20 && b !== del && !forbidden.includes(b))
-    && !holdsPair(name, dot, dot)
-    && !holdsPair(name, at, brace)
-    && name[name.length - 1] !== dot
-    && components(name).every(isComponent)
+export const isName = input => {
+    const name = byteArray(input)
+    return name.every(b => b >= 0x20 && b !== del && !forbidden.includes(b))
+        && !holdsPair(name, dot, dot)
+        && !holdsPair(name, at, brace)
+        && name[name.length - 1] !== dot
+        && components(name).every(isComponent)
+}

--- a/fjs/git/refname/module.f.mjs
+++ b/fjs/git/refname/module.f.mjs
@@ -18,6 +18,14 @@
  * because nothing in this repository reads a whole ref name yet;
  * [`todo/refs.md`](../todo/refs.md) is the step that will.
  *
+ * The name is materialised to be read, which costs eight bytes of heap per
+ * byte of name and is avoidable rather than merely shrinkable: every rule
+ * below is decidable in one forward pass with an accumulator of fixed size.
+ * [`todo/one-pass-name-check.md`](./todo/one-pass-name-check.md) has the
+ * measurements, and why neither a packed vector nor a hex string is the fix —
+ * a bit vector caps at 128 KiB and so cannot carry a payload of arbitrary
+ * size at all.
+ *
  * Measured against Git 2.43.0 rather than read off the manual page, since
  * two of the rules are not where a reader would guess. `.lock` is refused
  * at the end of *any* component, so `refs/a.lock/b` is refused; a trailing

--- a/fjs/git/refname/proof.f.mjs
+++ b/fjs/git/refname/proof.f.mjs
@@ -1,42 +1,11 @@
-import { assert, assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
+import { assert } from '../../asserts/module.f.mjs'
 import { latin1 } from '../testlib.f.mjs'
-import { components, isComponent, isName } from './module.f.mjs'
-
-/**
- * The components of a name, as strings, so a case reads as the name does.
- *
- * @type {(s: string) => readonly string[]}
- */
-const split = s => components(latin1(s)).map(c => String.fromCharCode(...c))
+import { isName } from './module.f.mjs'
 
 export const proof = {
-    // The components are the bytes between the slashes, so a name with
-    // none is one component and an empty stretch is an empty component.
-    // Measured against `git check-ref-format`, which refuses every name
-    // below that has one: `refs/heads/a/`, `/a`, `a//b`.
-    components: () => {
-        assertStructurallySame(split('a'), ['a'])
-        assertStructurallySame(split('a/b'), ['a', 'b'])
-        assertStructurallySame(split('a/b/c'), ['a', 'b', 'c'])
-        assertStructurallySame(split('a//b'), ['a', '', 'b'])
-        assertStructurallySame(split('/a'), ['', 'a'])
-        assertStructurallySame(split('a/'), ['a', ''])
-        assertStructurallySame(split(''), [''])
-        assertStructurallySame(split('/'), ['', ''])
-    },
-    // One component: not empty, not beginning with `.`, not ending in
-    // `.lock`. A name merely holding `.lock` is not one ending in it.
-    component: () => {
-        for (const c of ['a', 'lock', 'x.locky', 'a.lockb', 'a.b', 'a.', '@']) {
-            assert(isComponent(latin1(c)), c)
-        }
-        for (const c of ['', '.a', '.', 'a.lock', '.lock']) {
-            assert(!isComponent(latin1(c)), c)
-        }
-    },
     // A name below a prefix: every rule `git check-ref-format` applies to
-    // `<prefix>/<name>`, each accepted name and each refused one taken
-    // from that command on Git 2.43.0.
+    // `<prefix>/<name>`, each accepted name and each refused one taken from
+    // that command on Git 2.43.0.
     name: () => {
         for (const n of ['v1.0', 'release/1.0', 'a@b', 'a.b.c', 'lock', 'x.locky', 'a{b', 'a/b/c', '\xE9', '@', 'a./b']) {
             assert(isName(latin1(n)), n)
@@ -48,11 +17,23 @@ export const proof = {
             assert(!isName(latin1(n)), n)
         }
     },
+    // The components are the bytes between the slashes, and each must be
+    // one: not empty, not beginning with `.`, not ending in `.lock`. The
+    // splitting shows in which names are refused — an empty component is
+    // what refuses `/a`, `a/` and `a//b`, and a name with no slash at all is
+    // one component, so `lock` passes where `a.lock` does not.
+    components: () => {
+        for (const n of ['a', 'a/b', 'a/b/c', 'lock', 'a.locky']) {
+            assert(isName(latin1(n)), n)
+        }
+        for (const n of ['/a', 'a/', 'a//b', '/', 'a/.b', 'a/b.lock']) {
+            assert(!isName(latin1(n)), n)
+        }
+    },
     // The two rules a reader would place wrongly, so they are pinned apart.
     // A trailing `.` is refused at the end of the whole name only, and
     // `.lock` at the end of any component: `git check-ref-format` takes
-    // `refs/heads/a./b` and refuses `refs/heads/a/b.` and
-    // `refs/a.lock/b`.
+    // `refs/heads/a./b` and refuses `refs/heads/a/b.` and `refs/a.lock/b`.
     whereTheRulesApply: () => {
         assert(isName(latin1('a./b')))
         assert(!isName(latin1('a/b.')))
@@ -61,14 +42,20 @@ export const proof = {
     },
     // A name is as long as its author made it, and is checked once over
     // rather than once per byte: twenty thousand bytes, and the same in
-    // slashes, which a rule applied per component per byte would not
-    // finish.
+    // slashes, which a rule applied per component per byte would not finish.
     long: () => {
         assert(isName(latin1('n'.repeat(20000))))
         assert(isName(latin1(`${'n/'.repeat(10000)}n`)))
         // The same name with an empty last component is refused, so the
         // length is not what decides it.
         assert(!isName(latin1('n/'.repeat(10000))))
-        assertEq(components(latin1('n/'.repeat(10000))).length, 10001)
+    },
+    throw: {
+        // A value that is no byte is a caller's bug, not a name that is not
+        // one, and `byteArray` is where this repository refuses it. Both of
+        // these would otherwise be answered `true`: no rule has an upper
+        // bound, and `every` steps over a hole without looking at it.
+        aboveAByte: () => isName([256]),
+        holeInASparseArray: () => isName(new Array(1)),
     },
 }

--- a/fjs/git/refname/proof.f.mjs
+++ b/fjs/git/refname/proof.f.mjs
@@ -1,0 +1,74 @@
+import { assert, assertEq, assertStructurallySame } from '../../asserts/module.f.mjs'
+import { latin1 } from '../testlib.f.mjs'
+import { components, isComponent, isName } from './module.f.mjs'
+
+/**
+ * The components of a name, as strings, so a case reads as the name does.
+ *
+ * @type {(s: string) => readonly string[]}
+ */
+const split = s => components(latin1(s)).map(c => String.fromCharCode(...c))
+
+export const proof = {
+    // The components are the bytes between the slashes, so a name with
+    // none is one component and an empty stretch is an empty component.
+    // Measured against `git check-ref-format`, which refuses every name
+    // below that has one: `refs/heads/a/`, `/a`, `a//b`.
+    components: () => {
+        assertStructurallySame(split('a'), ['a'])
+        assertStructurallySame(split('a/b'), ['a', 'b'])
+        assertStructurallySame(split('a/b/c'), ['a', 'b', 'c'])
+        assertStructurallySame(split('a//b'), ['a', '', 'b'])
+        assertStructurallySame(split('/a'), ['', 'a'])
+        assertStructurallySame(split('a/'), ['a', ''])
+        assertStructurallySame(split(''), [''])
+        assertStructurallySame(split('/'), ['', ''])
+    },
+    // One component: not empty, not beginning with `.`, not ending in
+    // `.lock`. A name merely holding `.lock` is not one ending in it.
+    component: () => {
+        for (const c of ['a', 'lock', 'x.locky', 'a.lockb', 'a.b', 'a.', '@']) {
+            assert(isComponent(latin1(c)), c)
+        }
+        for (const c of ['', '.a', '.', 'a.lock', '.lock']) {
+            assert(!isComponent(latin1(c)), c)
+        }
+    },
+    // A name below a prefix: every rule `git check-ref-format` applies to
+    // `<prefix>/<name>`, each accepted name and each refused one taken
+    // from that command on Git 2.43.0.
+    name: () => {
+        for (const n of ['v1.0', 'release/1.0', 'a@b', 'a.b.c', 'lock', 'x.locky', 'a{b', 'a/b/c', '\xE9', '@', 'a./b']) {
+            assert(isName(latin1(n)), n)
+        }
+        for (const n of [
+            '', 'a b', 'a~b', 'a^b', 'a:b', 'a?b', 'a*b', 'a[b', 'a\\b', 'a\x01b', 'a\x7Fb',
+            'a..b', 'a@{b', 'a.', '.a', 'a/.b', 'a.lock', 'a.lock/b', 'a/', '/a', 'a//b',
+        ]) {
+            assert(!isName(latin1(n)), n)
+        }
+    },
+    // The two rules a reader would place wrongly, so they are pinned apart.
+    // A trailing `.` is refused at the end of the whole name only, and
+    // `.lock` at the end of any component: `git check-ref-format` takes
+    // `refs/heads/a./b` and refuses `refs/heads/a/b.` and
+    // `refs/a.lock/b`.
+    whereTheRulesApply: () => {
+        assert(isName(latin1('a./b')))
+        assert(!isName(latin1('a/b.')))
+        assert(!isName(latin1('a.lock/b')))
+        assert(!isName(latin1('a/b.lock')))
+    },
+    // A name is as long as its author made it, and is checked once over
+    // rather than once per byte: twenty thousand bytes, and the same in
+    // slashes, which a rule applied per component per byte would not
+    // finish.
+    long: () => {
+        assert(isName(latin1('n'.repeat(20000))))
+        assert(isName(latin1(`${'n/'.repeat(10000)}n`)))
+        // The same name with an empty last component is refused, so the
+        // length is not what decides it.
+        assert(!isName(latin1('n/'.repeat(10000))))
+        assertEq(components(latin1('n/'.repeat(10000))).length, 10001)
+    },
+}

--- a/fjs/git/refname/todo/one-pass-name-check.md
+++ b/fjs/git/refname/todo/one-pass-name-check.md
@@ -12,10 +12,17 @@ of heap per byte of name, because every slot holds a double. Measured on a
 
 | representation | heap at rest |
 | --- | --- |
-| dense `readonly number[]` | 159.5 KiB |
-| `bigint` | 16.3 KiB |
+| dense `readonly number[]` | 156.3 KiB |
+| `bigint` | 19.6 KiB |
 
-About ten to one, and the array is transient — it lives only for the length
+Each averaged over a hundred allocations, because a single `heapUsed` delta is
+noisy enough to read below the floor: 160000 bits needs 2501 64-bit limbs, so
+19.5 KiB is the least a `bigint` of this name can occupy, and a one-shot
+measurement of it came out at 16.3 KiB — under the floor, and therefore wrong.
+
+About eight to one, which is the eight bytes per byte a dense array of
+doubles costs and not a figure to round up from. The array is transient — it
+lives only for the length
 of the call — so this is a rate rather than a leak. A ref name is short, and
 nothing here is on a hot path, which is why this is P4 and not a fix in the
 branch that wrote it. The shape is also older than that branch: the rules
@@ -34,10 +41,14 @@ size, so it is the right carrier for an object id and the wrong one for a
 whole file. Where a large byte string must be held, the shape is a list or an
 array of bit vectors rather than one vector.
 
-Building a `bigint` a byte at a time is also a trap: the same 20000 bytes
-churn 3550 KiB of garbage that way, since every shift allocates a new value.
-`u8ListToVec` uses an absorbing concat fold and does not, which is why the
-packed representation is cheap here and expensive written by hand.
+Building a `bigint` a byte at a time is also a trap, and the cost is
+quadratic rather than large: every shift allocates a new value, so the total
+allocated over a name of `n` bytes is the sum of `1..n` bytes, which for
+20000 is about 190 MiB. The live heap stays small because the collector
+reclaims as it goes, so this is a rate of allocation rather than a footprint
+and `heapUsed` does not measure it. `u8ListToVec` uses an absorbing concat
+fold and does not pay it, which is why the packed representation is cheap
+here and expensive written by hand.
 
 A hex string is 2 bytes per byte where the runtime keeps a one-byte string,
 so 4x smaller than the array, but it doubles the length and puts the rules a

--- a/fjs/git/refname/todo/one-pass-name-check.md
+++ b/fjs/git/refname/todo/one-pass-name-check.md
@@ -1,0 +1,78 @@
+## `isName` materialises a name it could read in one pass
+
+**Priority:** P4
+**Status:** open
+
+### Problem
+
+[`isName`](../module.f.mjs) reads its input through `byteArray`, which
+materialises the name as a dense `readonly number[]`. That costs eight bytes
+of heap per byte of name, because every slot holds a double. Measured on a
+20000-byte name, against the same bytes packed in a `bigint`:
+
+| representation | heap at rest |
+| --- | --- |
+| dense `readonly number[]` | 159.5 KiB |
+| `bigint` | 16.3 KiB |
+
+About ten to one, and the array is transient — it lives only for the length
+of the call — so this is a rate rather than a leak. A ref name is short, and
+nothing here is on a hot path, which is why this is P4 and not a fix in the
+branch that wrote it. The shape is also older than that branch: the rules
+took an array when they were private to `fjs/git/tag`, and that module was
+calling `byteArray` at the call site.
+
+### Why the representation is not the fix
+
+Two obvious substitutions are both worse than they look.
+
+A `bigint` through `fjs/types/bit_vec` is 8x smaller at rest and bounded:
+`maxLength` is 1048576 bits, so **128 KiB**, a cap Bun's `bigint` constraint
+sets and the module documents as the smallest across the runtimes
+FunctionalScript supports. A bit vector cannot hold a payload of arbitrary
+size, so it is the right carrier for an object id and the wrong one for a
+whole file. Where a large byte string must be held, the shape is a list or an
+array of bit vectors rather than one vector.
+
+Building a `bigint` a byte at a time is also a trap: the same 20000 bytes
+churn 3550 KiB of garbage that way, since every shift allocates a new value.
+`u8ListToVec` uses an absorbing concat fold and does not, which is why the
+packed representation is cheap here and expensive written by hand.
+
+A hex string is 2 bytes per byte where the runtime keeps a one-byte string,
+so 4x smaller than the array, but it doubles the length and puts the rules a
+nibble away from the bytes they are about.
+
+### Proposal
+
+Do not hold the name at all. Every rule is decidable in one forward pass over
+the bytes with an accumulator of fixed size:
+
+- the previous byte, for `..` and `@{`;
+- a flag for being at the start of a component, for the empty-component and
+  leading-`.` rules;
+- a five-byte rolling window, for `.lock` at the end of any component;
+- the last byte seen, for the trailing `.` rule, which applies to the whole
+  name and not to a component.
+
+`fold` in [`fjs/types/list`](../../../types/list/module.f.mjs) is that pass.
+Such a version allocates nothing proportional to the name, so the eight-fold
+cost goes rather than shrinks, and it reads a `Bytes` and a `Vec` through
+`u8List` alike. It also checks each byte as it arrives, which is what
+`byteArray` currently buys, so the panic on a value that is no byte survives
+the change — see the `throw` cases in [`../proof.f.mjs`](../proof.f.mjs),
+which must keep passing.
+
+The rules themselves must not move. They are measured against
+`git check-ref-format` on Git 2.43.0 and the proof table is the record; a
+rewrite is only correct if that table still passes unchanged, and if deleting
+any one rule still reddens it.
+
+### Related
+
+- [`fjs/git/refname`](../module.f.mjs) — `isName`, and why it takes `Bytes`.
+- [`fjs/types/bit_vec`](../../../types/bit_vec/module.f.mjs) — `maxLength`,
+  and the absorbing fold that makes a packed vector cheap to build.
+- [`fjs/ebnf/byte`](../../../ebnf/byte/module.f.mjs) — `byteArray`, the
+  materialisation this would remove, and why a hole in a sparse array is
+  refused rather than stepped over.

--- a/fjs/git/refname/todo/one-pass-name-check.md
+++ b/fjs/git/refname/todo/one-pass-name-check.md
@@ -15,19 +15,27 @@ of heap per byte of name, because every slot holds a double. Measured on a
 | dense `readonly number[]` | 156.3 KiB |
 | `bigint` | 19.6 KiB |
 
-Each averaged over a hundred allocations, because a single `heapUsed` delta is
-noisy enough to read below the floor: 160000 bits needs 2501 64-bit limbs, so
-19.5 KiB is the least a `bigint` of this name can occupy, and a one-shot
-measurement of it came out at 16.3 KiB — under the floor, and therefore wrong.
+Each is a hundred allocations, with a collection forced before and after every
+sample, and that collection is what makes the figures mean anything —
+averaging alone does not. Without it, a hundred samples of the `bigint` gave
+75.7 KiB and then -136.8 and -137.8 KiB over three runs: a negative heap per
+instance is impossible, so the noise there is larger than the quantity and no
+number of samples averages it away.
 
-About eight to one, which is the eight bytes per byte a dense array of
-doubles costs and not a figure to round up from. The array is transient — it
-lives only for the length
-of the call — so this is a rate rather than a leak. A ref name is short, and
-nothing here is on a hot path, which is why this is P4 and not a fix in the
-branch that wrote it. The shape is also older than that branch: the rules
-took an array when they were private to `fjs/git/tag`, and that module was
-calling `byteArray` at the call site.
+The floor says so independently. A vector of this name stores 160001 bits, the
+160000 of payload and the sentinel bit above them, which is 2501 64-bit limbs
+and so 19.54 KiB — the least such a `bigint` can occupy. A one-shot `heapUsed`
+delta put it at 16.3 KiB, below the floor and therefore wrong whatever it was
+measuring. The floor is the check worth keeping: a measurement under it is
+refuted without a second run.
+
+About eight to one, which is the eight bytes per byte a dense array of doubles
+costs and not a figure to round up from. The array is transient — it lives
+only for the length of the call — so this is a rate rather than a leak. A ref
+name is short, and nothing here is on a hot path, which is why this is P4 and
+not a fix in the branch that wrote it. The shape is also older than that
+branch: the rules took an array when they were private to `fjs/git/tag`, and
+that module was calling `byteArray` at the call site.
 
 ### Why the representation is not the fix
 

--- a/fjs/git/tag/module.f.mjs
+++ b/fjs/git/tag/module.f.mjs
@@ -261,7 +261,7 @@ export const validate = oidBytes => {
         if (typeOf(typeValue) === null) { return error('unknown type') }
         const nameValue = valueAt(t, 2, 'tag')
         if (nameValue === null) { return error('no tag name') }
-        if (!isName(byteArray(nameValue))) { return error('bad tag name') }
+        if (!isName(nameValue)) { return error('bad tag name') }
         const taggerValue = valueAt(t, 3, 'tagger')
         return taggerValue !== null && readIdent(taggerValue) === null ? error('not a tagger') : ok(t)
     }

--- a/fjs/git/tag/module.f.mjs
+++ b/fjs/git/tag/module.f.mjs
@@ -26,12 +26,13 @@
  */
 
 import { assert, assertNotNullish } from '../../asserts/module.f.mjs'
-import { ascii, byteArray, byteLength } from '../../ebnf/byte/module.f.mjs'
+import { byteArray, byteLength } from '../../ebnf/byte/module.f.mjs'
 import { codePointListToString } from '../../text/utf16/module.f.mjs'
 import { error, ok } from '../../types/result/module.f.mjs'
 import { hasNulHeader, tryRead as readPayload, valueAt, write as writePayload } from '../header/module.f.mjs'
 import { tryRead as readIdent } from '../ident/module.f.mjs'
 import { objectTypes } from '../object/module.f.mjs'
+import { isName } from '../refname/module.f.mjs'
 import { tryFromHex, tryFromHexOf } from '../oid/module.f.mjs'
 
 /**
@@ -84,77 +85,6 @@ const typeOf = value => {
 
 /** The byte a line ends with, and the one a folded continuation leaves in a value. */
 const lf = /** @type {const} */ (0x0A)
-
-const dot = /** @type {const} */ (0x2E)
-
-const slash = /** @type {const} */ (0x2F)
-
-const at = /** @type {const} */ (0x40)
-
-const brace = /** @type {const} */ (0x7B)
-
-const del = /** @type {const} */ (0x7F)
-
-/** The bytes a ref name may not hold, besides the control characters. */
-const forbidden = ascii(' ~^:?*[\\')
-
-const lock = ascii('.lock')
-
-/**
- * Whether two bytes sit next to each other in a name, in that order.
- *
- * @type {(name: readonly number[], a: number, b: number) => boolean}
- */
-const holdsPair = (name, a, b) => name.some((x, i) => i !== 0 && name[i - 1] === a && x === b)
-
-/**
- * Whether a component of a ref name, between slashes, is one: not empty,
- * not beginning with `.`, not ending in `.lock`.
- *
- * @type {(component: readonly number[]) => boolean}
- */
-const isComponent = component =>
-    component.length !== 0
-    && component[0] !== dot
-    && !(component.length >= lock.length && lock.every((b, i) => component[component.length - lock.length + i] === b))
-
-/**
- * The components of a name, between its slashes: the bytes before the
- * first, between each two, and after the last, so a name with none is one
- * component and `a//b` has an empty one. Sliced once each, not grown byte
- * by byte, since a name is as long as its author made it.
- *
- * @type {(name: readonly number[]) => readonly (readonly number[])[]}
- */
-const components = name => {
-    const slashes = name.flatMap((b, i) => b === slash ? [i] : [])
-    /** @type {readonly number[]} */
-    const starts = [0, ...slashes.map(i => i + 1)]
-    /** @type {readonly number[]} */
-    const ends = [...slashes, name.length]
-    return starts.map((start, i) => name.slice(start, ends[i]))
-}
-
-/**
- * Whether a name is one `refs/tags/` takes, by the rules of
- * `git check-ref-format` over `refs/tags/<name>`: no control character,
- * no space and none of
- * `~ ^ : ? * [ \`, no `..` and no `@{`, not ending in `.`,
- * and every component between slashes one {@link isComponent} takes. A
- * name that is `@` alone passes, since the ref it names is `refs/tags/@`
- * and not `@`. `git fsck` only warns of a tag named otherwise, as
- * `badTagName`, and exits clean; `git mktag`, strict by default, refuses to
- * write it. This module refuses it too, since a name no ref takes names
- * nothing.
- *
- * @type {(name: readonly number[]) => boolean}
- */
-const isTagName = name =>
-    name.every(b => b >= 0x20 && b !== del && !forbidden.includes(b))
-    && !holdsPair(name, dot, dot)
-    && !holdsPair(name, at, brace)
-    && name[name.length - 1] !== dot
-    && components(name).every(isComponent)
 
 /**
  * The id the `object` header names: the first header, a hex id.
@@ -331,7 +261,7 @@ export const validate = oidBytes => {
         if (typeOf(typeValue) === null) { return error('unknown type') }
         const nameValue = valueAt(t, 2, 'tag')
         if (nameValue === null) { return error('no tag name') }
-        if (!isTagName(byteArray(nameValue))) { return error('bad tag name') }
+        if (!isName(byteArray(nameValue))) { return error('bad tag name') }
         const taggerValue = valueAt(t, 3, 'tagger')
         return taggerValue !== null && readIdent(taggerValue) === null ? error('not a tagger') : ok(t)
     }

--- a/fjs/git/tag/proof.f.mjs
+++ b/fjs/git/tag/proof.f.mjs
@@ -192,25 +192,15 @@ export const proof = {
         assertStructurallySame(validate20(tag(['', 'm\0'])), ['error', 'no object'])
         assertStructurallySame(validate20(replaced(5, 'm\0'))[0], 'ok')
     },
-    // A tag's name is a ref name: what `git check-ref-format` takes passes,
-    // and each of its rules refuses.
+    // A tag's name is a ref name, so `validate` asks `fjs/git/refname`
+    // whether it is one and reports `bad tag name` where it is not. Which
+    // names those are is that module's rule and its proof walks the table;
+    // here it is the wiring and the message, one name each way.
     name: () => {
-        for (const n of ['v1.0', 'release/1.0', 'a@b', 'a.b.c', 'lock', 'x.locky', 'a{b', 'a/b/c', '\xE9', '@']) {
-            assertStructurallySame(validate20(replaced(2, `tag ${n}`))[0], 'ok')
-        }
-        for (const n of [
-            '', 'a b', 'a~b', 'a^b', 'a:b', 'a?b', 'a*b', 'a[b', 'a\\b', 'a\x01b', 'a\x7Fb',
-            'a..b', 'a@{b', 'a.', '.a', 'a/.b', 'a.lock', 'a.lock/b', 'a/', '/a', 'a//b',
-        ]) {
-            assertStructurallySame(validate20(replaced(2, `tag ${n}`)), ['error', 'bad tag name'])
-        }
+        assertStructurallySame(validate20(replaced(2, 'tag release/1.0'))[0], 'ok')
+        assertStructurallySame(validate20(replaced(2, 'tag a..b')), ['error', 'bad tag name'])
         assertStructurallySame(validate20(replaced(3, 'tagger A <a@b> 1 +000')), ['error', 'not a tagger'])
         assertStructurallySame(validate20(replaced(3, 'tagger A')), ['error', 'not a tagger'])
-        // A name is as long as its author made it, and is checked once over,
-        // not once per byte: twenty thousand bytes, and the same with slashes.
-        assertStructurallySame(validate20(replaced(2, `tag ${'n'.repeat(20000)}`))[0], 'ok')
-        assertStructurallySame(validate20(replaced(2, `tag ${'n/'.repeat(10000)}n`))[0], 'ok')
-        assertStructurallySame(validate20(replaced(2, `tag ${'n/'.repeat(10000)}`)), ['error', 'bad tag name'])
     },
     // The well-known fields panic on a tag `validate` refuses.
     throw: {

--- a/fjs/git/todo/refs.md
+++ b/fjs/git/todo/refs.md
@@ -57,10 +57,14 @@ Two functions over the effects:
   for nothing that resolves a DISOT name.
 
 A ref name that is no ref name is refused by the rules
-[`fjs/git/tag`](../tag/module.f.mjs) already holds for a tag's name, which
-move to a shared place then. Reading is through `readFile` and `readdir`;
-writing a ref, with the lock file Git takes, is a later task, and so is
-the reflog, which expires and is no retention.
+[`fjs/git/refname`](../refname/module.f.mjs) holds, which is where they now
+live: `fjs/git/tag` held them first, because a tag's `tag` header is a ref
+name and its reader was the first thing that had to judge one, and they are
+not a fact about tags. A symbolic ref's target needs one rule more, since
+Git wants a whole ref name there — `refs/` and then a name those rules take,
+stricter than `git check-ref-format`, which accepts `a/b`. Reading is through
+`readFile` and `readdir`; writing a ref, with the lock file Git takes, is a
+later task, and so is the reflog, which expires and is no retention.
 
 ### Tasks
 

--- a/fjs/git/todo/refs.md
+++ b/fjs/git/todo/refs.md
@@ -65,7 +65,7 @@ the reflog, which expires and is no retention.
 ### Tasks
 
 - [ ] Grammars for the three files, and their readers.
-- [ ] The ref-name rules shared with the tag module.
+- [x] The ref-name rules shared with the tag module.
 - [ ] `roots` and `tryResolve`, over the effects, with the virtual
       filesystem as their proof.
 


### PR DESCRIPTION
Stacked on #2011. First of three for
[`fjs/git/todo/refs.md`](https://github.com/functionalscript/functionalscript/blob/main/fjs/git/todo/refs.md),
taking its second task: "the ref-name rules shared with the tag module".

`fjs/git/tag` held the rules `git check-ref-format` applies, because a tag's
`tag` header is a ref name and the tag reader was the first thing that needed
to judge one. They are not a fact about tags. `HEAD`, a loose ref and a
`packed-refs` line all carry ref names, so the rules move to
`fjs/git/refname` and the tag module imports `isName`.

**Re-measured rather than moved on faith.** Every name in the proof table
went through `git check-ref-format refs/tags/<name>` on Git 2.43.0, and two
rules are not where a reader would place them:

| spelling | `check-ref-format` | why |
| --- | --- | --- |
| `a.lock/b` | refused | `.lock` is refused at the end of *any* component |
| `a./b` | accepted | a trailing `.` is refused only at the end of the whole name |
| `a/b.` | refused | same rule, and here it is the end |
| `a/b.lock` | refused | any component again |

Both now have a proof case of their own, `whereTheRulesApply`, so the next
reader does not have to re-derive which rule is per-component and which is
per-name.

**The exhaustive table lives with the rules.** The tag proof kept twenty-odd
names walked through `validate`; it now keeps the wiring and the message it
reports, one name each way, and the table sits in the new module's proof
where the rules are.

**Findings fixed.**

`isName` was typed `readonly number[]`, narrower than the `Bytes` every other
reader in `fjs/git` takes. `Bytes` is `List<number>`, which is an array, a
cons cell, a concat node or a thunk, and the predicate needs a dense array
for `every`, `length`, `slice` and `flatMap`, so the conversion was mandatory
and the tag module was doing it at the call site. It moves inside, and all
four list shapes work where only the array did.

That conversion is `byteArray`, so the range check comes with it, which
closes the hole review found: `isName([256])` and `isName(new Array(1))` both
answered `true`. No rule had an upper bound, and `every` steps over a hole in
a sparse array without calling its predicate, so a name of one hole satisfied
every rule without a byte being read. A dense `undefined` was already
refused, which is why only the hole slipped. Both are pinned under a `throw`
key, per `fjs/AGENTS.md` §1.5.

`isComponent` and `components` are no longer exported. They had no caller
outside the proof, which is the dead code this pull request avoided for the
whole-name rule and should not have shipped for these.

`fjs/git/README.md` indexes every submodule and `refname/` was missing; every
earlier one arrived with its entry in the same commit, and `todo/refs.md`
points at that README as the map of the directory. `todo/refs.md`'s second
task is ticked, and the prose above it no longer says the rules will "move to
a shared place then" — ticking the task had left that sentence describing as
future what the same commit had done.

**What is documented and deliberately not implemented.** The rule for a
*whole* ref name is neither of the two rules here: it adds that the name has
at least two components and is not `@` alone. Measured —

```
$ git check-ref-format main                      # refused
$ git check-ref-format --allow-onelevel main     # ok
$ git check-ref-format --allow-onelevel @        # refused
$ git check-ref-format refs/heads/@              # ok
$ git check-ref-format refs/@/x                  # ok
```

— so `@` is fine as a component and refused as a whole name, which is why
`isName` takes it. The whole-name rule is in the module doc with no
implementation, because nothing reads a whole ref name until the next pull
request in this stack, and an exported predicate with no caller is dead code.
A symbolic ref's target turns out to want one rule more than that: `refs/`
and then a name these rules take, stricter than `check-ref-format`, which
accepts `a/b` where Git refuses `ref: a/b`.

**Recorded rather than fixed.**
[`fjs/git/refname/todo/one-pass-name-check.md`](https://github.com/functionalscript/functionalscript/blob/claude/git-refs/fjs/git/refname/todo/one-pass-name-check.md):
`isName` materialises the name to read it, at eight bytes of heap per byte.
Measured on a 20000-byte name, a hundred allocations each with a collection
forced before and after every sample:

| representation | heap at rest |
| --- | --- |
| dense `readonly number[]` | 156.3 KiB |
| `bigint` | 19.6 KiB |

About eight to one. The array is transient and a ref name is short, so it is
a rate rather than a leak, and the shape predates this branch — the rules
took an array while private to `fjs/git/tag`.

**The method is the trap, and two earlier revisions of this description got it
wrong in turn.** The first gave a single `heapUsed` delta, 16.3 KiB for the
`bigint`. The second credited the fix to the sample count. Neither holds: with
a hundred samples and no forced collection the `bigint` measures 75.7 KiB and
then -136.8 and -137.8 KiB over three runs, and a negative heap per instance
is impossible, so the noise is larger than the quantity and no number of
samples averages it away. Collecting around each sample is what makes the
figures mean anything.

The floor is the part that needs no run at all, and it now follows from
something: a vector stores a sentinel bit above the payload, so this name is
160001 bits rather than 160000, which is 2501 64-bit limbs and 19.54 KiB. The
earlier text derived 2501 limbs from 160000 bits, which is exactly 2500. Same
floor, and it is what refuted the 16.3 KiB figure on its own. The issue keeps
both discarded measurements, since the arithmetic was never the hard part.

The todo says why neither obvious substitution is the answer. A bit vector
caps at `maxLength`, 1048576 bits or **128 KiB**, set by Bun's `bigint`
constraint as the smallest across supported runtimes, so it cannot carry a
payload of arbitrary size; a list or an array of bit vectors is the shape for
that. Building one a byte at a time allocates the sum of `1..n` bytes, about
191 MiB at 20000, which `u8ListToVec`'s absorbing concat fold avoids. A hex
string is 4x smaller than the array but doubles the length and puts the rules
a nibble from the bytes they are about.

The fix is to hold nothing: every rule is decidable in one forward pass with
a fixed-size accumulator, which removes the cost rather than shrinking it.
That is its own change and not this one, so this stays the move it claims to
be.

**The rest of the stack**: the three file grammars and their readers, then
`roots` and `tryResolve` over the effects. The effects half needs the `under`
join that #2011 adds, which is why this branch is stacked there rather than
on `main`.

No changelog entry: `fjs/git/tag`'s exported set is identical before and
after — everything that moved was file-private, `isTagName` included — and
`fjs/git/refname` is a new module whose export has one caller inside the
repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdU8wW4oihFS1gj4dUAcPS