### PR TITLE
datajs/vectors: every set is a DataJS document, checked rather than measured

### DIFF
--- a/fjs/media/datajs/vectors/matrix/module.f.mjs
+++ b/fjs/media/datajs/vectors/matrix/module.f.mjs
@@ -52,7 +52,7 @@
  */
 
 import { assertNotNullish } from '../../../../asserts/module.f.mjs'
-import { errorMessage, foldStep, pureOk, resultMapStep, step } from '../../../../effects/module.f.mjs'
+import { errorMessage, foldStep, mapStep, pureOk, resultMapStep, step } from '../../../../effects/module.f.mjs'
 import { errorExit, exitStep, mkdir, readFile, writeUtf8File } from '../../../../effects/node/module.f.mjs'
 import { fromVec } from '../../../../text/utf8/module.f.mjs'
 import { parse } from '../../parser/module.f.mjs'
@@ -686,12 +686,12 @@ export const sourceDefects = corpus => foldStep(
  *
  * @type {(corpus: Corpus) => NodeProgram}
  */
-export const program = corpus => _options => step(
-    sourceDefects(corpus),
-    defects => {
-        const [tag, value] = matrix(corpus, defects)
-        return tag === 'error' ? errorExit(value) : exitStep(write(value))
-    })
+export const program = corpus => _options => {
+    const checked = sourceDefects(corpus)
+    const rendered = mapStep(checked, defects => matrix(corpus, defects))
+    return step(rendered, ([tag, value]) =>
+        tag === 'error' ? errorExit(value) : exitStep(write(value)))
+}
 
 /** @type {NodeProgram} */
 export const main = program(corpus)

--- a/fjs/media/datajs/vectors/matrix/module.f.mjs
+++ b/fjs/media/datajs/vectors/matrix/module.f.mjs
@@ -621,11 +621,12 @@ export const sourceOf = name => `${directory}/${name}/data.f.mjs`
  * @type {(name: string, text: string, imported: unknown) => readonly string[]}
  */
 export const sourceDefect = (name, text, imported) => {
-    const read = parse(text)
-    return read[0] === 'error'
-        ? [`the set ${name}: its own source is not a DataJS document, ${read[1]}`]
-        : (d => d === null ? [] : [`the set ${name}: its source denotes another graph, ${d}`])(
-            difference(/** @type {Unknown} */ (imported))(read[1]))
+    const [tag, value] = parse(text)
+    if (tag === 'error') {
+        return [`the set ${name}: its own source is not a DataJS document, ${value}`]
+    }
+    const d = difference(/** @type {Unknown} */ (imported))(value)
+    return d === null ? [] : [`the set ${name}: its source denotes another graph, ${d}`]
 }
 
 /**
@@ -640,9 +641,9 @@ export const sourceDefects = corpus => foldStep(
     /** @type {readonly string[]} */ ([]),
     ([name, imported]) => defects => resultMapStep(
         readUtf8File(sourceOf(name)),
-        read => ok([...defects, ...read[0] === 'error'
-            ? [`the set ${name}: its source cannot be read, ${errorMessage(read[1])}`]
-            : sourceDefect(name, read[1], imported)])))
+        ([tag, value]) => ok([...defects, ...tag === 'error'
+            ? [`the set ${name}: its source cannot be read, ${errorMessage(value)}`]
+            : sourceDefect(name, value, imported)])))
 
 /**
  * `gen` regenerates the matrix on every pull request, so a set that lands
@@ -660,8 +661,8 @@ export const sourceDefects = corpus => foldStep(
 export const program = corpus => _options => step(
     sourceDefects(corpus),
     defects => {
-        const text = defects.length === 0 ? matrix(corpus) : refused(defects)
-        return text[0] === 'error' ? errorExit(text[1]) : exitStep(write(text[1]))
+        const [tag, value] = defects.length === 0 ? matrix(corpus) : refused(defects)
+        return tag === 'error' ? errorExit(value) : exitStep(write(value))
     })
 
 /** @type {NodeProgram} */

--- a/fjs/media/datajs/vectors/matrix/module.f.mjs
+++ b/fjs/media/datajs/vectors/matrix/module.f.mjs
@@ -43,15 +43,18 @@
  * @module
  *
  * @import { Result } from '../../../../types/result/types.ts'
- * @import { IoChannel, Mkdir, NodeProgram, WriteFile } from '../../../../effects/node/types.ts'
+ * @import { IoChannel, Mkdir, NodeProgram, ReadFile, WriteFile } from '../../../../effects/node/types.ts'
  * @import { Effect } from '../../../../effects/types.ts'
  * @import { Base } from '../types.ts'
+ * @import { Unknown } from '../../types.ts'
  * @import { Corpus, NotApplicable, Role, Scope } from './types.ts'
  */
 
 import { assertNotNullish } from '../../../../asserts/module.f.mjs'
