### PR TITLE
datajs: the writer-side sets run against the writer

### DIFF
--- a/fjs/media/datajs/todo/parser-serializer.md
+++ b/fjs/media/datajs/todo/parser-serializer.md
@@ -256,9 +256,14 @@ reader's two sets, `accept` and `reject`, are this file's; the writer's three �
       bound-once and declare-before-use; the key rule on the decoded value.
 - [x] Reader proofs derived from the specification by hand, both sharing
       directions included.
-- [ ] Reader proofs from the corpus, which has landed, and the byte path —
-      `tryParseBytes` — with the BOM and invalid-UTF-8 vectors the corpus
-      assigns to stage 4.
+- [ ] The byte path, `tryParseBytes`, with the BOM and invalid-UTF-8 vectors the
+      corpus assigns to stage 4. The reader's proofs over the corpus are done —
+      [`fjs/media/datajs/vectors/proof.f.mjs`](../vectors/proof.f.mjs) reads
+      every accept document to the graph its vector asserts and refuses every
+      reject one — but they reach the byte documents by decoding with
+      `fjs/text/utf8` and reading the units, so the two rules only bytes can
+      break are pinned at the wrong layer until this lands and the set is rerun
+      through it.
 - [ ] The writer, in [`serializer.md`](./serializer.md) — including
       `module.f.mjs`, the public API of §Layout, which waits for something
       beyond the reader to hold.

--- a/fjs/media/datajs/todo/serializer.md
+++ b/fjs/media/datajs/todo/serializer.md
@@ -10,9 +10,11 @@ and `tryStringify` over the three passes of §1–§3, with every rule of §1 pr
 and the two worked examples of the hoisting and naming rules pinned. It refuses
 everything the specification refuses but **one host-built shape** — the
 `Array.prototype` impostor of §4, which no FunctionalScript caller can construct
-and which closes with either of the two decisions §4 names. What remains is the
-corpus proofs (§4), the module's own `module.f.mjs`, and a readable layout
-if one is wanted (§3).
+and which closes with either of the two decisions §4 names. The corpus proofs of
+§4 are done — all three writer-side sets run this writer — so what remains is
+the module's own `module.f.mjs`, the explicit-stack walk, the two quadratic
+steps measured, a readable layout if one is wanted (§3), and the impostor
+decision.
 **Blocked by:** nothing, for what is left of the implementation. What landed
 proves itself against the specification by hand, as
 [the reader](../parser/proof.f.mjs) does — that was the interim proof source, and
@@ -21,9 +23,10 @@ proofs below have their source.
 
 Its **corpus proofs** have their sets. The corpus's writer side is three sets,
 not four — `serializer-accept`, `graph-equivalence` and `normalize`, all three
-typed in [`../vectors/types.ts`](../vectors/types.ts) and all three in the tree;
-`normalize` carries 280 records and its own proof, which runs this writer over
-every one of them. There is no `serializer-reject`
+typed in [`../vectors/types.ts`](../vectors/types.ts), all three in the tree, and
+all three running this writer from their own proofs — `normalize` over its 280
+records byte for byte, `serializer-accept` over its 219 inputs, and
+`graph-equivalence` over its 16 sharing shapes. There is no `serializer-reject`
 and there are no **host recipes**: a serializer is handed a value of the data
 model and its type is the contract, so an accessor, a non-enumerable property,
 a `null` prototype and a cycle reach no serializer and the corpus describes
@@ -506,7 +509,9 @@ descriptor, so only a host caller reaches it — and a host caller is what the
       the reader takes denoting each; `graph-equivalence` does the same over its
       16 sharing shapes and also rules the output out of the vector's own
       `denotesNot` list, which needs no reader. A spelling is asserted only where
