### PR TITLE
fsc: the subset law is proved over the DataJS accept corpus, and it found the key order

### DIFF
--- a/fjs/djs/todo/compile-modules-to-edag.md
+++ b/fjs/djs/todo/compile-modules-to-edag.md
@@ -19,12 +19,14 @@ EDAG alone is not enough to represent an unresolved parsed module: module resolu
 also needs the module paths imported by that source file. Keep that information in a
 small temporary wrapper rather than adding module metadata to EDAG itself.
 
-The current parser/AST also cannot preserve the ordered object-entry representation
-required by EDAG. Object parsing accumulates properties in an `OrderedMap` with
-`setReplace` and eventually produces a plain `AstObject`; duplicate keys are therefore
-collapsed and integer-like keys can lose their written order before EDAG conversion.
-This task must preserve object entries as an ordered sequence in the parser/AST until
-they are converted to `['{}', [...entry]]`.
+The current parser/AST cannot fully preserve the ordered object-entry representation
+required by EDAG. Object parsing builds a plain `AstObject` in source order — it
+used to sort the members through an `OrderedMap`, which the subset law over the
+DataJS corpus found and stage 5 fixed — so a repeated key keeps its first position
+and takes its last value, as in JavaScript. What a plain object still cannot keep
+is the written order of integer-like keys, which JavaScript lists first, and the
+duplicates themselves. This task must preserve object entries as an ordered
+sequence in the parser/AST until they are converted to `['{}', [...entry]]`.
 
 ### Proposal
 

--- a/fjs/fsc/parser/module.f.mjs
+++ b/fjs/fsc/parser/module.f.mjs
@@ -46,6 +46,7 @@
  * @import { DjsTokenWithMetadata } from '../tokenizer/types.ts'
  * @import { AstArray, AstConst, AstModule, AstModuleRef, AstObject } from '../ast/types.ts'
  * @import { Const, Container, Entry, Import, Module, Node, Out, ParseError } from './types.ts'
+ * @import { Entry as ObjectEntry } from '../../types/object/types.ts'
  * @import { Items, Member, Value } from './grammar/types.ts'
  * @import { key, primitive } from './grammar/module.f.mjs'
  * @import { _Env, _Frame, _Leaf, _ListNode, _OptionalList, _Stack, _State, _TokenStream } from './private.ts'
@@ -54,6 +55,7 @@
 import { error, ok } from '../../types/result/module.f.mjs'
 import { concat, toArray } from '../../types/list/module.f.mjs'
 import { at, empty, setReplace } from '../../types/ordered_map/module.f.mjs'
+import { fromEntries } from '../../types/object/module.f.mjs'
 import { assert } from '../../asserts/module.f.mjs'
 import { symbolAt, unmapped } from '../../ebnf/ast/module.f.mjs'
 import { mapping, parser } from '../../ebnf/ll1/module.f.mjs'
@@ -422,13 +424,22 @@ const badKey = ([kind, items], index) => {
 }
 
 /**
+ * A member as an entry of the object being closed: its name, and the value
+ * at its index among the resolved values, which are the leading parameter
+ * so that the step lives here rather than closing over them.
+ *
+ * @type {(done: readonly AstConst[]) => (member: Entry, index: number) => ObjectEntry<AstConst>}
+ */
+const memberEntry = done => ({ name }, index) => [name, done[index]]
+
+/**
  * A container of the values its items resolved to: an array, or an object
  * with a property per member, in the order the members are written — the
  * order JavaScript gives the same literal, which is the order the graph a
  * module denotes has, so it is not the parser's to change. A repeated key
- * keeps its first position and takes its last value, as it does there: the
- * spread copies the properties so far, and the member then writes over its
- * own, which leaves a property where it first stood.
+ * keeps its first position and takes its last value, as it does there:
+ * `fromEntries` creates each property where its key first appears and
+ * writes the later value over it, in one pass over the members.
  *
  * @type {(container: Container, done: readonly AstConst[]) => AstConst}
  */
@@ -438,9 +449,7 @@ const close = ([kind, members], done) => {
         const array = ['array', done]
         return array
     }
