### PR TITLE
datajs/vectors: the shared-empty-array issue records its decision

### DIFF
--- a/spec/datajs/vectors/todo/shared-empty-array.md
+++ b/spec/datajs/vectors/todo/shared-empty-array.md
@@ -3,8 +3,14 @@
 **Priority:** P2 — one graph shape no consumer of the corpus can be tested on.
 Nothing is wrong with any vector that exists, and this repository's own writer is
 covered, which is why it is not P1.
-**Status:** open — the limitation is measured and stated below; the fix is a
-carrier or schema change and needs a decision first.
+**Status:** decided, and kept as the record — **the stated limitation
+stands.** The schema change below was weighed and refused: it is not worth every
+record type and every proof for one shape, and it would give up the property
+that a set is an ordinary graph `tsc` checks. Nothing here is waiting on anyone.
+The file stays because the gap it describes does: a reader who notices the
+missing vector should find this, not re-derive it, and whoever revisits the
+carrier should find the search that came back negative and the route that was
+refused rather than repeat either.
 
 ### Problem
 

--- a/spec/datajs/vectors/todo/shared-empty-array.md
+++ b/spec/datajs/vectors/todo/shared-empty-array.md
@@ -3,14 +3,19 @@
 **Priority:** P2 — one graph shape no consumer of the corpus can be tested on.
 Nothing is wrong with any vector that exists, and this repository's own writer is
 covered, which is why it is not P1.
-**Status:** decided, and kept as the record — **the stated limitation
-stands.** The schema change below was weighed and refused: it is not worth every
-record type and every proof for one shape, and it would give up the property
-that a set is an ordinary graph `tsc` checks. Nothing here is waiting on anyone.
-The file stays because the gap it describes does: a reader who notices the
-missing vector should find this, not re-derive it, and whoever revisits the
-carrier should find the search that came back negative and the route that was
-refused rather than repeat either.
+**Status:** decided — **the stated limitation stands.** The schema change below
+was weighed and refused: it is not worth every record type and every proof for
+one shape, and it would give up the property that a set is an ordinary graph
+`tsc` checks. Nothing here is waiting on anyone.
+
+Kept as the record rather than deleted, because two live documents cite it for
+what no surviving file says — the search for a spelling that came back negative,
+and the alternative that was refused and why:
+[`../README.md`](../README.md), beside the sharing rule, and
+[`../../todo/conformance-vectors.md`](../../todo/conformance-vectors.md), in the
+round that measured the limit. Both would lose their reference if this file went,
+and a reader who notices that a shared empty array has no vector in any role
+would be left to re-derive the whole thing.
 
 ### Problem
 


### PR DESCRIPTION
Stacked on [#2021](https://github.com/functionalscript/functionalscript/pull/2021).

[#2003](https://github.com/functionalscript/functionalscript/pull/2003) recorded the owner's decision in the issue's task list — the stated limitation stands rather than a schema change — and merged with the issue's header still saying it was **open** pending exactly that decision. A reader of the two could not tell whether work remained.

One paragraph, in the `Status:` line. It says the decision is made, what it was, that the schema change was weighed and refused because it is not worth every record type and every proof for one shape, and that nothing there is waiting on anyone.

## Why the file stays rather than going

The **decision** is closed. The **gap** is not, and will not be until the carrier changes: a shared empty array still has no vector in any role, because `const $e = [];` in a data module is an evolving `any[]` `tsc` refuses every read of. Someone who notices that missing vector should find the search that came back negative and the route that was refused, instead of re-deriving either. The status line now says so, so the file is a record rather than a task list nobody can close.

## Why it is its own pull request

It arrived on [#2005](https://github.com/functionalscript/functionalscript/pull/2005) because #2003 was in the merge queue and refused a push, and #2005 was the only open branch that could carry it. Review pointed out that this made the whitespace change carry a second, unrelated improvement under a whitespace-only title, which is right. It is out of #2005 and here instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzayQtZmCzP9rtExwHXtF2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzayQtZmCzP9rtExwHXtF2)_