-      the role permits it, which is `normalize` alone. There is no fourth set and
+      the role permits it, which is `normalize` alone, and `serializer-accept`
+      also checks its output has a UTF-8 encoding, which the round trip cannot
+      see. There is no fourth set and
       no host-input half, and neither is a scheduling question: a set is a DataJS
       data module, so a set for values outside the data model cannot be written
       at all, and the question whether a `proof.mjs` may prove this API against

--- a/fjs/media/datajs/todo/serializer.md
+++ b/fjs/media/datajs/todo/serializer.md
@@ -488,8 +488,14 @@ descriptor, so only a host caller reaches it — and a host caller is what the
       line and the hole-versus-`undefined` distinction proved.
 - [x] Normalized form and its byte-exact proofs, the `1e20`/`1e21` and
       `1e-6`/`1e-7` thresholds included.
-- [ ] Proofs over the three writer-side sets, all three of which have landed in
-      [the corpus](../../../../spec/datajs/vectors/README.md). There is no fourth
+- [x] Proofs over the three writer-side sets, all three of which have landed in
+      [the corpus](../../../../spec/datajs/vectors/README.md) and all three of
+      which now run this writer. `normalize` compares its 280 texts byte for
+      byte; `serializer-accept` hands over its 219 inputs and requires a document
+      the reader takes denoting each; `graph-equivalence` does the same over its
+      16 sharing shapes and also rules the output out of the vector's own
+      `denotesNot` list, which needs no reader. A spelling is asserted only where
+      the role permits it, which is `normalize` alone. There is no fourth set
       and no host-input half: the question whether a `proof.mjs` may prove this
       API against host-built inputs was retired rather than answered, and if the
       open `unknown` question above is settled the other way the fourth comes

--- a/spec/datajs/vectors/README.md
+++ b/spec/datajs/vectors/README.md
@@ -38,14 +38,17 @@ a set at the import, with the record types in
 [`fjs/media/datajs/vectors/types.ts`](../../../fjs/media/datajs/vectors/types.ts).
 A set ships a `proof.f.mjs` beside it, as every module does, proving the set's
 shape — every vector named and classed with a non-empty string, the ids one of a
-kind, the document and the graph present — and, where this repository holds the
-implementation a set is about, running it over every vector as well. A
-third-party implementation is closed by its own harness, reading the same sets.
+kind, the document and the graph present. Running a set against an
+implementation is a second thing, and where it lives depends on the role: the
+three writer-side sets are run from those same files, and the reader's two from
+the reader's side, in `fjs/media/datajs/vectors/proof.f.mjs`. Below the matrix
+says which run is where. A third-party implementation is closed by its own
+harness, reading the same sets.
 
 | set | directory | record | proved against |
 | - | - | - | - |
-| reader accept | `accept/` | `Accept` | the reader, as the set lands |
-| reader reject | `reject/` | `Reject` | the reader, as the set lands |
+| reader accept | `accept/` | `Accept` | the reader, from its own side |
+| reader reject | `reject/` | `Reject` | the reader, from its own side |
 | serializer accept | `serializer-accept/` | `SerializerAccept` | the serializer |
 | graph equivalence | `graph-equivalence/` | `GraphEquivalence` | the serializer |
 | normalize | `normalize/` | `Normalize` | the normalized serializer |

--- a/spec/datajs/vectors/README.md
+++ b/spec/datajs/vectors/README.md
@@ -36,11 +36,11 @@ of. A set carries no
 comments and no annotations, since the subset has neither; a consumer types
 a set at the import, with the record types in
 [`fjs/media/datajs/vectors/types.ts`](../../../fjs/media/datajs/vectors/types.ts).
-A set ships a `proof.f.mjs` beside it, as every module does, proving the
-set's shape — every vector named and classed with a non-empty string, the
-ids one of a kind, the document and the graph present — and the proof
-that runs the set against an implementation lives with that
-implementation.
+A set ships a `proof.f.mjs` beside it, as every module does, proving the set's
+shape — every vector named and classed with a non-empty string, the ids one of a
+kind, the document and the graph present — and, where this repository holds the
+implementation a set is about, running it over every vector as well. A
+third-party implementation is closed by its own harness, reading the same sets.
 
 | set | directory | record | proved against |
 | - | - | - | - |