-    /** @type {AstObject} */
-    const empty = {}
-    return members.reduce((object, { name }, index) => ({ ...object, [name]: done[index] }), empty)
+    return fromEntries(members.map(memberEntry(done)))
 }
 
 /**

--- a/fjs/fsc/parser/module.f.mjs
+++ b/fjs/fsc/parser/module.f.mjs
@@ -48,13 +48,12 @@
  * @import { Const, Container, Entry, Import, Module, Node, Out, ParseError } from './types.ts'
  * @import { Items, Member, Value } from './grammar/types.ts'
  * @import { key, primitive } from './grammar/module.f.mjs'
- * @import { _Env, _Frame, _Leaf, _ListNode, _OptionalList, _Properties, _Stack, _State, _TokenStream } from './private.ts'
+ * @import { _Env, _Frame, _Leaf, _ListNode, _OptionalList, _Stack, _State, _TokenStream } from './private.ts'
  */
 
 import { error, ok } from '../../types/result/module.f.mjs'
 import { concat, toArray } from '../../types/list/module.f.mjs'
 import { at, empty, setReplace } from '../../types/ordered_map/module.f.mjs'
-import { fromMap } from '../../types/object/module.f.mjs'
 import { assert } from '../../asserts/module.f.mjs'
 import { symbolAt, unmapped } from '../../ebnf/ast/module.f.mjs'
 import { mapping, parser } from '../../ebnf/ll1/module.f.mjs'
@@ -423,19 +422,13 @@ const badKey = ([kind, items], index) => {
 }
 
 /**
- * One member added to an object's properties: the value at its index among
- * the resolved values, under its name. The values ride in the accumulator so
- * that the step captures nothing.
- *
- * @type {(acc: _Properties, member: Entry, index: number) => _Properties}
- */
-const addMember = ([properties, done], { name }, index) =>
-    [setReplace(name)(done[index])(properties), done]
-
-/**
  * A container of the values its items resolved to: an array, or an object
- * with a property per member, a repeated key keeping its first position
- * and taking its last value.
+ * with a property per member, in the order the members are written — the
+ * order JavaScript gives the same literal, which is the order the graph a
+ * module denotes has, so it is not the parser's to change. A repeated key
+ * keeps its first position and takes its last value, as it does there: the
+ * spread copies the properties so far, and the member then writes over its
+ * own, which leaves a property where it first stood.
  *
  * @type {(container: Container, done: readonly AstConst[]) => AstConst}
  */
@@ -445,12 +438,9 @@ const close = ([kind, members], done) => {
         const array = ['array', done]
         return array
     }
-    /** @type {_Properties} */
-    const start = [empty, done]
-    const [properties] = members.reduce(addMember, start)
     /** @type {AstObject} */
-    const object = fromMap(properties)
-    return object
+    const empty = {}
+    return members.reduce((object, { name }, index) => ({ ...object, [name]: done[index] }), empty)
 }
 
 /**

--- a/fjs/fsc/parser/private.ts
+++ b/fjs/fsc/parser/private.ts
@@ -48,11 +48,6 @@ export type _ListNode = readonly [
 /** The names bound so far, each to the reference that names it. */
 export type _Env = OrderedMap<AstModuleRef>
 
-/**
- * An object being closed: its properties so far, beside the resolved values
- * of all its members, which the step reads by index.
- */
-export type _Properties = readonly [properties: OrderedMap<AstConst>, done: readonly AstConst[]]
 
 /**
  * A container being built: `container[1][index]` is being evaluated, and

--- a/fjs/fsc/parser/proof.f.mjs
+++ b/fjs/fsc/parser/proof.f.mjs
@@ -3,6 +3,7 @@
  */
 
 import { parseFromTokens } from './module.f.mjs'
+import { run } from '../ast/module.f.mjs'
 import { tokenize } from '../tokenizer/module.f.mjs'
 import { toArray } from '../../types/list/module.f.mjs'
 import { sort } from '../../types/object/module.f.mjs'
@@ -326,6 +327,22 @@ export const proof = {
             assertEq(value.metadata?.column, 11)
         },
     ],
+    // An object's members stand in the order they are written, as JavaScript
+    // reads the same literal, and a repeated key keeps its first position
+    // and takes its last value. The parser used to sort them, which the
+    // subset law over the DataJS corpus found: the graph a module denotes
+    // has an order, and a reader that changes it reads another graph. The
+    // stringified module proofs above cannot see this, since they serialize
+    // sorted, so it is pinned on the evaluated value.
+    memberOrder: () => {
+        const [tag, value] = parseFromTokens(tokenizeString('export default {"b": 1, "a": 2, "b": 3, "c": {"y": 0, "x": 0}};'))
+        assert(tag === 'ok', tag)
+        const object = run(value[1])([])
+        assert(typeof object === 'object' && object !== null && !(object instanceof Array), object)
+        assertEq(Object.keys(object).join(), 'b,a,c')
+        assertEq(object.b, 3)
+        assertEq(Object.keys(/** @type {object} */ (object.c)).join(), 'y,x')
+    },
     // None of the framing keywords is reserved: outside the positions that frame
     // a module, the parser accepts them as ordinary identifiers. Pinned here
     // because the grammar gives each its own token symbol, and a grammar