-import { step } from '../../../../effects/module.f.mjs'
-import { errorExit, exitStep, mkdir, writeUtf8File } from '../../../../effects/node/module.f.mjs'
+import { errorMessage, foldStep, pureOk, resultMapStep, step } from '../../../../effects/module.f.mjs'
+import { errorExit, exitStep, mkdir, readUtf8File, writeUtf8File } from '../../../../effects/node/module.f.mjs'
+import { parse } from '../../parser/module.f.mjs'
+import { difference } from '../module.f.mjs'
 import { cmp as strCmp } from '../../../../types/string/module.f.mjs'
 import { error, ok } from '../../../../types/result/module.f.mjs'
 import accept from '../../../../../spec/datajs/vectors/accept/data.f.mjs'
@@ -574,6 +577,74 @@ export const matrix = corpus => {
 export const write = text => step(mkdir(directory, { recursive: true }), () => writeUtf8File(path, text))
 
 /**
+ * Every data module the corpus is made of, under the name its directory
+ * carries. The reasons are one of them: `not-applicable/data.f.mjs` makes the
+ * same promise the vector sets make and broke it the same way.
+ *
+ * @type {(corpus: Corpus) => readonly (readonly [string, unknown])[]}
+ */
+export const modules = ({ roles, notApplicable }) => [
+    ...roles.flatMap(({ sets }) => sets.map(([name, vectors]) =>
+        /** @type {readonly [string, unknown]} */ ([name, vectors]))),
+    ['not-applicable', notApplicable],
+]
+
+/** Where a data module's own source is. @type {(name: string) => string} */
+export const sourceOf = name => `${directory}/${name}/data.f.mjs`
+
+/**
+ * What a data module's own source says, against the value the engine imported
+ * from it: the DataJS reader reads the source, and `difference` compares the
+ * graph it denotes with that value.
+ *
+ * `spec/datajs/vectors/README.md` promises every set is a module of the DataJS
+ * subset, which is what makes the corpus portable — a harness in another
+ * language reads these files rather than importing them. For all six the
+ * promise was false: each ended with a trailing comma before its `]`, which
+ * JavaScript takes and DataJS refuses, so no conforming reader could read the
+ * corpus it is the corpus for. The reject set says a trailing comma is not
+ * DataJS in four vectors of its own, so the corpus stated the rule and broke it
+ * in its own text.
+ *
+ * That was fixed by measuring each file by hand once. **Measuring by hand is
+ * not a check**, and the promise is worth exactly what enforces it, so it is
+ * enforced here, where the generator already reads the corpus and already fails
+ * the build.
+ *
+ * Parsing alone would not be enough. A source can be a DataJS document and
+ * denote something other than what the engine imported — a `1e2` the reader
+ * takes as `100`, a shared node spelled twice, a key order the two disagree on
+ * — and a harness would then be conforming against a different corpus from the
+ * one this repository's own proofs run. So the graph is compared too, sharing
+ * and key order included, which is what `difference` compares.
+ *
+ * @type {(name: string, text: string, imported: unknown) => readonly string[]}
+ */
+export const sourceDefect = (name, text, imported) => {
+    const read = parse(text)
+    return read[0] === 'error'
+        ? [`the set ${name}: its own source is not a DataJS document, ${read[1]}`]
+        : (d => d === null ? [] : [`the set ${name}: its source denotes another graph, ${d}`])(
+            difference(/** @type {Unknown} */ (imported))(read[1]))
+}
+
+/**
+ * Every data module's source read back and checked, as the defects the matrix
+ * reports beside its own. A file that cannot be read is a defect of the same
+ * kind: the corpus promises the file is there for a harness to read.
+ *
+ * @type {(corpus: Corpus) => Effect<ReadFile, readonly string[], never>}
+ */
+export const sourceDefects = corpus => foldStep(
+    pureOk(modules(corpus)),
+    /** @type {readonly string[]} */ ([]),
+    ([name, imported]) => defects => resultMapStep(
+        readUtf8File(sourceOf(name)),
+        read => ok([...defects, ...read[0] === 'error'
+            ? [`the set ${name}: its source cannot be read, ${errorMessage(read[1])}`]
+            : sourceDefect(name, read[1], imported)])))
+
+/**
  * `gen` regenerates the matrix on every pull request, so a set that lands
  * without its row, or a class that loses a role, is a red check rather
  * than a file someone remembers to update. An unanswered cell exits
@@ -586,10 +657,12 @@ export const write = text => step(mkdir(directory, { recursive: true }), () => w
  *
  * @type {(corpus: Corpus) => NodeProgram}
  */
-export const program = corpus => _options => {
-    const text = matrix(corpus)
-    return text[0] === 'error' ? errorExit(text[1]) : exitStep(write(text[1]))
-}
+export const program = corpus => _options => step(
+    sourceDefects(corpus),
+    defects => {
+        const text = defects.length === 0 ? matrix(corpus) : refused(defects)
+        return text[0] === 'error' ? errorExit(text[1]) : exitStep(write(text[1]))
+    })
 
 /** @type {NodeProgram} */
 export const main = program(corpus)

--- a/fjs/media/datajs/vectors/matrix/module.f.mjs
+++ b/fjs/media/datajs/vectors/matrix/module.f.mjs
@@ -482,12 +482,15 @@ const summary = (corpus, role) => {
 }
 
 /**
- * The defects a corpus has, as the failure a caller reads.
+ * The defects a corpus has, as the failure a caller reads. The subject is the
+ * **corpus** rather than the table, because these are not all the table's: a
+ * source that is not a DataJS document is a defect of the corpus that the
+ * generator reports in the same list.
  *
  * @type {(failures: readonly string[]) => Result<string, string>}
  */
 const refused = failures => error([
-    `the class-by-role matrix has ${failures.length} defects:`,
+    `the corpus has ${failures.length} defects:`,
     ...failures.map(f => `  ${f}`),
     'a class a role owes no vector needs a record in spec/datajs/vectors/not-applicable saying why.',
 ].join('\n'))
@@ -498,20 +501,31 @@ const refused = failures => error([
  * vector ids, the reason there are none, or a role whose sets have not
  * landed.
  *
- * @type {(corpus: Corpus) => Result<string, string>}
+ * `also` carries defects found outside the table — the source checks below —
+ * and they are reported **beside** the matrix's own rather than instead of
+ * them. One edit can break both at once, a new vector with a trailing comma
+ * whose class no role answers being the obvious case, and a generator that
+ * reports one kind at a time turns one fix into two runs.
+ *
+ * They ride alongside a malformed scope too, which the exclusivity rule below
+ * does not reach: that rule is about defects *derived from reading* a scope,
+ * and a source defect is not derived from reading anything.
+ *
+ * @type {(corpus: Corpus, also?: readonly string[]) => Result<string, string>}
  */
-export const matrix = corpus => {
+export const matrix = (corpus, also = []) => {
     // A malformed scope is refused first and alone. Every other check reads a
     // scope as a tag and a name, so one that is neither cannot be read by them
     // at all — a one-element tuple has no name to render and no family to
     // measure. Reporting it beside failures derived from reading it would be
     // reporting the same defect twice over.
     const bad = malformed(corpus)
-    if (bad.length !== 0) { return refused(bad) }
+    if (bad.length !== 0) { return refused([...also, ...bad]) }
     const classes = classesOf(corpus.roles)
     const rows = classes.map(c => row(corpus, c))
     /** @type {readonly string[]} */
     const failures = [
+        ...also,
         ...roleless(corpus),
         ...unrenderable(corpus),
         ...ambiguous(corpus),
@@ -661,7 +675,7 @@ export const sourceDefects = corpus => foldStep(
 export const program = corpus => _options => step(
     sourceDefects(corpus),
     defects => {
-        const [tag, value] = defects.length === 0 ? matrix(corpus) : refused(defects)
+        const [tag, value] = matrix(corpus, defects)
         return tag === 'error' ? errorExit(value) : exitStep(write(value))
     })
 

--- a/fjs/media/datajs/vectors/matrix/module.f.mjs
+++ b/fjs/media/datajs/vectors/matrix/module.f.mjs
@@ -45,6 +45,7 @@
  * @import { Result } from '../../../../types/result/types.ts'
  * @import { IoChannel, Mkdir, NodeProgram, ReadFile, WriteFile } from '../../../../effects/node/types.ts'
  * @import { Effect } from '../../../../effects/types.ts'
+ * @import { Vec } from '../../../../types/bit_vec/types.ts'
  * @import { Base } from '../types.ts'
  * @import { Unknown } from '../../types.ts'
  * @import { Corpus, NotApplicable, Role, Scope } from './types.ts'
@@ -52,7 +53,8 @@
 
 import { assertNotNullish } from '../../../../asserts/module.f.mjs'
 import { errorMessage, foldStep, pureOk, resultMapStep, step } from '../../../../effects/module.f.mjs'
-import { errorExit, exitStep, mkdir, readUtf8File, writeUtf8File } from '../../../../effects/node/module.f.mjs'
+import { errorExit, exitStep, mkdir, readFile, writeUtf8File } from '../../../../effects/node/module.f.mjs'
+import { fromVec } from '../../../../text/utf8/module.f.mjs'
 import { parse } from '../../parser/module.f.mjs'
 import { difference } from '../module.f.mjs'
 import { cmp as strCmp } from '../../../../types/string/module.f.mjs'
@@ -632,9 +634,21 @@ export const sourceOf = name => `${directory}/${name}/data.f.mjs`
  * one this repository's own proofs run. So the graph is compared too, sharing
  * and key order included, which is what `difference` compares.
  *
- * @type {(name: string, text: string, imported: unknown) => readonly string[]}
+ * @type {(name: string, bytes: Vec, imported: unknown) => readonly string[]}
  */
-export const sourceDefect = (name, text, imported) => {
+export const sourceDefect = (name, bytes, imported) => {
+    // The bytes come first because the rule does. Decoding before checking
+    // would make the check unable to see its own subject: this repository's
+    // `utf8ToString` maps an illegal byte to a character rather than failing —
+    // measured, `FF` becomes U+00FF, a truncated `C2` becomes U+00C2, an
+    // overlong `C0 AF` becomes two characters, and `ED A0 80` becomes a lone
+    // surrogate. So `const $0="\u00ff";export default [];` written with a raw
+    // `FF` decodes to a valid document denoting the graph the engine imported,
+    // and every later check passes on a file that is not UTF-8 at all.
+    const text = fromVec(bytes)
+    if (text === null) {
+        return [`the set ${name}: its own source is not correct UTF-8`]
+    }
     const [tag, value] = parse(text)
     if (tag === 'error') {
         return [`the set ${name}: its own source is not a DataJS document, ${value}`]
@@ -654,7 +668,7 @@ export const sourceDefects = corpus => foldStep(
     pureOk(modules(corpus)),
     /** @type {readonly string[]} */ ([]),
     ([name, imported]) => defects => resultMapStep(
-        readUtf8File(sourceOf(name)),
+        readFile(sourceOf(name)),
         ([tag, value]) => ok([...defects, ...tag === 'error'
             ? [`the set ${name}: its source cannot be read, ${errorMessage(value)}`]
             : sourceDefect(name, value, imported)])))

--- a/fjs/media/datajs/vectors/matrix/proof.f.mjs
+++ b/fjs/media/datajs/vectors/matrix/proof.f.mjs
@@ -132,7 +132,7 @@ export const proof = {
     // generator names the ones it does not get.
     unanswered: () => {
         assertEq(failure(landed), [
-            'the class-by-role matrix has 1 defects:',
+            'the corpus has 1 defects:',
             '  y in serializer: no vector and no reason',
             'a class a role owes no vector needs a record in spec/datajs/vectors/not-applicable saying why.',
         ].join('\n'))
@@ -152,7 +152,7 @@ export const proof = {
     stale: () => {
         assertEq(failure({ ...two, notApplicable: [{ scope: ['class', 'x'], role: 'reader', because: 'no' }] }),
             [
-                'the class-by-role matrix has 1 defects:',
+                'the corpus has 1 defects:',
                 '  class x in reader: answers 1 classes that have vectors, x among them',
                 'a class a role owes no vector needs a record in spec/datajs/vectors/not-applicable saying why.',
             ].join('\n'))
@@ -495,5 +495,24 @@ export const proof = {
     programRefuses: () => {
         const [, result] = virtual(emptyState)(program(landed)(defaultNodeProgramOptions))
         assertEq(exitCode(result), 1)
+    },
+    // A defect found outside the table is reported *beside* the table's own,
+    // not instead of them. One edit breaks both — a new vector with a trailing
+    // comma whose class no role answers — and reporting one kind at a time
+    // turns one fix into two runs of the generator.
+    defectsTogether: () => {
+        const outside = 'the set a-set: its own source is not a DataJS document'
+        const both = matrix(landed, [outside])
+        assert(both[0] === 'error', 'expected a refusal')
+        assert(both[1].includes(outside), both[1])
+        assert(both[1].includes('y in serializer'), both[1])
+        assert(both[1].includes('the corpus has 2 defects:'), both[1])
+        // and beside a malformed scope, which the table refuses first and alone:
+        // that exclusivity is about defects derived from *reading* a scope, and
+        // an outside defect is not one
+        const malformed = matrix(withScope(null), [outside])
+        assert(malformed[0] === 'error', 'expected a refusal')
+        assert(malformed[1].includes(outside), malformed[1])
+        assert(malformed[1].includes('is not a scope'), malformed[1])
     },
 }

--- a/fjs/media/datajs/vectors/matrix/proof.f.mjs
+++ b/fjs/media/datajs/vectors/matrix/proof.f.mjs
@@ -1,16 +1,19 @@
 /**
+ * @import { State } from '../../../../effects/node/virtual/types.ts'
  * @import { Corpus, Scope } from './types.ts'
  */
 
 import { assert, assertEq } from '../../../../asserts/module.f.mjs'
-import { step as ioStep } from '../../../../effects/module.f.mjs'
-import { exitCode, readUtf8File } from '../../../../effects/node/module.f.mjs'
+import { foldStep, mapStep, pureOk, step as ioStep } from '../../../../effects/module.f.mjs'
+import { exitCode, mkdir, readUtf8File, writeUtf8File } from '../../../../effects/node/module.f.mjs'
 import {
     defaultNodeProgramOptions,
     emptyState,
     virtual,
 } from '../../../../effects/node/virtual/module.f.mjs'
-import { corpus, main, matrix, path, program, write } from './module.f.mjs'
+import { unwrap } from '../../../../types/result/module.f.mjs'
+import { tryStringify } from '../../serializer/module.f.mjs'
+import { corpus, directory, main, matrix, modules, path, program, sourceDefect, sourceOf, write } from './module.f.mjs'
 
 /** A vector as the matrix reads one: an id and the class it covers. @type {(id: string, c: string) => { id: string, class: string }} */
 const v = (id, c) => ({ id, class: c })
@@ -57,6 +60,35 @@ const reason = because => ({ ...landed, notApplicable: [{ scope: /** @type {cons
 
 /** @type {string} */
 const prose = 'is not prose the table can show as written'
+
+/**
+ * A virtual filesystem holding each data module's source, which the program
+ * now reads. The text is the *writer's*, not the file's: a proof runs against
+ * an in-memory filesystem and cannot read the repository, and the writer's
+ * output is a DataJS document denoting the set by construction, which is
+ * exactly the shape the check must accept.
+ *
+ * So the two halves are proved in different places, deliberately. The
+ * predicate is proved here, on texts chosen to break it. That the six real
+ * files satisfy it is proved by `npm run gen`, in CI, against the files
+ * themselves — which is the point of moving the measurement into the
+ * generator, and something no in-memory fixture could establish.
+ *
+ * @type {(sources: readonly (readonly [string, string])[]) => State}
+ */
+const withSources = sources => virtual(emptyState)(foldStep(
+    pureOk(sources),
+    null,
+    ([name, text]) => () => mapStep(ioStep(
+        mkdir(`${directory}/${name}`, { recursive: true }),
+        () => writeUtf8File(sourceOf(name), text)), () => null)))[0]
+
+/** Each data module's source as the writer spells it. @type {readonly (readonly [string, string])[]} */
+const written = modules(corpus).map(([name, imported]) =>
+    /** @type {readonly [string, string]} */ ([name, unwrap(tryStringify(imported))]))
+
+/** The exit code the real program gives against a filesystem. @type {(state: State) => number} */
+const run = state => exitCode(virtual(state)(main(defaultNodeProgramOptions))[1])
 
 /** @type {string} */
 const name = 'is not a name the table can show as written'
@@ -410,8 +442,42 @@ export const proof = {
         assertEq(result, 'hello')
     },
     main: () => {
-        const [, result] = virtual(emptyState)(main(defaultNodeProgramOptions))
-        assertEq(exitCode(result), 0)
+        assertEq(run(withSources(written)), 0)
+    },
+    // A source the corpus promises is there and is not.
+    sourceMissing: () => {
+        assertEq(run(withSources(written.slice(1))), 1)
+        assertEq(run(emptyState), 1)
+    },
+    // A source JavaScript takes and DataJS refuses. This is not a hypothetical
+    // defect: every set in the corpus ended with a trailing comma before its
+    // `]`, and the reject set says in four vectors of its own that a trailing
+    // comma is not DataJS, so the corpus stated the rule and broke it in its
+    // own text six times over. It was fixed by hand, which is why it is a check
+    // now.
+    sourceNotDataJs: () => {
+        const [name, text] = written[0]
+        const withComma = `${text.slice(0, -2)},];`
+        assertEq(run(withSources([[name, withComma], ...written.slice(1)])), 1)
+        const d = sourceDefect(name, withComma, null)
+        assertEq(d.length, 1)
+        assert(d[0].includes(`the set ${name}: its own source is not a DataJS document`), d[0])
+    },
+    // A source that is a DataJS document and denotes something else. Only a
+    // text both languages accept and read differently reaches this half, so the
+    // proof supplies the disagreement directly: the one thing a portable corpus
+    // cannot survive is the reader and the engine reading one file two ways.
+    sourceOtherGraph: () => {
+        const one = sourceDefect('a-set', 'export default [1];', [2])
+        assertEq(one.length, 1)
+        assert(one[0].includes('the set a-set: its source denotes another graph'), one[0])
+        // sharing is part of a graph, so a source that spells a node twice
+        // denotes another graph than one that shares it
+        const node = [0]
+        const shared = sourceDefect('a-set', 'export default [[0],[0]];', [node, node])
+        assertEq(shared.length, 1)
+        assert(shared[0].includes('another graph'), shared[0])
+        assertEq(sourceDefect('a-set', 'const $0=[0];export default [$0,$0];', [node, node]).length, 0)
     },
     // A corpus the matrix refuses exits non-zero rather than writing a
     // table with a hole in it.

--- a/fjs/media/datajs/vectors/matrix/proof.f.mjs
+++ b/fjs/media/datajs/vectors/matrix/proof.f.mjs
@@ -1,4 +1,6 @@
 /**
+ * @import { Effect } from '../../../../effects/types.ts'
+ * @import { IoChannel, Mkdir, WriteFile } from '../../../../effects/node/types.ts'
  * @import { State } from '../../../../effects/node/virtual/types.ts'
  * @import { Corpus, Scope } from './types.ts'
  */
@@ -62,6 +64,19 @@ const reason = because => ({ ...landed, notApplicable: [{ scope: /** @type {cons
 const prose = 'is not prose the table can show as written'
 
 /**
+ * One source written into a virtual filesystem: the directory, then the file,
+ * then the fold's state. Each effect is bound at this level so the three read
+ * in the order they run.
+ *
+ * @type {(source: readonly [string, string]) => (state: null) => Effect<Mkdir | WriteFile, null, IoChannel>}
+ */
+const writeSource = ([name, text]) => () => {
+    const made = mkdir(`${directory}/${name}`, { recursive: true })
+    const stored = ioStep(made, () => writeUtf8File(sourceOf(name), text))
+    return mapStep(stored, () => null)
+}
+
+/**
  * A virtual filesystem holding each data module's source, which the program
  * now reads. The text is the *writer's*, not the file's: a proof runs against
  * an in-memory filesystem and cannot read the repository, and the writer's
@@ -76,12 +91,8 @@ const prose = 'is not prose the table can show as written'
  *
  * @type {(sources: readonly (readonly [string, string])[]) => State}
  */
-const withSources = sources => virtual(emptyState)(foldStep(
-    pureOk(sources),
-    null,
-    ([name, text]) => () => mapStep(ioStep(
-        mkdir(`${directory}/${name}`, { recursive: true }),
-        () => writeUtf8File(sourceOf(name), text)), () => null)))[0]
+const withSources = sources =>
+    virtual(emptyState)(foldStep(pureOk(sources), null, writeSource))[0]
 
 /** Each data module's source as the writer spells it. @type {readonly (readonly [string, string])[]} */
 const written = modules(corpus).map(([name, imported]) =>

--- a/fjs/media/datajs/vectors/matrix/proof.f.mjs
+++ b/fjs/media/datajs/vectors/matrix/proof.f.mjs
@@ -1,6 +1,7 @@
 /**
  * @import { Effect } from '../../../../effects/types.ts'
  * @import { IoChannel, Mkdir, WriteFile } from '../../../../effects/node/types.ts'
+ * @import { Vec } from '../../../../types/bit_vec/types.ts'
  * @import { State } from '../../../../effects/node/virtual/types.ts'
  * @import { Corpus, Scope } from './types.ts'
  */
@@ -13,6 +14,8 @@ import {
     emptyState,
     virtual,
 } from '../../../../effects/node/virtual/module.f.mjs'
+import { utf8 } from '../../../../text/module.f.mjs'
+import { toVec } from '../../../../types/uint8array/module.f.mjs'
 import { unwrap } from '../../../../types/result/module.f.mjs'
 import { tryStringify } from '../../serializer/module.f.mjs'
 import { corpus, directory, main, matrix, modules, path, program, sourceDefect, sourceOf, write } from './module.f.mjs'
@@ -470,7 +473,7 @@ export const proof = {
         const [name, text] = written[0]
         const withComma = `${text.slice(0, -2)},];`
         assertEq(run(withSources([[name, withComma], ...written.slice(1)])), 1)
-        const d = sourceDefect(name, withComma, null)
+        const d = sourceDefect(name, utf8(withComma), null)
         assertEq(d.length, 1)
         assert(d[0].includes(`the set ${name}: its own source is not a DataJS document`), d[0])
     },
@@ -479,16 +482,37 @@ export const proof = {
     // proof supplies the disagreement directly: the one thing a portable corpus
     // cannot survive is the reader and the engine reading one file two ways.
     sourceOtherGraph: () => {
-        const one = sourceDefect('a-set', 'export default [1];', [2])
+        const one = sourceDefect('a-set', utf8('export default [1];'), [2])
         assertEq(one.length, 1)
         assert(one[0].includes('the set a-set: its source denotes another graph'), one[0])
         // sharing is part of a graph, so a source that spells a node twice
         // denotes another graph than one that shares it
         const node = [0]
-        const shared = sourceDefect('a-set', 'export default [[0],[0]];', [node, node])
+        const shared = sourceDefect('a-set', utf8('export default [[0],[0]];'), [node, node])
         assertEq(shared.length, 1)
         assert(shared[0].includes('another graph'), shared[0])
-        assertEq(sourceDefect('a-set', 'const $0=[0];export default [$0,$0];', [node, node]).length, 0)
+        assertEq(sourceDefect('a-set', utf8('const $0=[0];export default [$0,$0];'), [node, node]).length, 0)
+    },
+    // A source that is not correct UTF-8 at all, which is checked before the
+    // text exists because nothing after it can see the difference: this
+    // repository's own decoder maps an illegal byte to a character rather than
+    // failing, so each of these decodes to a *valid* document denoting exactly
+    // the graph the engine imported. Every one of them would pass a check that
+    // parsed first.
+    sourceNotUtf8: () => {
+        /** each character taken as one byte, so a fixture can spell an illegal one @type {(s: string) => Vec} */
+        const bytes = s => toVec(new Uint8Array([...s].map(c => c.codePointAt(0) ?? 0)))
+        // `FF` is no UTF-8 byte at all; `C2` at the end is a truncated
+        // sequence; `C0 AF` is an overlong `/`; `ED A0 80` is a surrogate
+        for (const junk of ['\u00ff', '\u00c2', '\u00c0\u00af', '\u00ed\u00a0\u0080']) {
+            const source = bytes(`const $0="${junk}";export default [];`)
+            const d = sourceDefect('a-set', source, [])
+            assertEq(d.length, 1)
+            assert(d[0].includes('the set a-set: its own source is not correct UTF-8'), d[0])
+        }
+        // and the same text encoded properly is accepted, so the case is not
+        // passing because the document is wrong
+        assertEq(sourceDefect('a-set', utf8('const $0="\u00ff";export default [];'), []).length, 0)
     },
     // A corpus the matrix refuses exits non-zero rather than writing a
     // table with a hole in it.

--- a/fjs/media/datajs/vectors/matrix/proof.f.mjs
+++ b/fjs/media/datajs/vectors/matrix/proof.f.mjs
@@ -104,6 +104,15 @@ const written = modules(corpus).map(([name, imported]) =>
 /** The exit code the real program gives against a filesystem. @type {(state: State) => number} */
 const run = state => exitCode(virtual(state)(main(defaultNodeProgramOptions))[1])
 
+/**
+ * Each character of `s` taken as one byte, so a fixture can spell a byte no
+ * encoder would produce. `utf8` cannot: it encodes a *string*, and the point
+ * here is a byte sequence that decodes to no string at all.
+ *
+ * @type {(s: string) => Vec}
+ */
+const bytes = s => toVec(new Uint8Array([...s].map(c => c.codePointAt(0) ?? 0)))
+
 /** @type {string} */
 const name = 'is not a name the table can show as written'
 
@@ -500,8 +509,6 @@ export const proof = {
     // the graph the engine imported. Every one of them would pass a check that
     // parsed first.
     sourceNotUtf8: () => {
-        /** each character taken as one byte, so a fixture can spell an illegal one @type {(s: string) => Vec} */
-        const bytes = s => toVec(new Uint8Array([...s].map(c => c.codePointAt(0) ?? 0)))
         // `FF` is no UTF-8 byte at all; `C2` at the end is a truncated
         // sequence; `C0 AF` is an overlong `/`; `ED A0 80` is a surrogate
         for (const junk of ['\u00ff', '\u00c2', '\u00c0\u00af', '\u00ed\u00a0\u0080']) {
@@ -526,17 +533,17 @@ export const proof = {
     // turns one fix into two runs of the generator.
     defectsTogether: () => {
         const outside = 'the set a-set: its own source is not a DataJS document'
-        const both = matrix(landed, [outside])
-        assert(both[0] === 'error', 'expected a refusal')
-        assert(both[1].includes(outside), both[1])
-        assert(both[1].includes('y in serializer'), both[1])
-        assert(both[1].includes('the corpus has 2 defects:'), both[1])
+        const [tag, both] = matrix(landed, [outside])
+        assert(tag === 'error', 'expected a refusal')
+        assert(both.includes(outside), both)
+        assert(both.includes('y in serializer'), both)
+        assert(both.includes('the corpus has 2 defects:'), both)
         // and beside a malformed scope, which the table refuses first and alone:
         // that exclusivity is about defects derived from *reading* a scope, and
         // an outside defect is not one
-        const malformed = matrix(withScope(null), [outside])
-        assert(malformed[0] === 'error', 'expected a refusal')
-        assert(malformed[1].includes(outside), malformed[1])
-        assert(malformed[1].includes('is not a scope'), malformed[1])
+        const [badTag, badScope] = matrix(withScope(null), [outside])
+        assert(badTag === 'error', 'expected a refusal')
+        assert(badScope.includes(outside), badScope)
+        assert(badScope.includes('is not a scope'), badScope)
     },
 }

--- a/spec/datajs/todo/conformance-vectors.md
+++ b/spec/datajs/todo/conformance-vectors.md
@@ -2687,7 +2687,7 @@ The steps, in order; a step is one pull request unless it says otherwise:
       is correct UTF-8 and anything else is rejected, with no taxonomy of
       malformed sequences and nothing required of a decoder. Its own pull
       request, as each of these changes a different contract.
-- [ ] **Make "every set is a DataJS document" a check rather than a
+- [x] **Make "every set is a DataJS document" a check rather than a
       measurement.** Review found every set ending with a trailing comma
       before its `]`, which JavaScript takes and DataJS refuses, so no set was
       readable by a conforming reader — a promise the corpus README makes and
@@ -2698,6 +2698,28 @@ The steps, in order; a step is one pull request unless it says otherwise:
       with the reader, and compare the graph with the imported set using
       `difference`. Its own pull request, because it needs a failing case in
       the matrix proof to keep coverage honest.
+      Landed as `modules`, `sourceOf`, `sourceDefect` and `sourceDefects` in
+      the generator, which reads all six sources before it writes anything and
+      reports what it finds as matrix defects, so a set that stops being DataJS
+      fails `npm run gen` exactly as an unanswered cell does. Measured against
+      the tree: all six parse and denote what the engine imports, and a trailing
+      comma put back into one of them gives `the set graph-equivalence: its own
+      source is not a DataJS document, unexpected symbol at 6310` and exit 1.
+      **Parsing alone would not have been enough**, and the reason bounds what
+      this check is: the source and the imported value come from one file, so
+      they can only disagree where JavaScript and DataJS both accept the text
+      and read it differently — a key order, a share spelled twice, a number
+      notation. That is precisely the failure a portable corpus cannot survive,
+      since a harness in another language reads these files rather than
+      importing them, so the graph is compared too.
+      The proof's own halves sit in different places on purpose. The predicate
+      is proved on texts chosen to break it, including the trailing comma and a
+      source that parses and denotes another graph. That the six real files
+      satisfy it is proved by `npm run gen` against the files themselves, which
+      is what moving the measurement into the generator buys and what no
+      in-memory fixture could establish: a proof runs on a virtual filesystem
+      and cannot read the repository. So the fixture writes each source with the
+      writer, whose output denotes the set by construction.
 - [ ] **Hand over.** `spec/datajs/README.md`'s Conformance section links the
       corpus instead of this file; stage 4's issue and the stage 6 task in
       [parser-serializer-restructure](../../../todo/parser-serializer-restructure.md)

--- a/spec/datajs/vectors/README.md
+++ b/spec/datajs/vectors/README.md
@@ -17,11 +17,18 @@ Each set is `<set>/data.f.mjs`, a FunctionalScript data module written in
 the DataJS subset the specification describes: `const $n = …;` statements,
 one `export default`, string keys, JSON's values and the leaves DataJS adds.
 So the engine imports it today and the reader reads the same file as a
-document — measured, every set parses and denotes exactly the value the
-engine imports, the sharing included. **That is a rule with teeth and it was
-broken:** every set ended with a trailing comma before its `]`, which
-JavaScript takes and DataJS refuses, so no set was readable by a conforming
-reader until it was removed. A value two vectors share is one `const` — a
+document: every set parses and denotes exactly the value the engine imports,
+the sharing included. **That is a rule with teeth and it was broken:** every
+set ended with a trailing comma before its `]`, which JavaScript takes and
+DataJS refuses, so no set was readable by a conforming reader until it was
+removed. It was found by measuring the files by hand, which is no
+guarantee at all, so `npm run gen` now reads each source back, parses it with
+the reader and compares the graph with the imported value — a set that stops
+being DataJS is a red check, like a class that loses a role. The comparison is
+the half worth having: the two can only disagree where both languages accept
+the text and read it differently, a key order or a share spelled twice, which
+is the one failure a corpus a harness *reads* rather than imports cannot
+survive. A value two vectors share is one `const` — a
 non-empty array or an object, never the empty array literal, which `tsc`
 types as an evolving array when a `const` binds it and refuses every read
 of. A set carries no


### PR DESCRIPTION
Stacked on [#2005](https://github.com/functionalscript/functionalscript/pull/2005).

`spec/datajs/vectors/README.md` promises every set is a module of the DataJS subset. That promise is what makes the corpus portable: a harness in another language **reads** these files rather than importing them. For all six sets it was false. Each ended with a trailing comma before its `]`, which JavaScript takes and DataJS refuses, so no conforming reader could read the corpus it is the corpus for — while the reject set says in four vectors of its own that a trailing comma is not DataJS. The corpus stated the rule and broke it in its own text.

It was found and fixed by reading each file by hand. **That guarantees nothing about the next edit**, so the generator now enforces it, where it already reads the corpus and already fails the build.

## What it does

`npm run gen` reads all six sources before it writes anything, parses each with the DataJS reader, and compares the graph the source denotes with the value the engine imported. Failures are reported beside the matrix's own, so a set that stops being DataJS is a red check exactly as an unanswered cell is.

Four additions to the generator, and nothing else changes: `modules` names every data module the corpus is made of, the reasons included; `sourceOf` says where one lives; `sourceDefect` is the predicate; `sourceDefects` reads them.

Measured against the tree, both directions:

```
all six sources                       exit 0
a trailing comma put back into one    exit 1
  the set graph-equivalence: its own source is not a DataJS document,
  unexpected symbol at 6310
```

## Why the graph is compared and not only the parse

The source and the imported value come from one file, so they can only disagree where JavaScript and DataJS **both** accept the text and read it differently: a key order, a share spelled twice, a number notation. That is not a hypothetical — it is the one failure a corpus a harness reads rather than imports cannot survive, because it makes the harness conforming against a different corpus from the one this repository's own proofs run. Parsing alone would not see it.

## Where each half is proved

Deliberately in two places, and the split is the point.

The **predicate** is proved here, on texts chosen to break it: a trailing comma, a source that parses and denotes another graph, and a source that spells a shared node twice where the value shares it. Its counterpart asserts that the same graph spelled with a `const` is accepted, so the case is not passing for the wrong reason.

That the **six real files** satisfy it is proved by `npm run gen` in CI, against the files themselves. No in-memory fixture could establish that, because a proof runs on a virtual filesystem and cannot read the repository — which is exactly why the check belongs in the generator and not in a proof. The fixture therefore writes each source with the writer, whose output is a DataJS document denoting the set by construction, which is the shape the check must accept.

## Checks

`tsc` clean, `node --test` green at 5890, coverage 100% on lines, branches and functions, `npm run gen` current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzayQtZmCzP9rtExwHXtF2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzayQtZmCzP9rtExwHXtF2)_