@@ -50,14 +50,30 @@ implementation.
 | graph equivalence | `graph-equivalence/` | `GraphEquivalence` | the serializer |
 | normalize | `normalize/` | `Normalize` | the normalized serializer |
 
-The writer has landed, so those three name an implementation that exists
-rather than one to come. What each set's own `proof.f.mjs` does is narrower
-than the column: it proves the set's shape, and for graph equivalence also
-that every `denotes` claim is true and every `denotesNot` one false, read
-back through the reader. The `normalize` set's proof goes further and runs
-the shipped writer over every vector, comparing its output with the text.
-`serializer-accept` and `graph-equivalence` have no such proof, so a harness
-is what closes those two.
+The writer has landed, so those three name an implementation that exists rather
+than one to come, and every set is now run against it. The runs are in two
+places, by which role they are about. **The reader's** are with the reader, in
+[`fjs/media/datajs/vectors/proof.f.mjs`](../../../fjs/media/datajs/vectors/proof.f.mjs):
+every accept document read to the graph its vector asserts, and every reject
+document refused, with the layer each `rule` belongs to pinned before the
+refusal.
+
+**The writer's** are in each set's own proof, since what they check is the claim
+the record makes. `serializer-accept` hands every input to the writer, and the
+document that comes out must be one the reader takes, denoting the input: *a*
+valid document and never a particular spelling, which is what this role owes.
+`graph-equivalence` does the same over the sharing shapes, where `difference`
+comparing containers as a bijection is what refuses an expanded share or a merge
+of two distinct nodes — and it also checks the output against the vector's own
+`denotesNot` list, the one check here that needs no reader at all. `normalize`
+goes furthest and compares the output with the text, byte for byte, which is the
+only role that may.
+
+Reading a writer's output back through this repository's reader would agree with
+itself if both were wrong in compensating ways. What keeps it from being
+circular is that the reader is pinned by the accept set against graphs the
+writer has no part in, and the `denotesNot` check sees the one family of wrong
+outputs without consulting a reader.
 
 One directory holds no vectors: `not-applicable/` carries the reasons the
 matrix below needs. A record answers a **scope** rather than a single cell —

--- a/spec/datajs/vectors/README.md
+++ b/spec/datajs/vectors/README.md
@@ -63,8 +63,11 @@ refusal.
 
 **The writer's** are in each set's own proof, since what they check is the claim
 the record makes. `serializer-accept` hands every input to the writer, and the
-document that comes out must be one the reader takes, denoting the input: *a*
-valid document and never a particular spelling, which is what this role owes.
+document that comes out must be one the reader takes, denoting the input, and
+must have a UTF-8 encoding — *a* valid document and never a particular spelling,
+which is what this role owes. The encoding check is not redundant: a document is
+UTF-8, an unpaired surrogate has none, and the reader takes code units, so a
+writer emitting one raw round-trips and has still not written a document.
 `graph-equivalence` does the same over the sharing shapes, where `difference`
 comparing containers as a bijection is what refuses an expanded share or a merge
 of two distinct nodes — and it also checks the output against the vector's own

--- a/spec/datajs/vectors/graph-equivalence/proof.f.mjs
+++ b/spec/datajs/vectors/graph-equivalence/proof.f.mjs
@@ -6,6 +6,7 @@
 import { assert, assertEq } from '../../../../fjs/asserts/module.f.mjs'
 import { difference } from '../../../../fjs/media/datajs/vectors/module.f.mjs'
 import { parse } from '../../../../fjs/media/datajs/parser/module.f.mjs'
+import { tryStringify } from '../../../../fjs/media/datajs/serializer/module.f.mjs'
 import graphEquivalence from './data.f.mjs'
 
 /** The set, typed at the import since a data module carries no annotations. */