--- a/fjs/fsc/proof.f.mjs
+++ b/fjs/fsc/proof.f.mjs
@@ -1,15 +1,55 @@
 /**
  * @import { Unknown } from '../djs/types.ts'
+ * @import { Accept, Document } from '../media/datajs/vectors/types.ts'
  */
 
 import { exitCode } from '../effects/node/module.f.mjs'
 import { compile } from './module.f.mjs'
 import { transpile } from './transpiler/module.f.mjs'
+import { run } from './ast/module.f.mjs'
+import { parseFromTokens } from './parser/module.f.mjs'
+import { tokenize } from './tokenizer/module.f.mjs'
 import { stringify } from '../djs/serializer/module.f.mjs'
+import { bytes, difference } from '../media/datajs/vectors/module.f.mjs'
 import { virtual, emptyState } from '../effects/node/virtual/module.f.mjs'
 import { utf8, utf8ToString } from '../text/module.f.mjs'
+import { fromVec } from '../text/utf8/module.f.mjs'
+import { stringToList } from '../text/utf16/module.f.mjs'
 import { fromEntries, isObject, sort } from '../types/object/module.f.mjs'
+import { toVec } from '../types/uint8array/module.f.mjs'
 import { assert, assertEq, assertStructurallySame } from '../asserts/module.f.mjs'
+import accept from '../../spec/datajs/vectors/accept/data.f.mjs'
+
+/** The DataJS accept corpus, typed at the import since a data module carries no annotations. */
+const acceptSet = /** @type {readonly Accept[]} */ (accept)
+
+/**
+ * A vector's document as the front end reads it: a string as it is, and a
+ * byte-form document decoded — the front end takes code units, as
+ * `transpile` feeds it, so a byte document reaches it the way it reaches any
+ * code-unit reader, through a decoder that refuses what is not UTF-8. Every
+ * accept document is UTF-8, so `null` here is a corpus defect, not a case.
+ *
+ * @type {(document: Document) => string | null}
+ */
+const documentText = document => {
+    if (typeof document === 'string') { return document }
+    const octets = bytes(document[1])
+    return octets === null ? null : fromVec(toVec(new Uint8Array(octets)))
+}
+
+/**
+ * What the front end makes of a source: the graph the module denotes, or
+ * the error it reports. Tokenizer, parser and evaluator over the code units
+ * of the text, with no imports to resolve — a DataJS document has none —
+ * which is what `transpile` does behind the file system.
+ *
+ * @type {(source: string) => readonly ['ok', Unknown] | readonly ['error', string]}
+ */
+const evaluate = source => {
+    const [tag, value] = parseFromTokens(tokenize(stringToList(source))(''))
+    return tag === 'error' ? ['error', value.message] : ['ok', run(value[1])([])]
+}
 
 /** @type {(root: typeof emptyState.root, path: string) => string} */
 const readOutput = (root, path) => {
@@ -152,6 +192,24 @@ export const proof = {
         const [, result] = virtual({ ...emptyState, root })(transpile('input.f.js'))
         assert(result[0] === 'ok', result[1])
         assertStructurallySame(result[1], value, source)
+    }),
+    // The subset law, FunctionalScript's half: every DataJS accept document
+    // is a FunctionalScript module, and the front end reads it to the graph
+    // its vector asserts — sharing and key order included, which is what
+    // `difference` compares. The corpus proves the other half against a
+    // JavaScript engine; this is the one stage 5 was done for, and it runs
+    // over the whole set, the eight documents holding an unpaired surrogate
+    // included, since the front end takes code units and owes no byte
+    // encoding. Two things it found: the parser used to sort an object's
+    // keys, and it used to be fed code points by the proofs where
+    // `transpile` feeds it code units.
+    subsetLaw: acceptSet.map(({ id, document, graph }) => () => {
+        const source = documentText(document)
+        assert(source !== null, `${id}: the document is not UTF-8`)
+        const [tag, value] = evaluate(source)
+        assert(tag === 'ok', `${id}: the front end refused the document: ${value}`)
+        const d = difference(graph)(value)
+        assert(d === null, `${id}: the front end's graph is not the vector's: ${d}`)
     }),
     // The three numbers JSON cannot spell, end to end: read as the values
     // they name, written back as the same words. `NaN` is checked by

