### PR TITLE
datajs: a document is correct UTF-8, and nothing is required of a decoder

### DIFF
--- a/spec/datajs/README.md
+++ b/spec/datajs/README.md
@@ -78,9 +78,9 @@ included, measured against
 [`fjs/media/datajs/parser`](../../fjs/media/datajs/parser/module.f.mjs),
 which closed the reader-side gap this paragraph used to name. That entry
 point takes a string, so what parses today is the document as code units; the
-byte path of §Layout, which refuses invalid UTF-8 and a leading BOM before
-the reader sees a unit, is still to come and is what the corpus's byte-form
-vectors require.
+byte path of [§Encoding](#encoding), which refuses invalid UTF-8 and a leading
+BOM before the reader sees a unit, is still to come and is what the corpus's
+byte-form vectors require.
 The shipped `fjs/djs` serializer still differs from
 [normalized form](#normalized-form) in four ways, each of them stage 4–6 work
 rather than a bug:
@@ -124,6 +124,41 @@ document specifies **DataJS**, the narrow interchange format.
 
 ## Grammar
 
+### Encoding
+
+A document is a byte sequence, and it is **correct UTF-8**. Anything else is
+not a DataJS document and is **rejected**.
+
+That is the whole rule, and it is stated in the accepting form for the reason
+§Whitespace is: a taxonomy of malformed sequences — an overlong form, a
+surrogate encoded as three bytes, a truncated sequence, a continuation byte
+with no leader — is exactly the knowledge a data format should not ask an
+implementer to carry, and any list of them is one entry short of something.
+
+So this specification requires **nothing of a decoder**. It does not say
+whether an implementation exposes one, what it reports, where it stops, or
+whether it replaces anything: correct UTF-8 decodes to one sequence of code
+units, the grammar below reads that sequence, and every other byte sequence is
+refused. How an implementation discovers the refusal is its own business, and
+a decoder that substitutes U+FFFD rather than failing is simply a reader that
+accepts a document this specification rejects.
+
+A document also **has no BOM**, and that rule is not about encoding. The bytes
+`EF BB BF` are correct UTF-8 for U+FEFF, so they decode, and §Whitespace
+already refuses what they decode to: U+FEFF is not one of the four whitespace
+characters and begins no token.
+
+It is stated separately because **two layers a reader is likely to stand on
+remove it before the grammar ever sees it**, and both were measured rather than
+assumed. A JavaScript engine strips a leading BOM: the module
+`EF BB BF 65 78 70 6F 72 74 20 64 65 66 61 75 6C 74 20 31 3B` imports and
+exports `1`. A WHATWG `TextDecoder` strips it too, by default — `decode` of
+those three bytes yields the *empty string*, and only `ignoreBOM: true` returns
+U+FEFF. So an implementation can be built from correct parts and still accept a
+document this format rejects, without anything in it deciding to. Naming the
+rule is what makes that a defect instead of a difference of opinion, and the
+corpus carries the vector that finds it.
+
 ### Whitespace
 
 Whitespace is exactly JSON's: **space** (U+0020), **tab** (U+0009), **LF**
@@ -156,8 +191,6 @@ writer ever consults the next character to find out. The
 So the one-line spelling of a document is `const $0=[];export default [$0,$0];`,
 and `export default [1];`, `export default -1;` and `export default "a";` all
 carry the space.
-
-A document is UTF-8. It has no BOM.
 
 ### Tokens
 

--- a/spec/datajs/README.md
+++ b/spec/datajs/README.md
@@ -677,6 +677,16 @@ suite states it as: every accepted DataJS document parses in FunctionalScript
 to the same graph, and every DataJS document is accepted by a JavaScript
 engine with the same result.
 
+**The second law is over the documents an engine can be handed**, which is the
+documents with a byte encoding — every one of them, and that is not a hedge but
+the scope the claim has. A module reaches an engine as bytes, so the documents
+holding an unpaired surrogate ([§Encoding](#encoding)) are the one case where
+there is no experiment to run rather than a result nobody has measured: they are
+DataJS for a code-unit reader and are not loadable JavaScript modules, because
+no byte sequence spells them. The conformance corpus carries eight such
+documents, names them, and asserts that there are exactly eight, so one more
+appearing is a failure rather than a quiet fall in what the law covers.
+
 ## Files and media type
 
 Recognized extensions: `.data.js`, `.data.mjs`, `.d.js`, `.d.mjs`.

--- a/spec/datajs/README.md
+++ b/spec/datajs/README.md
@@ -143,6 +143,21 @@ refused. How an implementation discovers the refusal is its own business, and
 a decoder that substitutes U+FFFD rather than failing is simply a reader that
 accepts a document this specification rejects.
 
+**The decode is also where a reader divides in two**, and a reader says which
+half it is. One takes bytes and owes the rule above. One takes the code units
+and begins after it, which is what a reader whose entry point is a string does —
+every rule from §Whitespace down is stated over code units and applies to both
+unchanged.
+
+That distinction is not bookkeeping. An **unpaired surrogate** is a code unit no
+byte sequence encodes, so it can reach a code-unit reader and can never reach a
+byte one, and it is a real input to the first: a raw unpaired unit between the
+quotes and its `\uXXXX` escape are different paths through a reader, and one
+that handles the escape may mishandle the unit. So a document is a byte sequence
+where an implementation takes bytes, and a code-unit sequence where it takes
+those — the same document in every case a byte sequence exists for, which is
+every case but this one.
+
 A document also **has no BOM**, and that rule is not about encoding. The bytes
 `EF BB BF` are correct UTF-8 for U+FEFF, so they decode, and §Whitespace
 already refuses what they decode to: U+FEFF is not one of the four whitespace
@@ -697,7 +712,10 @@ that just reads it emits none.
 
 - A conforming **reader** accepts every document this specification accepts,
   rejects every document it rejects, and yields the graph the document
-  denotes, sharing included.
+  denotes, sharing included. It states whether it takes bytes or code units
+  ([§Encoding](#encoding)) and is judged on that form: a byte reader owes the
+  UTF-8 rule, and the documents holding an unpaired surrogate are a code-unit
+  reader's alone, since no byte sequence spells them.
 - A conforming **serializer** rejects every input outside
   [the data model](#what-may-be-serialized) and otherwise emits a valid
   document denoting the input graph.

--- a/spec/datajs/todo/conformance-vectors.md
+++ b/spec/datajs/todo/conformance-vectors.md
@@ -2712,6 +2712,29 @@ The steps, in order; a step is one pull request unless it says otherwise:
       `accepts`, and why prose alone could never have caught it.
       §Status's forward reference is corrected with it: it pointed at "§Layout",
       a section this specification does not have.
+      **Defining a document as bytes then broke eight accept vectors**, which
+      review caught and is the sharper half of this step. The eight
+      `string/surrogate/lone/raw/*` and `key/string/surrogate/lone/raw/*`
+      records carry a document holding an **unpaired surrogate**, and no byte
+      sequence encodes one — so under the new §Encoding they assert that a
+      reader accepts something the format says is not a document. The
+      whole-set proof has always skipped exactly those eight for the same
+      reason, which is the evidence the contradiction was real rather than
+      a reading.
+      Deleting them was the wrong fix, because the coverage is real: a raw
+      unpaired unit between the quotes and its `\uXXXX` escape are different
+      paths through a reader, and the round that added the raw four found the
+      escaped four standing for both. What was missing was the *layer*. A
+      reader divides at the decode: one takes bytes and owes the UTF-8 rule,
+      one takes code units and begins after it, which is what the shipped
+      entry point does and what §Status already said. Every rule from
+      §Whitespace down is stated over code units and applies to both.
+      §Encoding says that now, and §Conformance's reader bullet has a reader
+      state which form it takes, so the eight are a code-unit reader's vectors
+      and a byte reader is never asked for them. The corpus needed no change:
+      its schema has carried both forms all along, a code-unit string and a
+      tagged `['hex', …]`, and the type's own comment says why three records
+      use the second.
 - [x] **Make "every set is a DataJS document" a check rather than a
       measurement.** Review found every set ending with a trailing comma
       before its `]`, which JavaScript takes and DataJS refuses, so no set was

--- a/spec/datajs/todo/conformance-vectors.md
+++ b/spec/datajs/todo/conformance-vectors.md
@@ -1586,7 +1586,19 @@ formatter's rules on the reader's side anyway.
 Two properties worth proving directly rather than case by case: every
 **accept** document parses in FunctionalScript to the same graph, and every
 **accept** document is accepted by a JavaScript engine with the same result.
-Those are the subset laws, and they can run over the whole accept set.
+Those are the subset laws, and they run over every accept document a host can
+be handed — which is every one with a byte encoding.
+
+**That scope is a fact about modules, not a weakening.** Both laws hand a
+document to a host, and a host takes a module as bytes, so the eight documents
+holding an unpaired surrogate have no experiment rather than an unmeasured
+result: they are DataJS for a code-unit reader and are not loadable JavaScript
+modules, because no byte sequence spells them. A code-unit module check is not
+the alternative, because there is nothing to check it with — escaping the unit
+to carry it would test the *escaped* document, which is a different vector that
+the set already has. What keeps that honest is the count: the whole-set proof
+names the eight and asserts there are exactly eight, so a ninth is a failure
+rather than a silent narrowing of the law.
 
 **They land at different times, and this corpus only owes the second.** The
 FunctionalScript check cannot run when this corpus lands: today's front end has

--- a/spec/datajs/todo/conformance-vectors.md
+++ b/spec/datajs/todo/conformance-vectors.md
@@ -2683,10 +2683,35 @@ The steps, in order; a step is one pull request unless it says otherwise:
       needed no change — their `rule` already read "whitespace: exactly
       space, tab, LF and CR", which is the accepting form the spec now
       takes too.
-- [ ] **The decoder seam in the spec**, per decision 4: say that a document
+- [x] **The decoder seam in the spec**, per decision 4: say that a document
       is correct UTF-8 and anything else is rejected, with no taxonomy of
       malformed sequences and nothing required of a decoder. Its own pull
       request, as each of these changes a different contract.
+      Landed as [§Encoding](../README.md#encoding), the first subsection of the
+      grammar, where the bytes are. The rule it replaces was two sentences at
+      the *end of §Whitespace* — "A document is UTF-8. It has no BOM." — which
+      said what a document is and not what follows from it, in the one section
+      that is not about encoding. §Encoding says it in the accepting form
+      §Whitespace uses, and adds the two things the old sentences left to the
+      reader: anything that is not correct UTF-8 is **rejected**, and **nothing
+      is required of a decoder** — not whether one is exposed, what it reports,
+      where it stops, or whether it replaces anything. A decoder that
+      substitutes U+FFFD is then not a permitted variation but a reader that
+      accepts a document the format rejects, which is the sentence the corpus's
+      byte vectors need in order to mean anything.
+      **The BOM rule turned out to be worth more than it looked**, and the
+      round measured it rather than asserting it. `EF BB BF` is correct UTF-8
+      for U+FEFF, so it is not an encoding error at all, and §Whitespace already
+      refuses what it decodes to. It needs its own sentence because **two layers
+      a reader is likely to stand on remove it first**: a JavaScript engine
+      imports `EF BB BF 65 78 70 6F 72 74 20 64 65 66 61 75 6C 74 20 31 3B` and
+      exports `1`, and a WHATWG `TextDecoder` returns the *empty string* for
+      those three bytes unless `ignoreBOM` is set. So an implementation can be
+      assembled from correct parts and over-accept without any part of it
+      deciding to — which is why the reject vector for it records the host as
+      `accepts`, and why prose alone could never have caught it.
+      §Status's forward reference is corrected with it: it pointed at "§Layout",
+      a section this specification does not have.
 - [x] **Make "every set is a DataJS document" a check rather than a
       measurement.** Review found every set ending with a trailing comma
       before its `]`, which JavaScript takes and DataJS refuses, so no set was


### PR DESCRIPTION
Stacked on [#2022](https://github.com/functionalscript/functionalscript/pull/2022).

The encoding rule was two sentences at the **end of §Whitespace**:

> A document is UTF-8. It has no BOM.

They say what a document *is* and not what follows from it, and they sit in the one section of the grammar that is not about encoding. Everything a reader actually needs — what happens to a byte sequence that is not UTF-8, and what is asked of the thing that decodes it — was left to be inferred.

`§Encoding` is now the grammar's first subsection, where the bytes are, ahead of whitespace and tokens. It states the rule in the accepting form §Whitespace uses, and adds the two consequences:

- Anything that is not correct UTF-8 is **rejected**, with **no taxonomy of malformed sequences**. An overlong form, a surrogate encoded as three bytes, a truncated sequence, a continuation byte with no leader: that is the knowledge a data format should not ask an implementer to carry, and any list of it is one entry short of something. The accepting form cannot be short of anything.
- **Nothing is required of a decoder.** Not whether an implementation exposes one, what it reports, where it stops, or whether it replaces anything.

The second is the one that had to be written down, because of what it makes false. A decoder that substitutes U+FFFD for a malformed sequence is now not a permitted variation but **a reader that accepts a document this specification rejects** — and that is the sentence the corpus's byte vectors need in order to mean anything. Two of the three are records that a byte sequence is not a DataJS document, not tests of a decoder, and without this they would have been asserting a rule the specification never stated.

## The BOM rule is worth more than it looked

It is also not what it looked like. `EF BB BF` is **correct UTF-8** for U+FEFF, so a leading BOM is no encoding error at all, and §Whitespace already refuses what it decodes to: U+FEFF is not one of the four whitespace characters and begins no token. On that reading the sentence is redundant.

It is not, and the round measured why instead of arguing it. **Two layers a reader is likely to stand on remove the BOM before the grammar ever sees it:**

```
EF BB BF 65 78 70 6F 72 74 20 64 65 66 61 75 6C 74 20 31 3B
  imported as a module  ->  ok, exports 1

new TextDecoder('utf-8', { fatal: true }).decode(EF BB BF)
  ->  '' (empty string)
  with { ignoreBOM: true }  ->  U+FEFF
```

So an implementation can be assembled entirely from correct parts and over-accept without any part of it deciding to. That is why the reject vector for it records the host as `accepts`, and it is the kind of defect prose alone never catches. Naming the rule is what makes it a defect rather than a difference of opinion.

For completeness, the truncated-sequence vector's host behaviour was measured in the same run: `SyntaxError: Invalid or unexpected token`, and a `fatal: true` decoder raises `TypeError` on the same bytes. Both match what the corpus records.

## Also

§Status's forward reference pointed at "§Layout", a section this specification does not have. It points at §Encoding now, which is the section it was describing.

## Checks

`tsc` clean, `node --test` green at 5890, `npm run gen` current, and every in-document anchor in the specification resolves to a heading it has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzayQtZmCzP9rtExwHXtF2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzayQtZmCzP9rtExwHXtF2)_