@@ -32,11 +33,11 @@ const read = (id, document) => {
     return /** @type {Unknown} */ (result)
 }
 
-// The set's shape, and the claim each record makes, checked against the
-// reader that exists. What a *serializer* emits for these inputs arrives
-// with stage 4; this half is what makes the set meaningful before then,
-// since a `denotesNot` that in fact denotes the input would fail a
-// conforming serializer rather than a broken one.
+// The set's shape, the claim each record makes against the reader, and what
+// the writer emits for the same inputs. The reader half came first because a
+// `denotesNot` that in fact denotes the input would fail a conforming
+// serializer rather than a broken one; the writer half is the role this set
+// exists for.
 export const proof = {
     // Every vector names itself and its class with a non-empty string.
     named: () => { for (const vector of set) { named(vector, 'id'); named(vector, 'class') } },
@@ -79,6 +80,30 @@ export const proof = {
             }
         }
     },
+    // And the writer that exists, over the same inputs: every graph is
+    // accepted, and the document that comes out denotes it — which for this
+    // set means the sharing survives, since `difference` compares containers
+    // as a bijection and so refuses both an expanded share and a merge of two
+    // distinct nodes.
+    //
+    // The second check needs no reader and is the reason this set carries
+    // `denotesNot` at all: those documents are the plausible wrong outputs
+    // for these graphs, so a writer whose output is one of them is caught by
+    // comparing the text, even against a reader broken in the same direction.
+    // Measured, all sixteen outputs land among the `denotes` documents
+    // instead — which is not asserted, because a serializer owes any valid
+    // document denoting the graph and a spelling is `normalize`'s to pin.
+    shipped: () => {
+        for (const vector of set) {
+            const id = named(vector, 'id')
+            const [tag, out] = tryStringify(vector.input)
+            assert(tag === 'ok', `${id}: the writer refused the input: ${String(out)}`)
+            assert(!vector.denotesNot.includes(out),
+                `${id}: the writer emitted ${JSON.stringify(out)}, which this vector rules out`)
+            const d = difference(vector.input)(read(id, out))
+            assert(d === null, `${id}: the writer emitted ${JSON.stringify(out)}, which denotes another graph: ${d}`)
+        }
+    },
     // The one shape this carrier cannot spell, pinned here instead. A shared
     // empty *object* is a vector above; a shared empty **array** needs
     // `const $e = [];`, which `tsc` types as an evolving `any[]` and refuses
@@ -97,5 +122,14 @@ export const proof = {
             assert(difference(input)(read('shared-empty-array', document)) !== null,
                 `shared-empty-array: ${JSON.stringify(document)} denotes the input after all`)
         }
+        // And the writer over the same shape, which is the half a vector would
+        // have carried: what it emits denotes the shared graph, so it hoists
+        // the empty array rather than inlining `[]` twice — the two documents
+        // just ruled out are exactly what an inlining writer emits, so the
+        // round trip pins the direction and no spelling has to be named here.
+        // The one spelling is `normalize`'s to pin, and its proof does.
+        const [tag, out] = tryStringify(input)
+        assert(tag === 'ok', `shared-empty-array: the writer refused it: ${String(out)}`)
+        assertEq(difference(input)(read('shared-empty-array', out)), null)
     },
 }

--- a/spec/datajs/vectors/serializer-accept/proof.f.mjs
+++ b/spec/datajs/vectors/serializer-accept/proof.f.mjs
@@ -1,8 +1,12 @@
 /**
+ * @import { Unknown } from '../../../../fjs/media/datajs/types.ts'
  * @import { SerializerAccept } from '../../../../fjs/media/datajs/vectors/types.ts'
  */
 
 import { assert, assertEq } from '../../../../fjs/asserts/module.f.mjs'