--- a/fjs/fsc/proof.f.mjs
+++ b/fjs/fsc/proof.f.mjs
@@ -5,16 +5,13 @@
 
 import { exitCode } from '../effects/node/module.f.mjs'
 import { compile } from './module.f.mjs'
-import { transpile } from './transpiler/module.f.mjs'
+import { parse, transpile } from './transpiler/module.f.mjs'
 import { run } from './ast/module.f.mjs'
-import { parseFromTokens } from './parser/module.f.mjs'
-import { tokenize } from './tokenizer/module.f.mjs'
 import { stringify } from '../djs/serializer/module.f.mjs'
 import { bytes, difference } from '../media/datajs/vectors/module.f.mjs'
 import { virtual, emptyState } from '../effects/node/virtual/module.f.mjs'
 import { utf8, utf8ToString } from '../text/module.f.mjs'
 import { fromVec } from '../text/utf8/module.f.mjs'
-import { stringToList } from '../text/utf16/module.f.mjs'
 import { fromEntries, isObject, sort } from '../types/object/module.f.mjs'
 import { toVec } from '../types/uint8array/module.f.mjs'
 import { assert, assertEq, assertStructurallySame } from '../asserts/module.f.mjs'
@@ -40,14 +37,15 @@ const documentText = document => {
 
 /**
  * What the front end makes of a source: the graph the module denotes, or
- * the error it reports. Tokenizer, parser and evaluator over the code units
- * of the text, with no imports to resolve — a DataJS document has none —
- * which is what `transpile` does behind the file system.
+ * the error it reports. The transpiler's own `parse`, then its evaluator,
+ * with no imports to resolve — a DataJS document has none — which is what
+ * `transpile` does behind the file system; the parts are the compiler's,
+ * not a second assembly of them.
  *
  * @type {(source: string) => readonly ['ok', Unknown] | readonly ['error', string]}
  */
 const evaluate = source => {
-    const [tag, value] = parseFromTokens(tokenize(stringToList(source))(''))
+    const [tag, value] = parse('')(source)
     return tag === 'error' ? ['error', value.message] : ['ok', run(value[1])([])]
 }
 

--- a/fjs/fsc/transpiler/module.f.mjs
+++ b/fjs/fsc/transpiler/module.f.mjs
@@ -46,6 +46,18 @@ const mapDjs = context => path => {
 }
 
 /**
+ * The front end over a module's text: the tokenizer over its code units, then
+ * the parser, the one composition every reader of a module goes through —
+ * `transpile` behind the file system, and the subset-law proof over the
+ * DataJS corpus directly — so that a proof of the front end exercises the
+ * front end rather than a second assembly of its parts. `path` names the
+ * text in the positions an error carries.
+ *
+ * @type {(path: string) => (text: string) => Result<AstModule, ParseError>}
+ */
+export const parse = path => text => parseFromTokens(tokenize(stringToList(text))(path))
+
+/**
  * `catchStep` rather than a branch on the read's `Result`: however the read
  * failed — missing file, unreadable, a runner without `readFile` — the answer
  * a transpiler gives is the same `ParseError`, so the node channel is
@@ -53,9 +65,7 @@ const mapDjs = context => path => {
  *
  * @type {(path: string) => Effect<ReadFile, AstModule, ParseError>}
  */
-const parseModule = path => step(
-    notFound(readUtf8File(path)),
-    text => pure(parseFromTokens(tokenize(stringToList(text))(path))))
+const parseModule = path => step(notFound(readUtf8File(path)), text => pure(parse(path)(text)))
 
 /** @type {(path: string) => (module: AstModule) => (context: ParseContext) => Effect<ReadFile, ParseContext, ParseError>} */
 const transpileWithImports = path => module => context => {

--- a/fjs/types/object/proof.f.mjs
+++ b/fjs/types/object/proof.f.mjs
@@ -1,7 +1,16 @@
-import { at } from './module.f.mjs'
+import { at, fromMap } from './module.f.mjs'
+import { empty, setReplace } from '../ordered_map/module.f.mjs'
 import { assertEq } from '../../asserts/module.f.mjs'
 
 export const proof = {
+    // an ordered map as an object: its entries in the map's order, sorted
+    fromMap: () => {
+        const map = setReplace('b')(1)(setReplace('a')(2)(empty))
+        const object = fromMap(map)
+        assertEq(Object.keys(object).join(), 'a,b')
+        assertEq(object.a, 2)
+        assertEq(object.b, 1)
+    },
     ctor: () => {
         const a = {}
         const value = at('constructor')(a)

--- a/todo/parser-serializer-restructure.md
+++ b/todo/parser-serializer-restructure.md
@@ -517,7 +517,10 @@ combined marker would encode a redundant fact.
   cases DataJS gets for free — `truex` being a lexical error rather than
   `true` followed by a valid name — do not carry over.
 - Subset laws are proof obligations, not prose: every DataJS *accept* vector
-  parses in FunctionalScript to the same value graph; the normalizer closes
+  parses in FunctionalScript to the same value graph — **proved**, in
+  `fjs/fsc/proof.f.mjs`, over the whole accept set, sharing and key order
+  compared; it found the parser sorting an object's members, which is fixed,
+  the graph a module denotes having an order of its own; the normalizer closes
   the loop (`parse_datajs(normalize(m))` equals the evaluation of any
   data-only module `m`); FunctionalScript fixtures remain valid JS with
   identical meaning (checked against a real JS engine in proofs).
@@ -847,7 +850,9 @@ throughout.
       such as `serializer-children-helper` and `json-bigint-serialization`,
       stay beside `fjs/djs/serializer/` until stage 4 reworks it — and
       repoint every link into them.
-- [ ] Stage 6: normalizer + subset-law proofs; file its todo.
+- [ ] Stage 6: normalizer + subset-law proofs; file its todo. The
+      FunctionalScript half of the subset law is proved, in
+      `fjs/fsc/proof.f.mjs`; the normalizer and its loop remain.
 - [ ] Stage 7: `fjs/js/tokenizer` retirement and the breaking-change release.
 - [ ] Update affected issues as their subject matter moves (see below).
 - [ ] `tsc`, `fjs test` at every stage.


### PR DESCRIPTION
Stacked on #2015. The FunctionalScript half of the subset law, the first
proof obligation stage 6 of
[`todo/parser-serializer-restructure.md`](https://github.com/functionalscript/functionalscript/blob/claude/fsc-subset-law/todo/parser-serializer-restructure.md)
lists: every DataJS accept document is a FunctionalScript module, and the
front end reads it to the graph its vector asserts.

**The proof.** `fjs/fsc/proof.f.mjs` runs every vector of
`spec/datajs/vectors/accept` through the front end — tokenizer, parser,
evaluator, with no imports to resolve, which is what `transpile` does behind
the file system — and compares the result with the vector's graph using the
corpus's own `difference`, so sharing and key order count. It runs over the
whole set, the eight documents holding an unpaired surrogate included: the
front end takes code units, as `transpile` feeds it, and owes no byte
encoding, where the corpus's engine half has to name and skip those eight. A
byte-form document reaches it through a decoder that refuses what is not
UTF-8. 398 vectors, every one denoting the graph its vector asserts.

**What it found.** Two things, one of them a defect in the front end:

- The parser sorted an object's members. It folded them through an
  `OrderedMap` and produced the object from that, so `{ "b": 1, "a": 2 }`
  read as `{ a, b }` where JavaScript reads `{ b, a }`. The graph a module
  denotes has an order, and a reader that changes it reads another graph —
  26 vectors said so. Objects are built in source order now, a repeated key
  keeping its first position and taking its last value, as the fold's own
  comment always claimed; the parser's proof pins it on the evaluated value,
  since the stringified-module proofs serialize sorted and cannot see it.
  `fromMap` in `fjs/types/object`, which the parser was the only caller of,
  gets a proof of its own.
- The proofs fed the tokenizer code points where `transpile` feeds it code
  units. Over code points an unpaired surrogate arrives as the decoder's
  error sentinel, which the LL(1) machine refuses as not a symbol at all;
  over code units it is a code unit. The law's proof reads code units, as
  the compiler does. The proof helper `tokenizeString` still reads code
  points, which no user path reaches; it is left as it is.

The EDAG issue's record of the ordered-entry gap is corrected: what a plain
object still cannot keep is the written order of integer-like keys and the
duplicates themselves, which is what its explicit entry list is still for.
The plan records the law as proved and the normalizer as what remains of
stage 6.

Checks: `tsc`, `node --test`, `npm run cov` at the 100% thresholds pass;
`npm run gen` changes nothing.

Changelog:
- `fsc`, `fjs compile`: an object's members are evaluated in the order they
  are written, as JavaScript reads the same literal, where they used to be
  sorted by key. Module and JSON output are unaffected, since the serializer
  sorts keys itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJCd56sHrbuHK2ThsseSDZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJCd56sHrbuHK2ThsseSDZ)_