+import { difference } from '../../../../fjs/media/datajs/vectors/module.f.mjs'
+import { parse } from '../../../../fjs/media/datajs/parser/module.f.mjs'
+import { tryStringify } from '../../../../fjs/media/datajs/serializer/module.f.mjs'
 import serializerAccept from './data.f.mjs'
 
 /** The set, typed at the import since a data module carries no annotations. */
@@ -22,9 +26,10 @@ const named = (vector, name) => {
     return value
 }
 
-// The shape of the set. What a serializer does with it arrives with stage 4,
-// which reruns the set through the writer; until then this is what stands
-// between the corpus and a record nobody can act on.
+// The shape of the set, and its claim against the writer that exists. The
+// claim is what this role owes and no more: the input is accepted, and the
+// output is *a* valid document denoting it — never a particular spelling,
+// which belongs to `normalize` alone.
 export const proof = {
     // Every vector names itself and its class with a non-empty string, checked
     // before the ids are counted: a missing id is not one of a kind, and a
@@ -43,6 +48,29 @@ export const proof = {
     records: () => {
         for (const vector of set) {
             assert(hasOwn(vector, 'input'), `${named(vector, 'id')}: no input`)
+        }
+    },
+    // And the claim itself, against the serializer that exists: every input
+    // is accepted, and what comes out is a document the reader takes which
+    // denotes the input, sharing included. The issue expected this to wait
+    // for stage 4; stage 4 has landed, so the set tests the shipped writer
+    // rather than describing one to come.
+    //
+    // The output is read back through this repository's reader, so a reader
+    // and a writer wrong in compensating ways would agree. What keeps that
+    // from being circular is that the reader is pinned elsewhere and not by
+    // this: `fjs/media/datajs/vectors/proof.f.mjs` runs the whole accept set
+    // against it, document by document, with graphs the writer has no part
+    // in.
+    shipped: () => {
+        for (const vector of set) {
+            const id = named(vector, 'id')
+            const [tag, out] = tryStringify(vector.input)
+            assert(tag === 'ok', `${id}: the writer refused the input: ${String(out)}`)
+            const [readTag, graph] = parse(out)
+            assert(readTag === 'ok', `${id}: the writer emitted ${JSON.stringify(out)}, which the reader refuses: ${String(graph)}`)
+            const d = difference(vector.input)(/** @type {Unknown} */ (graph))
+            assert(d === null, `${id}: the writer emitted ${JSON.stringify(out)}, which denotes another graph: ${d}`)
         }
     },
 }

--- a/spec/datajs/vectors/serializer-accept/proof.f.mjs
+++ b/spec/datajs/vectors/serializer-accept/proof.f.mjs
@@ -7,6 +7,8 @@ import { assert, assertEq } from '../../../../fjs/asserts/module.f.mjs'
 import { difference } from '../../../../fjs/media/datajs/vectors/module.f.mjs'
 import { parse } from '../../../../fjs/media/datajs/parser/module.f.mjs'
 import { tryStringify } from '../../../../fjs/media/datajs/serializer/module.f.mjs'
+import { stringToCodePointList } from '../../../../fjs/text/utf16/module.f.mjs'
+import { toArray } from '../../../../fjs/types/list/module.f.mjs'
 import serializerAccept from './data.f.mjs'
 
 /** The set, typed at the import since a data module carries no annotations. */
@@ -25,6 +27,18 @@ const named = (vector, name) => {
     assert(typeof value === 'string' && value !== '', `${JSON.stringify(vector.id)}: ${name} is not a non-empty string`)
     return value
 }
+
+/**
+ * Whether a string has a UTF-8 encoding, which a document must: every code
+ * point of it is a real one. `stringToCodePointList` marks an unpaired
+ * surrogate with a negative code point instead, and an unpaired surrogate is
+ * the one thing a JavaScript string can hold that UTF-8 cannot spell — so a
+ * writer emitting one raw has emitted something that is not a document, which
+ * the round trip below cannot see: the reader takes code units and accepts it.
+ *
+ * @type {(text: string) => boolean}
+ */
+const utf8Encodable = text => toArray(stringToCodePointList(text)).every(c => c >= 0)
 
 // The shape of the set, and its claim against the writer that exists. The
 // claim is what this role owes and no more: the input is accepted, and the
@@ -56,6 +70,13 @@ export const proof = {
     // for stage 4; stage 4 has landed, so the set tests the shipped writer
     // rather than describing one to come.
     //
+    // The last check is the one the round trip cannot make. A document is
+    // UTF-8, and an unpaired surrogate has no UTF-8 encoding — but the reader
+    // takes code units, so it accepts a raw one and the round trip passes.
+    // Review measured exactly that: with the writer's escaping made to emit raw
+    // surrogates, every check above stayed green and only `normalize`, which
+    // compares bytes, went red.
+    //
     // The output is read back through this repository's reader, so a reader
     // and a writer wrong in compensating ways would agree. What keeps that
     // from being circular is that the reader is pinned elsewhere and not by
@@ -71,6 +92,7 @@ export const proof = {
             assert(readTag === 'ok', `${id}: the writer emitted ${JSON.stringify(out)}, which the reader refuses: ${String(graph)}`)
             const d = difference(vector.input)(/** @type {Unknown} */ (graph))
             assert(d === null, `${id}: the writer emitted ${JSON.stringify(out)}, which denotes another graph: ${d}`)
+            assert(utf8Encodable(out), `${id}: the writer emitted ${JSON.stringify(out)}, which has no UTF-8 encoding`)
         }
     },
 }

--- a/spec/datajs/vectors/todo/shared-empty-array.md
+++ b/spec/datajs/vectors/todo/shared-empty-array.md
@@ -45,9 +45,12 @@ node, where this is *expanding* one shared empty into two.
 annotation where a data module may not, so `sharedEmptyArray` in
 [`../graph-equivalence/proof.f.mjs`](../graph-equivalence/proof.f.mjs) builds
 the graph and checks it against four documents through the reader: the two
-spellings that denote it and the two that do not. The writer side is the same
-trick in [`../normalize/proof.f.mjs`](../normalize/proof.f.mjs), whose
-`sharedEmptyArray` asserts `tryStringify` gives
+spellings that denote it and the two that do not — and, since the writer-side
+runs landed, hands the same graph to `tryStringify` and requires the output to
+denote it, which the two ruled-out documents are exactly what an inlining writer
+would emit instead. The byte-exact side is the same trick in
+[`../normalize/proof.f.mjs`](../normalize/proof.f.mjs), whose `sharedEmptyArray`
+asserts `tryStringify` gives
 `const $0=[];const $1=[$0];export default [$1,$1,$0];`. Both roles are covered
 here, which is what the Status block above says.
 


### PR DESCRIPTION
Stacked on [#2030](https://github.com/functionalscript/functionalscript/pull/2030). The corpus has five sets; four were checked against an implementation and two of those four only for their own shape. The corpus README said it plainly — "`serializer-accept` and `graph-equivalence` have no such proof, so a harness is what closes those two" — so 219 serializer inputs and 16 sharing shapes sat in the tree with nothing running them through the writer.

Both sets close here, in their own proofs, beside `normalize`'s `shipped` check that already did this.

## What each set now asserts

| set | vectors | the writer must |
| - | - | - |
| `serializer-accept` | 219 | accept the input, and emit a document the reader takes which denotes it **and has a UTF-8 encoding** |
| `graph-equivalence` | 16 | the same, **and** not emit one of the vector's own `denotesNot` documents |
| `normalize` | 280 | emit exactly the text (already landed) |

*A* valid document, never a spelling: asserting one would take `normalize`'s role, which the corpus's own "assert more than its role requires" rule forbids. All 235 pass — the writer was already right, and what changes is that the corpus now says so rather than claiming it.

```
serializer-accept: 219 vectors, ok 219, refused 0, unreadable 0, mismatched 0
graph-equivalence:  16 vectors, ok  16, refused 0, unreadable 0, mismatched 0
```

## The one check that needs no reader

Reading a writer's output back through this repository's own reader would agree with itself if both were wrong in compensating ways, and the README now says so instead of leaving it implied. Two things keep it from being circular:

- the reader is pinned elsewhere and not by this — `fjs/media/datajs/vectors/proof.f.mjs` runs the whole 398-vector accept set against it, document by document, with graphs the writer has no part in;
- `graph-equivalence` compares the writer's output against its own `denotesNot` list **as text**. That list is exactly the plausible wrong outputs for these graphs, so a writer that expands a share or merges two distinct nodes is caught even by a reader broken in the same direction. This is the reason the set carries the list at all, and nothing was using it on the writer's side.

Measured: all sixteen outputs land among the `denotes` documents instead. Recorded in the proof, not asserted.

## Controls

Each check fires on the defect it is about — stubbing the writer's output per case, on `graph-sharing-array` (a shared node) and `graph-unshared-array-non-empty` (two distinct nodes):

```
a refusal                        FIRES (writer refused: a cycle)
output that is not a document    FIRES (not a document: unexpected symbol at 18)
sharing expanded                 FIRES (at $[1]: expected the node reached before, got another)
a listed denotesNot document     FIRES (same, and the text check catches it without the reader)
two distinct nodes merged        FIRES (at $[1]: expected a node of its own, got one reached before)
the real writer output           passes
```

`graph-equivalence`'s `sharedEmptyArray` case — the one shape a data module cannot spell, so it has no vector — gains the writer half too: the output must denote the shared graph, and the two documents the case already rules out are exactly what an inlining writer emits, so the direction is pinned without naming a spelling. Its [kept record](https://github.com/functionalscript/functionalscript/blob/main/spec/datajs/vectors/todo/shared-empty-array.md) is updated to say what now covers it.

## Two task lists

- The writer's box for **proofs over the three writer-side sets** is ticked, with what each set checks and which role may assert a spelling.
- The reader's box drops its reader half — `fjs/media/datajs/vectors/proof.f.mjs` has been reading every accept document to its asserted graph and refusing every reject one — and keeps the byte path, with the reason it is still owed: those runs reach the three byte documents by decoding with `fjs/text/utf8` and reading the units, so the two rules only bytes can break are pinned at the wrong layer until `tryParseBytes` reruns them.

## Review

Three findings. **The set now checks the encoding** (`a07c7b4b`): review mutated the writer's escaping to emit raw unpaired surrogates and found `shipped` stayed green — a code-unit reader accepts a raw surrogate, so the round trip cannot see it, and only `normalize` caught it. `serializer-accept` asserts the output encodes as UTF-8 now (an unpaired surrogate marks a negative code point; measured, all 219 encode, a raw one does not and its escape does). The writer's Status block goes with it: §4's proofs are done, so what remains is `module.f.mjs`, the explicit-stack walk, the quadratic steps, a readable layout and the impostor decision.

And one on the README, fixed in `e6beef79`: the sentence introducing the runs generalised from the two sets this PR changes. A set's co-located proof runs the implementation for the three **writer-side** sets; the reader's two are run from the reader's side, in `fjs/media/datajs/vectors/proof.f.mjs`. The README now says the shape check is the set's and the run's home depends on the role, and the table's "as the set lands" for the reader's two goes with it.

## Checks

`tsc` clean; `node ./fjs/module.mjs t` 6343 pass / 0 fail (up 2 for the new entries, the rest from `main`); `npm run cov` 100% lines/branches/functions with 6281 host tests; `npm run gen` leaves no diff; every relative link and cross-document anchor in the changed files resolves. The two new entries cost 66 ms and 4 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzayQtZmCzP9rtExwHXtF2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzayQtZmCzP9rtExwHXtF2)_

---
_Generated by [Claude Code](https://claude.ai/code)_